### PR TITLE
Cache permission paths + support multiple subject types on Relation with same resource_type & relation_name

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,9 @@
            ;; Datomic
            com.datomic/peer               {:mvn/version "1.0.6733"} ;; there is newer, but not sure about transactor
 
+           ;; Caching
+           org.clojure/core.cache         {:mvn/version "1.1.234"}
+
            ;; Logging
            org.clojure/tools.logging      {:mvn/version "1.3.0"}
            ch.qos.logback/logback-classic {:mvn/version "1.5.12"}}

--- a/src/eacl/datomic/impl/indexed.clj.orig
+++ b/src/eacl/datomic/impl/indexed.clj.orig
@@ -1,7 +1,6 @@
 (ns eacl.datomic.impl.indexed
-  ;; Indexed implementation of EACL
   (:require [datomic.api :as d]
-            [eacl.lazy-merge-sort :as lazy-sort :refer [lazy-merge-dedupe-sort lazy-merge-dedupe-sort-by]]
+            [eacl.lazy-merge-sort :refer [lazy-merge-dedupe-sort lazy-merge-dedupe-sort-by]]
             [eacl.core :refer [spice-object]]
             [clojure.tools.logging :as log]))
 
@@ -44,18 +43,22 @@
 ;         [?relation :eacl.relation/subject-type ?subject-type]]
 ;       db resource-type source-relation-name))
 
-(defn relation-datoms
-  "Returns a lazy seq of raw datoms for the given resource-type and relation-name.
-  Callers unpack :e (eid) and :v (subject-type) as needed; seq is realized on consumption."
+(defn find-relation-def
+  "Finds the Relation definition for a given resource-type and relation-name.
+  Returns map with :eacl.relation/subject-type as the target type for arrows, or nil if not found."
   [db resource-type relation-name]
-  (if (and resource-type relation-name)
-    (let [start-tuple [resource-type relation-name :a]
-          end-tuple   [resource-type relation-name :z]]
-      (d/index-range db :eacl.relation/resource-type+relation-name+subject-type start-tuple end-tuple))
-    (do
-      (log/warn 'relation-datoms 'called-with resource-type relation-name)
-      (throw (Exception. (str 'relation-datoms 'called-with resource-type relation-name)))
-      [])))
+  {:pre [(keyword? resource-type)
+         (keyword? relation-name)]}
+  ; this can be optimized, since we already know resource type & relation name.
+  ; only need to add subject-type.
+  (d/q '[:find (pull ?rel [:eacl.relation/subject-type
+                           :eacl.relation/resource-type
+                           :eacl.relation/relation-name]) .
+         :in $ ?rtype ?rname
+         :where
+         [?rel :eacl.relation/resource-type ?rtype]
+         [?rel :eacl.relation/relation-name ?rname]]
+    db resource-type relation-name))
 
 (defn find-permission-defs
   "Finds all Permission definitions that grant permission-name on resource-type.
@@ -69,90 +72,119 @@
       vec)))
 
 (defn resolve-self-relation [db resource-type target-relation-name]
-  (let [datoms (relation-datoms db resource-type target-relation-name)]
-    (if (seq datoms)
-      (map (fn [datom]
-             {:type         :relation
-              :name         target-relation-name
-              :subject-type (nth (:v datom) 2)
-              :relation-eid (:e datom)})                    ; For v7 compatibility
-        datoms)
-      (do
-        (log/warn "Missing Relation definition"
-          {:resource-type resource-type
-           :relation-name target-relation-name})
-        []))))
+  (if-let [rel-def (find-relation-def db resource-type target-relation-name)]
+    {:type         :relation
+     :name         target-relation-name
+     :subject-type (:eacl.relation/subject-type rel-def)}
+    (do                                                     ; Skip if missing. Do we handle this nil correctly?
+      (log/warn "Missing Relation definition"
+        {:resource-type resource-type
+         :relation-name target-relation-name})
+      nil)))
 
 (defn get-permission-paths
   "Recursively builds paths granting permission-name on resource-type.
   Returns vector of path maps, where each path is:
-  {:type :relation, :name keyword, :subject-type keyword, :relation-eid long} for direct path, or
-  {:type :arrow, :via keyword, :target-type keyword, :sub-paths [paths], :via-relation-eid long} for arrows.
-  Compatible with v6 (uses :subject-type kw) and v7 (uses :relation-eid)."
+  {:type :relation, :name keyword, :subject-type keyword} for direct
+  or {:type :arrow, :via keyword, :target-type keyword, :sub-paths [paths]} for arrows."
+<<<<<<< HEAD
+  [db resource-type permission-name]
+  (let [perm-defs (find-permission-defs db resource-type permission-name)]
+    (->> perm-defs
+      (keep (fn [{:as                   perm-def
+                  :eacl.permission/keys [source-relation-name
+                                         target-type
+                                         target-name]}]
+              ; how to handle {:relation :self :permission :local-permission} ?
+              ;(log/debug 'perm-def perm-def)
+              (assert resource-type "resource-type missing")
+              (assert source-relation-name "source-relation-name missing")
+              (if (= :self source-relation-name)
+                (case target-type
+                  :relation (resolve-self-relation db resource-type target-name) ; target-name can be nil here. why?
+                  :permission {:type              :self-permission
+                               :target-permission target-name
+                               :resource-type     resource-type})
+                (if-let [via-rel-def (find-relation-def db resource-type source-relation-name)]
+                  (let [intermediate-type (:eacl.relation/subject-type via-rel-def)]
+                    {:type              :arrow
+                     :via               source-relation-name ; this can be :self, but we don't handle it
+                     :target-type       intermediate-type   ;; This is the actual type of the intermediate
+                     :target-permission (when (= target-type :permission) target-name)
+                     :target-relation   (when (= target-type :relation) target-name)
+                     :sub-paths         (case target-type
+                                          ;; Recursive permission call - types already resolved in recursion
+                                          :permission (get-permission-paths db intermediate-type target-name)
+                                          ;; Direct relation - build the path with proper type resolution
+                                          :relation (if-let [target-rel-def (find-relation-def db intermediate-type target-name)]
+                                                      [{:type         :relation
+                                                        :name         target-name
+                                                        :subject-type (:eacl.relation/subject-type target-rel-def)}]
+                                                      (do   ; Return empty sub-paths if missing Relation
+                                                        (log/warn "Missing Relation definition for arrow target relation"
+                                                          {:intermediate-type    intermediate-type
+                                                           :target-relation-name target-name})
+                                                        [])))}) ; Skip this permission path
+                  (do
+                    (log/warn "Missing Relation definition for via relation"
+                      {:resource-type     resource-type
+                       :via-relation-name source-relation-name})
+                    nil)))))
+=======
   ([db resource-type permission-name]
    (get-permission-paths db resource-type permission-name #{}))
   ([db resource-type permission-name visited-perms]
-   (let [perm-defs       (find-permission-defs db resource-type permission-name)
-         perm-eids       (map :db/id perm-defs)
-         updated-visited (reduce conj visited-perms perm-eids)]
-     (->> perm-defs
-       (mapcat (fn [{:as                   perm-def
-                     perm-eid              :db/id
-                     :eacl.permission/keys [source-relation-name
-                                            target-type
-                                            target-name]}]
-                 (assert resource-type "resource-type missing")
-                 (assert source-relation-name "source-relation-name missing")
-
-                 ;; Cycle detection: check if we've already visited this permission
-                 (if (contains? visited-perms perm-eid)
-                   (do
-                     (log/warn "Cycle detected: " perm-def " in " visited-perms)
-                     [])
+   ;; Cycle detection: check if we've already visited this permission
+   (let [perm-key [resource-type permission-name]]
+     (if (contains? visited-perms perm-key)
+       (do
+         (log/warn "Cycle detected: " perm-key " in " visited-perms)
+         [])                                                ; Return empty paths if we detect a cycle. This should be detected during schema writes.
+       (let [updated-visited (conj visited-perms perm-key)
+             perm-defs       (find-permission-defs db resource-type permission-name)]
+         (->> perm-defs
+           (keep (fn [{:as                   perm-def
+                       :eacl.permission/keys [source-relation-name
+                                              target-type
+                                              target-name]}]
+                   ; how to handle {:relation :self :permission :local-permission} ?
+                   ;(log/debug 'perm-def perm-def)
+                   (assert resource-type "resource-type missing")
+                   (assert source-relation-name "source-relation-name missing")
                    (if (= :self source-relation-name)
                      (case target-type
-                       :relation (resolve-self-relation db resource-type target-name)
-                       :permission [{:type              :self-permission
-                                     :target-permission target-name
-                                     :resource-type     resource-type}])
-                     (let [datoms (relation-datoms db resource-type source-relation-name)]
-                       (if (seq datoms)
-                         (mapcat (fn [datom]
-                                   (let [intermediate-type (nth (:v datom) 2)
-                                         via-relation-eid  (:e datom)
-                                         sub-paths         (case target-type
-                                                             ;; Recursive permission call with cycle detection
-                                                             :permission (get-permission-paths db intermediate-type target-name updated-visited)
-                                                             ;; Direct relation - build the path with proper type resolution
-                                                             :relation (let [target-datoms (relation-datoms db intermediate-type target-name)]
-                                                                         (if (seq target-datoms)
-                                                                           (map (fn [target-datom]
-                                                                                  {:type         :relation
-                                                                                   :name         target-name
-                                                                                   :subject-type (nth (:v target-datom) 2)
-                                                                                   :relation-eid (:e target-datom)}) ; For v7
-                                                                             target-datoms)
-                                                                           (do
-                                                                             (log/warn "Missing Relation definition for arrow target relation"
-                                                                               {:intermediate-type    intermediate-type
-                                                                                :target-relation-name target-name})
-                                                                             []))))]
-                                     (if (seq sub-paths)
-                                       [{:type              :arrow
-                                         :via               source-relation-name
-                                         :target-type       intermediate-type
-                                         :via-relation-eid  via-relation-eid ; For v7
-                                         :target-permission (when (= target-type :permission) target-name)
-                                         :target-relation   (when (= target-type :relation) target-name)
-                                         :sub-paths         sub-paths}]
-                                       [])))
-                           datoms)
-                         (do
-                           (log/warn "Missing Relation definition for via relation"
-                             {:resource-type     resource-type
-                              :via-relation-name source-relation-name})
-                           [])))))))
-       (vec)))))
+                       :relation (resolve-self-relation db resource-type target-name) ; target-name can be nil here. why?
+                       :permission {:type              :self-permission
+                                    :target-permission target-name
+                                    :resource-type     resource-type})
+                     (if-let [via-rel-def (find-relation-def db resource-type source-relation-name)]
+                       (let [intermediate-type (:eacl.relation/subject-type via-rel-def)]
+                         {:type              :arrow
+                          :via               source-relation-name ; this can be :self, but we don't handle it
+                          :target-type       intermediate-type ;; This is the actual type of the intermediate
+                          :target-permission (when (= target-type :permission) target-name)
+                          :target-relation   (when (= target-type :relation) target-name)
+                          :sub-paths         (case target-type
+                                               ;; Recursive permission call with cycle detection
+                                               :permission (get-permission-paths db intermediate-type target-name updated-visited)
+                                               ;; Direct relation - build the path with proper type resolution
+                                               :relation (if-let [target-rel-def (find-relation-def db intermediate-type target-name)]
+                                                           [{:type         :relation
+                                                             :name         target-name
+                                                             :subject-type (:eacl.relation/subject-type target-rel-def)}]
+                                                           (do ; Return empty sub-paths if missing Relation
+                                                             (log/warn "Missing Relation definition for arrow target relation"
+                                                               {:intermediate-type    intermediate-type
+                                                                :target-relation-name target-name})
+                                                             [])))}) ; Skip this permission path
+                       (do
+                         (log/warn "Missing Relation definition for via relation"
+                           {:resource-type     resource-type
+                            :via-relation-name source-relation-name})
+                         nil)))))
+>>>>>>> ai/suggestions-2025-09-15
+
+           (vec)))))))
 
 (defn traverse-single-path
   "Recursively traverses a single path from a subject to find matching resources.
@@ -208,10 +240,8 @@
                           sub-path
                           resource-type
                           cursor-eid)))
-                 (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity))))
-        ;(lazy-merge-dedupe-sort)
-        ; do we need dedupe here?
-        (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity)))))
+                 (lazy-merge-dedupe-sort))))
+        (lazy-merge-dedupe-sort)))))
 
 (defn can?
   "Optimized can? implementation using direct index traversal.
@@ -292,98 +322,96 @@
   For direct relations: Uses forward index from subject
   For arrow permissions: Uses reverse traversal - finds intermediates
   with permission first, then resources connected to them."
-  ([db subject-type subject-eid permission-name resource-type cursor-eid]
-   (traverse-permission-path db subject-type subject-eid permission-name resource-type cursor-eid #{}))
-  ([db subject-type subject-eid permission-name resource-type cursor-eid visited-paths]
+  ([db subject-type subject-eid permission-name resource-type cursor-eid limit]
+   (traverse-permission-path db subject-type subject-eid permission-name resource-type cursor-eid limit #{}))
+  ([db subject-type subject-eid permission-name resource-type cursor-eid limit visited-paths]
    ;; Cycle detection for traversal
    (let [path-key [subject-type subject-eid permission-name resource-type]]
      (if (contains? visited-paths path-key)
        []                                                   ; Return empty if we detect a traversal cycle
-       (let [updated-visited   (conj visited-paths path-key)
-             paths             (get-permission-paths db resource-type permission-name)
+       (let [updated-visited (conj visited-paths path-key)
+             paths           (get-permission-paths db resource-type permission-name)
              ;; For each path, determine traversal strategy
-             lazy-path-results (->> paths
-                                 (map (fn [{:as path, path-type :type}]
-                                        (case path-type
+             path-results    (->> paths
+                               (map (fn [{:as path, path-type :type}]
+                                      (case path-type
 
-                                          :relation
-                                          ;; Direct relation - forward traversal
-                                          (when (= subject-type (:subject-type path))
-                                            (let [tuple-attr  :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                                  start-tuple [subject-type subject-eid (:name path) resource-type 0] ;(or cursor-eid 0)]
-                                                  end-tuple   [subject-type subject-eid (:name path) resource-type Long/MAX_VALUE]]
-                                              (->> (d/index-range db tuple-attr start-tuple end-tuple)
-                                                (map (fn [datom]
-                                                       (let [resource-eid (extract-resource-id-from-rel-tuple-datom datom)]
-                                                         (when (> resource-eid (or cursor-eid 0))
-                                                           [resource-eid path]))))
-                                                (filter some?))))
+                                        :relation
+                                        ;; Direct relation - forward traversal
+                                        (when (= subject-type (:subject-type path))
+                                          (let [tuple-attr  :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                start-tuple [subject-type subject-eid (:name path) resource-type 0] ;(or cursor-eid 0)]
+                                                end-tuple   [subject-type subject-eid (:name path) resource-type Long/MAX_VALUE]]
+                                            (->> (d/index-range db tuple-attr start-tuple end-tuple)
+                                              (map (fn [datom]
+                                                     (let [resource-eid (extract-resource-id-from-rel-tuple-datom datom)]
+                                                       (when (> resource-eid (or cursor-eid 0))
+                                                         [resource-eid path]))))
+                                              (filter some?))))
 
-                                          :self-permission
-                                          ;; Self-permission: recursively find resources where subject has target permission
-                                          (let [target-permission (:target-permission path)]
-                                            ;; Recursively traverse with target permission to find matching resources
-                                            (traverse-permission-path db subject-type subject-eid
-                                              target-permission resource-type cursor-eid updated-visited))
+                                        :self-permission
+                                        ;; Self-permission: recursively find resources where subject has target permission
+                                        (let [target-permission (:target-permission path)]
+                                          ;; Recursively traverse with target permission to find matching resources
+                                          (traverse-permission-path db subject-type subject-eid
+                                            target-permission resource-type cursor-eid limit updated-visited))
 
-                                          :arrow
-                                          ;; Arrow permission - traverse using index-range
-                                          (let [via-relation      (:via path)
-                                                intermediate-type (:target-type path)]
-                                            (if (:target-relation path)
-                                              ;; Arrow to relation: find intermediates with that relation to subject
-                                              (let [target-relation         (:target-relation path)
-                                                    intermediate-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                                    intermediate-start      [subject-type subject-eid target-relation intermediate-type 0] ;cursor-eid] ; cursor-eid can be nil
-                                                    intermediate-end        [subject-type subject-eid target-relation intermediate-type Long/MAX_VALUE]
-                                                    intermediate-eids       (->> (d/index-range db intermediate-tuple-attr
-                                                                                   intermediate-start intermediate-end)
-                                                                              (map extract-resource-id-from-rel-tuple-datom))]
-                                                ;; Now find resources connected to these intermediates using index-range
-                                                (let [resource-seqs
-                                                      (map (fn [intermediate-eid]
-                                                             ;; Use forward index from intermediate to resources
-                                                             (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                                                   resource-start      [intermediate-type intermediate-eid via-relation resource-type 0] ;cursor-eid] ; cursor-eid can be nil
-                                                                   resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
-                                                               (->> (d/index-range db resource-tuple-attr resource-start resource-end)
-                                                                 (map extract-resource-id-from-rel-tuple-datom)
-                                                                 (filter #(> % (or cursor-eid 0)))
-                                                                 (map (fn [resource-eid] [resource-eid path])))))
-                                                        intermediate-eids)]
-                                                  ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
-                                                  (if (seq resource-seqs)
-                                                    (lazy-sort/lazy-fold2-merge-dedupe-sorted-by first resource-seqs)
-                                                    ;(lazy-merge-dedupe-sort-by first resource-seqs)
-                                                    [])))
-                                              ;; Arrow to permission: recursively find intermediates with permission
-                                              (let [target-permission    (:target-permission path)
-                                                    ;; First get all intermediates the subject has permission on
-                                                    intermediate-results (traverse-permission-path db subject-type subject-eid
-                                                                           target-permission
-                                                                           intermediate-type nil updated-visited) ; this nil is expensive. how to avoid?
-                                                    intermediate-eids    (map first intermediate-results)]
-                                                ;; Then find resources connected to these intermediates using index-range
-                                                (let [resource-seqs (->> intermediate-eids
-                                                                      (map (fn [intermediate-eid]
-                                                                             ;; Use forward index from intermediate to resources
-                                                                             (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                                                                   resource-start      [intermediate-type intermediate-eid via-relation resource-type 0] ;cursor-eid]
-                                                                                   resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
-                                                                               (->> (d/index-range db resource-tuple-attr resource-start resource-end)
-                                                                                 (map extract-resource-id-from-rel-tuple-datom)
-                                                                                 (filter #(> % (or cursor-eid 0)))
-                                                                                 (map (fn [resource-eid] [resource-eid path])))))))]
-                                                  ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
-                                                  (if (seq resource-seqs)
-                                                    (lazy-sort/lazy-fold2-merge-dedupe-sorted-by first resource-seqs)
-                                                    ;(lazy-merge-dedupe-sort-by first resource-seqs)
-                                                    []))))))))
-                                 (filter some?)
-                                 ;(lazy-merge-dedupe-sort-by first)
-                                 (lazy-sort/lazy-fold2-merge-dedupe-sorted-by first))] ; Merge results from all paths
-         ; why is this returning dupes?
-         lazy-path-results)))))
+                                        :arrow
+                                        ;; Arrow permission - traverse using index-range
+                                        (let [via-relation      (:via path)
+                                              intermediate-type (:target-type path)]
+                                          (if (:target-relation path)
+                                            ;; Arrow to relation: find intermediates with that relation to subject
+                                            (let [target-relation         (:target-relation path)
+                                                  intermediate-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                  intermediate-start      [subject-type subject-eid target-relation intermediate-type 0] ;cursor-eid] ; cursor-eid can be nil
+                                                  intermediate-end        [subject-type subject-eid target-relation intermediate-type Long/MAX_VALUE]
+                                                  intermediate-eids       (->> (d/index-range db intermediate-tuple-attr
+                                                                                 intermediate-start intermediate-end)
+                                                                            (map extract-resource-id-from-rel-tuple-datom))]
+                                              ;; Now find resources connected to these intermediates using index-range
+                                              (let [resource-seqs
+                                                    (map (fn [intermediate-eid]
+                                                           ;; Use forward index from intermediate to resources
+                                                           (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                                 resource-start      [intermediate-type intermediate-eid via-relation resource-type 0] ;cursor-eid] ; cursor-eid can be nil
+                                                                 resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
+                                                             (->> (d/index-range db resource-tuple-attr resource-start resource-end)
+                                                               (map extract-resource-id-from-rel-tuple-datom)
+                                                               (filter #(> % (or cursor-eid 0)))
+                                                               (map (fn [resource-eid] [resource-eid path])))))
+                                                      intermediate-eids)]
+                                                ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
+                                                (if (seq resource-seqs)
+                                                  (lazy-merge-dedupe-sort-by first resource-seqs)
+                                                  [])))
+                                            ;; Arrow to permission: recursively find intermediates with permission
+                                            (let [target-permission    (:target-permission path)
+                                                  ;; First get all intermediates the subject has permission on
+                                                  intermediate-results (traverse-permission-path db subject-type subject-eid
+                                                                         target-permission
+                                                                         intermediate-type nil Integer/MAX_VALUE updated-visited) ; this nil is expensive. how to avoid?
+                                                  intermediate-eids    (map first intermediate-results)]
+                                              ;; Then find resources connected to these intermediates using index-range
+                                              (let [resource-seqs (->> intermediate-eids
+                                                                    (map (fn [intermediate-eid]
+                                                                           ;; Use forward index from intermediate to resources
+                                                                           (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                                                 resource-start      [intermediate-type intermediate-eid via-relation resource-type 0] ;cursor-eid]
+                                                                                 resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
+                                                                             (->> (d/index-range db resource-tuple-attr resource-start resource-end)
+                                                                               (map extract-resource-id-from-rel-tuple-datom)
+                                                                               (filter #(> % (or cursor-eid 0)))
+                                                                               (map (fn [resource-eid] [resource-eid path])))))))]
+                                                ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
+                                                (if (seq resource-seqs)
+                                                  (lazy-merge-dedupe-sort-by first resource-seqs)
+                                                  []))))))))
+                               (filter some?)
+                               (lazy-merge-dedupe-sort-by first)) ; Merge results from all paths
+             ;; Take the requested limit from merged results
+             limited-results (take limit path-results)]
+         limited-results)))))
 
 (defn direct-match-datoms-in-relationship-index
   [db subject-type subject-eid relation-name resource-type resource-eid]
@@ -394,7 +422,7 @@
 (defn traverse-permission-path-via-subject
   "Subject must be known. Returns lazy seq of resource eids."
   [db subject-type subject-eid path resource-type cursor-eid]
-  ;(prn 'traverse-permission-path-via-subject 'cursor-eid cursor-eid)
+  (prn 'traverse-permission-path-via-subject 'cursor-eid cursor-eid)
   (case (:type path)
     :relation
     ;; Direct relation - forward traversal
@@ -411,7 +439,7 @@
     ;; Self-permission: recursively get resources where subject has target permission
     (let [target-permission (:target-permission path)]
       ;; Use traverse-permission-path to get resources where subject has target permission
-      (->> (traverse-permission-path db subject-type subject-eid target-permission resource-type cursor-eid #{})
+      (->> (traverse-permission-path db subject-type subject-eid target-permission resource-type cursor-eid Long/MAX_VALUE #{})
         (map first)                                         ; Extract resource-eids from [resource-eid path] tuples
         (filter (fn [resource-eid]
                   (and resource-eid (> resource-eid (or cursor-eid 0)))))))
@@ -441,12 +469,15 @@
                            (map extract-resource-id-from-rel-tuple-datom)
                            (filter some?)
                            (filter (fn [resource-eid]
+<<<<<<< HEAD
+                                     (and resource-eid (if cursor-eid (> resource-eid cursor-eid) true)))))))
+=======
                                      (and resource-eid (> resource-eid (or cursor-eid 0))))))))
+>>>>>>> ai/suggestions-2025-09-15
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq resource-seqs)
-              (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity resource-seqs)
-              ;(lazy-merge-dedupe-sort resource-seqs)
+              (lazy-merge-dedupe-sort resource-seqs)
               [])))
         ;; Arrow to permission
         (let [target-permission    (:target-permission path)
@@ -454,8 +485,7 @@
               intermediate-results (traverse-permission-path db subject-type subject-eid
                                      target-permission
                                      intermediate-type
-                                     nil
-                                     #{})
+                                     cursor-eid Long/MAX_VALUE #{})
               intermediate-eids    (map first intermediate-results)]
           ;; Now find resources connected to these intermediates using index-range
           (let [resource-seqs
@@ -471,9 +501,7 @@
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq resource-seqs)
-              ; why no dedupe here?
-              (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity resource-seqs)
-              ;(lazy-merge-dedupe-sort resource-seqs)
+              (lazy-merge-dedupe-sort resource-seqs)
               [])))))))
 
 (defn lazy-merged-lookup-resources
@@ -483,37 +511,30 @@
   (let [{subject-type :type
          subject-id   :id} subject
 
-        subject-eid         (d/entid db subject-id)
+        subject-eid    (d/entid db subject-id)
 
         {cursor-resource :resource} cursor
-        cursor-eid          (:id cursor-resource)           ; can be nil.
-        ; we can't validate cursor because may have been deleted since previous call.
-        ;_                   (prn 'lazy-merged-lookup-resources 'cursor cursor)
+        cursor-eid     (:id cursor-resource)                ; can be nil.
 
-        paths               (get-permission-paths db type permission)
-        path-seqs           (->> paths
-                              (keep (fn [path]
-                                      (let [results (traverse-permission-path-via-subject db subject-type subject-eid
-                                                      path type cursor-eid)]
-                                        (when (seq results)
-                                          results)))))      ; Already sorted by eid
+        paths          (get-permission-paths db type permission)
+        path-seqs      (->> paths
+                         (keep (fn [path]
+                                 (let [results (traverse-permission-path-via-subject db subject-type subject-eid
+                                                 path type cursor-eid)]
+                                   (when (seq results)
+                                     results)))))           ; Already sorted by eid
 
-        lazy-merged-results (if (seq path-seqs)
-                              (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity path-seqs)
-                              ;(lazy-merge-dedupe-sort path-seqs)
-                              [])]
-    lazy-merged-results))
+        merged-results (if (seq path-seqs)
+                         (lazy-merge-dedupe-sort path-seqs)
+                         [])]
+    merged-results))
 
 (defn lookup-resources
-  "Default :limit 1000.
-  Pass :limit -1 for all results (or any negative value)."
   [db {:as   query
        :keys [subject permission resource/type limit cursor]
        :or   {limit 1000}}]
   (let [merged-results  (lazy-merged-lookup-resources db query)
-        limited-results (if (>= limit 0)
-                          (take limit merged-results)
-                          merged-results)
+        limited-results (take limit merged-results)
         resources       (map #(spice-object type %) limited-results)
         last-resource   (last resources)
         next-cursor     {:resource (or last-resource (:resource cursor))}]
@@ -546,8 +567,7 @@
                                        target-path subject-type cursor-eid)))
                               (filter seq))]
       (if (seq path-seqs)
-        (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity path-seqs)
-        ;(lazy-merge-dedupe-sort path-seqs)
+        (lazy-merge-dedupe-sort path-seqs)
         []))
 
     :arrow
@@ -579,8 +599,7 @@
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq subject-seqs)
-              (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity subject-seqs)
-              ;(lazy-merge-dedupe-sort subject-seqs)
+              (lazy-merge-dedupe-sort subject-seqs)
               [])))
         ;; Arrow to permission:
         ;; 1. Use reverse index to find intermediates connected to resource via via-relation
@@ -602,14 +621,12 @@
                                                               sub-path subject-type cursor-eid)))
                                                      (filter seq))]
                                       (if (seq sub-seqs)
-                                        (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity sub-seqs)
-                                        ;(lazy-merge-dedupe-sort sub-seqs)
+                                        (lazy-merge-dedupe-sort sub-seqs)
                                         [])))
                                intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq subject-seqs)
-              (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity subject-seqs)
-              ;(lazy-merge-dedupe-sort subject-seqs)
+              (lazy-merge-dedupe-sort subject-seqs)
               [])))))))
 
 (defn lazy-merged-lookup-subjects
@@ -633,23 +650,19 @@
                                      results)))))
 
         merged-results (if (seq path-seqs)
-                         (lazy-sort/lazy-fold2-merge-dedupe-sorted-by identity path-seqs)
-                         ;(lazy-merge-dedupe-sort path-seqs)
+                         (lazy-merge-dedupe-sort path-seqs)
                          [])]
     merged-results))
 
 (defn lookup-subjects
   "Indexed implementation of lookup-subjects using direct index access.
-  Returns subjects that can access the given resource with the specified permission.
-  Pass :limit -1 for all results (can be slow)."
+  Returns subjects that can access the given resource with the specified permission."
   [db {:as   query
        :keys [resource permission subject/type limit cursor]
        :or   {limit 1000}}]
   {:pre [(:type resource) (:id resource)]}
   (let [merged-results  (lazy-merged-lookup-subjects db query)
-        limited-results (if (>= limit 0)
-                          (take limit merged-results)
-                          merged-results)
+        limited-results (take limit merged-results)
         subjects        (map #(spice-object type %) limited-results)
         last-subject    (last subjects)
         next-cursor     {:subject (or last-subject (:subject cursor))}]
@@ -657,18 +670,5 @@
      :cursor next-cursor}))
 
 (defn count-resources
-  "Returns {:keys [count cursor limit]}, where limit matches input.
-  Pass :limit -1 for all results."
-  [db {:as   query
-       :keys [limit cursor]
-       :or   {limit -1}}]
-  (let [merged-results  (lazy-merged-lookup-resources db query)
-        limited-results (if (>= limit 0)
-                          (take limit merged-results)
-                          merged-results)
-        resources       (map #(spice-object type %) limited-results)
-        last-resource   (last resources)
-        next-cursor     {:resource (or last-resource (:resource cursor))}]
-    {:count  (count limited-results)
-     :limit  limit
-     :cursor next-cursor}))
+  [db query]
+  (count (lazy-merged-lookup-resources db query)))

--- a/test/eacl/datomic/fixtures.clj
+++ b/test/eacl/datomic/fixtures.clj
@@ -5,6 +5,7 @@
 
 ; These are helpers specific to CA (todo move out):
 (def ->user (partial spice-object :user))
+(def ->group (partial spice-object :group)) ; new: to test multi-type support on Permission.
 (def ->team (partial spice-object :team))
 (def ->server (partial spice-object :server))
 (def ->platform (partial spice-object :platform))
@@ -77,10 +78,11 @@
 
    ; Accounts:
    (Relation :account :owner :user)                         ; Account has an owner (a user)
+   (Relation :account :owner :group)                        ; to demonstrate multiple subject types permission.
    (Relation :account :platform :platform)
 
    ; definition account { permission admin = owner + platform->super_admin }
-   (Permission :account :admin {:relation :owner})          ; Owner of account gets admin on account
+   (Permission :account :admin {:relation :owner})          ; Owner of account gets admin on account (can be :user or :group)
    (Permission :account :admin {:arrow :platform :relation :super_admin})
 
    ; definition account { permission view = owner + platform->super_admin }
@@ -215,6 +217,11 @@
     :db/ident :test/user2
     :eacl/id  "user-2"}
 
+   ; Group 1 (to test multiple subject types for account :owner relation):
+   {:db/id    "group-1"
+    :db/ident :test/group1
+    :eacl/id  "group-1"}
+
    ; Super User can do all the things:
    {:db/id    "super-user"
     :db/ident :user/super-user
@@ -307,6 +314,8 @@
    (Relationship (->user "super-user") :super_admin (->platform "platform"))
 
    (Relationship (->user "user-2") :owner (->account "account-2"))
+
+   (Relationship (->group "group-1") :owner (->account "account-1")) ; new.
 
    (Relationship (->platform "platform") :platform (->account "account-1"))
    (Relationship (->platform "platform") :platform (->account "account-2"))

--- a/test/eacl/datomic/impl/indexed_test.clj
+++ b/test/eacl/datomic/impl/indexed_test.clj
@@ -3,7 +3,7 @@
             [clojure.tools.logging :as log]
             [datomic.api :as d]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
-            [eacl.datomic.fixtures :as fixtures :refer [->user ->server ->account ->vpc ->nic ->network ->lease ->backup ->backup-schedule]]
+            [eacl.datomic.fixtures :as fixtures :refer [->user ->group ->server ->account ->vpc ->nic ->network ->lease ->backup ->backup-schedule]]
             [eacl.core :as eacl :refer [spice-object]]
             [eacl.datomic.schema :as schema]
             [eacl.lazy-merge-sort :refer [lazy-merge-dedupe-sort]]
@@ -239,11 +239,16 @@
     (testing "We can enumerate subjects that can access a resource."
       ; Bug: currently returns the subject itself which needs a fix.
       (is (= #{(->user "user-1")
-               ;(spice-object :account "account-1")
                (->user "super-user")}
             (->> (lookup-subjects db {:resource     (->server (d/entid db :test/server1))
                                       :permission   :view
                                       :subject/type :user})
+              (paginated->spice-set db))))
+
+      (is (= #{(->group "group-1")}
+            (->> (lookup-subjects db {:resource     (->server (d/entid db :test/server1))
+                                      :permission   :view
+                                      :subject/type :group})
               (paginated->spice-set db))))
 
       (testing ":test/user2 is only subject who can delete :test/server2"
@@ -450,9 +455,9 @@
             server1  (d/entity db :test/server1)]
         (is (> (:db/id account1) (:db/id server1)))))
 
-    (testing "what happens when find-relation-def is called with source-relation-name `:self`?"
-      ; what do we expect here?
-      (is (nil? (impl.indexed/find-relation-def db :server :self))))
+    ;(testing "what happens when find-relation-def is called with source-relation-name `:self`?"
+    ;  ; what do we expect here?
+    ;  (is (nil? (impl.indexed/find-relation-def db :server :self))))
 
     (testing "lookup of :view against :vpc works"
       (is (= #{(->vpc "vpc-1")
@@ -737,11 +742,11 @@
                 (is (empty? (paginated-data->spice db' page3-data))))
 
               (testing "lookup-resources returns cursor input when looking beyond any values"
-                (let [page3-empty (lookup-resources db'{:limit         100
-                                                        :cursor        page2-cursor
-                                                        :resource/type :account
-                                                        :permission    :view
-                                                        :subject       (->user super-user-eid)})]
+                (let [page3-empty (lookup-resources db' {:limit         100
+                                                         :cursor        page2-cursor
+                                                         :resource/type :account
+                                                         :permission    :view
+                                                         :subject       (->user super-user-eid)})]
                   (is (empty? (:data page3-empty)))
                   (is (= page2-cursor (:cursor page3-empty)))))
 
@@ -821,11 +826,11 @@
         (is (nil? (impl.indexed/find-relation-def db nil :something)))
         (is (nil? (impl.indexed/find-relation-def db :something nil))))
 
-    (testing "find-relation-def"
-      (is (= {:eacl.relation/subject-type  :account
-              :eacl.relation/resource-type :server
-              :eacl.relation/relation-name :account}
-            (impl.indexed/find-relation-def db :server :account))))
+    ;(testing "find-relation-def"
+    ;  (is (= {:eacl.relation/subject-type  :account
+    ;          :eacl.relation/resource-type :server
+    ;          :eacl.relation/relation-name :account}
+    ;        (impl.indexed/find-relation-def db :server :account))))
 
     (testing "find-permission-defs"
       (is (pos? (count (impl.indexed/find-permission-defs db :server :view))))
@@ -835,33 +840,21 @@
   (let [db (d/db *conn*)]
     (testing "Direct permission paths"
       (let [paths (impl.indexed/get-permission-paths db :account :view)]
-        ;; :account :view has both direct (owner) and arrow (platform->platform_admin) paths
-        (is (= 2 (count paths)))
+        ;; :account :view has direct (owner) and arrow (platform->super_admin) paths
+        ;; Direct owner now returns two paths due to polymorphic :user and :group
+        (is (= 3 (count paths)))
         (is (some #(and (= (:type %) :relation)
                      (= (:name %) :owner)
                      (= (:subject-type %) :user))
+              paths))
+        (is (some #(and (= (:type %) :relation)
+                     (= (:name %) :owner)
+                     (= (:subject-type %) :group))
               paths))
         (is (some #(and (= (:type %) :arrow)
                      (= (:via %) :platform)
                      (= (:target-type %) :platform))
               paths))))
-
-    ;(testing "Arrow permission to relation"
-    ; these tests currently broken because fixtures changed.
-    ;  (let [paths (impl.indexed/get-permission-paths db :server :view)]
-    ;
-    ;    (prn 'paths paths)
-    ;    ;; Should have multiple paths: direct and arrow
-    ;    (is (> (count paths) 1))
-    ;    ;; Check for direct path through shared_admin
-    ;    (is (some #(and (= (:type %) :relation)
-    ;                    (= (:name %) :shared_admin))
-    ;              paths))
-    ;    ;; Check for arrow path through account
-    ;    (is (some #(and (= (:type %) :arrow)
-    ;                    (= (:via %) :account)
-    ;                    (= (:target-type %) :account))
-    ;              paths))))
 
     (testing "Arrow permission to permission"
       (let [paths (impl.indexed/get-permission-paths db :vpc :admin)]


### PR DESCRIPTION
Note that until `eacl/write-schema!` lands, cache is only evicted on startup. So if you make permission schema changes at runtime, you need to run `evict-permission-paths-cache!`