### PR TITLE
Fix count-resources cursor type and ID coercion

### DIFF
--- a/src/eacl/datomic/core.clj
+++ b/src/eacl/datomic/core.clj
@@ -158,7 +158,8 @@
   [db
    {:as   opts
     :keys [spice-object->internal
-           spice-cursor->internal]}
+           spice-cursor->internal
+           internal-cursor->spice]}
    {:as query :keys [subject]}]
   (let [subject-ent (spice-object->internal db subject)]
     (assert (:id subject-ent) (str "subject passed to count-resources does not exist: " (pr-str subject)))
@@ -166,7 +167,8 @@
     (->> query
          (S/setval [:subject] subject-ent)
          (S/transform [:cursor] #(spice-cursor->internal db opts %))
-         (impl/count-resources db))))
+         (impl/count-resources db)
+         (S/transform [:cursor] #(internal-cursor->spice db opts %)))))
 
 (defn spiceomic-lookup-subjects
   [db

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -683,12 +683,13 @@
   Pass :limit -1 for all results."
   [db {:as   query
        :keys [limit cursor]
+       resource-type :resource/type
        :or   {limit -1}}]
   (let [merged-results  (lazy-merged-lookup-resources db query)
         limited-results (if (>= limit 0)
                           (take limit merged-results)
                           merged-results)
-        resources       (map #(spice-object type %) limited-results)
+        resources       (map #(spice-object resource-type %) limited-results)
         last-resource   (last resources)
         next-cursor     {:resource (or last-resource (:resource cursor))}]
     {:count  (count limited-results)

--- a/test/eacl/datomic/config_test.clj
+++ b/test/eacl/datomic/config_test.clj
@@ -44,9 +44,9 @@
                                                                 :permission    :view
                                                                 :resource/type :server})))))
 
-          (is (= 2 (eacl/count-resources client {:subject       (->user :test/user1)
-                                                 :permission    :view
-                                                 :resource/type :server})))
+          (is (= 2 (:count (eacl/count-resources client {:subject       (->user :test/user1)
+                                                                :permission    :view
+                                                                :resource/type :server}))))
 
           (is (= 2 (count (:data (eacl/lookup-subjects client {:resource     (->server :test/server1)
                                                                :permission   :view

--- a/test/eacl/spice_test.clj
+++ b/test/eacl/spice_test.clj
@@ -321,6 +321,23 @@
           (is (= (:id (last (:data page2)))
                  (get-in page2-cursor [:resource :id]))))))
 
+    (testing "count-resources returns cursor with correct type and coerced ID (issue #47)"
+      (let [{:keys [count cursor]} (eacl/count-resources *client
+                                                          {:subject       (->user "super-user")
+                                                           :permission    :view
+                                                           :resource/type :server
+                                                           :limit         2})]
+        (testing "count-resources returns a count"
+          (is (pos? count)))
+
+        (testing "cursor resource type should be a keyword, not clojure.core/type function"
+          (is (keyword? (get-in cursor [:resource :type]))
+              "Bug #47: cursor :type was clojure.core/type function instead of resource type keyword"))
+
+        (testing "cursor resource id should be coerced to external format (string), not internal eid (long)"
+          (is (string? (get-in cursor [:resource :id]))
+              "Bug #47: cursor :id was not coerced to external format"))))
+
     (testing "spice-read-relationships results are constrained by filters for resource type & ID"
       (testing "transact the test entities we are about to use"
         @(d/transact conn (for [object [(->account "test-account")


### PR DESCRIPTION
## Summary
- Fix `count-resources` missing `resource/type` destructuring, which caused `:type` in cursor to be `clojure.core/type` function instead of resource type keyword
- Add cursor ID coercion in `spiceomic-count-resources` to match `spiceomic-lookup-resources` behavior

Fixes #47

## Test plan
- [ ] Reload namespaces and run `(run-tests 'eacl.spice-test)`
- [ ] Verify cursor `:type` is a keyword after calling `count-resources`
- [ ] Verify cursor `:id` is coerced to external format

🤖 Generated with [Claude Code](https://claude.com/claude-code)