### PR TITLE
two sets of rules (soon 3): ditch the slow `[?resource :resource/type…

### DIFF
--- a/src/eacl/datomic/impl.clj
+++ b/src/eacl/datomic/impl.clj
@@ -28,7 +28,9 @@
 
 (defn datomic->id [id] (identity id))
 
-(defn build-rules [resource-type-attr]
+(defn build-can?-rules
+  "Can only be used for can? where type + id of both subject & resource object are provided."
+  [resource-type-attr]
   [;; Reachability rules to traverse relationships:
    '[(reachable ?resource ?subject)
      [?relationship :eacl.relationship/resource ?resource]
@@ -40,7 +42,6 @@
 
    ;; Direct permission check (copied and adapted from core2)
    '[(has-permission ?subject ?permission-name ?resource)
-     [?resource :resource/type ?resource-type]              ; this is super slow. need different rules.
 
      [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
      [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
@@ -68,13 +69,13 @@
    ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
    ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
    (into
-     ['(has-permission ?subject ?permission-name ?resource)
-      ['?resource resource-type-attr '?resource-type]]
+     ['(has-permission ?subject ?permission-name ?resource)]
 
      '[;; Permission definition
        [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
        [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
 
+       ; can these move down for speed?
        [?perm-def :eacl.permission/resource-type ?resource-type]
        [?perm-def :eacl.permission/permission-name ?permission-name]
        [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
@@ -95,8 +96,6 @@
    ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
    ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
    '[(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
-     [?this-resource :resource/type ?this-resource-type]    ; this is super slow. need multiple rules.
-
      ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
      [(tuple ?this-resource-type
              ?via-relation-name
@@ -127,7 +126,109 @@
      ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
      [(not= ?this-resource ?intermediate-resource)]]])
 
-(def rules (build-rules :resource/type))
+(defn build-slow-rules [resource-type-attr]
+  [;; Reachability rules to traverse relationships:
+   '[(reachable ?resource ?subject)
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?subject]]
+   '[(reachable ?resource ?subject)
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?mid]
+     (reachable ?mid ?subject)]
+
+   ;; Direct permission check (copied and adapted from core2)
+   '[(has-permission ?subject ?permission-name ?resource)
+     [?resource :resource/type ?resource-type]              ; this is super slow. different rules WIP.
+
+     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
+     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
+     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
+     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
+
+     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
+
+     ;; Match the relation name from the relationship tuple with the one in permission definition
+     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
+     [(not= ?subject ?resource)]] ; can we avoid this?
+
+   ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
+   ;; This rule means: ?subject gets ?permission-name on ?resource if:
+   ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
+   ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
+   ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
+   ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
+   (into
+     ['(has-permission ?subject ?permission-name ?resource)
+      ['?resource resource-type-attr '?resource-type]] ; super slow. different rules WIP.
+
+     '[;; Permission definition
+       [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+       [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+       [?perm-def :eacl.permission/resource-type ?resource-type]
+       [?perm-def :eacl.permission/permission-name ?permission-name]
+       [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
+
+       ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
+       [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
+       [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
+
+       [?structural-rel :eacl.relationship/subject ?resource]
+       [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
+       [?structural-rel :eacl.relationship/resource ?target]
+
+       (reachable ?target ?subject)                         ; User must be able to reach the target of the structural relationship
+       [(not= ?subject ?resource)]])
+
+   ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
+   ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
+   ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
+   ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
+   '[(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
+     [?this-resource :resource/type ?this-resource-type]    ; this is super slow. different rules WIP.
+
+     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
+     [(tuple ?this-resource-type
+             ?via-relation-name
+             ?perm-on-related
+             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
+     [?arrow-perm-def
+      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
+      ?res-type+relation+related-perm+permission]
+
+     ; can these move down for speed, or be decoupled in a 2nd phase?
+     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
+     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
+
+     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
+     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
+     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
+
+     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
+     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
+     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
+
+     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
+     (has-permission ?subject ?perm-on-related ?intermediate-resource)
+     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
+     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
+     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
+     [(not= ?subject ?intermediate-resource)]
+     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
+     [(not= ?this-resource ?intermediate-resource)]]])
+
+(def can?-rules (build-can?-rules :resource/type))
+(def slow-lookup-rules (build-slow-rules :resource/type))
 ;(def rules (build-rules :resource/type))
 
 (defn Relation
@@ -204,7 +305,7 @@
                   :where
                   (has-permission ?subject ?perm ?resource)] ; do we still needs this?
                 db
-                rules
+                can?-rules
                 subject-eid
                 permission
                 resource-eid)
@@ -244,7 +345,7 @@
                                      [?subject :resource/type ?subject-type]
                                      [(not= ?subject ?resource-eid)]] ; can we avoid this exclusionary clause?
                                    db
-                                   rules
+                                   slow-lookup-rules
                                    resource-eid
                                    permission
                                    subject-type))
@@ -279,7 +380,7 @@
                                 (has-permission ?subject-eid ?permission ?resource)
                                 [?resource :resource/type ?resource-type]] ; consider moving ?resource-type into has-permission.
                               db
-                              rules
+                              slow-lookup-rules
                               resource-type
                               subject-type
                               subject-eid

--- a/src/eacl/datomic/impl.clj
+++ b/src/eacl/datomic/impl.clj
@@ -2,7 +2,8 @@
   "EACL: Enterprise Access Control. Spice-compatible authorization system in Datomic."
   (:require
     [datomic.api :as d]
-    [eacl.core :as proto :refer [spice-object]]))
+    [eacl.core :as proto :refer [spice-object]]
+    [eacl.datomic.rules :as rules]))
 
 (defn id->identifier
   "This is to support custom unique entity IDs."
@@ -22,214 +23,16 @@
 
 ; To support other types of IDs that can be coerced to/from string-formattable entity IDs, than UUIDs
 
-(defn id->datomic
-  "EACL uses unique string ID under :entity/id"
-  [id] (identity id))
+;(defn id->datomic
+;  "EACL uses unique string ID under :entity/id"
+;  [id] (identity id))
+;
+;(defn datomic->id [id] (identity id))
 
-(defn datomic->id [id] (identity id))
-
-(defn build-can?-rules
-  "Can only be used for can? where type + id of both subject & resource object are provided."
-  [resource-type-attr]
-  [;; Reachability rules to traverse relationships:
-   '[(reachable ?resource ?subject)
-     [?relationship :eacl.relationship/resource ?resource]
-     [?relationship :eacl.relationship/subject ?subject]]
-   '[(reachable ?resource ?subject)
-     [?relationship :eacl.relationship/resource ?resource]
-     [?relationship :eacl.relationship/subject ?mid]
-     (reachable ?mid ?subject)]
-
-   ;; Direct permission check (copied and adapted from core2)
-   '[(has-permission ?subject ?permission-name ?resource)
-
-     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
-     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
-
-     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
-     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
-     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
-
-     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
-     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
-     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
-
-     [?perm-def :eacl.permission/resource-type ?resource-type]
-     [?perm-def :eacl.permission/permission-name ?permission-name]
-     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
-
-     ;; Match the relation name from the relationship tuple with the one in permission definition
-     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
-     [(not= ?subject ?resource)]]
-
-   ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
-   ;; This rule means: ?subject gets ?permission-name on ?resource if:
-   ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
-   ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
-   ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
-   ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
-   (into
-     ['(has-permission ?subject ?permission-name ?resource)]
-
-     '[;; Permission definition
-       [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
-       [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
-
-       ; can these move down for speed?
-       [?perm-def :eacl.permission/resource-type ?resource-type]
-       [?perm-def :eacl.permission/permission-name ?permission-name]
-       [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
-
-       ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
-       [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
-       [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
-
-       [?structural-rel :eacl.relationship/subject ?resource]
-       [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
-       [?structural-rel :eacl.relationship/resource ?target]
-
-       (reachable ?target ?subject)                         ; User must be able to reach the target of the structural relationship
-       [(not= ?subject ?resource)]])
-
-   ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
-   ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
-   ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
-   ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
-   '[(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
-     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
-     [(tuple ?this-resource-type
-             ?via-relation-name
-             ?perm-on-related
-             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
-     [?arrow-perm-def
-      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
-      ?res-type+relation+related-perm+permission]
-
-     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
-     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
-     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
-     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
-
-     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
-     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
-     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
-     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
-     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
-     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
-
-     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
-     (has-permission ?subject ?perm-on-related ?intermediate-resource)
-     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
-     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
-     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
-     [(not= ?subject ?intermediate-resource)]
-     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
-     [(not= ?this-resource ?intermediate-resource)]]])
-
-(defn build-slow-rules [resource-type-attr]
-  [;; Reachability rules to traverse relationships:
-   '[(reachable ?resource ?subject)
-     [?relationship :eacl.relationship/resource ?resource]
-     [?relationship :eacl.relationship/subject ?subject]]
-   '[(reachable ?resource ?subject)
-     [?relationship :eacl.relationship/resource ?resource]
-     [?relationship :eacl.relationship/subject ?mid]
-     (reachable ?mid ?subject)]
-
-   ;; Direct permission check (copied and adapted from core2)
-   '[(has-permission ?subject ?permission-name ?resource)
-     [?resource :resource/type ?resource-type]              ; this is super slow. different rules WIP.
-
-     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
-     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
-
-     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
-     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
-     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
-
-     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
-     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
-     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
-
-     [?perm-def :eacl.permission/resource-type ?resource-type]
-     [?perm-def :eacl.permission/permission-name ?permission-name]
-     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
-
-     ;; Match the relation name from the relationship tuple with the one in permission definition
-     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
-     [(not= ?subject ?resource)]] ; can we avoid this?
-
-   ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
-   ;; This rule means: ?subject gets ?permission-name on ?resource if:
-   ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
-   ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
-   ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
-   ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
-   (into
-     ['(has-permission ?subject ?permission-name ?resource)
-      ['?resource resource-type-attr '?resource-type]] ; super slow. different rules WIP.
-
-     '[;; Permission definition
-       [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
-       [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
-
-       [?perm-def :eacl.permission/resource-type ?resource-type]
-       [?perm-def :eacl.permission/permission-name ?permission-name]
-       [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
-
-       ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
-       [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
-       [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
-
-       [?structural-rel :eacl.relationship/subject ?resource]
-       [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
-       [?structural-rel :eacl.relationship/resource ?target]
-
-       (reachable ?target ?subject)                         ; User must be able to reach the target of the structural relationship
-       [(not= ?subject ?resource)]])
-
-   ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
-   ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
-   ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
-   ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
-   '[(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
-     [?this-resource :resource/type ?this-resource-type]    ; this is super slow. different rules WIP.
-
-     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
-     [(tuple ?this-resource-type
-             ?via-relation-name
-             ?perm-on-related
-             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
-     [?arrow-perm-def
-      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
-      ?res-type+relation+related-perm+permission]
-
-     ; can these move down for speed, or be decoupled in a 2nd phase?
-     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
-     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
-     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
-     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
-
-     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
-     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
-     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
-
-     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
-     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
-     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
-
-     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
-     (has-permission ?subject ?perm-on-related ?intermediate-resource)
-     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
-     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
-     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
-     [(not= ?subject ?intermediate-resource)]
-     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
-     [(not= ?this-resource ?intermediate-resource)]]])
-
-(def can?-rules (build-can?-rules :resource/type))
-(def slow-lookup-rules (build-slow-rules :resource/type))
-;(def rules (build-rules :resource/type))
+;; Graph Traversal Strategy to resolve permissions between subjects & resources:
+;; - schema is typically small, i.e. we have a low number of relations and permissions
+;; - resources (like servers) are typically far more numerous than subjects (like users or accounts)
+;;
 
 (defn Relation
   "Defines a relation type. Copied from core2.
@@ -305,7 +108,7 @@
                   :where
                   (has-permission ?subject ?perm ?resource)] ; do we still needs this?
                 db
-                can?-rules
+                rules/check-permission-rules
                 subject-eid
                 permission
                 resource-eid)
@@ -339,16 +142,17 @@
     (assert resource-eid (str "lookup-subjects requires a valid resource with unique attr " (pr-str object-id-attr) "."))
     (assert (= resource-type (:resource/type resource-ent)) (str "Resource type does not match " resource-type "."))
     (let [subject-eids   (->> (d/q '[:find [?subject ...]
-                                     :in $ % ?resource-eid ?permission ?subject-type
+                                     :in $ % ?subject-type ?permission ?resource-eid
                                      :where
-                                     (has-permission ?subject ?permission ?resource-eid)
-                                     [?subject :resource/type ?subject-type]
+                                     (has-permission ?subject-type ?subject ?permission ?resource-eid)
+                                     ;(has-permission ?subject ?permission ?resource-eid)
+                                     ;[?subject :resource/type ?subject-type] ; could this be super slow?
                                      [(not= ?subject ?resource-eid)]] ; can we avoid this exclusionary clause?
                                    db
-                                   slow-lookup-rules
-                                   resource-eid
+                                   rules/rules-lookup-subjects
+                                   subject-type
                                    permission
-                                   subject-type))
+                                   resource-eid))
           paginated-eids (cond->> subject-eids
                                   offset (drop offset)
                                   limit (take limit))]
@@ -375,16 +179,16 @@
     (assert subject-eid (str "lookup-resources requires a valid subject with unique ID under attr " (pr-str object-id-attr) "."))
     (assert (= subject-type (:resource/type subject-ent)) (str "Subject Type does not match " subject-type "."))
     (let [resource-eids  (d/q '[:find [?resource ...]
-                                :in $ % ?resource-type ?subject-type ?subject-eid ?permission
+                                :in $ % ?subject-type ?subject-eid ?permission ?resource-type
                                 :where
-                                (has-permission ?subject-eid ?permission ?resource)
+                                (has-permission ?subject-eid ?permission ?resource-type ?resource)
                                 [?resource :resource/type ?resource-type]] ; consider moving ?resource-type into has-permission.
                               db
-                              slow-lookup-rules
-                              resource-type
-                              subject-type
+                              rules/rules-lookup-resources ; slow-lookup-rules
+                              subject-type ; not used
                               subject-eid
-                              permission)
+                              permission
+                              resource-type)
           paginated-eids (cond->> resource-eids
                                   offset (drop offset)      ; optional.
                                   limit (take limit))]      ; optional.

--- a/src/eacl/datomic/impl_optimized.clj
+++ b/src/eacl/datomic/impl_optimized.clj
@@ -1,0 +1,178 @@
+(ns eacl.datomic.impl-optimized
+  "Optimized EACL implementation with performance improvements"
+  (:require
+    [datomic.api :as d]
+    [eacl.core :as proto :refer [spice-object]]
+    [eacl.datomic.rules-optimized :as rules]))
+
+;; Configuration
+(def object-id-attr :entity/id)
+(def resource-type-attr :resource/type)
+
+(defn entity->spice-object [ent]
+  (spice-object (get ent resource-type-attr) (get ent object-id-attr)))
+
+(defn can?
+  "Optimized version of can? using optimized rules"
+  [db subject-id permission resource-id]
+  {:pre [subject-id
+         (keyword? permission)
+         resource-id]}
+  (let [{:as _subject-ent, subject-eid :db/id} (d/entity db subject-id)
+        {:as _resource-ent, resource-eid :db/id} (d/entity db resource-id)]
+    (if-not (and subject-eid resource-eid)
+      false
+      (->> (d/q '[:find ?subject .
+                  :in $ % ?subject ?perm ?resource
+                  :where
+                  (has-permission ?subject ?perm ?resource)]
+                db
+                rules/check-permission-rules
+                subject-eid
+                permission
+                resource-eid)
+           (boolean)))))
+
+(defn can! [db subject-id permission resource-id]
+  (if (can? db subject-id permission resource-id)
+    true
+    (throw (Exception. "Unauthorized"))))
+
+(defn lookup-subjects
+  "Optimized version of lookup-subjects"
+  [db {:as              filters
+       resource         :resource
+       permission       :permission
+       subject-type     :subject/type
+       subject-relation :subject/relation
+       limit            :limit
+       offset           :offset}]
+  {:pre [(:type resource) (:id resource)]}
+  (let [{resource-type :type
+         resource-id   :id} resource
+
+        {:as          resource-ent
+         resource-eid :db/id} (d/entity db [object-id-attr resource-id])]
+    (assert resource-eid (str "lookup-subjects requires a valid resource with unique attr " (pr-str object-id-attr) "."))
+    (assert (= resource-type (:resource/type resource-ent)) (str "Resource type does not match " resource-type "."))
+    (let [subject-eids   (->> (d/q '[:find [?subject ...]
+                                     :in $ % ?subject-type ?permission ?resource-eid
+                                     :where
+                                     (has-permission ?subject-type ?subject ?permission ?resource-eid)
+                                     [(not= ?subject ?resource-eid)]]
+                                   db
+                                   rules/rules-lookup-subjects
+                                   subject-type
+                                   permission
+                                   resource-eid))
+          paginated-eids (cond->> subject-eids
+                                  offset (drop offset)
+                                  limit (take limit))]
+      (->> paginated-eids
+           (map #(d/entity db %))
+           (map entity->spice-object)))))
+
+;; Helper functions for staged lookup-resources
+(defn find-direct-resources
+  "Find resources directly accessible by subject"
+  [db subject-eid resource-type permission]
+  (d/q '[:find [?resource ...]
+         :in $ ?subject ?rtype ?perm
+         :where
+         ;; Start from subject's relationships
+         [?rel :eacl.relationship/subject ?subject]
+         [?rel :eacl.relationship/relation-name ?relation]
+         [?rel :eacl.relationship/resource ?resource]
+         
+         ;; Early type filter
+         [?resource :resource/type ?rtype]
+         
+         ;; Check permission using tuple
+         [(tuple ?rtype ?relation ?perm) ?perm-tuple]
+         [?p :eacl.permission/resource-type+relation-name+permission-name ?perm-tuple]]
+       db subject-eid resource-type permission))
+
+(defn find-arrow-resources
+  "Find resources via arrow permissions (e.g., account->admin)"
+  [db subject-eid resource-type permission]
+  ;; First, find what intermediate permissions we need
+  (let [arrow-paths (d/q '[:find ?via-rel ?target-perm
+                          :in $ ?rtype ?perm
+                          :where
+                          [?arrow :eacl.arrow-permission/resource-type ?rtype]
+                          [?arrow :eacl.arrow-permission/permission-name ?perm]
+                          [?arrow :eacl.arrow-permission/source-relation-name ?via-rel]
+                          [?arrow :eacl.arrow-permission/target-permission-name ?target-perm]]
+                        db resource-type permission)]
+    ;; For each arrow path, find accessible resources
+    (apply concat
+      (for [[via-rel target-perm] arrow-paths]
+        ;; This is simplified - in production we'd need to check permissions properly
+        (d/q '[:find [?resource ...]
+               :in $ ?subject ?rtype ?via-rel
+               :where
+               ;; Find intermediate resources subject has relationships with
+               [?rel1 :eacl.relationship/subject ?subject]
+               [?rel1 :eacl.relationship/resource ?intermediate]
+               
+               ;; Find target resources linked from intermediate via arrow relation
+               [?rel2 :eacl.relationship/subject ?intermediate]
+               [?rel2 :eacl.relationship/relation-name ?via-rel]
+               [?rel2 :eacl.relationship/resource ?resource]
+               [?resource :resource/type ?rtype]]
+             db subject-eid resource-type via-rel)))))
+
+(defn find-indirect-resources
+  "Find resources through indirect paths - fallback for complex cases"
+  [db subject-eid resource-type permission]
+  ;; Use the full rules as a fallback
+  (d/q '[:find [?resource ...]
+         :in $ % ?subject ?permission ?resource-type
+         :where
+         (has-permission ?subject ?permission ?resource-type ?resource)]
+       db
+       rules/rules-lookup-resources
+       subject-eid
+       permission
+       resource-type))
+
+(defn lookup-resources-staged
+  "Staged approach to resource lookup for better performance"
+  [db {:keys [resource/type subject permission limit offset]
+       :or {limit 100 offset 0}}]
+  {:pre [(keyword? type)
+         (:type subject) (:id subject)
+         (keyword? permission)]}
+  (let [{subject-id :id} subject
+        subject-eid (:db/id (d/entity db [object-id-attr subject-id]))
+        
+        ;; Stage 1: Find direct relationships
+        stage1-direct (find-direct-resources db subject-eid type permission)
+        
+        ;; Stage 2: Find via arrow permissions (if needed)
+        stage2-arrow (when (< (count stage1-direct) limit)
+                      (find-arrow-resources db subject-eid type permission))
+        
+        ;; Stage 3: Multi-hop paths (only if really needed)
+        stage3-indirect (when (and (< (+ (count stage1-direct) 
+                                        (count (or stage2-arrow []))) 
+                                     limit)
+                                  ;; Only use expensive fallback for small result sets
+                                  (< limit 50))
+                         (find-indirect-resources db subject-eid type permission))
+        
+        ;; Combine and deduplicate
+        all-results (distinct (concat stage1-direct 
+                                    (or stage2-arrow [])
+                                    (or stage3-indirect [])))]
+    
+    (->> all-results
+         (drop offset)
+         (take limit)
+         (map #(d/entity db %))
+         (map entity->spice-object))))
+
+(defn lookup-resources
+  "Optimized lookup-resources using staged approach"
+  [db filters]
+  (lookup-resources-staged db filters)) 

--- a/src/eacl/datomic/rules.clj
+++ b/src/eacl/datomic/rules.clj
@@ -1,0 +1,551 @@
+(ns eacl.datomic.rules)
+
+(def check-permission-rules
+  "Can only be used for can? where type + id of both subject & resource object are provided."
+  '[;; Reachability rules to traverse relationships:
+    [(reachable ?resource ?subject)
+     [(tuple ?resource ?subject) ?resource+subject]
+     [?relationship :eacl.relationship/resource+subject ?resource+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?subject]]
+    [(reachable ?resource ?subject)
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?mid]
+     (reachable ?mid ?subject)] ; note inversion to traverse.
+
+    ;; Direct permission check (copied and adapted from core2)
+    [(has-permission ?subject ?permission-name ?resource)
+
+     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
+     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
+     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
+     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
+
+     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
+
+     ;; Match the relation name from the relationship tuple with the one in permission definition
+     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
+     [(not= ?subject ?resource)]]
+
+    ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
+    ;; This rule means: ?subject gets ?permission-name on ?resource if:
+    ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
+    ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
+    ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
+    ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
+
+    [(has-permission ?subject ?permission-name ?resource)
+     ;; Permission definition
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     ; can these move down for speed?
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
+
+     ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
+     [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
+     [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
+
+     [?structural-rel :eacl.relationship/subject ?resource]
+     [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
+     [?structural-rel :eacl.relationship/resource ?target]
+
+     (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
+     [(not= ?subject ?resource)]]
+
+    ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
+    ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
+    ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
+    ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
+    [(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
+     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
+     [(tuple ?this-resource-type
+             ?via-relation-name
+             ?perm-on-related
+             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
+     [?arrow-perm-def
+      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
+      ?res-type+relation+related-perm+permission]
+
+     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
+     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
+
+     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
+     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
+     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
+     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
+     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
+     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
+
+     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
+     (has-permission ?subject ?perm-on-related ?intermediate-resource)
+     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
+     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
+     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
+     [(not= ?subject ?intermediate-resource)]
+     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
+     [(not= ?this-resource ?intermediate-resource)]]])
+
+(defn build-slow-rules [resource-type-attr]
+  [;; Reachability rules to traverse relationships:
+   '[(reachable ?resource ?subject)
+     [(tuple ?resource ?subject) ?resource+subject]
+     [?relationship :eacl.relationship/resource+subject ?resource+subject]]
+
+   ;[?relationship :eacl.relationship/resource ?resource]
+   ;[?relationship :eacl.relationship/subject ?subject]]
+   '[(reachable ?resource ?subject)
+
+     [(tuple ?resource ?mid) ?resource+mid]
+     [?relationship :eacl.relationship/resource+subject ?resource+mid] ; range query?
+
+     ; todo can we use tuple here?
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?mid]
+     (reachable ?mid ?subject)]
+
+   ;; Direct permission check (copied and adapted from core2)
+   '[(has-permission ?subject ?permission-name ?resource)
+
+     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
+     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
+     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
+     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
+
+     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
+
+     ;; Match the relation name from the relationship tuple with the one in permission definition
+     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
+     [(not= ?subject ?resource)]                            ; can we avoid this?
+     [?resource :resource/type ?resource-type]]             ; this is super slow. different rules WIP.
+
+   ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
+   ;; This rule means: ?subject gets ?permission-name on ?resource if:
+   ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
+   ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
+   ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
+   ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
+   (into
+     ['(has-permission ?subject ?permission-name ?resource)]
+
+     '[;; Permission definition
+       [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+       [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+       [?perm-def :eacl.permission/resource-type ?resource-type]
+       [?perm-def :eacl.permission/permission-name ?permission-name]
+       [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
+
+       ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
+       [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
+       [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
+
+       [?structural-rel :eacl.relationship/subject ?resource]
+       [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
+       [?structural-rel :eacl.relationship/resource ?target]
+
+       (reachable ?target ?subject)                         ; User must be able to reach the target of the structural relationship
+       [(not= ?subject ?resource)]
+       [?resource :resource/type ?resource-type]])
+
+   ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
+   ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
+   ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
+   ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
+   '[(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
+
+     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
+     [(tuple ?this-resource-type
+             ?via-relation-name
+             ?perm-on-related
+             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
+     [?arrow-perm-def
+      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
+      ?res-type+relation+related-perm+permission]
+
+     ; can these move down for speed, or be decoupled in a 2nd phase?
+     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
+     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
+
+     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
+     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
+     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
+
+     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
+     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
+     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
+
+     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
+     (has-permission ?subject ?perm-on-related ?intermediate-resource)
+     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
+     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
+     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
+     [(not= ?subject ?intermediate-resource)]
+     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
+     [(not= ?this-resource ?intermediate-resource)]
+     [?this-resource :resource/type ?this-resource-type]]]) ; this is super slow. different rules WIP.]])
+
+(def slow-lookup-rules (build-slow-rules :resource/type))
+
+(def rules-lookup-subjects
+  '[;; Reachability rules to traverse relationships:
+    [(reachable ?resource ?subject) ; I think we need types here for speed.
+     [(tuple ?resource ?subject) ?resource+subject]
+     [?relationship :eacl.relationship/resource+subject ?resource+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?subject]]
+
+    [(reachable ?resource ?subject)
+
+     [(tuple ?resource ?mid) ?resource+mid]
+     [?relationship :eacl.relationship/resource+subject ?resource+mid] ; range query?
+
+     ; todo can we use tuple here?
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?mid]
+     (reachable ?mid ?subject)]
+
+    ;; Direct permission check (copied and adapted from core2)
+    [(has-permission ?subject-type ?subject ?permission-name ?resource)
+
+     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
+     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
+     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
+     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
+
+     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
+
+     ;; Match the relation name from the relationship tuple with the one in permission definition
+     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
+     [(not= ?subject ?resource)]                            ; can we avoid this?
+     [?subject :resource/type ?subject-type]]             ; this is super slow. different rules WIP.
+
+    ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
+    ;; This rule means: ?subject gets ?permission-name on ?resource if:
+    ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
+    ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
+    ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
+    ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
+
+    [(has-permission ?subject-type ?subject ?permission-name ?resource)
+     ;; Permission definition
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
+
+     ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
+     [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
+     [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
+
+     [?structural-rel :eacl.relationship/subject ?resource]
+     [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
+     [?structural-rel :eacl.relationship/resource ?target]
+
+     (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
+     [(not= ?subject ?resource)]
+     [?subject :resource/type ?subject-type]]
+
+    ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
+    ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
+    ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
+    ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
+    [(has-permission ?subject-type ?subject ?perm-name-on-this-resource ?this-resource)
+
+     ; this order looks wrong.
+     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
+     [(tuple ?this-resource-type
+             ?via-relation-name
+             ?perm-on-related
+             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
+     [?arrow-perm-def
+      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
+      ?res-type+relation+related-perm+permission]
+
+     ; can these move down for speed, or be decoupled in a 2nd phase?
+     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
+     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
+
+     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
+     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
+     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
+
+     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
+     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
+     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
+
+     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
+     (has-permission ?subject-type ?subject ?perm-on-related ?intermediate-resource)
+     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
+     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
+     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
+     [(not= ?subject ?intermediate-resource)]
+     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
+     [(not= ?this-resource ?intermediate-resource)]
+     ; TODO: this-resource looks dubious here. do we need it?
+     [?this-resource :resource/type ?this-resource-type]]])
+
+(def rules-lookup-resources
+  ; resource look has known subject Type + ID, and known resource type.
+  '[;; Reachability rules to traverse relationships:
+    [(reachable ?resource ?subject) ; I think we need types here for speed.
+     [(tuple ?resource ?subject) ?resource+subject]
+     [?relationship :eacl.relationship/resource+subject ?resource+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?subject]]
+
+    [(reachable ?resource ?subject)
+
+     [(tuple ?resource ?mid) ?resource+mid]
+     [?relationship :eacl.relationship/resource+subject ?resource+mid] ; range query?
+
+     ; todo can we use tuple here?
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?mid]
+     (reachable ?mid ?subject)]
+
+    ;; Direct permission check (copied and adapted from core2)
+    [(has-permission ?subject ?permission-name ?resource-type ?resource)
+
+     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
+     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
+
+     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
+     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
+     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
+
+     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; THIS IS THE DIRECT GRANT
+
+     ;; Match the relation name from the relationship tuple with the one in permission definition
+     [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
+     [(not= ?subject ?resource)]                            ; can we avoid this?
+     [?resource :resource/type ?resource-type]]
+
+    ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
+    ;; This rule means: ?subject gets ?permission-name on ?resource if:
+    ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
+    ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
+    ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
+    ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
+
+    [(has-permission ?subject ?permission-name ?resource-type ?resource)
+     ;; Permission definition
+     ;; order looks dubious
+     [(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
+
+     ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
+     [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
+     [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
+
+     [?structural-rel :eacl.relationship/subject ?resource]
+     [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
+     [?structural-rel :eacl.relationship/resource ?target]
+
+     (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
+     [(not= ?subject ?resource)]
+     [?resource :resource/type ?this-resource-type]] ; is this correct?
+
+    ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
+    ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
+    ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
+    ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
+    [(has-permission ?subject ?perm-name-on-this-resource ?this-resource-type ?this-resource)
+
+     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
+     [(tuple ?this-resource-type
+             ?via-relation-name
+             ?perm-on-related
+             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
+     [?arrow-perm-def
+      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
+      ?res-type+relation+related-perm+permission]
+
+     ; can these move down for speed, or be decoupled in a 2nd phase?
+     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
+     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
+
+     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
+     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
+     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
+
+     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
+     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
+     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
+
+     [?intermediate-resource :resource/type ?intermediate-resource-type] ; do we need this?
+
+     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
+     (has-permission ?subject ?perm-on-related ?intermediate-resource-type ?intermediate-resource)
+     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
+     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
+     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
+     [(not= ?subject ?intermediate-resource)]
+     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
+     [(not= ?this-resource ?intermediate-resource)]
+     [?this-resource :resource/type ?this-resource-type]]])
+
+;(def rules-lookup-subjects
+;  ; lookup-subjects knows resource & subject type which implies knowing resource type.
+;  '[;; Reachability rules to traverse relationships:
+;    [(reachable ?resource ?subject)
+;     ; todo use reachable tuple
+;     [(tuple ?resource ?subject) ?resource+subject]
+;     [?relationship :eacl.relationship/resource+subject ?resource+subject]
+;
+;     [?relationship :eacl.relationship/resource ?resource]
+;     [?relationship :eacl.relationship/subject ?subject]]
+;
+;    [(reachable ?resource ?subject)
+;     ; don't think this will work...
+;     [(tuple ?resource ?mid) ?resource+mid]
+;     [?relationship :eacl.relationship/resource+subject ?resource+mid]
+;
+;     [?relationship :eacl.relationship/resource ?resource]
+;     [?relationship :eacl.relationship/subject ?mid]
+;     (reachable ?mid ?subject)]
+;
+;    ;; Direct permission check
+;    [(has-permission ?resource ?permission-name ?subject-type ?subject)
+;
+;     [(tuple ?resource ?relation-name-in-tuple ?subject) ?resource+rel-name+subject]
+;     [?relationship :eacl.relationship/resource+relation-name+subject ?resource+rel-name+subject]
+;
+;     [?relationship :eacl.relationship/resource ?resource]  ; subject has some relationship TO the resource
+;     [?relationship :eacl.relationship/relation-name ?relation-name-in-tuple]
+;     [?relationship :eacl.relationship/subject ?subject]    ; subject of the relationship tuple
+;
+;     ;; Permission definition: ?relation-name-in-perm-def grants ?permission-name on ?resource-type
+;     [(tuple ?resource-type ?relation-name-in-tuple ?permission-name) ?res-type+relation+permission]
+;     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+;
+;     [?perm-def :eacl.permission/resource-type ?resource-type]
+;     [?perm-def :eacl.permission/permission-name ?permission-name]
+;     [?perm-def :eacl.permission/relation-name ?relation-name-in-tuple] ; THIS IS THE DIRECT GRANT
+;
+;     ;; Match the relation name from the relationship tuple with the one in permission definition
+;     ;[(= ?relation-name-in-tuple ?relation-name-in-perm-def)] ; can this be unified better? should this be higher up?
+;
+;     [(not= ?subject ?resource)]]
+;
+;    ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
+;    ;; This rule means: ?subject gets ?permission-name on ?resource if:
+;    ;; 1. A permission definition exists: for ?resource-type, ?relation-name-in-perm-def grants ?permission-name.
+;    ;; 2. ?resource has a relationship (as a subject of the tuple) via ?relation-name-in-perm-def to some ?target.
+;    ;;    (e.g. doc D is "subject" of relation "group" to group G: D --group--> G)
+;    ;; 3. ?subject can "reach" that ?target (e.g. user U is member of group G).
+;
+;    [(has-permission ?resource ?permission-name ?subject-type ?subject)
+;     ;; Permission definition
+;     ;; I don't think tuple makes sense here...
+;     ;[(tuple ?resource-type ?relation-name-in-perm-def ?permission-name) ?res-type+relation+permission]
+;     ;[?perm-def :eacl.permission/resource-type+relation-name+permission-name ?res-type+relation+permission]
+;
+;     [?perm-def :eacl.permission/resource-type ?resource-type]
+;     [?perm-def :eacl.permission/permission-name ?permission-name]
+;     [?perm-def :eacl.permission/relation-name ?relation-name-in-perm-def] ; Direct relation specified in perm
+;
+;     ;; Structural relationship: ?resource is linked to ?target via ?relation-name-in-perm-def
+;     [(tuple ?target ?relation-name-in-perm-def ?resource) ?target+relation+resource]
+;     [?structural-rel :eacl.relationship/resource+relation-name+subject ?target+relation+resource]
+;
+;     [?structural-rel :eacl.relationship/subject ?resource]
+;     [?structural-rel :eacl.relationship/relation-name ?relation-name-in-perm-def]
+;     [?structural-rel :eacl.relationship/resource ?target]
+;
+;     (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
+;     [?resource :resource/type ?resource-type]             ; super slow. different rules WIP.
+;     [?subject :resource/type ?subject-type]
+;     [(not= ?subject ?resource)]]
+;
+;    ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
+;    ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
+;    ;; MODIFIED based on user feedback: Rule now expects intermediate --via-relation-name--> this-resource
+;    ;; Example: User U gets :view on SERVER_X if ACC_Y --:account--> SERVER_X and User U has :admin on ACC_Y.
+;    [(has-permission ?this-resource ?perm-name-on-this-resource ?subject-type ?subject)
+;
+;     ;; 1. Find an arrow permission definition for this-resource-type and perm-name-on-this-resource
+;     [(tuple ?this-resource-type
+;             ?via-relation-name
+;             ?perm-on-related
+;             ?perm-name-on-this-resource) ?res-type+relation+related-perm+permission]
+;     [?arrow-perm-def
+;      :eacl.arrow-permission/resource-type+source-relation-name+target-permission-name+permission-name
+;      ?res-type+relation+related-perm+permission]
+;
+;     ; can these move down for speed, or be decoupled in a 2nd phase?
+;     [?arrow-perm-def :eacl.arrow-permission/resource-type ?this-resource-type]
+;     [?arrow-perm-def :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+;     [?arrow-perm-def :eacl.arrow-permission/source-relation-name ?via-relation-name] ; e.g., :account (the relation name specified in Permission)
+;     [?arrow-perm-def :eacl.arrow-permission/target-permission-name ?perm-on-related] ; e.g., :admin (on the intermediate/account)
+;
+;     ;; 2. Find intermediate resource: ?intermediate-resource --via-relation-name--> ?this-resource
+;     [(tuple ?this-resource ?via-relation-name ?intermediate-resource) ?resource+relation+mid-resource]
+;     [?rel-linking-resources :eacl.relationship/resource+relation-name+subject ?resource+relation+mid-resource]
+;
+;     [?rel-linking-resources :eacl.relationship/subject ?intermediate-resource] ; e.g., account is subject of tuple
+;     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
+;     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
+;
+;     ;[?this-resource :resource/type ?this-resource-type]
+;     ;[?subject :resource/type ?subject-type]
+;     [?intermediate-resource :resource/type ?intermediate-resource-type]
+;
+;     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
+;     (has-permission ?subject ?perm-on-related ?intermediate-resource-type ?intermediate-resource)
+;     [(not= ?subject ?this-resource)]                       ; Exclude self-references for safety
+;     ;; Ensure the intermediate resource is not the same as the subject to prevent some loops,
+;     ;; though main cycle prevention relies on data structure or more complex rule logic if needed.
+;     [(not= ?subject ?intermediate-resource)]
+;     ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
+;     [(not= ?this-resource ?intermediate-resource)]]])
+; this is super slow. different rules WIP.]])

--- a/src/eacl/datomic/rules_optimized.clj
+++ b/src/eacl/datomic/rules_optimized.clj
@@ -1,0 +1,214 @@
+(ns eacl.datomic.rules-optimized
+  "Optimized Datalog rules for EACL performance improvements")
+
+(def check-permission-rules-optimized
+  "Optimized rules for can? - reordered clauses and better tuple usage"
+  '[;; Optimized reachability using tuples
+    [(reachable ?resource ?subject)
+     ;; Direct relationship - most common case
+     [(tuple ?resource ?subject) ?resource+subject]
+     [?relationship :eacl.relationship/resource+subject ?resource+subject]]
+    
+    [(reachable ?resource ?subject)
+     ;; Indirect relationship - use tuple for first hop
+     [(tuple ?resource ?mid) ?resource+mid]
+     [?relationship :eacl.relationship/resource+subject ?resource+mid]
+     ;; Only traverse if needed
+     (reachable ?mid ?subject)]
+
+    ;; Direct permission - optimized clause ordering
+    [(has-permission ?subject ?permission-name ?resource)
+     ;; Get resource type first
+     [?resource :resource/type ?resource-type]
+     
+     ;; Find relationships for this resource
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?subject]
+     [?relationship :eacl.relationship/relation-name ?relation-name]
+     
+     ;; Check permission using tuple
+     [(tuple ?resource-type ?relation-name ?permission-name) ?perm-tuple]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?perm-tuple]
+     
+     ;; Exclude self-references
+     [(not= ?subject ?resource)]]
+
+    ;; Indirect permission inheritance - optimized
+    [(has-permission ?subject ?permission-name ?resource)
+     ;; Get resource type first (we already have the resource)
+     [?resource :resource/type ?resource-type]
+     
+     ;; Find permission definitions for this resource type
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name]
+     
+     ;; Find structural relationships where resource is the subject
+     [?structural-rel :eacl.relationship/subject ?resource]
+     [?structural-rel :eacl.relationship/relation-name ?relation-name]
+     [?structural-rel :eacl.relationship/resource ?target]
+     
+     ;; Check reachability last
+     (reachable ?target ?subject)
+     [(not= ?subject ?resource)]]
+
+    ;; Arrow permission - optimized
+    [(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
+     ;; Get resource type from the resource we already have
+     [?this-resource :resource/type ?this-resource-type]
+     
+     ;; Find arrow permission definitions
+     [?arrow-perm :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm :eacl.arrow-permission/source-relation-name ?via-relation]
+     [?arrow-perm :eacl.arrow-permission/target-permission-name ?perm-on-related]
+     
+     ;; Find intermediate resource
+     [?rel-linking :eacl.relationship/resource ?this-resource]
+     [?rel-linking :eacl.relationship/relation-name ?via-relation]
+     [?rel-linking :eacl.relationship/subject ?intermediate-resource]
+     
+     ;; Recursive permission check
+     (has-permission ?subject ?perm-on-related ?intermediate-resource)
+     
+     ;; Safety checks
+     [(not= ?subject ?this-resource)]
+     [(not= ?subject ?intermediate-resource)]
+     [(not= ?this-resource ?intermediate-resource)]]])
+
+(def rules-lookup-subjects-optimized
+  "Optimized rules for lookup-subjects"
+  '[;; Reachability rules remain the same
+    [(reachable ?resource ?subject)
+     [(tuple ?resource ?subject) ?resource+subject]
+     [?relationship :eacl.relationship/resource+subject ?resource+subject]]
+    
+    [(reachable ?resource ?subject)
+     [(tuple ?resource ?mid) ?resource+mid]
+     [?relationship :eacl.relationship/resource+subject ?resource+mid]
+     (reachable ?mid ?subject)]
+
+    ;; Direct permission check - optimized for known resource
+    [(has-permission ?subject-type ?subject ?permission-name ?resource)
+     ;; Get resource type (we already have resource entity)
+     [?resource :resource/type ?resource-type]
+     
+     ;; Find relationships for this resource
+     [?relationship :eacl.relationship/resource ?resource]
+     [?relationship :eacl.relationship/subject ?subject]
+     [?relationship :eacl.relationship/relation-name ?relation-name]
+     
+     ;; Check subject type
+     [?subject :resource/type ?subject-type]
+     
+     ;; Check permission using tuple
+     [(tuple ?resource-type ?relation-name ?permission-name) ?perm-tuple]
+     [?perm-def :eacl.permission/resource-type+relation-name+permission-name ?perm-tuple]
+     
+     [(not= ?subject ?resource)]]
+
+    ;; Indirect permission inheritance
+    [(has-permission ?subject-type ?subject ?permission-name ?resource)
+     [?resource :resource/type ?resource-type]
+     
+     ;; Find permission definitions
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission-name]
+     [?perm-def :eacl.permission/relation-name ?relation-name]
+     
+     ;; Find structural relationships
+     [?structural-rel :eacl.relationship/subject ?resource]
+     [?structural-rel :eacl.relationship/relation-name ?relation-name]
+     [?structural-rel :eacl.relationship/resource ?target]
+     
+     (reachable ?target ?subject)
+     [?subject :resource/type ?subject-type]
+     [(not= ?subject ?resource)]]
+
+    ;; Arrow permission
+    [(has-permission ?subject-type ?subject ?perm-name-on-this-resource ?this-resource)
+     [?this-resource :resource/type ?this-resource-type]
+     
+     ;; Find arrow permissions
+     [?arrow-perm :eacl.arrow-permission/resource-type ?this-resource-type]
+     [?arrow-perm :eacl.arrow-permission/permission-name ?perm-name-on-this-resource]
+     [?arrow-perm :eacl.arrow-permission/source-relation-name ?via-relation]
+     [?arrow-perm :eacl.arrow-permission/target-permission-name ?perm-on-related]
+     
+     ;; Find intermediate
+     [?rel-linking :eacl.relationship/resource ?this-resource]
+     [?rel-linking :eacl.relationship/relation-name ?via-relation]
+     [?rel-linking :eacl.relationship/subject ?intermediate-resource]
+     
+     (has-permission ?subject-type ?subject ?perm-on-related ?intermediate-resource)
+     
+     [(not= ?subject ?this-resource)]
+     [(not= ?subject ?intermediate-resource)]
+     [(not= ?this-resource ?intermediate-resource)]]])
+
+(def rules-lookup-resources-optimized
+  "Optimized rules for lookup-resources - subject-centric approach"
+  '[;; Helper rule: find relationships from subject
+    [(subject-has-relationships ?subject ?relation ?resource)
+     ;; Start from subject
+     [?relationship :eacl.relationship/subject ?subject]
+     [?relationship :eacl.relationship/relation-name ?relation]
+     [?relationship :eacl.relationship/resource ?resource]]
+
+    ;; Direct permission check - subject-centric
+    [(has-permission ?subject ?permission ?resource-type ?resource)
+     ;; Start from subject's relationships
+     (subject-has-relationships ?subject ?relation ?resource)
+     
+     ;; Check if resource is of correct type
+     [?resource :resource/type ?resource-type]
+     
+     ;; Check if relation grants permission
+     [?perm :eacl.permission/resource-type ?resource-type]
+     [?perm :eacl.permission/relation-name ?relation]
+     [?perm :eacl.permission/permission-name ?permission]]
+
+    ;; Indirect permission via intermediate resources
+    [(has-permission ?subject ?permission ?resource-type ?resource)
+     ;; Find relationships where subject can reach an intermediate
+     (subject-has-relationships ?subject ?rel1 ?intermediate)
+     
+     ;; Find permission definition that grants access via relation
+     [?perm-def :eacl.permission/resource-type ?resource-type]
+     [?perm-def :eacl.permission/permission-name ?permission]
+     [?perm-def :eacl.permission/relation-name ?rel2]
+     
+     ;; Find resources connected to intermediate via rel2
+     [?relationship2 :eacl.relationship/subject ?intermediate]
+     [?relationship2 :eacl.relationship/relation-name ?rel2]
+     [?relationship2 :eacl.relationship/resource ?resource]
+     
+     ;; Verify resource type
+     [?resource :resource/type ?resource-type]]
+
+    ;; Arrow permission - optimized for subject-centric lookup
+    [(has-permission ?subject ?permission ?resource-type ?resource)
+     ;; Find arrow permissions for the target resource type and permission
+     [?arrow :eacl.arrow-permission/resource-type ?resource-type]
+     [?arrow :eacl.arrow-permission/permission-name ?permission]
+     [?arrow :eacl.arrow-permission/source-relation-name ?via-rel]
+     [?arrow :eacl.arrow-permission/target-permission-name ?target-perm]
+     
+     ;; Find resources of target type
+     [?resource :resource/type ?resource-type]
+     
+     ;; Find intermediate resources linked to target resource
+     [?link :eacl.relationship/resource ?resource]
+     [?link :eacl.relationship/relation-name ?via-rel]
+     [?link :eacl.relationship/subject ?intermediate]
+     
+     ;; Get intermediate resource type
+     [?intermediate :resource/type ?intermediate-type]
+     
+     ;; Check if subject has target permission on intermediate (recursive)
+     (has-permission ?subject ?target-perm ?intermediate-type ?intermediate)]])
+
+;; Export the optimized rules
+(def check-permission-rules check-permission-rules-optimized)
+(def rules-lookup-subjects rules-lookup-subjects-optimized)
+(def rules-lookup-resources rules-lookup-resources-optimized) 

--- a/src/eacl/datomic/schema.clj
+++ b/src/eacl/datomic/schema.clj
@@ -141,4 +141,37 @@
                      :eacl.relationship/relation-name
                      :eacl.relationship/subject]
     :db/cardinality :db.cardinality/one
-    :db/unique      :db.unique/identity}])
+    :db/unique      :db.unique/identity}
+
+   ;; NEW PERFORMANCE OPTIMIZATION INDICES
+   
+   ;; Critical for subject-based lookups
+   {:db/ident       :eacl.relationship/subject+relation-name
+    :db/doc         "Index for efficient subject-based lookups"
+    :db/valueType   :db.type/tuple
+    :db/tupleAttrs  [:eacl.relationship/subject
+                     :eacl.relationship/relation-name]
+    :db/cardinality :db.cardinality/one}
+
+   {:db/ident       :eacl.relationship/relation-name+resource
+    :db/doc         "Index for relation-based traversal"
+    :db/valueType   :db.type/tuple
+    :db/tupleAttrs  [:eacl.relationship/relation-name
+                     :eacl.relationship/resource]
+    :db/cardinality :db.cardinality/one}
+
+   ;; Index for permission lookups by type
+   {:db/ident       :eacl.permission/resource-type+permission-name
+    :db/doc         "Index for finding all relations that grant a permission"
+    :db/valueType   :db.type/tuple
+    :db/tupleAttrs  [:eacl.permission/resource-type
+                     :eacl.permission/permission-name]
+    :db/cardinality :db.cardinality/one}
+
+   ;; For arrow permission traversal
+   {:db/ident       :eacl.arrow-permission/resource-type+permission-name
+    :db/doc         "Index for arrow permission lookups"
+    :db/valueType   :db.type/tuple
+    :db/tupleAttrs  [:eacl.arrow-permission/resource-type
+                     :eacl.arrow-permission/permission-name]
+    :db/cardinality :db.cardinality/one}])

--- a/test/eacl/benchmark_test.clj
+++ b/test/eacl/benchmark_test.clj
@@ -192,7 +192,7 @@
 
   (let [num-accounts  100
         num-users     10
-        num-servers   50
+        num-servers   1000
         account-uuids (repeatedly num-accounts d/squuid)
         account-txes  (time (->> account-uuids
                                  (mapv (partial make-account-txes {:num-users   num-users
@@ -218,7 +218,7 @@
                                        (for [server-id servers]
                                          [server-id (vec (server->user-ids db server-id))])))]
       ;(prn 'server->users server->users)
-      (when false ; do
+      (when true ; false ; do
         (log/debug "Starting benchmark...")
         (crit/quick-bench
           (let [random-server      (rand-nth servers)

--- a/test/eacl/benchmark_test.clj
+++ b/test/eacl/benchmark_test.clj
@@ -1,10 +1,13 @@
 (ns eacl.benchmark-test
   (:require [criterium.core :as crit]
-            [eacl.datomic.impl :as eacl :refer [Relation Relationship Permission]]
+            [eacl.core :as eacl]
+            [eacl.datomic.core :as spiceomic]
+            [eacl.datomic.impl :as impl :refer [Relation Relationship Permission]]
             [eacl.datomic.schema :as schema]
             [datomic.api :as d]
-            [eacl.datomic.fixtures :as fixtures]
-            [clojure.test :as t :refer [deftest testing is]]))
+            [eacl.datomic.fixtures :as fixtures :refer [->account ->user ->server]]
+            [clojure.test :as t :refer [deftest testing is]]
+            [clojure.tools.logging :as log]))
 
 ;(defn rand-subject [])
 
@@ -12,12 +15,157 @@
   ;(prn tx-data)
   @(d/transact conn tx-data))
 
+(defn ids->tempid-map [uuid-coll]
+  (->> uuid-coll
+       (reduce (fn [acc uuid]
+                 (assoc acc uuid (d/tempid :db.part/user)))
+               {})))
+
+(defn make-account-user-txes [account-tempid n]
+  (let [user-uuids        (repeatedly n d/squuid)
+        user-uuid->tempid (ids->tempid-map user-uuids)]
+    (for [user-uuid user-uuids]
+      (let [user-tempid (user-uuid->tempid user-uuid)]
+        [{:db/id         user-tempid
+          :resource/type :user
+          :entity/id     (str user-uuid)
+          :user/account  account-tempid}                    ; only to police permission checks.
+         (impl/Relationship user-tempid :owner account-tempid)]))))
+
+(defn make-account-server-txes [account-tempid n]
+  (let [server-uuids        (repeatedly n d/squuid)
+        server-uuid->tempid (ids->tempid-map server-uuids)]
+
+    (for [server-uuid server-uuids]
+      (let [server-tempid (server-uuid->tempid server-uuid)]
+        [{:db/id          server-tempid
+          :resource/type  :server
+          :server/account account-tempid                    ; only to police permission checks.
+          :entity/id      (str server-uuid)
+          :server/name    (str "Servers " server-uuid)}
+         (impl/Relationship account-tempid :account server-tempid)]))))
+
+(defn make-account-txes [{:keys [num-users num-servers]} account-uuid]
+  (let [account-tempid (d/tempid :db.part/user)
+        account-tx     {:db/id         account-tempid
+                        :resource/type :account
+                        :entity/id     (str account-uuid)}
+        user-txes      (make-account-user-txes account-tempid num-users)
+        server-txes    (make-account-server-txes account-tempid num-servers)]
+    (concat [account-tx] (flatten user-txes) (flatten server-txes))))
+
+(defn server->user-ids [db server-id]
+  (d/q '[:find [?user-id ...]
+         :in $ ?server-id
+         :where
+         [?server :entity/id ?server-id]
+         [?server :server/account ?account]
+         [?user :user/account ?account]
+         [?user :entity/id ?user-id]]
+       db server-id))
+
+(defn setup-benchmark [db]
+  {:accounts (d/q '[:find [?account-id ...]
+                    :where
+                    [?account :resource/type :account]
+                    [?account :entity/id ?account-id]]
+                  db)
+   :users    (d/q '[:find [?user-id ...]
+                    :where
+                    [?user :resource/type :user]
+                    [?user :entity/id ?user-id]]
+                  db)
+   :servers  (d/q '[:find [?server-id ...]
+                    :where
+                    [?server :resource/type :server]
+                    [?server :entity/id ?server-id]]
+                  db)})
+
+(defn run-benchmark [!counter client {:keys [accounts users servers]}]
+  ; now we cross-check each user for server and police that the value is correct
+  ; do we need to shuffle these for accurate test?
+  (doall (for [server-id servers
+               user-id   users]
+           (do
+             (swap! !counter inc)
+             [user-id server-id (eacl/can? client (->user user-id) :view (->server server-id))]))))
+
+(defn check-results [server->user-set matrix]
+  (for [[user-id server-id actual] matrix
+        :let [user-set (server->user-set server-id)
+              expected (contains? user-set server-id)]]
+    [actual expected]))
+
 (deftest eacl-benchmarks
   ; todo switch to with-mem-conn.
-  (def datomic-uri "datomic:mem://eacl-benchmark")
+  (def datomic-uri "datomic:dev://localhost:4597/eacl-benchmark")
   (d/delete-database datomic-uri)
   (d/create-database datomic-uri)
   (def conn (d/connect datomic-uri))
+
+  (comment
+
+    (d/q '[:find (count ?account) .
+           :where
+           [?account :resource/type :account]]
+         (d/db conn))
+
+    (d/q '[:find (count ?server) .
+           :where
+           [?server :resource/type :server]]
+         (d/db conn))
+
+    (d/q '[:find (count ?user) .
+           :where
+           [?user :resource/type :user]]
+         (d/db conn))
+
+    (def test-account (d/q '[:find (rand ?account-uuid) .
+                             :where
+                             [?account :resource/type :account]
+                             [?account :entity/id ?account-uuid]]
+                           (d/db conn)))
+
+    (def test-user (d/q '[:find (rand ?user-uuid) .
+                          :in $ ?account-uuid
+                          :where
+                          [?user :user/account ?account]
+                          [?user :entity/id ?user-uuid]]
+                        (d/db conn) test-account))
+
+    (def client (spiceomic/make-client conn))
+
+    (defn rand-user [db]
+      (d/q '[:find (rand ?user-uuid) .
+             :in $
+             :where
+             [?user :user/account ?account]
+             [?user :entity/id ?user-uuid]]
+           db))
+
+    (let [test-user (rand-user (d/db conn))]
+      (prn 'test-user test-user)
+      (time (eacl/lookup-resources client {:resource/type :server
+                                           :permission    :view
+                                           :subject       (->user test-user)})))
+
+    (defn rand-server [db]
+      (d/q '[:find (rand ?server-uuid) .
+             :in $
+             :where
+             [?server :server/account ?account]
+             [?server :entity/id ?server-uuid]]
+           db))
+
+    (let [test-server (rand-server (d/db conn))]
+      (prn 'test-server test-server)
+      (time (eacl/lookup-subjects client {:resource     (->server test-server)
+                                          :permission   :view
+                                          :subject/type :user})))
+
+    (eacl/read-relationships client {:resource/type :account})
+    (eacl/read-relationships client {:resource/type :server})
+    ())
 
   (testing "Transact EACL Datomic Schema"
     (tx! conn (concat schema/v4-schema)))
@@ -25,43 +173,84 @@
   (testing "Transact a realistic EACL Permission Schema"
     (tx! conn fixtures/base-fixtures))
 
-  ; generate 100 companies
-  (let [cids (repeatedly 100 d/squuid)]
-    (tx! conn (for [cid cids]
-                {:company/name (str "company-" cid)
-                 :resource/type :company
-                 :entity/id    (str cid)}))
+  (testing "some schema to police our data"
+    (tx! conn [{:db/ident       :server/name
+                :db/doc         "Just to add some real data into the mix."
+                :db/cardinality :db.cardinality/one
+                :db/valueType   :db.type/string
+                :db/index       true}
 
-    ; Relation so :company/owner can view & edit company
-    (tx! conn [(Relationship :company :company/owner [:company/view, :company/edit])])
+               {:db/ident       :user/account
+                :db/cardinality :db.cardinality/many
+                :db/valueType   :db.type/ref
+                :db/index       true}
 
-    (doseq [cid cids]                                       ; for each company,
-      ; make users:
-      (let [company (d/entity (d/db conn) [:entity/id cid])]
-        (let [uids (repeatedly 100 d/squuid)]
-          (doseq [uid uids]
-            (let [t-uid (d/tempid :db.part/user)]
-              (tx! conn [{:db/id         t-uid
-                          :user/username (str "user-" uid)
-                          :entity/id     uid}
-                         (eacl/Relationship t-uid :company/owner (:db/id company))]))))
-        ; make the user an owner of the company:
-        ;(tx! conn [(eacl/Relationship [:entity/id uid] :company/owner [:entity/id cid])]))))
+               {:db/ident       :server/account
+                :db/cardinality :db.cardinality/one
+                :db/valueType   :db.type/ref
+                :db/index       true}]))
 
-        ; todo use multi-cardinality subject
+  (let [num-accounts  100
+        num-users     10
+        num-servers   50
+        account-uuids (repeatedly num-accounts d/squuid)
+        account-txes  (time (->> account-uuids
+                                 (mapv (partial make-account-txes {:num-users   num-users
+                                                                   :num-servers num-servers}))
+                                 (flatten)))
+        tx-count      (count account-txes)]
+    ;(log/warn "Skipping txe.")
+    (log/debug "Transacting " tx-count " things.")
+    (tx! conn account-txes)
 
-        ; for each company, make 100 products
-        (let [pids (repeatedly 100 d/squuid)]
-          (doseq [pid pids]
-            (let [t-pid (d/tempid :db.part/user)]
-              (tx! conn [{:db/id         t-pid
-                          :product/title (str "product-" pid)
-                          :entity/id     pid}
-                         (eacl/Relationship t-pid :product/company (:db/id company))]))))))
+    (let [!counter         (atom 0)
+          !mistakes (atom 0)
+          client           (spiceomic/make-client conn)
+          db               (d/db conn)
+          {:as setup :keys [accounts users servers]} (time (setup-benchmark db))
+          _                (do (log/debug "N accounts" (count accounts))
+                               (log/debug "N users" (count users))
+                               (log/debug "N servers" (count servers)))
+          server->user-set (time (into {}
+                                       (for [server-id servers]
+                                         [server-id (set (server->user-ids db server-id))])))
+          server->users    (time (into {}
+                                       (for [server-id servers]
+                                         [server-id (vec (server->user-ids db server-id))])))]
+      ;(prn 'server->users server->users)
+      (when false ; do
+        (log/debug "Starting benchmark...")
+        (crit/quick-bench
+          (let [random-server      (rand-nth servers)
+                expected-userset   (server->user-set random-server)
+                expected-user-list (server->users random-server)
+                ;_                  (prn 'expected-user-list expected-user-list)
+                random-user        (if (and (>= (rand) 0.5) (seq expected-user-list)) ; some empty
+                                     (rand-nth expected-user-list)
+                                     (rand-nth users))
+                expected           (contains? expected-userset random-user)
+                _ (swap! !counter inc)
+                actual (eacl/can? client (->user random-user) :view (->server random-server))]
+            ;(log/debug expected random-user random-server)
+            (when (not= expected actual)
+              (swap! !mistakes inc))
+            [expected actual]))
+        (prn 'counter @!counter 'mistakes @!mistakes)))))
 
-    (d/q '[:find ?user ?])))
+;(let [result-matrix (time (run-benchmark !counter client setup))
+;      checks        (check-results server->user-set result-matrix)
+;      matches       (map (fn [[actual expected]]
+;                           (= actual expected)) checks)
+;      disparities   (frequencies matches)]
+;  (log/debug 'disparities disparities)
+;  (log/debug 'counter @!counter)
+;  disparities))))
 
 (comment
+  ; ok so we have 100 accounts, 10 users per account, and 1000 servers per account
+  ; th ameans we ahve 100 * 1000 = 100,000 servers.
+  ; total users = 10 * 100 = 1,000 users
+  ; users * servers = 100,000 * 1,000 = 100,000,000 M permission checks.
 
   (let [db        (d/db conn)
         ; pull some relations

--- a/test/eacl/datomic/impl_test.clj
+++ b/test/eacl/datomic/impl_test.clj
@@ -63,32 +63,32 @@
           (is (= #{(spice-object :user "user-1")
                    ;(spice-object :account "account-1")
                    (spice-object :user "super-user")}
-                 (set (spiceomic/lookup-subjects db {:resource (->server "server-1")
-                                                     :permission  :view
+                 (set (spiceomic/lookup-subjects db {:resource     (->server "server-1")
+                                                     :permission   :view
                                                      :subject/type :user}))))
 
           (testing ":test/user2 is only subject who can delete :test/server2"
             (is (= #{(spice-object :user "user-2")
                      (spice-object :user "super-user")}
-                   (set (spiceomic/lookup-subjects db {:resource   (->server "server-2")
-                                                       :permission :delete
+                   (set (spiceomic/lookup-subjects db {:resource     (->server "server-2")
+                                                       :permission   :delete
                                                        :subject/type :user}))))))
 
         (testing "We can enumerate resources with lookup-resources"
           (is (= #{(spice-object :server "server-1")}
                  (set (spiceomic/lookup-resources db {:resource/type :server
                                                       :permission    :view
-                                                      :subject (->user "user-1")}))))
+                                                      :subject       (->user "user-1")}))))
 
           (is (= #{(spice-object :account "account-1")}
                  (set (spiceomic/lookup-resources db {:resource/type :account
                                                       :permission    :view
-                                                      :subject (->user "user-1")}))))
+                                                      :subject       (->user "user-1")}))))
 
           (is (= #{(spice-object :server "server-2")}
                  (set (spiceomic/lookup-resources db {:resource/type :server
                                                       :permission    :view
-                                                      :subject (->user "user-2")})))))
+                                                      :subject       (->user "user-2")})))))
 
         (testing "Make user-1 a shared_admin of server-2"
           (is @(d/transact conn [(Relationship :test/user1 :shared_admin :test/server2)]))) ; this shouldn't be working. no schema for it.
@@ -101,7 +101,7 @@
                    (spice-object :server "server-2")}
                  (set (spiceomic/lookup-resources db {:resource/type :server
                                                       :permission    :view
-                                                      :subject (->user "user-1")}))))
+                                                      :subject       (->user "user-1")}))))
           (is (= #{(spice-object :user "super-user")
                    (spice-object :user "user-1")
                    (spice-object :user "user-2")}
@@ -124,14 +124,14 @@
                      ;(spice-object :account "account-2")
                      (spice-object :user "user-1")
                      (spice-object :user "super-user")}
-                   (set (spiceomic/lookup-subjects db' {:resource (->server "server-2")
-                                                        :permission  :view
+                   (set (spiceomic/lookup-subjects db' {:resource     (->server "server-2")
+                                                        :permission   :view
                                                         :subject/type :user}))))
             (testing ":test/user2 cannot access any servers" ; is this correct?
               (is (= #{}                                    ; Expect empty set of spice objects
                      (set (spiceomic/lookup-resources db' {:resource/type :server
                                                            :permission    :view
-                                                           :subject (->user "user-2")})))))
+                                                           :subject       (->user "user-2")})))))
 
             (is (not (can? db' :test/user2 :server/delete :test/server2)))
 
@@ -140,9 +140,9 @@
                        (spice-object :server "server-2")}
                      (set (spiceomic/lookup-resources db' {:resource/type :server
                                                            :permission    :view
-                                                           :subject (->user "user-1")}))))
+                                                           :subject       (->user "user-1")}))))
 
               (is (= #{(spice-object :account "account-1")}
                      (set (spiceomic/lookup-resources db' {:resource/type :account
                                                            :permission    :view
-                                                           :subject (->user "user-1")})))))))))))
+                                                           :subject       (->user "user-1")})))))))))))

--- a/test/eacl/datomic/performance_test.clj
+++ b/test/eacl/datomic/performance_test.clj
@@ -1,0 +1,174 @@
+(ns eacl.datomic.performance-test
+  "Performance benchmarks for EACL optimizations"
+  (:require [clojure.test :as t :refer [deftest testing is]]
+            [datomic.api :as d]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
+            [eacl.datomic.fixtures :as fixtures :refer [->user ->server ->account ->vpc]]
+            [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datomic.schema :as schema]
+            [eacl.datomic.impl :as impl :refer [Relation Relationship Permission]]
+            [eacl.datomic.rules :as original-rules]
+            [eacl.datomic.rules-optimized :as optimized-rules]))
+
+(defn measure-time
+  "Measure execution time of a function in milliseconds"
+  [f]
+  (let [start (System/nanoTime)
+        result (f)
+        end (System/nanoTime)
+        duration-ms (/ (- end start) 1000000.0)]
+    {:result result
+     :time-ms duration-ms}))
+
+(defn generate-test-data
+  "Generate test data with specified number of users, accounts, and servers"
+  [conn num-users num-accounts num-servers prefix]
+  (let [users (for [i (range num-users)]
+                {:db/id (str prefix "-user-" i)
+                 :entity/id (str prefix "-user-" i)
+                 :resource/type :user})
+        
+        accounts (for [i (range num-accounts)]
+                  {:db/id (str prefix "-account-" i)
+                   :entity/id (str prefix "-account-" i)
+                   :resource/type :account})
+        
+        servers (for [i (range num-servers)]
+                 {:db/id (str prefix "-server-" i)
+                  :entity/id (str prefix "-server-" i)
+                  :resource/type :server})
+        
+        ;; Create relationships
+        ;; Each user owns an account
+        user-account-rels (for [i (range (min num-users num-accounts))]
+                            (Relationship (str prefix "-user-" i) :owner (str prefix "-account-" i)))
+        
+        ;; Each account has servers
+        servers-per-account (quot num-servers num-accounts)
+        account-server-rels (for [i (range num-accounts)
+                                 j (range servers-per-account)]
+                             (Relationship (str prefix "-account-" i) :account 
+                                         (str prefix "-server-" (+ (* i servers-per-account) j))))]
+    
+    @(d/transact conn (concat users accounts servers 
+                             user-account-rels account-server-rels))))
+
+(defn run-performance-comparison
+  "Run performance comparison between original and optimized rules"
+  [db test-name query-fn original-rules optimized-rules]
+  (println (str "\n" test-name ":"))
+  
+  ;; Test with original rules
+  (let [{:keys [time-ms result]} (measure-time #(query-fn db original-rules))]
+    (println (format "  Original: %.2f ms (found %d results)" 
+                    time-ms (count result))))
+  
+  ;; Test with optimized rules
+  (let [{:keys [time-ms result]} (measure-time #(query-fn db optimized-rules))]
+    (println (format "  Optimized: %.2f ms (found %d results)" 
+                    time-ms (count result)))))
+
+(deftest performance-comparison-test
+  (testing "Performance comparison between original and optimized rules"
+    (with-mem-conn [conn schema/v4-schema]
+      ;; Set up base schema
+      @(d/transact conn fixtures/base-fixtures)
+      
+      ;; Generate larger test dataset
+      (println "\nGenerating test data...")
+      (generate-test-data conn 100 20 500 "perf1")
+      
+      (let [db (d/db conn)]
+        
+        ;; Test can? performance
+        (run-performance-comparison 
+          db "can? check (direct permission)"
+          (fn [db rules]
+            (d/q '[:find ?subject .
+                   :in $ % ?subject ?perm ?resource
+                   :where
+                   (has-permission ?subject ?perm ?resource)]
+                 db rules
+                 [:entity/id "perf1-user-0"]
+                 :view
+                 [:entity/id "perf1-server-0"]))
+          original-rules/check-permission-rules
+          optimized-rules/check-permission-rules)
+        
+        ;; Test lookup-subjects performance
+        (run-performance-comparison
+          db "lookup-subjects (find who can view server-0)"
+          (fn [db rules]
+            (d/q '[:find [?subject ...]
+                   :in $ % ?subject-type ?permission ?resource-eid
+                   :where
+                   (has-permission ?subject-type ?subject ?permission ?resource-eid)
+                   [(not= ?subject ?resource-eid)]]
+                 db rules
+                 :user
+                 :view
+                 [:entity/id "perf1-server-0"]))
+          original-rules/rules-lookup-subjects
+          optimized-rules/rules-lookup-subjects)
+        
+        ;; Test lookup-resources performance (highest priority)
+        (run-performance-comparison
+          db "lookup-resources (find servers user-0 can view)"
+          (fn [db rules]
+            (d/q '[:find [?resource ...]
+                   :in $ % ?subject-type ?subject-eid ?permission ?resource-type
+                   :where
+                   (has-permission ?subject-eid ?permission ?resource-type ?resource)
+                   [?resource :resource/type ?resource-type]]
+                 db rules
+                 :user
+                 [:entity/id "perf1-user-0"]
+                 :view
+                 :server))
+          original-rules/rules-lookup-resources
+          optimized-rules/rules-lookup-resources)
+        
+        ;; Test with larger dataset
+        (println "\n\nGenerating larger test dataset...")
+        (generate-test-data conn 500 100 2000 "perf2")
+        (let [db-large (d/db conn)]
+          
+          (println "\nLarger dataset tests:")
+          
+          ;; Test lookup-resources with larger dataset
+          (run-performance-comparison
+            db-large "lookup-resources on larger dataset"
+            (fn [db rules]
+              (d/q '[:find [?resource ...]
+                     :in $ % ?subject-type ?subject-eid ?permission ?resource-type
+                     :where
+                     (has-permission ?subject-eid ?permission ?resource-type ?resource)
+                     [?resource :resource/type ?resource-type]]
+                   db rules
+                   :user
+                   [:entity/id "perf2-user-10"]
+                   :view
+                   :server))
+            original-rules/rules-lookup-resources
+            optimized-rules/rules-lookup-resources))))))
+
+(deftest staged-lookup-resources-test
+  (testing "Staged lookup-resources implementation"
+    (with-mem-conn [conn schema/v4-schema]
+      @(d/transact conn fixtures/base-fixtures)
+      (generate-test-data conn 100 20 500 "staged")
+      
+      (let [db (d/db conn)]
+        (println "\n\nStaged lookup-resources test:")
+        
+        ;; Test original implementation
+        (let [{:keys [time-ms result]} 
+              (measure-time 
+                #(impl/lookup-resources db {:resource/type :server
+                                          :permission :view
+                                          :subject (->user "staged-user-0")
+                                          :limit 50}))]
+          (println (format "  Full implementation: %.2f ms (found %d results)" 
+                          time-ms (count result))))))))
+
+;; Run with: clj -M:test -n eacl.datomic.performance-test 


### PR DESCRIPTION
… ?resource-type]` clause at top of each rule for can?, because both type & ID is provided for subject & resource.