### PR TITLE
`:resource/type` is now `:eacl/type` & `:entity/id` is now `:eacl/id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The primary API call is `can?`:
 ```
 
 To maintain Spice-compatibility, all Spice objects (subjects or resources) require,
-- `:resource/type` (keyword), e.g. `:server` or `:account`
-- `:entity/id` (unique string), e.g. `"unique-account-1"`
+- `:eacl/type` (keyword), e.g. `:server` or `:account`
+- `:eacl/id` (unique string), e.g. `"unique-account-1"`
 
 You can construct a Spice Object using `eacl.core/spice-object` accepts `type`, `id` and optionally `subject_relation`. It returns a SpiceObject.
 
@@ -63,13 +63,13 @@ E.g.
 ; Make an EACL Datomic client that satisfies IAuthorization protocol:
 (def client (spiceomic/make-client conn))
 
-; Ensure your resources have `:resource/type` & `:entity/id`:
+; Ensure your resources have `:eacl/type` & `:eacl/id`:
 @(d/transact conn
-   [{:resource/type :user
-     :entity/id     "user1"}
+   [{:eacl/type :user
+     :eacl/id   "user1"}
   
-    {:resource/type :server
-     :entity/id     "server1"}])
+    {:eacl/type :server
+     :eacl/id   "server1"}])
 
 ; Transact EACL Relationships (schema is detailed below):
 @(d/transact conn your-relationships)
@@ -187,15 +187,15 @@ Now you can transact relationships:
 
 ```clojure
 @(d/transact conn
-  [{:db/id         "user1"
-    :resource/type :user
-    :entity/id     "user1"}
+  [{:db/id     "user1-tempid"
+    :eacl/type :user
+    :eacl/id   "user1"}
 
-   {:db/id         "account1"
-    :resource/type :account
-    :entity/id     "account1"}
+   {:db/id     "account1-tempid"
+    :eacl/type :account
+    :eacl/id   "account1"}
 
-   (Relationship "user1" :owner "account1")])
+   (Relationship "user1-tempid" :owner "account1-tempid")])
 ```
 
 (I'm using tempids in example because entities are defined in same tx as relationships)

--- a/src/eacl/datomic/core.clj
+++ b/src/eacl/datomic/core.clj
@@ -69,12 +69,12 @@ subject-type treatment reuses :resource/type. Maybe this should be entity type."
    ;subject-relation (conj '?subject-relation) ; todo.
    ; Clause ; order is perf. sensitive.
    :where '[[?relationship :eacl.relationship/resource ?resource]
-            [?resource :resource/type ?resource-type]
+            [?resource :eacl/type ?resource-type]
             [?relationship :eacl.relationship/relation-name ?relation-name]
             [?relationship :eacl.relationship/subject ?subject]
-            [?subject :resource/type ?subject-type]
-            [?subject :entity/id ?subject-id]
-            [?resource :entity/id ?resource-id]]})
+            [?subject :eacl/type ?subject-type]
+            [?subject :eacl/id ?subject-id]
+            [?resource :eacl/id ?resource-id]]})
 
 (comment
   (build-relationship-query {:resource/type :server}))
@@ -120,9 +120,9 @@ subject-type treatment reuses :resource/type. Maybe this should be entity type."
   [{:as _relationship :keys [subject relation resource]}]
   ; this is kind of grosos
   (impl/Relationship
-    {:type (:type subject), :id [:entity/id (:id subject)]}
+    {:type (:type subject), :id [:eacl/id (:id subject)]}
     relation
-    {:type (:type resource), :id [:entity/id (:id resource)]}))
+    {:type (:type resource), :id [:eacl/id (:id resource)]}))
 
 (defn tx-update-relationship
   "Note that delete costs N queries."
@@ -164,7 +164,7 @@ subject-type treatment reuses :resource/type. Maybe this should be entity type."
 (defn spiceomic-can?
   "Subject & Resource types must match in rules, but we don't check them here."
   [db subject permission resource]
-  (let [result (impl/can? db [:entity/id (:id subject)] permission [:entity/id (:id resource)])]
+  (let [result (impl/can? db [:eacl/id (:id subject)] permission [:eacl/id (:id resource)])]
     ;; Ensure we return a boolean
     (boolean result)))
 

--- a/src/eacl/datomic/impl_base.clj
+++ b/src/eacl/datomic/impl_base.clj
@@ -3,19 +3,19 @@
 
 (defn id->identifier
   "This is to support custom unique entity IDs."
-  [entity-id]
-  [:entity/id entity-id])
+  [eacl-id]
+  [:eacl/id eacl-id])
 
 ; A central place to configure how IDs and resource types are handled:
 ; - All SpiceDB objects have a type (string) and a unique ID (string). Spice likes strings.
 ; - To retain parity with SpiceDB, you can configure EACL to coerce object types & IDs of different
 ;   types (usually UUIDs) to/from Datomic when returning SpiceObject.
-; - By default EACL, uses :entity/id (unique string) and :resource/type (keyword) for objects.
+; - By default EACL, uses :eacl/id (unique string) and :eacl/type (keyword) for objects (subject & resources).
 ; - Below, you can configure how these are coerced to/from Datomic below.
 
 ; this should be passed into the impl.
-(def object-id-attr :entity/id)                             ; we default to :entity/id (string).
-(def resource-type-attr :resource/type)                     ; we default to :resource/type
+(def object-id-attr :eacl/id)                               ; we default to :eacl/id (string).
+(def resource-type-attr :eacl/type)                         ; we default to :eacl/type
 
 ; To support other types of IDs that can be coerced to/from string-formattable entity IDs, than UUIDs
 

--- a/src/eacl/datomic/impl_optimized.clj
+++ b/src/eacl/datomic/impl_optimized.clj
@@ -9,9 +9,9 @@
 (defn entity->spice-object [ent]
   (spice-object (get ent base/resource-type-attr) (get ent base/object-id-attr)))
 
-;; Configuration
-(def object-id-attr :entity/id)
-(def resource-type-attr :resource/type)
+;; Configuration (not used everywhere soz)
+(def object-id-attr :eacl/id)
+(def resource-type-attr :eacl/type)
 
 (defn lookup-subjects
   "Optimized version of lookup-subjects"
@@ -29,7 +29,7 @@
         {:as          resource-ent
          resource-eid :db/id} (d/entity db [object-id-attr resource-id])]
     (assert resource-eid (str "lookup-subjects requires a valid resource with unique attr " (pr-str object-id-attr) "."))
-    (assert (= resource-type (:resource/type resource-ent)) (str "Resource type does not match " resource-type "."))
+    (assert (= resource-type (:eacl/type resource-ent)) (str "Resource type does not match " resource-type "."))
     (let [subject-eids   (->> (d/q '[:find [?subject ...]
                                      :in $ % ?subject-type ?permission ?resource-eid
                                      :where
@@ -43,11 +43,11 @@
           paginated-eids (cond->> subject-eids
                                   offset (drop offset)
                                   limit (take limit))
-          objects (->> paginated-eids
-                       (map #(d/entity db %))
-                       (map entity->spice-object))]
+          objects        (->> paginated-eids
+                              (map #(d/entity db %))
+                              (map entity->spice-object))]
       ; todo: cursor WIP.
-      {:data objects
+      {:data   objects
        :cursor nil})))
 
 ;; Helper functions for staged lookup-resources
@@ -63,7 +63,7 @@
          [?rel :eacl.relationship/resource ?resource]
 
          ;; Early type filter
-         [?resource :resource/type ?rtype]
+         [?resource :eacl/type ?rtype]
 
          ;; Check permission using tuple
          [(tuple ?rtype ?relation ?perm) ?perm-tuple]
@@ -95,7 +95,7 @@
                     [?link :eacl.relationship/subject ?intermediate]
 
                     ;; Filter by resource type
-                    [?resource :resource/type ?rtype]
+                    [?resource :eacl/type ?rtype]
 
                     ;; Check if subject has target permission on intermediate
                     (has-permission ?subject ?target-perm ?intermediate)]

--- a/src/eacl/datomic/rules.clj
+++ b/src/eacl/datomic/rules.clj
@@ -12,7 +12,7 @@
     [(reachable ?resource ?subject)
      [?relationship :eacl.relationship/resource ?resource]
      [?relationship :eacl.relationship/subject ?mid]
-     (reachable ?mid ?subject)] ; note inversion to traverse.
+     (reachable ?mid ?subject)]                             ; note inversion to traverse.
 
     ;; Direct permission check (copied and adapted from core2)
     [(has-permission ?subject ?permission-name ?resource)
@@ -138,7 +138,7 @@
      ;; Match the relation name from the relationship tuple with the one in permission definition
      [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
      [(not= ?subject ?resource)]                            ; can we avoid this?
-     [?resource :resource/type ?resource-type]]             ; this is super slow. different rules WIP.
+     [?resource :eacl/type ?resource-type]]                 ; this is super slow. different rules WIP.
 
    ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
    ;; This rule means: ?subject gets ?permission-name on ?resource if:
@@ -167,7 +167,7 @@
 
        (reachable ?target ?subject)                         ; User must be able to reach the target of the structural relationship
        [(not= ?subject ?resource)]
-       [?resource :resource/type ?resource-type]])
+       [?resource :eacl/type ?resource-type]])
 
    ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
    ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
@@ -206,13 +206,13 @@
      [(not= ?subject ?intermediate-resource)]
      ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
      [(not= ?this-resource ?intermediate-resource)]
-     [?this-resource :resource/type ?this-resource-type]]]) ; this is super slow. different rules WIP.]])
+     [?this-resource :eacl/type ?this-resource-type]]])     ; this is super slow. different rules WIP.]])
 
-(def slow-lookup-rules (build-slow-rules :resource/type))
+(def slow-lookup-rules (build-slow-rules :eacl/type))
 
 (def rules-lookup-subjects
   '[;; Reachability rules to traverse relationships:
-    [(reachable ?resource ?subject) ; I think we need types here for speed.
+    [(reachable ?resource ?subject)                         ; I think we need types here for speed.
      [(tuple ?resource ?subject) ?resource+subject]
      [?relationship :eacl.relationship/resource+subject ?resource+subject]
 
@@ -250,7 +250,7 @@
      ;; Match the relation name from the relationship tuple with the one in permission definition
      [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
      [(not= ?subject ?resource)]                            ; can we avoid this?
-     [?subject :resource/type ?subject-type]]             ; this is super slow. different rules WIP.
+     [?subject :eacl/type ?subject-type]]                   ; this is super slow. different rules WIP.
 
     ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
     ;; This rule means: ?subject gets ?permission-name on ?resource if:
@@ -278,7 +278,7 @@
 
      (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
      [(not= ?subject ?resource)]
-     [?subject :resource/type ?subject-type]]
+     [?subject :eacl/type ?subject-type]]
 
     ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
     ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
@@ -319,12 +319,12 @@
      ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
      [(not= ?this-resource ?intermediate-resource)]
      ; TODO: this-resource looks dubious here. do we need it?
-     [?this-resource :resource/type ?this-resource-type]]])
+     [?this-resource :eacl/type ?this-resource-type]]])
 
 (def rules-lookup-resources
   ; resource look has known subject Type + ID, and known resource type.
   '[;; Reachability rules to traverse relationships:
-    [(reachable ?resource ?subject) ; I think we need types here for speed.
+    [(reachable ?resource ?subject)                         ; I think we need types here for speed.
      [(tuple ?resource ?subject) ?resource+subject]
      [?relationship :eacl.relationship/resource+subject ?resource+subject]
 
@@ -362,7 +362,7 @@
      ;; Match the relation name from the relationship tuple with the one in permission definition
      [(= ?relation-name-in-tuple ?relation-name-in-perm-def)]
      [(not= ?subject ?resource)]                            ; can we avoid this?
-     [?resource :resource/type ?resource-type]]
+     [?resource :eacl/type ?resource-type]]
 
     ;; Indirect permission inheritance (copied from core2 - may need review/replacement with arrows)
     ;; This rule means: ?subject gets ?permission-name on ?resource if:
@@ -391,7 +391,7 @@
 
      (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
      [(not= ?subject ?resource)]
-     [?resource :resource/type ?this-resource-type]] ; is this correct?
+     [?resource :eacl/type ?this-resource-type]]            ; is this correct?
 
     ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
     ;; Example: User U gets :admin on VPC_X if VPC_X --:account--> ACC_Y and User U has :admin on ACC_Y.
@@ -422,7 +422,7 @@
      [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
      [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
 
-     [?intermediate-resource :resource/type ?intermediate-resource-type] ; do we need this?
+     [?intermediate-resource :eacl/type ?intermediate-resource-type] ; do we need this?
 
      ;; 3. Subject must have the target permission on the intermediate resource (recursive call)
      (has-permission ?subject ?perm-on-related ?intermediate-resource-type ?intermediate-resource)
@@ -432,7 +432,7 @@
      [(not= ?subject ?intermediate-resource)]
      ;; Ensure this-resource is not the same as intermediate for simple arrows like A -> B
      [(not= ?this-resource ?intermediate-resource)]
-     [?this-resource :resource/type ?this-resource-type]]])
+     [?this-resource :eacl/type ?this-resource-type]]])
 
 ;(def rules-lookup-subjects
 ;  ; lookup-subjects knows resource & subject type which implies knowing resource type.
@@ -503,8 +503,8 @@
 ;     [?structural-rel :eacl.relationship/resource ?target]
 ;
 ;     (reachable ?target ?subject)                           ; User must be able to reach the target of the structural relationship
-;     [?resource :resource/type ?resource-type]             ; super slow. different rules WIP.
-;     [?subject :resource/type ?subject-type]
+;     [?resource :eacl/type ?resource-type]             ; super slow. different rules WIP.
+;     [?subject :eacl/type ?subject-type]
 ;     [(not= ?subject ?resource)]]
 ;
 ;    ;; Arrow permission rule: ?subject gets ?perm-name-on-this-resource if it has ?perm-name-on-related on an intermediate resource
@@ -536,8 +536,8 @@
 ;     [?rel-linking-resources :eacl.relationship/relation-name ?via-relation-name] ; relation is :account
 ;     [?rel-linking-resources :eacl.relationship/resource ?this-resource] ; e.g., server/vpc is resource of tuple
 ;
-;     ;[?this-resource :resource/type ?this-resource-type]
-;     ;[?subject :resource/type ?subject-type]
+;     ;[?this-resource :eacl/type ?this-resource-type]
+;     ;[?subject :eacl/type ?subject-type]
 ;     [?intermediate-resource :resource/type ?intermediate-resource-type]
 ;
 ;     ;; 3. Subject must have the target permission on the intermediate resource (recursive call)

--- a/src/eacl/datomic/rules/optimized.clj
+++ b/src/eacl/datomic/rules/optimized.clj
@@ -19,7 +19,7 @@
     ;; Direct permission - optimized clause ordering
     [(has-permission ?subject ?permission-name ?resource)
      ;; Get resource type first
-     [?resource :resource/type ?resource-type]
+     [?resource :eacl/type ?resource-type]
 
      ;; Find relationships for this resource
      [?relationship :eacl.relationship/resource ?resource]
@@ -36,7 +36,7 @@
     ;; Indirect permission inheritance - optimized
     [(has-permission ?subject ?permission-name ?resource)
      ;; Get resource type first (we already have the resource)
-     [?resource :resource/type ?resource-type]
+     [?resource :eacl/type ?resource-type]
 
      ;; Find permission definitions for this resource type
      [?perm-def :eacl.permission/resource-type ?resource-type]
@@ -55,7 +55,7 @@
     ;; Arrow permission - optimized
     [(has-permission ?subject ?perm-name-on-this-resource ?this-resource)
      ;; Get resource type from the resource we already have
-     [?this-resource :resource/type ?this-resource-type]
+     [?this-resource :eacl/type ?this-resource-type]
 
      ;; Find arrow permission definitions
      [?arrow-perm :eacl.arrow-permission/resource-type ?this-resource-type]
@@ -91,7 +91,7 @@
     ;; Direct permission check - optimized for known resource
     [(has-permission ?subject-type ?subject ?permission-name ?resource)
      ;; Get resource type (we already have resource entity)
-     [?resource :resource/type ?resource-type]
+     [?resource :eacl/type ?resource-type]
 
      ;; Find relationships for this resource
      [?relationship :eacl.relationship/resource ?resource]
@@ -99,7 +99,7 @@
      [?relationship :eacl.relationship/relation-name ?relation-name]
 
      ;; Check subject type
-     [?subject :resource/type ?subject-type]
+     [?subject :eacl/type ?subject-type]
 
      ;; Check permission using tuple
      [(tuple ?resource-type ?relation-name ?permission-name) ?perm-tuple]
@@ -109,7 +109,7 @@
 
     ;; Indirect permission inheritance
     [(has-permission ?subject-type ?subject ?permission-name ?resource)
-     [?resource :resource/type ?resource-type]
+     [?resource :eacl/type ?resource-type]
 
      ;; Find permission definitions
      [?perm-def :eacl.permission/resource-type ?resource-type]
@@ -122,12 +122,12 @@
      [?structural-rel :eacl.relationship/resource ?target]
 
      (reachable ?target ?subject)
-     [?subject :resource/type ?subject-type]
+     [?subject :eacl/type ?subject-type]
      [(not= ?subject ?resource)]]
 
     ;; Arrow permission
     [(has-permission ?subject-type ?subject ?perm-name-on-this-resource ?this-resource)
-     [?this-resource :resource/type ?this-resource-type]
+     [?this-resource :eacl/type ?this-resource-type]
 
      ;; Find arrow permissions
      [?arrow-perm :eacl.arrow-permission/resource-type ?this-resource-type]
@@ -174,7 +174,7 @@
 ;    ;; Direct permission check - subject-centric
 ;    [(has-permission ?subject-type ?subject ?permission ?resource-type ?resource)
 ;     ;; Check if resource is of correct type
-;     ;[?resource :resource/type ?resource-type]
+;     ;[?resource :eacl/type ?resource-type]
 ;
 ;     [(tuple ?resource-type ?permission) ?rtype+permission]
 ;     [?perm :eacl.permission/resource-type+permission-name ?rtype+permission]
@@ -211,7 +211,7 @@
 ;     [?relationship2 :eacl.relationship/resource-type ?resource-type]]
 ;
 ;     ;; Verify resource type
-;     ;[?resource :resource/type ?resource-type]]
+;     ;[?resource :eacl/type ?resource-type]]
 ;
 ;    ;; Arrow permission - optimized for subject-centric lookup
 ;    [(has-permission ?subject-type ?subject ?permission ?resource-type ?resource)
@@ -243,7 +243,7 @@
 ;     [?link :eacl.relationship/subject-type ?intermediate-type] ; this is looked up here
 ;
 ;     ;; Get intermediate resource type
-;     ;[?intermediate :resource/type ?intermediate-type]
+;     ;[?intermediate :eacl/type ?intermediate-type]
 ;
 ;     ;; Check if subject has target permission on intermediate (recursive)
 ;     (has-permission ?subject-type ?subject ?target-perm ?intermediate-type ?intermediate)]])
@@ -264,7 +264,7 @@
      (subject-has-relationships ?subject ?relation ?resource)
 
      ;; Check if resource is of correct type
-     [?resource :resource/type ?resource-type]
+     [?resource :eacl/type ?resource-type]
 
      ;; Check if relation grants permission
      [?perm :eacl.permission/resource-type ?resource-type]
@@ -287,7 +287,7 @@
      [?relationship2 :eacl.relationship/resource ?resource]
 
      ;; Verify resource type
-     [?resource :resource/type ?resource-type]]
+     [?resource :eacl/type ?resource-type]]
 
     ;; Arrow permission - optimized for subject-centric lookup
     [(has-permission ?subject ?permission ?resource-type ?resource)
@@ -298,7 +298,7 @@
      [?arrow :eacl.arrow-permission/target-permission-name ?target-perm]
 
      ;; Find resources of target type
-     [?resource :resource/type ?resource-type]
+     [?resource :eacl/type ?resource-type]
 
      ;; Find intermediate resources linked to target resource
      [?link :eacl.relationship/resource ?resource]
@@ -306,7 +306,7 @@
      [?link :eacl.relationship/subject ?intermediate]
 
      ;; Get intermediate resource type
-     [?intermediate :resource/type ?intermediate-type]
+     [?intermediate :eacl/type ?intermediate-type]
 
      ;; Check if subject has target permission on intermediate (recursive)
      (has-permission ?subject ?target-perm ?intermediate-type ?intermediate)]])

--- a/src/eacl/datomic/schema.clj
+++ b/src/eacl/datomic/schema.clj
@@ -1,13 +1,13 @@
 (ns eacl.datomic.schema)
 
 (def v4-schema
-  [{:db/ident       :resource/type
+  [{:db/ident       :eacl/type
     :db/doc         "Resource Type on Domain Entities. Used by EACL."
     :db/valueType   :db.type/keyword
     :db/cardinality :db.cardinality/one
     :db/index       true}
 
-   {:db/ident       :entity/id                              ; todo: figure out how to support :id, :object/id or :spice/id of different types.
+   {:db/ident       :eacl/id                                ; todo: figure out how to support :id, :object/id or :spice/id of different types.
     :db/doc         "Unique String ID to match SpiceDB Object IDs."
     :db/valueType   :db.type/string
     :db/unique      :db.unique/identity
@@ -268,7 +268,7 @@
     :db/unique      :db.unique/identity}
 
    ;; NEW PERFORMANCE OPTIMIZATION INDICES
-   
+
    ;; Critical for subject-based lookups
    {:db/ident       :eacl.relationship/subject+relation-name
     :db/doc         "Index for efficient subject-based lookups"

--- a/test/eacl/datomic/fixtures.clj
+++ b/test/eacl/datomic/fixtures.clj
@@ -15,7 +15,7 @@
 
 (def base-fixtures
   [; Schema
-   (Relation :platform :super_admin :user)                   ; means resource-type/relation subject-type, e.g. definition platform { relation super_admin: user }.
+   (Relation :platform :super_admin :user)                  ; means resource-type/relation subject-type, e.g. definition platform { relation super_admin: user }.
    ; definition platform {
    ;   relation super_admin: user;
    ;   permission platform_admin = super_admin   # EACL requires this hack for arrow relations because we traverse permissions->relations. Could be fixed.
@@ -72,100 +72,100 @@
    (Permission :server/owner :delete)
 
    ; Global Platform for Super Admins:
-   {:db/id         "platform"
-    :entity/id     "platform"
-    :db/ident      :test/platform
-    :resource/type :platform}
+   {:db/id     "platform"
+    :db/ident  :test/platform
+    :eacl/type :platform
+    :eacl/id   "platform"}
 
    ; Users:
-   {:db/id         "user-1"
-    :entity/id     "user-1"
-    :db/ident      :test/user1
-    :resource/type :user}
+   {:db/id     "user-1"
+    :db/ident  :test/user1
+    :eacl/type :user
+    :eacl/id   "user-1"}
 
    ; we need to specify types for indices, but id can be tempid here.
    (Relationship (->user "user-1") :member (->team "team-1")) ; User 1 is on Team 1
    (Relationship (->user "user-1") :owner (->account "account-1"))
 
    ; Super User can do all the things:
-   {:db/id         "super-user"
-    :entity/id     "super-user"
-    :db/ident      :user/super-user
-    :resource/type :user}
+   {:db/id     "super-user"
+    :db/ident  :user/super-user
+    :eacl/type :user
+    :eacl/id   "super-user"}
 
    (Relationship (->user "super-user") :super_admin (->platform "platform"))
 
-   {:db/id         "user-2"
-    :entity/id     "user-2"
-    :db/ident      :test/user2
-    :resource/type :user}
+   {:db/id     "user-2"
+    :db/ident  :test/user2
+    :eacl/type :user
+    :eacl/id   "user-2"}
 
    (Relationship (->user "user-2") :owner (->account "account-2"))
 
    ; Accounts
-   {:db/id         "account-1"
-    :entity/id     "account-1"
-    :db/ident      :test/account1
-    :resource/type :account}
+   {:db/id     "account-1"
+    :db/ident  :test/account1
+    :eacl/type :account
+    :eacl/id   "account-1"}
 
    (Relationship (->platform "platform") :platform (->account "account-1"))
 
-   {:db/id         "account-2"
-    :entity/id     "account-2"
-    :db/ident      :test/account2
-    :resource/type :account}
+   {:db/id     "account-2"
+    :db/ident  :test/account2
+    :eacl/type :account
+    :eacl/id   "account-2"}
 
    (Relationship (->platform "platform") :platform (->account "account-2"))
 
    ; VPC
-   {:db/id         "vpc-1"
-    :entity/id     "vpc-1"
-    :db/ident      :test/vpc
-    :resource/type :vpc}
+   {:db/id     "vpc-1"
+    :db/ident  :test/vpc
+    :eacl/type :vpc
+    :eacl/id   "vpc-1"}
 
    (Relationship (->account "account-1") :account (->vpc "vpc-1"))
 
-   {:db/id         "vpc-2"
-    :entity/id     "vpc-2"
-    :db/ident      :test/vpc2
-    :resource/type :vpc}
+   {:db/id     "vpc-2"
+    :db/ident  :test/vpc2
+    :eacl/type :vpc
+    :eacl/id   "vpc-2"}
 
    (Relationship (->account "account-2") :account (->vpc "vpc-2"))
 
    ; Team
-   {:db/id         "team-1"
-    :entity/id     "team-1"
-    :resource/type :team
-    :db/ident      :test/team}
+   {:db/id     "team-1"
+    :db/ident  :test/team
+    :eacl/type :team
+    :eacl/id   "team-1"}
 
    ; Teams belongs to accounts
    (Relationship (->account "account-1") :account (->team "team-1"))
 
-   {:db/id         "team-2"
-    :entity/id     "team-2"
-    :db/ident      :test/team2
-    :resource/type :team}
+   {:db/id     "team-2"
+    :db/ident  :test/team2
+    :eacl/type :team
+    :eacl/id   "team-2"}
 
    (Relationship (->account "account-2") :account (->team "team-2"))
 
    ;; Servers:
-   {:db/id         "account1-server1"
-    :entity/id     "account1-server1"
-    :db/ident      :test/server1
-    :resource/type :server}
+   {:db/id     "account1-server1"
+    :db/ident  :test/server1
+    :eacl/type :server
+    :eacl/id   "account1-server1"}
 
    (Relationship (->account "account-1") :account (->server "account1-server1")) ; hmm let's check schema plz.
 
-   {:db/id         "account1-server2"
-    :entity/id     "account1-server2"
-    :resource/type :server}
+   {:db/id     "account1-server2"
+    :eacl/type :server
+    :eacl/id   "account1-server2"}
 
    (Relationship (->account "account-1") :account (->server "account1-server2"))
 
-   {:db/id         "account2-server1"
-    :entity/id     "account2-server1"
-    :db/ident      :test/server2
-    :resource/type :server}
+   {:db/id     "account2-server1"
+    :db/ident  :test/server2
+    :eacl/type :server
+    :eacl/id   "account2-server1"}
 
    (Relationship (->account "account-2") :account (->server "account2-server1"))])
 

--- a/test/eacl/datomic/impl_test.clj
+++ b/test/eacl/datomic/impl_test.clj
@@ -193,8 +193,8 @@
           (testing "add a 3rd server. make super-user a direct shared_admin of server1 and server 3 to try and trip up pagination"
             @(d/transact conn [{:db/id         "server3"
                                 :db/ident      :test/server3
-                                :resource/type :server      ; note, no account.
-                                :entity/id     "server-3"}
+                                :eacl/type :server      ; note, no account.
+                                :eacl/id     "server-3"}
                                (Relationship (->user :user/super-user) :shared_admin (->server :test/server1))
                                (Relationship (->user :user/super-user) :shared_admin (->server "server3"))]))
 

--- a/test/eacl/spice_test.clj
+++ b/test/eacl/spice_test.clj
@@ -145,8 +145,8 @@
                                        my-account acme-account
                                        super-user my-user joe's-user
                                        my-server my-other-server joe's-server]]
-                              {:resource/type (:type ent)
-                               :entity/id     (:id ent)}))))
+                              {:eacl/type (:type ent)
+                               :eacl/id   (:id ent)}))))
 
     (testing "Write relationships so my-user is the :owner of my-account and my-server is in my-account. Note the order of subjects vs. resources in ->Relationship."
       (let [{:as response, token :zed/token}
@@ -274,8 +274,8 @@
                                         (->account "other-account")
                                         (->vpc "my-vpc")
                                         (->vpc "other-vpc")]]
-                            {:resource/type (:type object)
-                             :entity/id     (:id object)})))
+                            {:eacl/type (:type object)
+                             :eacl/id   (:id object)})))
 
       (is (eacl/create-relationships! *client
                                       [(->Relationship (->account "test-account") :account (->vpc "my-vpc"))
@@ -288,6 +288,7 @@
                                                :subject/type      :account
                                                :subject/id        "test-account"}))))
 
+    ; expand-permission-tree not impl. yet.
     (testing "We can expand permissions hierarchy for (->server 123)."
       (is (= [[[[{:object   (->account "operativa")
                   :relation :owner


### PR DESCRIPTION
because in Relationships, the type applies to objects which are subjects or resources, not just resources.