### PR TITLE
Use client-lifecycle schema caches; harden counts and tuple integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ Situated AuthZ offers some advantages for typical use-cases:
 - The performance goal for EACL is to handle 10M permissioned entities with real-time performance.
 - EACL does not support all SpiceDB features. Please refer to the [limitations section](#limitations-deficiencies--gotchas) to decide if EACL is right for you.
 - Presently, EACL has _no result cache_ because graph traversal is fast enough over Datomic's aggressive datom caching even for ~1M permissioned resources. A cache is planned and once it lands, should bring query latency down to ~1-2ms per API call, even for large pages.
-- EACL does cache resolved *permission paths*. Cache entries are scoped by an exact fingerprint of the EACL definition datoms visible in the `db` value you query, so two `db` values share a cached path set only when their schemas are identical — however the schema changed. That means `write-schema!`, a raw `d/transact` of `Relation`/`Permission` maps, an excision, a `d/filter` that hides definitions and a speculative `d/with` database each resolve against their own schema, and none of them can publish paths under another's key. There is nothing to invalidate manually.
-  - The fingerprint is `O(number of definitions)` — never `O(number of relationships)` — and is memoised on the `db` value itself, so it is computed once per `db` value you query and never again. An unrelated `d/transact` yields a new `db` value with the *same* fingerprint, so relationship write load re-verifies the (small) definition index once and every permission-path entry still hits: no path is ever recomputed unless the definitions actually changed (issue #74).
-  - The cost that remains is one definition-index scan per new `db` value. If your database advances between essentially every `can?` — and your schema is very large — that scan is on the hot path. It is a few microseconds for a normal schema; see the `permission-check-benchmark` in `test/eacl/bench/pagination_test.clj` for warm and cold numbers.
-  - `:eacl/schema-version` is still stamped by `write-schema!`, but it is now informational (a readable schema generation, including under `d/as-of`) rather than the cache key.
+- EACL caches resolved *permission paths* for one client schema generation. `make-client` reads `:eacl/schema-version` once from the schema entity; ordinary authorization calls do not reread it, scan definitions, key by `db`, or retain Datomic database values. Unrelated transactions therefore leave a hot client cache untouched even when the connection advances for every request.
+  - `eacl/write-schema!` is the required schema mutation boundary. Calling it through a client atomically swaps that client's generation after the schema transaction. An identical write keeps the existing generation hot.
+  - If another client or process changes schema, recreate existing clients. `eacl.datomic.integrity/client-schema-status` is an explicit one-entity diagnostic for detecting an outdated client; it is never invoked on the authorization hot path.
+  - Low-level calls against arbitrary `db`, `d/as-of`, `d/with`, or filtered values are deliberately uncached. EACL does not provide time-travel semantics for a connection-backed client, and speculative/historic evaluation cannot publish paths into its cache.
+  - A fresh database with no schema stamp remains uncached until its first `write-schema!`; this is not a v6 compatibility mode.
 - Acyclic lookup cursors retain a per-permission-path intermediate frontier. Later pages resume each arrow path at the earliest intermediate that can still contribute, and permanently skip paths exhausted in that scan direction. This prevents deep pages from repeatedly scanning intermediates that were already proved irrelevant.
 - Acyclic lookup performance should scale roughly with permission graph complexity * `O(logN)` for `N` resources in terminal resource Relationship indices. Recursive lookup pages are deterministic traversal-order pages with request-local dedupe; they avoid materializing the full closure, but late pages replay the traversal prefix instead of seeking directly to a global sort key. Subjects are typically sparse compared to resources, i.e. 1k users will have access to 1M resources – rarely the other way around.
 
@@ -59,7 +60,7 @@ Public `eacl3_` cursors are string-safe AES-GCM envelopes. Authentication is req
 > [!WARNING]
 > EACL is under active development.
 > I try hard not to introduce breaking changes, but if data structures change, the major version will increment.
-> v7.3 is the current development version of EACL. It retains the v7.2 pagination API and recursive traversal engine, and adds direction-scoped cursor frontiers for deep acyclic lookup pages. Releases are not tagged yet, so pin the Git SHA.
+> The changes on this branch are the v7.4 candidate (they may be released as a v7.3 patch because v7.3 is recent). They retain the pagination API, replace per-`db` schema fingerprints with client-lifecycle caches, and add bounded counting/integrity diagnostics. Releases are not tagged yet, so pin the Git SHA.
 > Upgrading from v6? The relationship storage model changed — follow the [v6 → v7 migration guide](docs/migration-v6-to-v7.md).
 
 ## ReBAC: Relationship-based Access Control
@@ -123,6 +124,10 @@ The `IAuthorization` protocol in [src/eacl/core.clj](src/eacl/core.clj) defines 
 - `(eacl/lookup-subjects acl filters) => {:data [subjects...] :page-info {...}}`
 - `(eacl/lookup-resources acl filters) => {:data [resources...] :page-info {...}}`
 - `(eacl/count-resources acl filters) => {:keys [count limit]}` counts the full result set.
+- `(eacl/count-subjects acl filters) => {:keys [count limit]}` counts the full subject result set.
+
+Pass `:count-limit n` to either count operation to bound work. The result then includes
+`:truncated?`; `true` means at least one additional result exists.
 
 ### Relationship Maintenance
 
@@ -131,7 +136,7 @@ The `IAuthorization` protocol in [src/eacl/core.clj](src/eacl/core.clj) defines 
   - where `updates` is a collection of `[operation relationship]`, and `operation` is one of `:create`, `:touch` or `:delete`.
 - `(eacl/create-relationships! acl relationships)` simply calls `write-relationships!` with `:create` operation.
 - `(eacl/delete-relationships! acl relationships)` simply calls `write-relationships!` with `:delete` operation.
-- `(eacl/delete-object! acl object) => {:zed/token 'db-basis, :retracted-datoms n}` removes every relationship touching `object`, in both directions. Call this before retracting a permissioned entity — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
+- `(eacl/delete-object! acl object) => {:zed/token 'db-basis, :retracted-datoms n}` is a convenience helper that removes every relationship touching `object`, in both directions. Consumers are expected to delete relationships before retracting a permissioned entity — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
 
 All list APIs use the v7.3 pagination contract:
 
@@ -146,6 +151,11 @@ All list APIs use the v7.3 pagination contract:
 - `(eacl/write-schema! acl schema-string)` parses a SpiceDB schema DSL string, validates it, computes deltas against existing schema, checks for orphaned relationships, and transacts changes atomically.
 - `(eacl/read-schema acl)` returns the current schema as a map of `{:relations [...] :permissions [...]}`.
 - `(eacl/expand-permission-tree acl filters)` is not impl. yet. It is a low priority to implement.
+
+All schema changes must use `eacl/write-schema!`. EACL clients deliberately do not detect raw
+definition transactions on every authorization call. After an out-of-band schema write, recreate
+other clients (or call `eacl.datomic.integrity/client-schema-status` explicitly to detect the
+generation mismatch).
 
 ### Example Queries
 
@@ -481,7 +491,7 @@ The default options are to use the built-in EACL string attr `:eacl/id`, but you
 
 `make-client` validates its options: unknown keys throw `{:type :eacl/invalid-config}` (a silently dropped ID-coercion key would mean silently wrong external IDs). `:entity->object-id` (`(fn [entity] id)`) is a deprecated alias for `:entid->object-id`; supplying both throws. Page tokens expire after 5 minutes by default; tune with `:page-token-ttl-seconds`.
 
-`:recursive-traversal-limits` raises the safety ceilings on recursive permission traversal (see [Limitations](#limitations-deficiencies--gotchas)):
+`:recursive-traversal-limits` tunes hard safety ceilings on recursive permission traversal (see [Limitations](#limitations-deficiencies--gotchas)):
 
 ```clojure
 (def acl (eacl.datomic.core/make-client conn
@@ -489,6 +499,8 @@ The default options are to use the built-in EACL string attr `:eacl/id`, but you
 ```
 
 Keys you omit keep their defaults (`eacl.datomic.impl.indexed/default-recursive-traversal-limits`), so a partial override cannot silently disable the limits it does not mention.
+These are heap-protection limits, not ordinary page-size controls. Prefer `:count-limit` for
+situated authorization counts; raise traversal ceilings only after load-testing the host JVM.
 
 For multi-peer deployments, configure a shared page-token key so `eacl3_...` cursors survive restarts and can be decoded by every peer:
 
@@ -502,13 +514,13 @@ For multi-peer deployments, configure a shared page-token key so `eacl3_...` cur
 
 EACL follows SpiceDB semantics for object IDs that don't resolve to an entity:
 
-- **Reads** (`can?`, `lookup-resources`, `lookup-subjects`, `count-resources`, `read-relationships`) treat unknown IDs as matching nothing: `can?` returns `false`, lookups and reads return empty pages.
+- **Reads** (`can?`, `lookup-resources`, `lookup-subjects`, `count-resources`, `count-subjects`, `read-relationships`) treat unknown IDs as matching nothing: `can?` returns `false`, lookups and reads return empty pages.
 - **Writes** (`write-relationships!` and friends) throw `ex-info {:type :eacl/unknown-object, :object {:type … :id …}}` — a relationship to a nonexistent entity is unsatisfiable, and failing loudly beats minting ghost entities or raw Datomic errors.
 
 ### Deleting a permissioned entity
 
 > [!IMPORTANT]
-> `:db.fn/retractEntity` does **not** remove an entity's EACL relationships. Call `eacl/delete-object!` first.
+> `:db.fn/retractEntity` does **not** remove an entity's EACL relationships. Delete those relationships first; `eacl/delete-object!` is a convenience helper for doing so.
 
 A v7 relationship is two datoms living on two different entities, each naming its peer *inside a tuple value*:
 
@@ -519,7 +531,8 @@ A v7 relationship is two datoms living on two different entities, each naming it
 
 Datomic's `:db.fn/retractEntity` follows `:db.type/ref` *attributes*; it does not follow ref-typed *components of a heterogeneous tuple* (and a heterogeneous tuple cannot be `:db/isComponent`). So retracting a permissioned entity directly removes only the half stored on that entity and leaves the peer's half behind, where it keeps answering queries — a deleted resource still passes `can?`, a deleted subject still appears in `lookup-subjects` — and the survivor is unreachable through `write-relationships!`, because resolving either endpoint now throws `:eacl/unknown-object`.
 
-Delete relationships first, then the entity:
+The expected workflow is to call `eacl/delete-relationships!` for relationships known by the
+consumer, then retract the entity. `delete-object!` is a convenient catch-all:
 
 ```clojure
 (eacl/delete-object! acl (->account "acme"))   ; removes both halves of every relationship touching it
@@ -537,11 +550,17 @@ Or in one application transaction, using the tx-data directly:
 
 `delete-object!` retracts relationships only — retracting the entity itself stays your call. It is idempotent, and it also accepts the raw eid of an entity you already retracted, which is how you clean up after the fact.
 
-To find and repair relationships orphaned by earlier bare `retractEntity` calls (an offline maintenance pass — it scans both relationship indexes):
+EACL does not prevent direct `:db.fn/retractEntity` calls or add existence probes to every read.
+To detect and repair relationship halves left by such calls, use the explicit offline integrity
+API (it scans both relationship indexes):
 
 ```clojure
-(take 10 (impl/orphaned-relationship-halves (d/db conn)))     ; inspect
-@(d/transact conn (impl/tx-retract-orphaned-relationships (d/db conn)))
+(require '[eacl.datomic.integrity :as integrity])
+
+(integrity/dangling-relationship-report (d/db conn) {:sample-size 20})
+
+(doseq [tx-data (integrity/repair-tx-batches (d/db conn) {:batch-size 1000})]
+  @(d/transact conn tx-data))
 ```
 
 ## Schema Syntax
@@ -563,21 +582,12 @@ EACL uses the SpiceDB schema DSL. Use `eacl/write-schema!` to define your schema
    }")
 ```
 
-### Advanced: Programmatic Schema (Optional)
+### Internal Definition Records
 
-For advanced use cases, you can also define schema programmatically using the internal `Relation` and `Permission` functions:
-
-> Programmatic definition changes take effect immediately: the permission-path cache is scoped by a fingerprint of the definition datoms themselves, not by `write-schema!`'s version stamp (see the caching note above). You still lose `write-schema!`'s parse-time validation, reference checking and orphaned-relationship guard, so prefer `write-schema!` where you can.
-
-```clojure
-(require '[eacl.datomic.impl :refer [Relation Permission]])
-
-@(d/transact conn
-  [(Relation :account :owner :user)
-   (Permission :account :admin {:relation :owner})
-   (Relation :server :account :account)
-   (Permission :server :admin {:arrow :account :permission :admin})])
-```
+`eacl.datomic.impl/Relation` and `Permission` are implementation records used by migrations and
+tests. Transacting them directly is not a supported schema API: it bypasses validation, the
+schema-generation stamp, and client cache replacement. Use `eacl/write-schema!` for every schema
+change. If an operational tool bypasses that boundary, recreate every affected client.
 
 `Permission` supports the following spec syntax:
 - `{:relation some_relation}` - direct permission via relation
@@ -652,8 +662,8 @@ Now you can transact relationships. The usual way is `eacl/create-relationships!
 - `subject.relation` is not currently supported. It's useful for group memberships.
 - `expand-permission-tree` is not implemented yet.
 - *No cache:* EACL does not presently have a result cache, because Datomic Peers cache datoms aggressively and queries so far are fast enough. A cache is planned. (Resolved *permission paths* are cached — see [Performance](#performance).)
-- *Deleting entities:* `:db.fn/retractEntity` does not remove an entity's relationships. Call `eacl/delete-object!` first — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
-- *Recursive permissions do not paginate cheaply:* a permission that transitively depends on itself (`permission read = reader + parent->read`) is evaluated in traversal order, and each page resumes by replaying the traversal prefix and discarding results up to the cursor. Work per page therefore grows with the page's offset — enumerating `N` results is `O(N²/page-size)` — and a single page is capped by `:max-derived-grants` (default 100 000), so a recursive permission with a very large grant set starts failing on *deep* pages while page 1 still succeeds. Raise the ceiling with `make-client`'s `:recursive-traversal-limits` (it is a memory bound), or model the permission acyclically. Acyclic permissions have no such limit: they resume from per-path cursor frontiers and cost `O(log N)` per page.
+- *Deleting entities:* `:db.fn/retractEntity` does not remove an entity's relationships. Consumers should delete relationships first; `delete-object!` is a convenience helper, and `eacl.datomic.integrity` provides explicit detection/repair — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
+- *Recursive permissions do not paginate cheaply:* a permission that transitively depends on itself (`permission read = reader + parent->read`) is evaluated in traversal order, and each page resumes by replaying the traversal prefix and discarding results up to the cursor. Enumerating `N` results is therefore `O(N²/page-size)`. Fixing that without moving unbounded traversal state into page tokens requires a persisted effective-grant index; see `docs/plans/2026-05-17-recursive-pagination-effective-grants-plan.md`. Until then, bare recursive `:last` is rejected, recursive work has hard heap-protection ceilings, and counts use one traversal rather than page replay. Use `:count-limit` to bound count work; do not raise `:recursive-traversal-limits` without JVM load tests. Acyclic pages seek from cursor frontiers and do not have this replay cost.
 - *Return order:* Acyclic EACL lookups enumerate in Datomic eid order and relationship reads enumerate in tuple-index order. Recursive lookups enumerate in deterministic traversal order. SpiceDB returns results in discovery or schema order. You should not rely on either system's order as a domain sort order.
 
 ## How to Run All Tests

--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Situated AuthZ offers some advantages for typical use-cases:
 - The performance goal for EACL is to handle 10M permissioned entities with real-time performance.
 - EACL does not support all SpiceDB features. Please refer to the [limitations section](#limitations-deficiencies--gotchas) to decide if EACL is right for you.
 - Presently, EACL has _no result cache_ because graph traversal is fast enough over Datomic's aggressive datom caching even for ~1M permissioned resources. A cache is planned and once it lands, should bring query latency down to ~1-2ms per API call, even for large pages.
-- EACL does cache resolved *permission paths*. The cache is invalidated **only by `eacl/write-schema!`**, which bumps a schema-version stamp (`:eacl/schema-version`) stored in the database in the same transaction as the definition change — so invalidation reaches every peer, `d/as-of` views resolve the paths of their own era, and unrelated `d/transact` calls never touch a cache key (zero per-transaction overhead — issue #74). Editing relation/permission datoms outside `write-schema!` is not detected by design; if you must, call `eacl.datomic.impl.indexed/evict-permission-paths-cache!` on every peer afterwards.
+- EACL does cache resolved *permission paths*. Cache entries are scoped by an exact fingerprint of the EACL definition datoms visible in the `db` value you query, so two `db` values share a cached path set only when their schemas are identical — however the schema changed. That means `write-schema!`, a raw `d/transact` of `Relation`/`Permission` maps, an excision, a `d/filter` that hides definitions and a speculative `d/with` database each resolve against their own schema, and none of them can publish paths under another's key. There is nothing to invalidate manually.
+  - The fingerprint is `O(number of definitions)` — never `O(number of relationships)` — and is memoised on the `db` value itself, so it is computed once per `db` value you query and never again. An unrelated `d/transact` yields a new `db` value with the *same* fingerprint, so relationship write load re-verifies the (small) definition index once and every permission-path entry still hits: no path is ever recomputed unless the definitions actually changed (issue #74).
+  - The cost that remains is one definition-index scan per new `db` value. If your database advances between essentially every `can?` — and your schema is very large — that scan is on the hot path. It is a few microseconds for a normal schema; see the `permission-check-benchmark` in `test/eacl/bench/pagination_test.clj` for warm and cold numbers.
+  - `:eacl/schema-version` is still stamped by `write-schema!`, but it is now informational (a readable schema generation, including under `d/as-of`) rather than the cache key.
 - Acyclic lookup cursors retain a per-permission-path intermediate frontier. Later pages resume each arrow path at the earliest intermediate that can still contribute, and permanently skip paths exhausted in that scan direction. This prevents deep pages from repeatedly scanning intermediates that were already proved irrelevant.
 - Acyclic lookup performance should scale roughly with permission graph complexity * `O(logN)` for `N` resources in terminal resource Relationship indices. Recursive lookup pages are deterministic traversal-order pages with request-local dedupe; they avoid materializing the full closure, but late pages replay the traversal prefix instead of seeking directly to a global sort key. Subjects are typically sparse compared to resources, i.e. 1k users will have access to 1M resources – rarely the other way around.
 
@@ -128,6 +131,7 @@ The `IAuthorization` protocol in [src/eacl/core.clj](src/eacl/core.clj) defines 
   - where `updates` is a collection of `[operation relationship]`, and `operation` is one of `:create`, `:touch` or `:delete`.
 - `(eacl/create-relationships! acl relationships)` simply calls `write-relationships!` with `:create` operation.
 - `(eacl/delete-relationships! acl relationships)` simply calls `write-relationships!` with `:delete` operation.
+- `(eacl/delete-object! acl object) => {:zed/token 'db-basis, :retracted-datoms n}` removes every relationship touching `object`, in both directions. Call this before retracting a permissioned entity — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
 
 All list APIs use the v7.3 pagination contract:
 
@@ -477,6 +481,15 @@ The default options are to use the built-in EACL string attr `:eacl/id`, but you
 
 `make-client` validates its options: unknown keys throw `{:type :eacl/invalid-config}` (a silently dropped ID-coercion key would mean silently wrong external IDs). `:entity->object-id` (`(fn [entity] id)`) is a deprecated alias for `:entid->object-id`; supplying both throws. Page tokens expire after 5 minutes by default; tune with `:page-token-ttl-seconds`.
 
+`:recursive-traversal-limits` raises the safety ceilings on recursive permission traversal (see [Limitations](#limitations-deficiencies--gotchas)):
+
+```clojure
+(def acl (eacl.datomic.core/make-client conn
+           {:recursive-traversal-limits {:max-derived-grants 1000000}}))
+```
+
+Keys you omit keep their defaults (`eacl.datomic.impl.indexed/default-recursive-traversal-limits`), so a partial override cannot silently disable the limits it does not mention.
+
 For multi-peer deployments, configure a shared page-token key so `eacl3_...` cursors survive restarts and can be decoded by every peer:
 
 ```clojure
@@ -491,6 +504,45 @@ EACL follows SpiceDB semantics for object IDs that don't resolve to an entity:
 
 - **Reads** (`can?`, `lookup-resources`, `lookup-subjects`, `count-resources`, `read-relationships`) treat unknown IDs as matching nothing: `can?` returns `false`, lookups and reads return empty pages.
 - **Writes** (`write-relationships!` and friends) throw `ex-info {:type :eacl/unknown-object, :object {:type … :id …}}` — a relationship to a nonexistent entity is unsatisfiable, and failing loudly beats minting ghost entities or raw Datomic errors.
+
+### Deleting a permissioned entity
+
+> [!IMPORTANT]
+> `:db.fn/retractEntity` does **not** remove an entity's EACL relationships. Call `eacl/delete-object!` first.
+
+A v7 relationship is two datoms living on two different entities, each naming its peer *inside a tuple value*:
+
+```
+[<subject-eid>  :eacl.v7.relationship/subject-type+relation+resource-type+resource  [subject-type relation-eid resource-type <resource-eid>]]
+[<resource-eid> :eacl.v7.relationship/resource-type+relation+subject-type+subject   [resource-type relation-eid subject-type <subject-eid>]]
+```
+
+Datomic's `:db.fn/retractEntity` follows `:db.type/ref` *attributes*; it does not follow ref-typed *components of a heterogeneous tuple* (and a heterogeneous tuple cannot be `:db/isComponent`). So retracting a permissioned entity directly removes only the half stored on that entity and leaves the peer's half behind, where it keeps answering queries — a deleted resource still passes `can?`, a deleted subject still appears in `lookup-subjects` — and the survivor is unreachable through `write-relationships!`, because resolving either endpoint now throws `:eacl/unknown-object`.
+
+Delete relationships first, then the entity:
+
+```clojure
+(eacl/delete-object! acl (->account "acme"))   ; removes both halves of every relationship touching it
+@(d/transact conn [[:db.fn/retractEntity account-eid]])
+```
+
+Or in one application transaction, using the tx-data directly:
+
+```clojure
+(require '[eacl.datomic.impl :as impl])
+
+@(d/transact conn (conj (impl/tx-delete-object (d/db conn) account-eid)
+                        [:db.fn/retractEntity account-eid]))
+```
+
+`delete-object!` retracts relationships only — retracting the entity itself stays your call. It is idempotent, and it also accepts the raw eid of an entity you already retracted, which is how you clean up after the fact.
+
+To find and repair relationships orphaned by earlier bare `retractEntity` calls (an offline maintenance pass — it scans both relationship indexes):
+
+```clojure
+(take 10 (impl/orphaned-relationship-halves (d/db conn)))     ; inspect
+@(d/transact conn (impl/tx-retract-orphaned-relationships (d/db conn)))
+```
 
 ## Schema Syntax
 
@@ -515,7 +567,7 @@ EACL uses the SpiceDB schema DSL. Use `eacl/write-schema!` to define your schema
 
 For advanced use cases, you can also define schema programmatically using the internal `Relation` and `Permission` functions:
 
-> **Cache caveat:** transacting `Relation`/`Permission` datoms directly bypasses `write-schema!`'s cache invalidation (see the caching note above). After a programmatic schema change, call `(eacl.datomic.impl.indexed/evict-permission-paths-cache!)` on every peer — or prefer `write-schema!`, which handles this for you.
+> Programmatic definition changes take effect immediately: the permission-path cache is scoped by a fingerprint of the definition datoms themselves, not by `write-schema!`'s version stamp (see the caching note above). You still lose `write-schema!`'s parse-time validation, reference checking and orphaned-relationship guard, so prefer `write-schema!` where you can.
 
 ```clojure
 (require '[eacl.datomic.impl :refer [Relation Permission]])
@@ -599,7 +651,9 @@ Now you can transact relationships. The usual way is `eacl/create-relationships!
 - You need to specify a `Permission` for each relation in a sum-type permission. In future this can be shortened.
 - `subject.relation` is not currently supported. It's useful for group memberships.
 - `expand-permission-tree` is not implemented yet.
-- *No cache:* EACL does not presently have a cache, because Datomic Peers cache datoms aggressively and queries so far are fast enough. A cache is planned.
+- *No cache:* EACL does not presently have a result cache, because Datomic Peers cache datoms aggressively and queries so far are fast enough. A cache is planned. (Resolved *permission paths* are cached — see [Performance](#performance).)
+- *Deleting entities:* `:db.fn/retractEntity` does not remove an entity's relationships. Call `eacl/delete-object!` first — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
+- *Recursive permissions do not paginate cheaply:* a permission that transitively depends on itself (`permission read = reader + parent->read`) is evaluated in traversal order, and each page resumes by replaying the traversal prefix and discarding results up to the cursor. Work per page therefore grows with the page's offset — enumerating `N` results is `O(N²/page-size)` — and a single page is capped by `:max-derived-grants` (default 100 000), so a recursive permission with a very large grant set starts failing on *deep* pages while page 1 still succeeds. Raise the ceiling with `make-client`'s `:recursive-traversal-limits` (it is a memory bound), or model the permission acyclically. Acyclic permissions have no such limit: they resume from per-path cursor frontiers and cost `O(log N)` per page.
 - *Return order:* Acyclic EACL lookups enumerate in Datomic eid order and relationship reads enumerate in tuple-index order. Recursive lookups enumerate in deterministic traversal order. SpiceDB returns results in discovery or schema order. You should not rely on either system's order as a domain sort order.
 
 ## How to Run All Tests

--- a/deps.edn
+++ b/deps.edn
@@ -9,9 +9,6 @@
            ;; Datomic
         com.datomic/peer {:mvn/version "1.0.7622"}
 
-           ;; Caching
-        org.clojure/core.cache {:mvn/version "1.1.234"}
-
            ;; Parsing
         instaparse/instaparse {:mvn/version "1.5.0"}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,6 +174,8 @@ The `IAuthorization` protocol in [src/eacl/core.clj](src/eacl/core.clj) defines 
 - `(eacl/lookup-subjects client filters) => {:data [subjects...] :page-info {...}}`
 - `(eacl/lookup-resources client filters) => {:data [resources...] :page-info {...}}`
 - `(eacl/count-resources client filters) => {:keys [count limit]}` counts the full result set.
+- `(eacl/count-subjects client filters) => {:keys [count limit]}` counts the full subject result set.
+- Add `:count-limit n` to either count operation to bound work and receive `:truncated?`.
 - `(eacl/read-relationships client filters) => {:data [relationships...] :page-info {...}}`
 - `(eacl/write-relationships! client updates) => {:zed/token 'db-basis}`,
   - where `updates` is just a coll of `[operation relationship]` where `operation` is one of `:create`, `:touch` or `:delete`.
@@ -506,25 +508,13 @@ EACL uses the SpiceDB schema DSL. Use `eacl/write-schema!` to define your schema
    }")
 ```
 
-### Advanced: Programmatic Schema (Optional)
+### Schema Mutation Contract
 
-For advanced use cases, you can also define schema programmatically using the internal `Relation` and `Permission` functions:
-
-```clojure
-(require '[eacl.datomic.impl :refer [Relation Permission]])
-
-@(d/transact conn
-  [(Relation :account :owner :user)
-   (Permission :account :admin {:relation :owner})
-   (Relation :server :account :account)
-   (Permission :server :admin {:arrow :account :permission :admin})])
-```
-
-`Permission` supports the following spec syntax:
-- `{:relation some_relation}` - direct permission via relation
-- `{:permission some_permission}` - permission via another permission
-- `{:arrow source :permission via_permission}` - arrow to permission
-- `{:arrow source :relation via_relation}` - arrow to relation
+Use `eacl/write-schema!` for every schema change. The internal `Relation` and `Permission`
+records are not a supported schema API: transacting them directly bypasses validation, the
+schema-generation stamp, and client cache replacement. EACL reads `:eacl/schema-version` once
+when a client is created, never on ordinary authorization calls. Recreate clients after any
+out-of-band schema write.
 
 ## Example Schema
 

--- a/docs/reports/2026-07-29-eacl-full-source-bug-hunt.md
+++ b/docs/reports/2026-07-29-eacl-full-source-bug-hunt.md
@@ -1,0 +1,696 @@
+# EACL Full-Source Bug Hunt — Cache Scoping, Dangling Tuples, Recursive Scaling
+
+**Date:** 2026-07-29
+**Scope:** Complete read of `src/` at `2ccc6c4` (branch `codex/v7.3-cursor-frontiers`), plus runtime
+verification of every finding on a **freshly started nREPL** (port 7788, `clojure -M:dev:nrepl`).
+**Baseline:** `73 tests, 1297 assertions, 0 failures, 0 errors` on that fresh REPL
+(`indexed-test`, `spice-test`, `schema-test`, `config-test`, `parser-test`, `differential-test`,
+`v6-to-v7-test`, `schema-basis-test`). Every bug below is present with the suite fully green.
+
+> Read alongside [2026-07-28-v7.3-cursor-frontier-review.md](2026-07-28-v7.3-cursor-frontier-review.md).
+> That review's findings 1–7, 9, 11 are fixed on this branch and are **not** repeated here.
+> Its finding 8 (silent-empty on unknown permission names) is re-raised only where a *new* variant
+> was found (§4). Its finding 10 (`count-subjects` unexposed) is still open and is noted in §12.
+
+---
+
+## What I could not break
+
+Before the findings, the things I actively attacked and could not falsify — these are solid:
+
+| Attacked | Result |
+|---|---|
+| v7.3 direction-scoped cursor frontiers: 20 accounts × 200 servers, shuffled eids so intermediate order is uncorrelated with result order; 3 seeds × 4 users × 2 permissions × page sizes {1,2,3,5,7,13,100}, forward **and** backward, against a `can?` oracle | **168/168 walks exact**, 13 314 results enumerated, zero skips/dupes |
+| `count-resources` agreement with the paginated union on the same corpus | exact |
+| Recursive **reverse** lookup (`lookup-subjects` through `parent->read`), 6 seeds × 8 folders, vs. `can?` oracle, incl. page size 1 and `count-subjects` | **48/48 exact** — note this path has *no* coverage in `differential-test`, which only checks recursive forward |
+| Token layer: `d/as-of` basis pinning (wrote new grants mid-walk, page 3 correctly did not see them), cross-subject token replay | pinned correctly; replay rejected with `Page token does not match the current query.` |
+| `write-schema!` idempotency: second write of an identical schema string | zero deltas, schema-version **not** bumped |
+
+The frontier algorithm itself is correct. Every bug below is in the layers around it.
+
+---
+
+## Severity index
+
+| # | Sev | Finding | Verified |
+|---|---|---|---|
+| 1 | **Critical** | `d/with` speculative db **poisons the live db's permission-path cache** → `can?` grants a permission the committed schema does not define | REPL |
+| 2 | **High** | Databases with no `:eacl/schema-version` stamp cache permission paths **forever**, with no invalidation path — a whole class of installs (programmatic schema, `migrate!` without `:schema`) | REPL |
+| 3 | **High** | `:db.fn/retractEntity` on a permissioned entity leaves **dangling relationship tuples**: `can?` returns `true` for deleted resources, `lookup-subjects` lists deleted subjects, and the orphans are **unremovable through the public API** | REPL |
+| 4 | **High** | Recursive pagination is O(N²) and **hard-fails mid-walk** at `:max-derived-grants` — page 1 succeeds, page 100 throws | REPL |
+| 5 | Medium | `{:subject/id nil}` (and any anchor key present-but-nil) defeats the `:eacl.filters/missing-anchor` guard → silent **global index scan** | REPL |
+| 6 | Medium | Bare `:last` works for acyclic permissions and **throws** for recursive ones — adding `parent->read` to a schema breaks existing callers | REPL |
+| 7 | Medium | `count-resources` / `count-subjects` `doall` the entire result set — head-retention OOM on large grant sets | code |
+| 8 | Medium | Recursive `:last`/`:before` at ordinal 0 returns `has-next-page? true` with a `nil` `end-cursor`; `:after nil` silently restarts at page 1 → naive loops never terminate | REPL |
+| 9 | Low | `eacl.datomic.impl/can?` 2-arity is broken (`ArityException`) | REPL |
+| 10 | Low | `:create` conflict, `:unspecified` and `can!` throw bare `java.lang.Exception` — undiscriminable by callers | REPL |
+| 11 | Low | `relationship-exists?` consults only the forward index, so a half-written pair can never be repaired by `:touch`/`:delete` | code |
+| 12 | Info | Performance: reflective `(.id db)` on the hot cache path, uncached `traversal-permission?`, per-datom vector allocation in the scan loop, full relation-table scan per `read-relationships` | REPL |
+
+---
+
+## 1. `d/with` speculative databases poison the live permission-path cache — **Critical**
+
+**Files:** [indexed.clj:325-350](../../src/eacl/datomic/impl/indexed.clj#L325-L350) (`classified-view`,
+`schema-cache-scope`), [indexed.clj:363-437](../../src/eacl/datomic/impl/indexed.clj#L363-L437)
+(`permission-paths-cache-key`, `get-permission-paths`).
+
+### The defect
+
+The cache scope is `[(str (.id db)) (str (schema-version db))]`. Neither component distinguishes a
+`d/with` speculative database from the committed database it was derived from:
+
+- `(.id db)` is the **database** uuid; a `d/with` db inherits it verbatim.
+- `d/is-filtered` / `d/as-of-t` / `d/since-t` are all `false`/`nil` on a `d/with` db, so
+  `classified-view` positively classifies it as `:plain`.
+- `:eacl/schema-version` is only asserted by `write-schema!`, so a `d/with` that adds a
+  `Permission` entity does not change it.
+
+Result: a `d/with` db and its source share a cache key while having **different schemas**.
+Whichever one is queried first writes its permission paths into the shared slot.
+
+### Verified repro (fresh REPL)
+
+```clojure
+(schema/write-schema! conn "definition user {}
+                            definition account { relation owner: user
+                                                 permission admin = owner }")
+;; …u owns a…
+(def db (d/db conn))
+;; preview a schema change WITHOUT committing it
+(def spec (:db-after (d/with db [(base/Permission :account :view {:relation :owner})])))
+
+(idx/can? spec (spice-object :user U) :view (spice-object :account A))  ;=> true   (correct for `spec`)
+(idx/can? db   (spice-object :user U) :view (spice-object :account A))  ;=> true   ← WRONG
+```
+
+`:view` **does not exist** in the committed database. Expected `false`. The false grant persists
+for the life of the process (or until `evict-permission-paths-cache!`), affects every peer thread,
+and is silent.
+
+The mirror case is equally real: a `d/with` that *retracts* a `Permission`, evaluated first, caches
+the narrowed path set onto the live db and produces false **denials**.
+
+### Why the existing note does not cover this
+
+[indexed.clj:298-302](../../src/eacl/datomic/impl/indexed.clj#L298-L302) says programmatic edits
+"do not bump the version, so caches may serve paths computed from the pre-edit schema." That
+describes the *speculative db reading stale live paths*. The demonstrated failure is the opposite
+and far worse direction: **the speculative db writes its schema into the live db's cache slot.**
+Nothing in the code or docs anticipates that.
+
+### Recommended fix
+
+The invariant that must hold is: *two db values sharing a cache key must have identical Relation +
+Permission datom sets.* Three options, cheapest-correct first:
+
+**(a) Content fingerprint, memoised per basis (recommended).** Key the path cache on a fingerprint
+derived from the schema datoms, and memoise the *fingerprint* (not the paths) on
+`[db-id, basis-t, as-of-t]` in a small bounded map:
+
+```clojure
+(defn- schema-fingerprint* [db]
+  (letfn [(f [attr] (reduce (fn [[n mx] d] [(inc n) (max mx (:tx d))]) [0 0]
+                            (d/datoms db :aevt attr)))]
+    [(f :eacl.relation/relation-name)
+     (f :eacl.permission/permission-name)
+     (some-> (schema-version db) str)]))
+```
+
+This is exact (additions change the count and tx; retractions change the count; same-tx
+retract+add changes the max tx), and it preserves the whole point of issue #74: a
+relationship-only transaction bumps `basis-t`, so the fingerprint is recomputed once — and comes
+out **identical**, so every path entry still hits. A `d/with` db has its own `basis-t`
+(verified: source `1008`, with-db `1009`), so it gets its own fingerprint computation and, because
+its schema differs, its own cache key. Cost: one O(#schema-entities) scan per new db value,
+amortised across every query at that basis.
+
+**(b) Include `(d/basis-t db)` in the scope.** One line, exact, closes both this and §2 — but
+re-introduces exactly what #74 removed: every write transaction invalidates every path entry.
+
+**(c) Bail out of the cache when the stamp is absent.** Closes §2 only, not this. See §2.
+
+Whatever is chosen, `evict-permission-paths-cache!` should be documented as *mandatory* after any
+`d/with`-based permission evaluation until the fix lands, and the note at
+[indexed.clj:288-309](../../src/eacl/datomic/impl/indexed.clj#L288-L309) should be corrected —
+today it understates the failure mode.
+
+---
+
+## 2. Databases with no schema-version stamp cache paths permanently — **High**
+
+**Files:** [indexed.clj:339-350](../../src/eacl/datomic/impl/indexed.clj#L339-L350),
+[schema.clj:437-459](../../src/eacl/datomic/schema.clj#L437-L459),
+[v6_to_v7.clj:348](../../src/eacl/migrations/v6_to_v7.clj#L348).
+
+### The defect
+
+`schema-version` is `nil` unless `write-schema!` has run at least once. When it is `nil` the scope
+degrades to `[(str (.id db)) nil]` — a key that is **constant for the lifetime of the database**.
+Every permission path computed against such a database is cached forever, and nothing can ever
+invalidate it, because `write-schema!` is the only writer of the stamp.
+
+Affected installs:
+
+- Anyone building schema programmatically with `eacl.datomic.impl/Relation` and
+  `eacl.datomic.impl/Permission` — a documented public API, and the style EACL's own
+  `test/eacl/datomic/fixtures.clj` uses.
+- Any database migrated with `(migrate! conn {})` — `write-schema!` runs only `(when schema …)`,
+  so a v6→v7 migration without `:schema` never stamps.
+- Any database whose schema predates the `:eacl/schema-version` attribute and has not been
+  re-written since.
+
+### Verified repro (fresh REPL)
+
+```clojure
+@(d/transact conn [(base/Relation :account :owner :user)])   ; programmatic schema, no write-schema!
+;; …u owns a…
+(idx/can? (d/db conn) (spice-object :user U) :admin (spice-object :account A))  ;=> false (correct — no :admin yet)
+
+@(d/transact conn [(base/Permission :account :admin {:relation :owner})])       ; add the permission
+
+(idx/schema-version (d/db conn))                                               ;=> nil
+(idx/can? (d/db conn) (spice-object :user U) :admin (spice-object :account A))  ;=> false  ← WRONG, expected true
+(idx/get-permission-paths (d/db conn) :account :admin)                          ;=> []     ← stale empty
+(idx/evict-permission-paths-cache!)
+(idx/can? (d/db conn) (spice-object :user U) :admin (spice-object :account A))  ;=> true   (proves the cache is the cause)
+```
+
+The failure direction shown here is fail-closed (a granted permission does not work). The
+retraction direction is fail-**open**: programmatically retracting a `Permission` leaves the cache
+granting it indefinitely.
+
+### Recommended fix
+
+1. Adopt §1(a) — a content fingerprint makes this class of bug structurally impossible.
+2. Independently, and cheaply, **make the contract enforceable instead of aspirational**:
+   - `schema-cache-scope` should return `uncached-scope` when `(schema-version db)` is `nil`.
+     Un-stamped databases then get correct-but-uncached behaviour rather than fast-and-wrong.
+   - Export a public `eacl.datomic.schema/stamp-schema-version!` so programmatic-schema users can
+     opt back into caching after their own writes.
+   - Have `migrate!` stamp a version unconditionally (it already transacts a schema-string entity
+     in `stamp-storage-version!` — one extra `:eacl/schema-version (d/squuid)` there is free).
+   - Consider a `make-client` warning (not a hard failure) when the database contains
+     `:eacl.relation/*` definitions but no `:eacl/schema-version` — same spirit as
+     `assert-storage-compatible!`.
+
+---
+
+## 3. `retractEntity` leaves dangling relationship tuples — **High**
+
+**Files:** [impl.clj:130-146](../../src/eacl/datomic/impl.clj#L130-L146) (`add-relationship-txes`
+/ `retract-relationship-txes`), [schema.clj:176-195](../../src/eacl/datomic/schema.clj#L176-L195)
+(the two `:db.type/tuple` attributes), [core.clj:329-349](../../src/eacl/datomic/core.clj#L329-L349)
+(`resolve-existing-object`).
+
+### The defect
+
+A v7 relationship is two datoms on two *different* entities:
+
+```
+[subject-eid  …/subject-type+relation+resource-type+resource  [st rel-eid rt resource-eid]]
+[resource-eid …/resource-type+relation+subject-type+subject   [rt rel-eid st subject-eid]]
+```
+
+The peer entities appear only *inside the tuple values*. Datomic's `:db.fn/retractEntity` follows
+`:db.type/ref` **attributes**; it does not follow ref-typed *components of a heterogeneous tuple*,
+and heterogeneous tuples cannot be `:db/isComponent`. So retracting a permissioned entity — the
+ordinary Datomic idiom for deleting a domain entity — removes only the half of each relationship
+that happens to live on that entity, and leaves the other half dangling.
+
+### Verified repro A — deleted **resource**, `can?` returns `true`
+
+```clojure
+;; user "u" is :owner of account "a"; permission admin = owner
+@(d/transact conn [[:db.fn/retractEntity A]])            ; delete the account entity
+
+(seq (d/datoms (d/db conn) :eavt A))                                             ;=> nil  (entity is gone)
+(idx/can? (d/db conn) (spice-object :user U) :admin (spice-object :account A))   ;=> true  ← WRONG
+(idx/lookup-resources (d/db conn) {…:permission :admin :resource/type :account}) ;=> [17592186045423]
+(idx/count-resources  (d/db conn) {…})                                           ;=> {:count 1}
+```
+
+With the default `:eacl/id` coercion the public `can?` is accidentally shielded (the lookup ref no
+longer resolves). But with the **README-documented** eid-as-external-id configuration
+([README.md:473-475](../../README.md#L473)):
+
+```clojure
+(def acl (core/make-client conn {:object-id->ident identity
+                                 :entid->object-id (fn [_ e] e)}))
+(eacl/can? acl (spice-object :user U) :admin (spice-object :account A))  ;=> true  ← privilege on a deleted entity
+```
+
+Through *any* configuration, `lookup-resources` still returns the ghost, coerced to
+`#SpiceObject{:type :account, :id nil}`.
+
+### Verified repro B — deleted **subject**, orphan is unremovable
+
+```clojure
+@(d/transact conn [[:db.fn/retractEntity SU]])           ; delete the user entity
+
+(idx/lookup-subjects db {:resource (spice-object :account SA) :permission :admin
+                         :subject/type :user :first 5})
+;=> [17592186045422]                                     ← deleted user still listed
+(eacl/lookup-subjects acl {…})
+;=> [#SpiceObject{:type :user, :id nil, :relation nil}]
+
+;; and it can never be cleaned up through EACL:
+(eacl/delete-relationship! acl (spice-object :user "su") :owner (spice-object :account "sa"))
+;=> throws  "Unknown object: :user with id \"su\" does not exist."
+(eacl/delete-relationship! acl (spice-object :user SU)   :owner (spice-object :account "sa"))
+;=> throws  "Unknown object: :user with id 17592186045422 does not exist."
+```
+
+`resolve-existing-object` correctly refuses to write relationships for nonexistent endpoints — but
+that same guard makes the orphan **permanently unreachable**. Only a raw `d/transact` retracting
+the tuple datom by hand can remove it.
+
+Note also that `can?` and `lookup-subjects` now **disagree**, which breaks the invariant
+`differential-test` asserts everywhere else. Any downstream job driven by `lookup-subjects`
+("notify all admins", "sync relationships to SpiceDB") will act on ghost subjects with `nil` ids.
+
+### Recommended fix
+
+This needs both a runtime guard and a documented workflow:
+
+1. **Ship a cascade helper**, e.g. `eacl.datomic.impl/tx-delete-object`, that emits retractions for
+   both directions of every relationship touching an eid — `d/datoms :eavt eid <forward-attr>` for
+   the forward half, and for the reverse half a bounded `d/index-range` over
+   `…/resource-type+relation+subject-type+subject` per (type, relation) pair. Expose it on
+   `IAuthorization` as `delete-object!` / `delete-relationships-for-object!`.
+2. **Document it prominently** in the README's write section and in "Limitations, Deficiencies &
+   Gotchas": *"`:db.fn/retractEntity` on a permissioned entity does not remove its relationships.
+   Call `eacl/delete-object!` first."* Today the README says nothing about this at all.
+3. Consider a cheap consistency checker (`eacl.datomic.repair/find-orphaned-tuples`) plus a
+   repair transaction, since existing production databases will already contain orphans.
+4. Optional hardening: have `lookup-resources` / `lookup-subjects` skip results whose eid has no
+   datoms. That is one extra `d/datoms` probe per returned row and would make ghosts invisible even
+   before an operator repairs the data — worth measuring against the latency budget.
+
+---
+
+## 4. Recursive pagination is O(N²) and hard-fails mid-walk — **High**
+
+**Files:** [indexed.clj:570-573](../../src/eacl/datomic/impl/indexed.clj#L570-L573)
+(`*recursive-traversal-limits*`), [indexed.clj:942-982](../../src/eacl/datomic/impl/indexed.clj#L942-L982)
+(`collect-forward-after` seek mode), [indexed.clj:1750-1778](../../src/eacl/datomic/impl/indexed.clj#L1750-L1778)
+(`count-resources`).
+
+### The defect
+
+Recursive pages carry an **ordinal**, and resuming replays the traversal from scratch, discarding
+results until the ordinal is reached. Work per page therefore grows linearly with the page's
+offset, and the per-page `:derived-grants` counter is checked against a hard limit of `100 000`.
+
+### Verified measurement
+
+400 folders, all children of one root the user reads; `permission read = reader + parent->read`;
+page size 10, walking to the end:
+
+| page | `:derived-grants` | `:advanced-stream-datoms` |
+|---|---|---|
+| 0 | 11 | 11 |
+| 8 | 91 | 91 |
+| 16 | 171 | 171 |
+| 24 | 251 | 251 |
+| 32 | 331 | 331 |
+| 40 | 401 | 401 |
+
+Exactly `page × page-size` — full prefix replay, no reuse. Total cost to enumerate N results is
+`O(N² / page-size)`.
+
+The limit then converts that into an outright failure. Scaling the limit down proportionally to
+demonstrate the mechanism at test size:
+
+```clojure
+(binding [idx/*recursive-traversal-limits* {:max-derived-grants 200 …}]
+  (count (:data (idx/lookup-resources fdb (assoc fq :first 10))))  ;=> 10        page 1 fine
+  (count (collect-fwd fdb fq 10))                                  ;=> throws :eacl.recursive-traversal/limit-exceeded
+  (idx/count-resources fdb fq))                                    ;=> throws :eacl.recursive-traversal/limit-exceeded
+```
+
+With the shipped default of `100 000`, any recursive permission whose grant set exceeds ~100 k
+**breaks partway through pagination**: page 1 returns fine, deep pages throw. `count-resources` and
+`count-subjects` on such a permission always throw, because they walk to the end
+([indexed.clj:1760-1773](../../src/eacl/datomic/impl/indexed.clj#L1760-L1773)). This directly
+contradicts the README's stated goal of "10M permissioned entities with real-time performance" for
+any schema containing a recursive permission (the common `folder`/`group` hierarchy shape).
+
+Compounding it: `*recursive-traversal-limits*` is a dynamic var with no `make-client` option, so an
+operator cannot raise it without `alter-var-root` or a `binding` around every call site — and the
+5-minute default page-token TTL means a slow deep walk can expire before it completes anyway.
+
+### Recommended fix
+
+Short term, cheap:
+
+- Make the limits configurable through `make-client` (thread them through `opts` rather than the
+  dynamic var), and document the ceiling explicitly in "Limitations".
+- Track the replay separately from genuinely new work: the seek phase should either not count
+  toward `:max-derived-grants`, or count against a much larger dedicated budget. Failing a deep
+  page because the *prefix* was large is the wrong signal.
+- Make `count-resources` / `count-subjects` on recursive permissions either stream without
+  ordinal-replay (one traversal, count as you go — they already control the whole walk, so they do
+  not need cursors at all) or document that they are bounded.
+
+Medium term: this is the materialised-grants design already sketched in
+`docs/plans/2026-05-17-recursive-pagination-effective-grants-plan.md`. The ordinal-replay engine is
+correct but is not a pagination strategy that scales; deep pages need a resumable frontier, as the
+acyclic engine got in v7.3.
+
+---
+
+## 5. Present-but-nil anchor keys defeat the `read-relationships` guard — **Medium**
+
+**File:** [impl.clj:436-440](../../src/eacl/datomic/impl.clj#L436-L440).
+
+```clojure
+(when-not (some #(contains? filters %) relationship-anchor-keys) (throw …))
+```
+
+`contains?` tests key *presence*, not value. `{:subject/id nil}` therefore satisfies the guard,
+while every downstream consumer treats the value as absent
+(`subject-eid (when subject-id (d/entid db subject-id))` →`nil`), so `scan-plan` falls through to
+`:global-reverse` with a `nil` tuple prefix — an unbounded scan of the entire reverse relationship
+index.
+
+Verified:
+
+```clojure
+(count (:data (impl/read-relationships db {:subject/id nil :first 5})))  ;=> 5   (global scan, no error)
+(impl/read-relationships db {:first 3})                                  ;=> throws :eacl.filters/missing-anchor
+```
+
+This is a regression of the fix for finding 3 in the 2026-07-28 review, and `{:subject/id nil}` is
+exactly what you get from `{:subject/id (get-in request [:params :user-id])}` when the parameter is
+missing — the realistic path to an accidental full-index scan in production.
+
+**Fix:** `(some #(some? (get filters %)) relationship-anchor-keys)`, and reject explicit `nil`
+values for anchor keys with a distinct message so the caller learns their parameter was empty.
+
+Related, lower priority: `{:resource/relation :owner}` alone is accepted as an anchor but also
+produces a global scan whenever more than one relation shares that name
+([impl.clj:227-233](../../src/eacl/datomic/impl.clj#L227-L233) only builds a tuple prefix when
+`single-relation-hint` matches exactly one relation). Worth either documenting or requiring a type
+alongside a bare relation filter.
+
+---
+
+## 6. Bare `:last` is accepted for acyclic permissions and rejected for recursive ones — **Medium**
+
+**Files:** [indexed.clj:1031-1034](../../src/eacl/datomic/impl/indexed.clj#L1031-L1034),
+[indexed.clj:1340-1343](../../src/eacl/datomic/impl/indexed.clj#L1340-L1343).
+
+```clojure
+(idx/lookup-resources db  (assoc acyclic-q :last 2))     ;=> works, returns the last page
+(idx/lookup-resources db4 (assoc recursive-q :last 2))   ;=> throws "Bare :last is not supported for
+                                                         ;;          recursive traversal pagination."
+```
+
+Whether a permission is "recursive" is a property of the *schema*, invisible at the call site. A
+caller doing `{:last 20}` to show the newest page works fine until someone adds
+`permission read = reader + parent->read` to the schema — at which point the same call starts
+throwing at runtime. That is a breaking schema change disguised as an additive one.
+
+**Fix:** pick one contract and make it uniform. Either (a) support bare `:last` for recursive
+permissions by exhausting the traversal into a bounded ring buffer — honest but O(N), so it should
+be gated on the same configurable limit as §4 — or (b) reject bare `:last` for *all* permissions
+and require an explicit `:before`, which is a breaking change but at least a consistent one. If (a)
+is chosen, note that `count-resources` already exhausts the traversal, so the cost is precedented.
+Either way, `traversal-permission?` should be exposed (or surfaced in `read-schema`) so callers can
+discover which permissions have which capabilities.
+
+---
+
+## 7. `count-resources` / `count-subjects` retain the whole result set — **Medium**
+
+**Files:** [indexed.clj:1774-1778](../../src/eacl/datomic/impl/indexed.clj#L1774-L1778),
+[indexed.clj:1804-1808](../../src/eacl/datomic/impl/indexed.clj#L1804-L1808).
+
+```clojure
+(let [{:keys [results]} (lazy-merged-lookup db forward-direction query page-req)
+      counted (doall results)]
+  {:count (count counted) :limit -1})
+```
+
+`counted` is bound to the **head** of the fully realised lazy seq, so the entire grant set is
+materialised and held for the duration. At EACL's stated target of ~10 M permissioned entities,
+counting a broad permission retains ~10 M boxed `Long`s plus cons cells — several hundred MB, on a
+call the README describes only as "slow".
+
+**Fix:** one line each — `(reduce (fn [n _] (inc n)) 0 results)`. Nothing else consumes `counted`.
+
+While there: the `:size max-page-size` in the constructed `page-req` is dead
+(`lazy-merged-lookup` reads only `:direction` and `:bound`), which reads as if counting were capped
+at 10 000 when it is not. Drop it or make it real.
+
+---
+
+## 8. Recursive backward pagination emits an inconsistent empty page; `:after nil` restarts — **Medium**
+
+**Files:** [indexed.clj:1055-1059](../../src/eacl/datomic/impl/indexed.clj#L1055-L1059),
+[indexed.clj:1364-1368](../../src/eacl/datomic/impl/indexed.clj#L1364-L1368),
+[indexed.clj:39-82](../../src/eacl/datomic/impl/indexed.clj#L39-L82) (`normalize-page-request`).
+
+Paging backward from the *first* result of a recursive walk (ordinal 0):
+
+```clojure
+{:data []
+ :page-info {:start-cursor nil, :end-cursor nil,
+             :has-next-page? true,          ; ← hard-coded at indexed.clj:1058
+             :has-previous-page? false}}
+```
+
+`has-next-page? true` with a `nil` `end-cursor` violates the contract every other page upholds.
+It becomes a liveness bug when combined with `normalize-page-request`, which accepts an explicit
+`nil` bound and silently means "start over":
+
+```clojure
+(idx/lookup-resources db (assoc q :first 2 :after nil))  ;=> page 1, no error
+```
+
+So the natural client loop —
+`(loop [c nil] (let [p (lookup … :after c)] (when (has-next-page? p) (recur (end-cursor p)))))` —
+never terminates once it lands on that page: `has-next-page?` is true, `end-cursor` is nil,
+`:after nil` returns page 1, repeat.
+
+**Fix:** two independent one-liners.
+1. `:has-next? (boolean (seq items))` in the recursive `:desc` branches — an empty backward page has
+   no successor to point at.
+2. In `normalize-page-request`, treat a present-but-`nil` `:after`/`:before` as an error
+   (`:eacl.pagination/invalid-cursor`), mirroring the `:cursor`/`:limit` rejections directly above
+   it. Silently restarting is the worst of the three options.
+
+---
+
+## 9. `eacl.datomic.impl/can?` 2-arity is broken — **Low**
+
+**Files:** [impl.clj:18-22](../../src/eacl/datomic/impl.clj#L18-L22),
+[indexed.clj:1618](../../src/eacl/datomic/impl/indexed.clj#L1618).
+
+```clojure
+(impl/can? db {:subject … :permission … :resource …})
+;=> clojure.lang.ArityException: Wrong number of args (2) passed to: eacl.datomic.impl.indexed/can?
+```
+
+`impl/can?` declares `([db demand] (impl.indexed/can? db demand))` but `impl.indexed/can?` has only
+the 4-arity form. The map arity has never worked. (The protocol-level `eacl/can?` map arity on
+`Spiceomic` is fine — it destructures before dispatching.)
+
+**Fix:** either implement the map arity in `impl.indexed/can?` or delete the dead 2-arity from
+`impl/can?`. It has no test coverage either way.
+
+---
+
+## 10. Bare `java.lang.Exception` for write conflicts — **Low**
+
+**Files:** [impl.clj:42-47](../../src/eacl/datomic/impl.clj#L42-L47) (`can!`),
+[impl.clj:490-500](../../src/eacl/datomic/impl.clj#L490-L500) (`:create` / `:unspecified`).
+
+```clojure
+(impl/tx-update-relationship db {:operation :create :relationship <existing>})
+;=> java.lang.Exception  ":create relationship conflicts with existing tuple relationship"
+```
+
+Everything else in EACL throws `ex-info` with a typed `:eacl/error` or `:type` key; these three do
+not, so a caller cannot distinguish "this relationship already exists" (usually retryable/ignorable
+— it is exactly what `:touch` is for) from any other failure without string-matching the message.
+
+**Fix:** `ex-info` with `{:type :eacl/relationship-conflict, :relationship …}`,
+`{:type :eacl/unsupported-operation}` and `{:type :eacl/unauthorized, :subject …, :permission …,
+:resource …}` respectively.
+
+---
+
+## 11. `relationship-exists?` checks only the forward index — **Low**
+
+**File:** [impl.clj:148-158](../../src/eacl/datomic/impl.clj#L148-L158).
+
+`:touch` skips writing when the forward datom exists, and `:delete` skips retracting when it does
+not. Either half of a relationship pair being absent — which §3 shows is reachable — leaves the
+other half permanently unrepairable through the API: `:touch` decides "already there", `:delete`
+decides "nothing to do".
+
+**Fix:** check both tuples, and make `:touch` assert whichever half is missing (`add-relationship-txes`
+is already idempotent) and `:delete` retract both unconditionally. Datomic ignores a retraction of an
+absent datom, so `:delete` can simply drop the existence check entirely.
+
+---
+
+## 12. Performance observations (measured)
+
+Not bugs, but each is on a hot path and each is cheap to fix.
+
+**a. Reflective `(.id db)` in the cache key.** [indexed.clj:348](../../src/eacl/datomic/impl/indexed.clj#L348)
+has no type hint, so every `get-permission-paths` call makes a reflective invocation. Measured cost
+of `schema-cache-scope` ≈ **1.2 µs/call**, of which `(.id db)` is the bulk. `get-permission-paths`
+is called once per path expansion per recursion level, so this is multiplied several times per
+query. Measured `can?` on a trivial 1-relation schema: **3.2 µs** single-threaded — cache-key
+construction is a substantial share of that.
+
+Throughput does still scale with cores (12-core box: 3.17 µs/op at 1 thread → 0.797 µs/op at 8
+threads, a 4× aggregate speedup), so the `swap!` on the LRU atom is not currently a hard
+serialisation point — but it is sub-linear, and every cache *hit* performs
+`(swap! permission-paths-cache cache/hit cache-key)`, which rebuilds the LRU map on a single shared
+atom. Worth revisiting if the cache-key work is reduced and this becomes the dominant term.
+
+**b. `traversal-permission?` is recomputed on every lookup.** [indexed.clj:554-559](../../src/eacl/datomic/impl/indexed.clj#L554-L559),
+called at [indexed.clj:1732](../../src/eacl/datomic/impl/indexed.clj#L1732) and
+[:1746](../../src/eacl/datomic/impl/indexed.clj#L1746). It walks the whole permission dependency
+graph via `permission-query-dependencies` → `get-permission-paths` on every single
+`lookup-resources` / `lookup-subjects` / `count-*` call. Measured **7.8 µs** on a two-node graph;
+it grows with schema size and is a pure function of the schema. It should share the same
+schema-scoped cache as the paths themselves.
+
+**c. Per-datom vector allocation in the scan loop.** `subject->resources` /`resource->subjects`
+([indexed.clj:181-191](../../src/eacl/datomic/impl/indexed.clj#L181-L191),
+[:206-216](../../src/eacl/datomic/impl/indexed.clj#L206-L216)) evaluate
+`(= prefix (subvec (vec v) 0 3))` for **every datom scanned** — two allocations plus a vector
+compare per datom, in the innermost loop of the whole engine. Comparing the three elements
+positionally (`(and (= (nth v 0) …) (= (nth v 1) …) (= (nth v 2) …))`) is allocation-free and
+identical in behaviour.
+
+**d. `read-relationships` scans every relation definition per call.**
+[impl.clj:172-190](../../src/eacl/datomic/impl.clj#L172-L190) runs an unbounded `d/q` over all
+`:eacl.relation/relation-name` datoms and filters in Clojure, when
+`:eacl.relation/resource-type+relation-name+subject-type` exists precisely to make this an index
+seek. Schemas are small, so this is bounded — but it is per-call overhead on a read API.
+
+**e. Duplicate path traversal after self-permission expansion.** `frontier-permission-paths`
+([indexed.clj:439-456](../../src/eacl/datomic/impl/indexed.clj#L439-L456)) can emit the same path
+twice — e.g. `permission view = owner + admin` where `permission admin = owner` expands to
+`[{:relation owner} {:relation owner}]`. Results are correct (the merge dedupes), but the index is
+scanned twice and both entries collapse onto one `path-frontier-key`. `(distinct …)` on the
+expansion, keyed by `path-frontier-identity`, removes the duplicate work.
+
+---
+
+## 13. Test-coverage gaps worth closing
+
+Every bug above survived a green 73-test / 1297-assertion suite. The gaps that let them through:
+
+| Gap | Suggested test |
+|---|---|
+| No test ever evaluates a permission against a `d/with` or otherwise non-`(d/db conn)` database | §1 repro verbatim, asserting the live db is unaffected |
+| No test uses programmatic schema **and** mutates it mid-test on one connection | §2 repro verbatim |
+| Nothing deletes a permissioned entity | §3 repros A and B; assert `can?` ⇔ `lookup-resources` ⇔ `lookup-subjects` agreement after `retractEntity` |
+| `differential-test` covers recursive **forward** only | add `check-reverse-invariants!` to `differential-recursive-test` — I verified 48/48 exact, so this should land green and stay green |
+| No test walks a recursive permission deep enough to hit `:max-derived-grants` | a `binding`-scoped small-limit test asserting the intended error contract, whatever it becomes |
+| Anchor-filter tests pass only *absent* keys | add `{:subject/id nil}`, `{:resource/type nil}` |
+| No test asserts the `has-next-page? ⇒ end-cursor` invariant | property-check it across every page of every existing pagination test |
+
+---
+
+## 14. Suggested order of work
+
+1. **§1 + §2 together** — one fix (schema-content fingerprint) closes both, and they are the only
+   findings that make EACL grant access it should not. Ship the `evict-permission-paths-cache!`
+   guidance immediately as a stopgap.
+2. **§3** — `delete-object!` plus README warning plus an orphan finder. Production databases
+   almost certainly contain orphans already, so the repair tool matters as much as the fix.
+3. **§5, §7, §8, §11** — small, self-contained, no API change.
+4. **§4 and §6** — these need a design decision (limits as config vs. resumable recursive
+   frontiers, and one uniform `:last` contract). Worth their own plan document.
+5. **§9, §10, §12** — cleanup, safe to batch.
+
+---
+
+*Verification environment: fresh nREPL on port 7788 (`clojure -M:dev:nrepl`), Datomic Peer
+1.0.7622, in-memory databases, Clojure 1.11.4, 12-core darwin. Every code block marked "verified"
+was executed against that REPL; findings 7, 11 and 12d/12e are code reads and are marked as such.*
+
+---
+
+## Remediation (2026-07-29, branch `fix/2026-07-29-cache-scope-dangling-tuples`)
+
+| # | Status | Change |
+|---|---|---|
+| 1, 2 | **Fixed** | The permission-path cache scope is now an exact fingerprint of the EACL definition datoms in the queried `db` value (`attr-fingerprint` over the two `:db.unique/identity` composite tuples: count + entity hash + max tx — Datomic re-asserts a composite tuple with a fresh tx whenever any component changes), memoised on the `db` value itself. `d/with`, `d/filter`, unstamped and programmatically-edited databases each resolve against their own schema and cannot share a slot. Issue #74's requirement is preserved and now pinned by a test: an unrelated `d/transact` yields the same fingerprint, so no path is recomputed. `:eacl/schema-version` is retained but demoted to informational. |
+| 3 | **Fixed** | New `eacl/delete-object!` (protocol) / `impl/tx-delete-object` retracts both halves of every relationship touching an object, finding them from the object's own datoms *and* by exact `:avet` lookup per schema Relation — so it works before or after the entity is retracted. `impl/orphaned-relationship-halves` + `impl/tx-retract-orphaned-relationships` repair existing damage. The public `can?` no longer answers from a retracted entity's surviving half (`existing-eid` datom probe, closing the eid-as-external-id privilege escalation). README gained a "Deleting a permissioned entity" section and a Limitations entry. |
+| 4 | **Partly fixed** | `count-resources`/`count-subjects` on recursive permissions now do ONE traversal instead of replaying the prefix per `max-page-size` page (was `O(N²)` and tripped the limit long before a large grant set could be counted). Limits are configurable via `make-client`'s `:recursive-traversal-limits` (merged with defaults so a partial override cannot disable the rest), and the limit-exceeded message explains the deep-page cause and the fix. **The `O(N²)` page replay itself remains** — that needs the materialised-grants engine in `docs/plans/2026-05-17-recursive-pagination-effective-grants-plan.md`. Now documented in Limitations. |
+| 5 | **Fixed** | Anchor check uses `some?` on the value, not `contains?` on the key; the error names the nil-valued keys. |
+| 6 | **Fixed** | Bare `:last` works for recursive permissions (`collect-trailing-items`), matching the acyclic contract. |
+| 7 | **Fixed** | `count-*` reduce instead of `doall`; the dead `:size` in the constructed page-req is gone. |
+| 8 | **Fixed** | `page-response` (and `relationship-page`) clamp both `has-*-page?` flags to false on an empty page, so `has-next-page?` always implies a usable `end-cursor`. A present-but-nil `:after`/`:before` now throws `:eacl.pagination/invalid-cursor` instead of silently restarting at page 1. |
+| 9 | **Fixed** | `impl/can?` map arity destructures and forwards to the 4-arity. |
+| 10 | **Fixed** | `:eacl/relationship-conflict`, `:eacl/unsupported-operation`, `:eacl/unauthorized` via `ex-info`. |
+| 11 | **Fixed** | `relationship-exists?` requires both halves; `:delete` retracts unconditionally (Datomic ignores absent retractions), so a half-pair is repairable by `:touch` and removable by `:delete`. |
+| 12 | **Fixed** (a, b, c, e) / **deferred** (d) | (a) `(.id ^datomic.Database db)` is hinted and now runs once per `db` value, not per call; the scope memo is a plain map (LRU hit bookkeeping cost ~6x a map lookup on the hottest path). (b) `traversal-permission?` is memoised under the same schema scope. (c) Element-wise tuple-prefix comparison — no per-datom vector allocation. (e) `frontier-permission-paths` dedupes by `path-frontier-identity`. (d) `find-relations`' relation-table scan is unchanged: bounded by schema size, and touching the `read-relationships` scan planner was more risk than the gain. |
+
+**Not done, deliberately.** Read-time filtering of ghost results from `lookup-resources`/`lookup-subjects`
+was considered and rejected for this change: it costs one datom probe per candidate row on every
+page, and doing it inside the recursive engine would shift emission ordinals and invalidate
+in-flight cursors. `delete-object!` plus the orphan repair pass fixes the data instead. The
+residual is that a database with existing orphans still lists them until repaired.
+
+### Verification
+
+Full suite on a **fresh** nREPL: **90 tests, 1636 assertions, 0 failures, 0 errors**
+(baseline before this change: 73 / 1297). New coverage: `object-deletion-test` (7 tests),
+`api-contract-test` (9), `schema-basis-test` gained the speculative-db, unstamped-database and
+scope-memo-cost contracts, and `differential-test` gained recursive **reverse** invariants —
+a path that previously had none (860 assertions in that namespace, up from ~360).
+
+**Benchmarks.** Protocol: fresh JVM per version, `^:benchmark` suite only, two consecutive runs,
+second run reported (the first is JIT-dominated — first-run first-page medians ranged 2.3–2.7 ms
+on *both* versions, so any single-run comparison is meaningless here).
+
+`multipath-pagination-benchmark`, 15 000 servers over a 4-arrow-path permission:
+
+| | before | after |
+|---|---|---|
+| First page (`:first 50`) median / p95 | 1.36 / 2.26 ms | 1.34 / 1.95 ms |
+| Forward pagination, early / late / max page | 1.56 / 1.37 / 1.75 ms | 1.40 / 1.30 / 1.64 ms |
+| Reverse pagination, early / late / max page | 1.62 / 1.51 / 1.75 ms | 1.61 / 1.42 / 1.84 ms |
+| Deep-page medians, first / middle / last | 1.32 / 0.86 / 0.44 ms | 1.24 / 0.86 / 0.41 ms |
+| Traversal calls by depth (frontier effectiveness) | 282 / 184 / 79 | 282 / 184 / 79 |
+
+**Flat, within run-to-run noise, no regression.** The identical traversal-call counts confirm the
+frontier algorithm is untouched. Paging is dominated by index traversal (~282 scan calls for a
+50-row page), so cache-key overhead was never a large share of it.
+
+`can?` is where the cache change actually lands. Measured with identical version-agnostic code on
+a fresh JVM per version, median of 9 batches after warmup:
+
+| schema | | before | after | |
+|---|---|---|---|---|
+| 51 definitions | **public `eacl/can?`** | 2.90 µs | **2.24 µs** | **−23%** |
+| 601 definitions | **public `eacl/can?`** | 3.12 µs | **2.52 µs** | **−19%** |
+| 51 definitions | raw `impl.indexed/can?`, warm | 2.29 µs | **1.37 µs** | −40% |
+| 601 definitions | raw `impl.indexed/can?`, warm | 2.69 µs | **1.50 µs** | −44% |
+| 51 definitions | raw, a new `db` value every call | 2.34 µs | 3.42 µs | +46% |
+| 601 definitions | raw, a new `db` value every call | 2.54 µs | 15.67 µs | +518% |
+
+The public path is what applications call, and it is **19–23% faster** — even though finding 3
+added two datom existence probes to it. The cache work more than paid for them.
+
+The last two rows are the whole cost of exact scoping, stated plainly: a `db` value the memo has
+not seen pays one definition-index scan. "A new `db` value every call" means the database advances
+between *every single check*; the scan is bounded by schema size, never by data size, and 601
+definitions (60 definition blocks) is a deliberately extreme schema. The constant was already
+reduced ~4x during this work — direct index iteration instead of a seq walk (2x), and a plain-map
+memo instead of LRU hit bookkeeping (2x on the hit path).
+
+Pinned going forward by `permission-check-benchmark` (warm and cold `can?` medians, with
+thresholds) and by `schema-scope-is-computed-once-per-db-value-test`, which deterministically
+asserts the scan happens once per `db` value and not per call.

--- a/docs/reports/2026-07-29-eacl-full-source-bug-hunt.md
+++ b/docs/reports/2026-07-29-eacl-full-source-bug-hunt.md
@@ -7,6 +7,11 @@ verification of every finding on a **freshly started nREPL** (port 7788, `clojur
 (`indexed-test`, `spice-test`, `schema-test`, `config-test`, `parser-test`, `differential-test`,
 `v6-to-v7-test`, `schema-basis-test`). Every bug below is present with the suite fully green.
 
+> **Operator-review note:** the findings and first-pass recommendations below describe the
+> v7.3 baseline investigation. The [Remediation](#remediation-2026-07-29-branch-fix2026-07-29-cache-scope-dangling-tuples)
+> section records the revised lifecycle contract and supersedes the fingerprint/time-travel,
+> read-time ghost filtering, and recursive bare-`:last` recommendations.
+
 > Read alongside [2026-07-28-v7.3-cursor-frontier-review.md](2026-07-28-v7.3-cursor-frontier-review.md).
 > That review's findings 1–7, 9, 11 are fixed on this branch and are **not** repeated here.
 > Its finding 8 (silent-empty on unknown permission names) is re-raised only where a *new* variant
@@ -625,72 +630,60 @@ was executed against that REPL; findings 7, 11 and 12d/12e are code reads and ar
 
 | # | Status | Change |
 |---|---|---|
-| 1, 2 | **Fixed** | The permission-path cache scope is now an exact fingerprint of the EACL definition datoms in the queried `db` value (`attr-fingerprint` over the two `:db.unique/identity` composite tuples: count + entity hash + max tx — Datomic re-asserts a composite tuple with a fresh tx whenever any component changes), memoised on the `db` value itself. `d/with`, `d/filter`, unstamped and programmatically-edited databases each resolve against their own schema and cannot share a slot. Issue #74's requirement is preserved and now pinned by a test: an unrelated `d/transact` yields the same fingerprint, so no path is recomputed. `:eacl/schema-version` is retained but demoted to informational. |
-| 3 | **Fixed** | New `eacl/delete-object!` (protocol) / `impl/tx-delete-object` retracts both halves of every relationship touching an object, finding them from the object's own datoms *and* by exact `:avet` lookup per schema Relation — so it works before or after the entity is retracted. `impl/orphaned-relationship-halves` + `impl/tx-retract-orphaned-relationships` repair existing damage. The public `can?` no longer answers from a retracted entity's surviving half (`existing-eid` datom probe, closing the eid-as-external-id privilege escalation). README gained a "Deleting a permissioned entity" section and a Limitations entry. |
-| 4 | **Partly fixed** | `count-resources`/`count-subjects` on recursive permissions now do ONE traversal instead of replaying the prefix per `max-page-size` page (was `O(N²)` and tripped the limit long before a large grant set could be counted). Limits are configurable via `make-client`'s `:recursive-traversal-limits` (merged with defaults so a partial override cannot disable the rest), and the limit-exceeded message explains the deep-page cause and the fix. **The `O(N²)` page replay itself remains** — that needs the materialised-grants engine in `docs/plans/2026-05-17-recursive-pagination-effective-grants-plan.md`. Now documented in Limitations. |
+| 1, 2 | **Fixed (revised after operator review)** | Definition fingerprints and per-`db` cache scopes were removed. A connection-backed client reads `:eacl/schema-version` once from the canonical schema entity at construction and owns one in-memory permission-path generation. New `db` values caused by ordinary transactions perform no schema read, definition scan, cache-key work, or database-value retention. `eacl/write-schema!` through that client replaces the generation under a schema write lock; identical writes retain it. Arbitrary/historic/speculative low-level databases are uncached and cannot publish into a client. An unstamped fresh v7 database stays uncached until its first supported schema write; this is not a v6 compatibility mode. Out-of-band schema mutation is outside the lifecycle contract; `eacl.datomic.integrity/client-schema-status` provides an explicit one-entity mismatch diagnostic without taxing `can?`. |
+| 3 | **Fixed to the operator's contract** | Consumers remain responsible for calling `delete-relationships!` before `:db.fn/retractEntity`; EACL does not intercept Datomic or add per-candidate entity-existence probes to authorization reads. `eacl/delete-object!` / `impl/tx-delete-object` remains a convenience helper that retracts both halves. The public `eacl.datomic.integrity` namespace now exposes a bounded-memory dangling-half report and lazy batched repair transactions. |
+| 4 | **Count fixed; pagination redesign deferred** | Recursive `count-resources`/`count-subjects` do one traversal instead of page replay and accept `:count-limit` for an early, explicitly truncated result. `count-subjects` is now public. Recursive page enumeration still replays the traversal prefix and remains `O(N²/page-size)`: eliminating that while keeping stateless, bounded tokens requires the persisted effective-grant index in `docs/plans/2026-05-17-recursive-pagination-effective-grants-plan.md`. The current release documents that boundary and keeps hard heap-protection ceilings rather than pretending a larger limit is a performance solution. |
 | 5 | **Fixed** | Anchor check uses `some?` on the value, not `contains?` on the key; the error names the nil-valued keys. |
-| 6 | **Fixed** | Bare `:last` works for recursive permissions (`collect-trailing-items`), matching the acyclic contract. |
-| 7 | **Fixed** | `count-*` reduce instead of `doall`; the dead `:size` in the constructed page-req is gone. |
+| 6 | **Resolved by an explicit contract** | Bare recursive `:last` is rejected with `:eacl.pagination/unsupported-recursive-last`; implementing it by exhausting the closure was removed because it puts unbounded work on an ordinary page request. `:last` with `:before` remains supported for previous-page navigation. |
+| 7 | **Fixed** | `count-*` no longer `doall` or retain the realized head. Acyclic counts stream in constant application memory; recursive counts retain only their request-local, hard-capped traversal state. `:count-limit` stops both engines early and reports `:truncated?`. |
 | 8 | **Fixed** | `page-response` (and `relationship-page`) clamp both `has-*-page?` flags to false on an empty page, so `has-next-page?` always implies a usable `end-cursor`. A present-but-nil `:after`/`:before` now throws `:eacl.pagination/invalid-cursor` instead of silently restarting at page 1. |
 | 9 | **Fixed** | `impl/can?` map arity destructures and forwards to the 4-arity. |
 | 10 | **Fixed** | `:eacl/relationship-conflict`, `:eacl/unsupported-operation`, `:eacl/unauthorized` via `ex-info`. |
 | 11 | **Fixed** | `relationship-exists?` requires both halves; `:delete` retracts unconditionally (Datomic ignores absent retractions), so a half-pair is repairable by `:touch` and removable by `:delete`. |
-| 12 | **Fixed** (a, b, c, e) / **deferred** (d) | (a) `(.id ^datomic.Database db)` is hinted and now runs once per `db` value, not per call; the scope memo is a plain map (LRU hit bookkeeping cost ~6x a map lookup on the hottest path). (b) `traversal-permission?` is memoised under the same schema scope. (c) Element-wise tuple-prefix comparison — no per-datom vector allocation. (e) `frontier-permission-paths` dedupes by `path-frontier-identity`. (d) `find-relations`' relation-table scan is unchanged: bounded by schema size, and touching the `read-relationships` scan planner was more risk than the gain. |
+| 12 | **Fixed** (a, b, c, e) / **deferred** (d) | (a) Database identity/schema generation are captured once per client, not per `db` value; global LRU caches and hit bookkeeping were deleted. (b) `traversal-permission?` is memoised inside the same client generation. (c) Element-wise tuple-prefix comparison avoids per-datom vector allocation. (e) `frontier-permission-paths` dedupes by `path-frontier-identity`. (d) `find-relations`' relation-table scan is unchanged: bounded by schema size. |
 
-**Not done, deliberately.** Read-time filtering of ghost results from `lookup-resources`/`lookup-subjects`
-was considered and rejected for this change: it costs one datom probe per candidate row on every
-page, and doing it inside the recursive engine would shift emission ordinals and invalidate
-in-flight cursors. `delete-object!` plus the orphan repair pass fixes the data instead. The
-residual is that a database with existing orphans still lists them until repaired.
+**Not done, deliberately.** Read-time filtering of ghost results remains rejected: it costs
+existence probes on situated authorization reads and changes recursive emission ordinals.
+`retractEntity` is still available, dangling halves remain visible until repaired, and operators
+can now detect that state explicitly. Time travel is likewise not a connection-client goal.
 
 ### Verification
 
-Full suite on a **fresh** nREPL: **90 tests, 1636 assertions, 0 failures, 0 errors**
-(baseline before this change: 73 / 1297). New coverage: `object-deletion-test` (7 tests),
-`api-contract-test` (9), `schema-basis-test` gained the speculative-db, unstamped-database and
-scope-memo-cost contracts, and `differential-test` gained recursive **reverse** invariants —
-a path that previously had none (860 assertions in that namespace, up from ~360).
+Full suite on a **fresh** nREPL: **92 tests, 1656 assertions, 0 failures, 0 errors**
+(baseline before the PR: 73 / 1297). Coverage now pins client-lifecycle schema reads,
+generation replacement, out-of-band mismatch diagnostics, uncached arbitrary-db evaluation,
+bounded counts, the public `count-subjects` API, dangling-half audit/repair, and the explicit
+recursive bare-`:last` rejection.
 
-**Benchmarks.** Protocol: fresh JVM per version, `^:benchmark` suite only, two consecutive runs,
-second run reported (the first is JIT-dominated — first-run first-page medians ranged 2.3–2.7 ms
-on *both* versions, so any single-run comparison is meaningless here).
+**Benchmarks against v7.3 (`2ccc6c4`).** Protocol: separate nREPL/JVM per version, identical
+in-memory seed and query, warm-up before measurement. The heavy pagination suite was run twice;
+the second run is reported because the first is JIT-dominated.
 
 `multipath-pagination-benchmark`, 15 000 servers over a 4-arrow-path permission:
 
-| | before | after |
+| | v7.3 | v7.4 candidate |
 |---|---|---|
-| First page (`:first 50`) median / p95 | 1.36 / 2.26 ms | 1.34 / 1.95 ms |
-| Forward pagination, early / late / max page | 1.56 / 1.37 / 1.75 ms | 1.40 / 1.30 / 1.64 ms |
-| Reverse pagination, early / late / max page | 1.62 / 1.51 / 1.75 ms | 1.61 / 1.42 / 1.84 ms |
-| Deep-page medians, first / middle / last | 1.32 / 0.86 / 0.44 ms | 1.24 / 0.86 / 0.41 ms |
+| First page (`:first 50`) median / p95 | 1.18 / 1.92 ms | 1.21 / 1.90 ms |
+| Forward pagination, early / late / max page | 1.40 / 1.34 / 1.51 ms | 1.29 / 1.26 / 1.51 ms |
+| Reverse pagination, early / late / max page | 1.26 / 1.15 / 1.33 ms | 1.37 / 1.29 / 1.44 ms |
+| Deep-page medians, first / middle / last | 1.20 / 0.89 / 0.48 ms | 1.14 / 0.85 / 0.41 ms |
 | Traversal calls by depth (frontier effectiveness) | 282 / 184 / 79 | 282 / 184 / 79 |
 
-**Flat, within run-to-run noise, no regression.** The identical traversal-call counts confirm the
-frontier algorithm is untouched. Paging is dominated by index traversal (~282 scan calls for a
-50-row page), so cache-key overhead was never a large share of it.
+The mixed single-digit changes are within run-to-run timing noise; identical traversal-call
+counts confirm the acyclic pagination algorithm is unchanged.
 
-`can?` is where the cache change actually lands. Measured with identical version-agnostic code on
-a fresh JVM per version, median of 9 batches after warmup:
+`can?` is where the lifecycle cache lands. Hot figures are the median of nine 10,000-call batches
+on the second warmed run. The moving-connection figures are the median of 1,000 individual
+authorization calls, each made immediately after an unrelated transaction; transaction time is
+excluded. The larger schema has 311 relation/permission definition-index rows.
 
-| schema | | before | after | |
-|---|---|---|---|---|
-| 51 definitions | **public `eacl/can?`** | 2.90 µs | **2.24 µs** | **−23%** |
-| 601 definitions | **public `eacl/can?`** | 3.12 µs | **2.52 µs** | **−19%** |
-| 51 definitions | raw `impl.indexed/can?`, warm | 2.29 µs | **1.37 µs** | −40% |
-| 601 definitions | raw `impl.indexed/can?`, warm | 2.69 µs | **1.50 µs** | −44% |
-| 51 definitions | raw, a new `db` value every call | 2.34 µs | 3.42 µs | +46% |
-| 601 definitions | raw, a new `db` value every call | 2.54 µs | 15.67 µs | +518% |
+| definition rows | workload | v7.3 | v7.4 candidate | change |
+|---|---|---:|---:|---:|
+| 11 | hot public `eacl/can?` | 16.66 µs | 9.70 µs | **−42%** |
+| 311 | hot public `eacl/can?` | 16.95 µs | 9.43 µs | **−44%** |
+| 11 | new connection value before every `can?` | 22.50 µs | 16.54 µs | **−26%** |
+| 311 | new connection value before every `can?` | 22.04 µs | 12.63 µs | **−43%** |
 
-The public path is what applications call, and it is **19–23% faster** — even though finding 3
-added two datom existence probes to it. The cache work more than paid for them.
-
-The last two rows are the whole cost of exact scoping, stated plainly: a `db` value the memo has
-not seen pays one definition-index scan. "A new `db` value every call" means the database advances
-between *every single check*; the scan is bounded by schema size, never by data size, and 601
-definitions (60 definition blocks) is a deliberately extreme schema. The constant was already
-reduced ~4x during this work — direct index iteration instead of a seq walk (2x), and a plain-map
-memo instead of LRU hit bookkeeping (2x on the hit path).
-
-Pinned going forward by `permission-check-benchmark` (warm and cold `can?` medians, with
-thresholds) and by `schema-scope-is-computed-once-per-db-value-test`, which deterministically
-asserts the scan happens once per `db` value and not per call.
+The key result is the absence of schema-size growth on a moving connection: the candidate performs
+zero automatic schema reads or definition scans after construction. The committed heavy
+`permission-check-benchmark` also passes (warm 1.00 µs, explicitly cold paths 1.08 µs).

--- a/docs/reports/2026-07-29-eacl-full-source-bug-hunt.md
+++ b/docs/reports/2026-07-29-eacl-full-source-bug-hunt.md
@@ -272,7 +272,8 @@ the tuple datom by hand can remove it.
 
 Note also that `can?` and `lookup-subjects` now **disagree**, which breaks the invariant
 `differential-test` asserts everywhere else. Any downstream job driven by `lookup-subjects`
-("notify all admins", "sync relationships to SpiceDB") will act on ghost subjects with `nil` ids.
+("notify all admins", "sync authorization relationships downstream") will act on ghost subjects
+with `nil` ids.
 
 ### Recommended fix
 

--- a/src/eacl/core.clj
+++ b/src/eacl/core.clj
@@ -58,6 +58,15 @@
   ; construct a seq using ->Relationship.
   (delete-relationships! [this relationships])
 
+  (delete-object! [this object])
+  ; delete-object! removes every relationship touching `object` in both
+  ; directions, including the halves stored on the peer entities. Datomic's
+  ; :db.fn/retractEntity does NOT do this — v7 relationships name their peer
+  ; inside a tuple value, which retractEntity does not follow — so retracting a
+  ; permissioned entity without calling this first leaves relationship halves
+  ; that keep answering can?/lookup-resources/lookup-subjects.
+  ; Call it before retracting the entity. It does not retract the entity itself.
+
   (delete-relationship!
     [this subject relation resource]
     [this {:as relationship :keys [subject relation resource]}])

--- a/src/eacl/core.clj
+++ b/src/eacl/core.clj
@@ -83,7 +83,8 @@
 	  ;                                  :has-next-page? ... :has-previous-page? ...}}.
 
   (count-resources [this {:as query :keys [consistency]}])
-  ; counting can be slow because it enumerates the full lookup-resources result set
+  ; counting can be slow because it enumerates the full lookup-resources result
+  ; set. Pass :count-limit to bound work and receive :truncated? in the result.
 
   (lookup-subjects [this {:as query :keys [consistency]}])
 	  ; lookup-subjects (formerly 'who-can?') accepts:
@@ -92,6 +93,10 @@
 	  ; - :subject/type (keyword) required.
 	  ; - :subject/relation is NOT supported and throws :eacl.pagination/unsupported-filter.
 	  ; - :first/:after or :last/:before pagination, as above.
+
+  (count-subjects [this {:as query :keys [consistency]}])
+  ; Mirrors count-resources for lookup-subjects. Pass :count-limit to bound
+  ; work and receive :truncated? in the result.
 
   (expand-permission-tree [this {:as query :keys [resource permission consistency]}]))
 

--- a/src/eacl/datomic/core.clj
+++ b/src/eacl/datomic/core.clj
@@ -18,6 +18,7 @@
   (:import [java.nio.charset StandardCharsets]
            [java.security MessageDigest SecureRandom]
            [java.util Base64]
+           [java.util.concurrent.locks Lock ReentrantReadWriteLock]
            [javax.crypto Cipher]
            [javax.crypto.spec GCMParameterSpec SecretKeySpec]))
 
@@ -231,8 +232,12 @@
                                :first :last :after :before
                                :cursor :limit :page/basis :consistency)}))
 
+(defn- client-schema-version
+  [opts]
+  (some-> opts :schema-state deref :schema-version str))
+
 (defn- validate-page-token!
-  [op query-shape decoded]
+  [opts op query-shape decoded]
   (when decoded
     (when-not (= op (:op decoded))
       (throw (ex-info "Page token was created for a different operation."
@@ -244,6 +249,11 @@
                        :actual (:query-shape decoded)})))
     (when-not (= :stable (:basis decoded))
       (throw (ex-info "Unsupported page token basis." {:basis (:basis decoded)})))
+    (when-not (= (client-schema-version opts) (:schema-version decoded))
+      (throw (ex-info "Page token was created under a different EACL schema generation."
+                      {:type :eacl.pagination/stale-schema
+                       :expected (client-schema-version opts)
+                       :actual (:schema-version decoded)})))
     true))
 
 (defn- internal-page-query
@@ -261,6 +271,7 @@
                          :query-shape query-shape
                          :basis-t basis-t
                          :basis :stable
+                         :schema-version (client-schema-version opts)
                          :edge edge}
                   (:page-token-ttl-seconds opts)
                   (assoc :ttl-seconds (:page-token-ttl-seconds opts))))))
@@ -322,7 +333,7 @@
                            resource-id (assoc :resource/id resource-eid))
             query-shape  (list-query-shape :read-relationships filters')
             internal-query (internal-page-query filters' page-req decoded)]
-        (validate-page-token! :read-relationships query-shape decoded)
+        (validate-page-token! opts :read-relationships query-shape decoded)
         (coerce-relationship-page db opts :read-relationships query-shape basis-t
                                   (impl/read-relationships db internal-query))))))
 
@@ -360,15 +371,6 @@
         basis (d/basis-t db-after)]
     {:zed/token (str basis)}))
 
-(defn- existing-eid
-  "d/entid passes any long through unchanged, including the eid of a retracted
-  entity, so an id-coercion that hands EACL raw eids (a documented option) let
-  can? answer from relationship halves left behind by :db.fn/retractEntity.
-  Datom presence is the same existence test writes already use."
-  [db eid]
-  (when (and eid (seq (d/datoms db :eavt eid)))
-    eid))
-
 (defmacro ^:private with-recursive-limits
   "Applies the client's :recursive-traversal-limits, if configured, for the
   duration of one list call. Recursive permissions with large grant sets need
@@ -379,6 +381,28 @@
        (binding [impl.indexed/*recursive-traversal-limits* limits#]
          ~@body)
        (do ~@body))))
+
+(defmacro ^:private with-client-schema-read
+  "Runs one client operation against its latched schema generation. The read
+  lock permits concurrent authorization calls while excluding write-schema!'s
+  transaction-and-cache-swap window."
+  [schema-lock schema-state & body]
+  `(let [^Lock lock# (.readLock ^ReentrantReadWriteLock ~schema-lock)]
+     (.lock lock#)
+     (try
+       (binding [impl.indexed/*schema-cache* (deref ~schema-state)]
+         ~@body)
+       (finally
+         (.unlock lock#)))))
+
+(defmacro ^:private with-client-schema-write
+  [schema-lock & body]
+  `(let [^Lock lock# (.writeLock ^ReentrantReadWriteLock ~schema-lock)]
+     (.lock lock#)
+     (try
+       ~@body
+       (finally
+         (.unlock lock#)))))
 
 (def ^:private delete-object-batch-size 1000)
 
@@ -417,9 +441,9 @@
              {:type :eacl/unsupported-consistency
               :consistency consistency})))
   (let [subject-type (:type subject)
-        subject-eid  (existing-eid db (object->entid db subject))
+        subject-eid  (object->entid db subject)
         resource-type (:type resource)
-        resource-eid  (existing-eid db (object->entid db resource))]
+        resource-eid  (object->entid db resource)]
     (if-not (and subject-eid resource-eid)
       false
       (impl/can? db
@@ -444,20 +468,30 @@
       (let [query' (assoc query :subject internal-subject)
             query-shape (list-query-shape :lookup-resources query')
             internal-query (internal-page-query query' page-req decoded)]
-        (validate-page-token! :lookup-resources query-shape decoded)
+        (validate-page-token! opts :lookup-resources query-shape decoded)
         (coerce-lookup-page db opts :lookup-resources query-shape basis-t
                             (impl/lookup-resources db internal-query))))))
 
+(defn- empty-count-response
+  [query]
+  (if (contains? query :count-limit)
+    (let [limit (:count-limit query)]
+      (when-not (and (integer? limit) (not (neg? limit)))
+        (throw (ex-info ":count-limit must be a non-negative integer."
+                        {:eacl/error :eacl.count/invalid-limit
+                         :count-limit limit})))
+      {:count 0 :limit limit :truncated? false})
+    {:count 0 :limit -1}))
+
 (defn spiceomic-count-resources
   [db
-   {:as opts
-    :keys [spice-object->internal]}
+   {:keys [spice-object->internal]}
    {:as query :keys [subject]}]
   (validate-consistency! query)
   (let [subject-ent (spice-object->internal db subject)]
     (if (nil? (:id subject-ent))
       ;; Unknown subjects match nothing (SpiceDB-consistent; can? is false).
-      {:count 0 :limit -1}
+      (empty-count-response query)
       (->> query
            (S/setval [:subject] subject-ent)
            (impl/count-resources db)))))
@@ -477,87 +511,132 @@
       (let [query' (assoc query :resource internal-resource)
             query-shape (list-query-shape :lookup-subjects query')
             internal-query (internal-page-query query' page-req decoded)]
-        (validate-page-token! :lookup-subjects query-shape decoded)
+        (validate-page-token! opts :lookup-subjects query-shape decoded)
         (coerce-lookup-page db opts :lookup-subjects query-shape basis-t
                             (impl/lookup-subjects db internal-query))))))
 
-(defrecord Spiceomic [conn opts]
+(defn spiceomic-count-subjects
+  [db
+   {:keys [spice-object->internal]}
+   query]
+  (validate-consistency! query)
+  (let [resource-ent (spice-object->internal db (:resource query))]
+    (if (nil? (:id resource-ent))
+      (empty-count-response query)
+      (->> query
+           (S/setval [:resource] resource-ent)
+           (impl/count-subjects db)))))
+
+(defrecord Spiceomic [conn opts schema-state schema-lock]
   IAuthorization
   (can? [_ subject permission resource]
-    (spiceomic-can? (d/db conn) opts subject permission resource consistency/fully-consistent))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-can? (d/db conn) opts subject permission resource consistency/fully-consistent)))
 
   (can? [_ subject permission resource consistency]
-    (spiceomic-can? (d/db conn) opts subject permission resource consistency))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-can? (d/db conn) opts subject permission resource consistency)))
 
   (can? [_ {:keys [subject permission resource consistency]}]
-    (spiceomic-can? (d/db conn) opts subject permission resource
-                    (or consistency consistency/fully-consistent)))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-can? (d/db conn) opts subject permission resource
+                      (or consistency consistency/fully-consistent))))
 
   (read-schema [_]
-    (schema/read-schema (d/db conn)))
+    (with-client-schema-read schema-lock schema-state
+      (schema/read-schema (d/db conn))))
 
   (write-schema! [_ schema-string]
-    (schema/write-schema! conn schema-string))
+    (with-client-schema-write schema-lock
+      (let [deltas      (schema/write-schema!
+                         conn schema-string
+                         {}
+                         (:schema-version @schema-state))
+            next-version (:eacl/schema-version (meta deltas))
+            next-cache  (impl.indexed/make-schema-cache (d/db conn) next-version)]
+        (when-not (= (:schema-version @schema-state)
+                     (:schema-version next-cache))
+          (reset! schema-state next-cache))
+        deltas)))
 
   (read-relationships [_ filters]
-    (spiceomic-read-relationships conn opts filters))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-read-relationships conn opts filters)))
 
   (write-relationships! [_ updates]
-    (spiceomic-write-relationships! conn opts updates))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts updates)))
 
   (create-relationships! [_ relationships]
-    (spiceomic-write-relationships! conn opts
-                                    (for [rel relationships]
-                                      (->RelationshipUpdate :create rel))))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      (for [rel relationships]
+                                        (->RelationshipUpdate :create rel)))))
 
   (create-relationship! [_ relationship]
-    (spiceomic-write-relationships! conn opts
-                                    [(->RelationshipUpdate :create relationship)]))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      [(->RelationshipUpdate :create relationship)])))
 
   (create-relationship! [_ subject relation resource]
-    (spiceomic-write-relationships! conn opts
-                                    [(->RelationshipUpdate :create (->Relationship subject relation resource))]))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      [(->RelationshipUpdate :create (->Relationship subject relation resource))])))
 
   ;; Audit §13: these were declared on the protocol but unimplemented ->
   ;; AbstractMethodError at runtime.
   (write-relationship! [_ operation subject relation resource]
-    (spiceomic-write-relationships! conn opts
-                                    [(->RelationshipUpdate operation (->Relationship subject relation resource))]))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      [(->RelationshipUpdate operation (->Relationship subject relation resource))])))
 
   (write-relationship! [_ {:keys [operation subject relation resource]}]
-    (spiceomic-write-relationships! conn opts
-                                    [(->RelationshipUpdate operation (->Relationship subject relation resource))]))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      [(->RelationshipUpdate operation (->Relationship subject relation resource))])))
 
   (delete-relationship! [_ subject relation resource]
-    (spiceomic-write-relationships! conn opts
-                                    [(->RelationshipUpdate :delete (->Relationship subject relation resource))]))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      [(->RelationshipUpdate :delete (->Relationship subject relation resource))])))
 
   (delete-relationship! [_ {:keys [subject relation resource]}]
-    (spiceomic-write-relationships! conn opts
-                                    [(->RelationshipUpdate :delete (->Relationship subject relation resource))]))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-write-relationships! conn opts
+                                      [(->RelationshipUpdate :delete (->Relationship subject relation resource))])))
 
   (delete-relationships! [_ relationships]
-    (let [relationships' (if (map? relationships)
-                           (:data relationships)
-                           relationships)]
-      (spiceomic-write-relationships! conn opts
-                                      (for [rel relationships']
-                                        (->RelationshipUpdate :delete rel)))))
+    (with-client-schema-read schema-lock schema-state
+      (let [relationships' (if (map? relationships)
+                             (:data relationships)
+                             relationships)]
+        (spiceomic-write-relationships! conn opts
+                                        (for [rel relationships']
+                                          (->RelationshipUpdate :delete rel))))))
 
   (delete-object! [_ object]
-    (spiceomic-delete-object! conn opts object))
+    (with-client-schema-read schema-lock schema-state
+      (spiceomic-delete-object! conn opts object)))
 
   (lookup-resources [_ query]
-    (with-recursive-limits opts
-      (spiceomic-lookup-resources conn opts query)))
+    (with-client-schema-read schema-lock schema-state
+      (with-recursive-limits opts
+        (spiceomic-lookup-resources conn opts query))))
 
   (count-resources [_ query]
-    (with-recursive-limits opts
-      (spiceomic-count-resources (d/db conn) opts query)))
+    (with-client-schema-read schema-lock schema-state
+      (with-recursive-limits opts
+        (spiceomic-count-resources (d/db conn) opts query))))
 
   (lookup-subjects [_ query]
-    (with-recursive-limits opts
-      (spiceomic-lookup-subjects conn opts query)))
+    (with-client-schema-read schema-lock schema-state
+      (with-recursive-limits opts
+        (spiceomic-lookup-subjects conn opts query))))
+
+  (count-subjects [_ query]
+    (with-client-schema-read schema-lock schema-state
+      (with-recursive-limits opts
+        (spiceomic-count-subjects (d/db conn) opts query))))
 
   (expand-permission-tree [_ _]
     (throw (ex-info "expand-permission-tree is not implemented yet."
@@ -593,7 +672,8 @@
     for list calls, e.g. {:max-derived-grants 1000000 :max-advanced-datoms 1000000
     :max-queued-work 1000000}. Deep pages of a recursive permission replay the
     traversal prefix, so a grant set approaching the default 100k trips the
-    ceiling on later pages while page 1 still succeeds. These are a memory bound.
+    ceiling on later pages while page 1 still succeeds. These are host-JVM
+    memory bounds; tune them only after representative heap/load tests.
   - :auto-migrate-v6 — opt-in automatic v6->v7 storage migration at startup.
     Construction fails with {:type :eacl/storage-version} when the database
     holds unmigrated v6 relationship entities (v7 would silently answer false/
@@ -643,7 +723,9 @@
   ;; silently answer every check with false/empty. Throws :eacl/storage-version
   ;; unless the DB is v7/fresh/stamped, or :auto-migrate-v6 opts into migration.
   (migrations/assert-storage-compatible! conn {:auto-migrate-v6 auto-migrate-v6})
-  (let [entid->object-id   (or entid->object-id
+  (let [schema-state       (atom (impl.indexed/make-schema-cache (d/db conn)))
+        schema-lock        (ReentrantReadWriteLock.)
+        entid->object-id   (or entid->object-id
                                (when entity->object-id
                                  (fn [db eid] (entity->object-id (d/entity db eid))))
                                (fn [db eid] (:eacl/id (d/entity db eid))))
@@ -664,6 +746,7 @@
                                              {:page-token-kid current-kid
                                               :available-kids (set (keys keyring))})))
         opts               {:object-id->ident object-id->ident
+                            :schema-state schema-state
                             :entid->object-id entid->object-id
                             :object-id->entid object-id->entid
                             :object->entid (fn [db {:keys [id]}]
@@ -680,4 +763,4 @@
                             :recursive-traversal-limits (when recursive-traversal-limits
                                                           (merge impl.indexed/default-recursive-traversal-limits
                                                                  recursive-traversal-limits))}]
-    (->Spiceomic conn opts)))
+    (->Spiceomic conn opts schema-state schema-lock)))

--- a/src/eacl/datomic/core.clj
+++ b/src/eacl/datomic/core.clj
@@ -360,6 +360,56 @@
         basis (d/basis-t db-after)]
     {:zed/token (str basis)}))
 
+(defn- existing-eid
+  "d/entid passes any long through unchanged, including the eid of a retracted
+  entity, so an id-coercion that hands EACL raw eids (a documented option) let
+  can? answer from relationship halves left behind by :db.fn/retractEntity.
+  Datom presence is the same existence test writes already use."
+  [db eid]
+  (when (and eid (seq (d/datoms db :eavt eid)))
+    eid))
+
+(defmacro ^:private with-recursive-limits
+  "Applies the client's :recursive-traversal-limits, if configured, for the
+  duration of one list call. Recursive permissions with large grant sets need
+  headroom above the defaults on deep pages."
+  [opts & body]
+  `(let [limits# (:recursive-traversal-limits ~opts)]
+     (if limits#
+       (binding [impl.indexed/*recursive-traversal-limits* limits#]
+         ~@body)
+       (do ~@body))))
+
+(def ^:private delete-object-batch-size 1000)
+
+(defn spiceomic-delete-object!
+  "Retracts every relationship touching `object`, in both directions, in
+  batches. Returns {:zed/token ... :retracted-datoms <n>}.
+
+  The object's own entity is left alone — retract it yourself once this
+  returns (or in the same application transaction, using
+  eacl.datomic.impl/tx-delete-object directly)."
+  [conn {:keys [object-id->entid] :as _opts} object]
+  (let [object-id (if (map? object) (:id object) object)
+        db        (d/db conn)
+        eid       (or (try (object-id->entid db object-id)
+                           (catch Exception _ nil))
+                      ;; A retracted entity no longer resolves through the
+                      ;; caller's id coercion, but its raw eid still cleans up.
+                      (when (number? object-id) object-id))
+        tx-data   (impl/tx-delete-object db eid)]
+    (if (empty? tx-data)
+      {:zed/token (str (d/basis-t db)) :retracted-datoms 0}
+      (loop [batches   (partition-all delete-object-batch-size tx-data)
+             retracted 0
+             token     nil]
+        (if-let [batch (first batches)]
+          (let [{:keys [db-after]} @(d/transact conn (vec batch))]
+            (recur (next batches)
+                   (+ retracted (count batch))
+                   (str (d/basis-t db-after))))
+          {:zed/token token :retracted-datoms retracted})))))
+
 (defn spiceomic-can?
   [db {:keys [object->entid]} subject permission resource consistency]
   (when-not (= consistency/fully-consistent consistency)
@@ -367,9 +417,9 @@
              {:type :eacl/unsupported-consistency
               :consistency consistency})))
   (let [subject-type (:type subject)
-        subject-eid  (object->entid db subject)
+        subject-eid  (existing-eid db (object->entid db subject))
         resource-type (:type resource)
-        resource-eid  (object->entid db resource)]
+        resource-eid  (existing-eid db (object->entid db resource))]
     (if-not (and subject-eid resource-eid)
       false
       (impl/can? db
@@ -494,14 +544,20 @@
                                       (for [rel relationships']
                                         (->RelationshipUpdate :delete rel)))))
 
+  (delete-object! [_ object]
+    (spiceomic-delete-object! conn opts object))
+
   (lookup-resources [_ query]
-    (spiceomic-lookup-resources conn opts query))
+    (with-recursive-limits opts
+      (spiceomic-lookup-resources conn opts query)))
 
   (count-resources [_ query]
-    (spiceomic-count-resources (d/db conn) opts query))
+    (with-recursive-limits opts
+      (spiceomic-count-resources (d/db conn) opts query)))
 
   (lookup-subjects [_ query]
-    (spiceomic-lookup-subjects conn opts query))
+    (with-recursive-limits opts
+      (spiceomic-lookup-subjects conn opts query)))
 
   (expand-permission-tree [_ _]
     (throw (ex-info "expand-permission-tree is not implemented yet."
@@ -517,6 +573,7 @@
     :page-token-keyring
     :page-token-kid
     :page-token-ttl-seconds
+    :recursive-traversal-limits
     :auto-migrate-v6})
 
 (defn make-client
@@ -532,6 +589,11 @@
     page tokens do not survive restarts and are not portable across peers;
     supply stable key material in production.
   - :page-token-ttl-seconds — overrides the default page-token expiry.
+  - :recursive-traversal-limits — overrides eacl.datomic.impl.indexed/default-recursive-traversal-limits
+    for list calls, e.g. {:max-derived-grants 1000000 :max-advanced-datoms 1000000
+    :max-queued-work 1000000}. Deep pages of a recursive permission replay the
+    traversal prefix, so a grant set approaching the default 100k trips the
+    ceiling on later pages while page 1 still succeeds. These are a memory bound.
   - :auto-migrate-v6 — opt-in automatic v6->v7 storage migration at startup.
     Construction fails with {:type :eacl/storage-version} when the database
     holds unmigrated v6 relationship entities (v7 would silently answer false/
@@ -547,6 +609,7 @@
            page-token-keyring
            page-token-kid
            page-token-ttl-seconds
+           recursive-traversal-limits
            auto-migrate-v6]
     :or   {object-id->ident (fn [obj-id] [:eacl/id obj-id])}}]
   (when-let [unknown-keys (seq (remove known-client-opt-keys (keys config-opts)))]
@@ -563,6 +626,19 @@
     (throw (ex-info "EACL Config Error: object-id->ident must be a fn that coerces a Spice Object ID to a Datomic ident resolvable by d/entid."
              {:type :eacl/invalid-config
               :key :object-id->ident})))
+  (when recursive-traversal-limits
+    (let [known (set (keys impl.indexed/default-recursive-traversal-limits))]
+      (when-not (and (map? recursive-traversal-limits)
+                     (every? known (keys recursive-traversal-limits))
+                     (every? (fn [v] (and (integer? v) (pos? v)))
+                             (vals recursive-traversal-limits)))
+        (throw (ex-info (str "EACL Config Error: :recursive-traversal-limits must be a map of "
+                             (pr-str (vec (sort known)))
+                             " to positive integers.")
+                 {:type :eacl/invalid-config
+                  :key :recursive-traversal-limits
+                  :known-keys known
+                  :value recursive-traversal-limits})))))
   ;; Refuse to run v7 code against unmigrated v6 relationship data — it would
   ;; silently answer every check with false/empty. Throws :eacl/storage-version
   ;; unless the DB is v7/fresh/stamped, or :auto-migrate-v6 opts into migration.
@@ -598,5 +674,10 @@
                                                       (update obj :id #(when (some? %) (object-id->entid db %))))
                             :page-token-current-kid current-kid
                             :page-token-keyring keyring
-                            :page-token-ttl-seconds page-token-ttl-seconds}]
+                            :page-token-ttl-seconds page-token-ttl-seconds
+                            ;; merged, so a partial override cannot silently
+                            ;; disable the limits it does not mention
+                            :recursive-traversal-limits (when recursive-traversal-limits
+                                                          (merge impl.indexed/default-recursive-traversal-limits
+                                                                 recursive-traversal-limits))}]
     (->Spiceomic conn opts)))

--- a/src/eacl/datomic/impl.clj
+++ b/src/eacl/datomic/impl.clj
@@ -520,8 +520,11 @@
 ;; Worse, the survivor is unreachable through write-relationships!, because
 ;; resolving either endpoint of the relationship now throws :eacl/unknown-object.
 ;;
-;; tx-delete-object is the supported way to delete: call it (or the client's
-;; delete-object!) BEFORE retracting the entity.
+;; EACL consumers are expected to delete relationships before retracting an
+;; entity. tx-delete-object and the client's delete-object! are convenience
+;; helpers for that workflow. A bare retractEntity remains valid Datomic, but
+;; callers should run the explicit integrity audit if it might have left a
+;; surviving peer half.
 
 (defn- relation-triples
   "[resource-type relation-eid subject-type] for every Relation in the schema.
@@ -631,10 +634,10 @@
 (defn tx-retract-orphaned-relationships
   "Retraction tx-data for orphaned-relationship-halves. Fails closed: an
   orphan means one endpoint is gone, so the survivor should stop granting.
-  Transact in batches on large databases."
+  Returns a lazy sequence; transact in batches on large databases."
   [db]
-  (mapv (fn [{:keys [e attr v]}] [:db/retract e attr v])
-        (orphaned-relationship-halves db)))
+  (map (fn [{:keys [e attr v]}] [:db/retract e attr v])
+       (orphaned-relationship-halves db)))
 
 (defn tx-relationship
   "Translate relationship data into v7 tuple writes.

--- a/src/eacl/datomic/impl.clj
+++ b/src/eacl/datomic/impl.clj
@@ -18,8 +18,10 @@
 (defn can?
   ([db subject permission resource]
    (impl.indexed/can? db subject permission resource))
-  ([db demand]
-   (impl.indexed/can? db demand)))
+  ;; The map arity used to forward to a 2-arity impl.indexed/can? that does not
+  ;; exist, so every call threw ArityException.
+  ([db {:keys [subject permission resource]}]
+   (impl.indexed/can? db subject permission resource)))
 
 (defn lookup-subjects
   [db query]
@@ -33,6 +35,10 @@
   [db query]
   (impl.indexed/count-resources db query))
 
+(defn count-subjects
+  [db query]
+  (impl.indexed/count-subjects db query))
+
 (def ^:private forward-relationship-attr
   :eacl.v7.relationship/subject-type+relation+resource-type+resource)
 
@@ -40,11 +46,15 @@
   :eacl.v7.relationship/resource-type+relation+subject-type+subject)
 
 (defn can!
-  "The thrown exception should probably be configurable."
+  "Like can?, but throws :eacl/unauthorized instead of returning false."
   [db subject permission resource]
   (if (can? db subject permission resource)
     true
-    (throw (Exception. "Unauthorized"))))
+    (throw (ex-info "Unauthorized"
+             {:type :eacl/unauthorized
+              :subject subject
+              :permission permission
+              :resource resource}))))
 
 (defn- unknown-object!
   [object-id]
@@ -145,17 +155,28 @@
     reverse-relationship-attr
     (reverse-relationship-tuple resolved)]])
 
+(defn- forward-tuple-exists?
+  [db {:keys [subject-eid] :as resolved}]
+  (boolean (seq (d/datoms db :eavt subject-eid forward-relationship-attr
+                          (relationship-tuple resolved)))))
+
+(defn- reverse-tuple-exists?
+  [db {:keys [resource-eid] :as resolved}]
+  (boolean (seq (d/datoms db :eavt resource-eid reverse-relationship-attr
+                          (reverse-relationship-tuple resolved)))))
+
 (defn- relationship-exists?
+  "True only when BOTH halves of the relationship are present.
+
+  Checking the forward index alone made a half-written pair unrepairable:
+  :touch saw 'already there' and :delete saw 'nothing to do', so the surviving
+  half kept answering lookups forever. A half-pair now reads as absent, which
+  lets :touch re-assert it and :delete retract it."
   [db {:keys [subject-eid resource-eid] :as resolved}]
-  (if (and (number? subject-eid) (number? resource-eid))
-    (boolean
-     (seq
-      (d/datoms db
-                :eavt
-                subject-eid
-                forward-relationship-attr
-                (relationship-tuple resolved))))
-    false))
+  (and (number? subject-eid)
+       (number? resource-eid)
+       (forward-tuple-exists? db resolved)
+       (reverse-tuple-exists? db resolved)))
 
 (defn find-one-relationship-id
   "Returns the resolved tuple identity for an existing relationship, or nil.
@@ -394,15 +415,20 @@
                       (case direction
                         :asc (take size realized)
                         :desc (reverse (take size realized))))]
-      {:data (mapv :node items)
-       :page-info {:start-cursor (some-> items first :cursor)
-                   :end-cursor (some-> items last :cursor)
-                   :has-next-page? (case direction
-                                     :asc (> (count realized) size)
-                                     :desc (boolean bound))
-                   :has-previous-page? (case direction
-                                         :asc (boolean bound)
-                                         :desc (> (count realized) size))}})))
+      ;; An empty page carries no cursors, so it can advertise neither
+      ;; direction — see eacl.datomic.impl.indexed/page-response.
+      (let [any? (boolean (seq items))]
+        {:data (mapv :node items)
+         :page-info {:start-cursor (some-> items first :cursor)
+                     :end-cursor (some-> items last :cursor)
+                     :has-next-page? (and any?
+                                          (case direction
+                                            :asc (> (count realized) size)
+                                            :desc (boolean bound)))
+                     :has-previous-page? (and any?
+                                              (case direction
+                                                :asc (boolean bound)
+                                                :desc (> (count realized) size)))}}))))
 
 (def ^:private known-relationship-filter-keys
   "Filter + pagination keys read-relationships accepts. :cursor and :limit are
@@ -433,11 +459,18 @@
                          ". Known keys: " (pr-str (vec (sort known-relationship-filter-keys))) ".")
              {:eacl/error :eacl.filters/unknown-filter
               :unknown-keys (vec unknown-keys)})))
-  (when-not (some #(contains? filters %) relationship-anchor-keys)
-    (throw (ex-info (str "read-relationships requires at least one anchor filter of "
+  ;; some? not contains?: a present-but-nil anchor (the shape you get from
+  ;; {:subject/id (get-in req [:params :user-id])} with the param missing) is
+  ;; treated as absent by every consumer below, so accepting it as an anchor
+  ;; degraded the read to exactly the global scan this guard exists to prevent.
+  (when-not (some #(some? (get filters %)) relationship-anchor-keys)
+    (throw (ex-info (str "read-relationships requires at least one non-nil anchor filter of "
                          (pr-str (vec (sort relationship-anchor-keys)))
                          ". An unfiltered read would scan the entire relationship index.")
-             {:eacl/error :eacl.filters/missing-anchor}))))
+             {:eacl/error :eacl.filters/missing-anchor
+              :nil-anchor-keys (vec (sort (filter #(and (contains? filters %)
+                                                        (nil? (get filters %)))
+                                                  relationship-anchor-keys)))}))))
 
 (defn read-relationships
   [db filters]
@@ -445,8 +478,10 @@
   (let [relations    (find-relations db filters)
         subject-id    (:subject/id filters)
         resource-id   (:resource/id filters)
-        subject-eid  (when subject-id (d/entid db subject-id))
-        resource-eid (when resource-id (d/entid db resource-id))
+        ;; object-eid, not d/entid: a raw-impl caller passing a string id got a
+        ;; bare :db.error/not-a-keyword out of Datomic.
+        subject-eid  (when (some? subject-id) (impl.indexed/object-eid db subject-id))
+        resource-eid (when (some? resource-id) (impl.indexed/object-eid db resource-id))
         normalized-filters (cond-> filters
                              subject-eid (assoc :subject/id subject-eid)
                              resource-eid (assoc :resource/id resource-eid))]
@@ -461,6 +496,145 @@
 
       :else
       (relationship-page db relations normalized-filters subject-eid resource-eid))))
+
+;; --- Object deletion --------------------------------------------------------
+;;
+;; A v7 relationship is two datoms living on two DIFFERENT entities, each
+;; naming its peer inside a tuple VALUE:
+;;
+;;   [subject-eid  <forward-attr> [subject-type relation-eid resource-type resource-eid]]
+;;   [resource-eid <reverse-attr> [resource-type relation-eid subject-type subject-eid]]
+;;
+;; :db.fn/retractEntity follows :db.type/ref ATTRIBUTES. It does not follow
+;; ref-typed components of a heterogeneous tuple, and a heterogeneous tuple
+;; cannot be :db/isComponent. So retracting a permissioned entity the ordinary
+;; Datomic way removes only the half stored ON that entity and leaves the peer's
+;; half behind, where it keeps answering queries:
+;;
+;;   - delete a RESOURCE  -> the subject keeps its forward tuple, so can? still
+;;                           answers true and lookup-resources still lists it;
+;;   - delete a SUBJECT   -> the resource keeps its reverse tuple, so
+;;                           lookup-subjects still lists the deleted subject
+;;                           while can? answers false — the two APIs disagree.
+;;
+;; Worse, the survivor is unreachable through write-relationships!, because
+;; resolving either endpoint of the relationship now throws :eacl/unknown-object.
+;;
+;; tx-delete-object is the supported way to delete: call it (or the client's
+;; delete-object!) BEFORE retracting the entity.
+
+(defn- relation-triples
+  "[resource-type relation-eid subject-type] for every Relation in the schema.
+  Bounded by schema size, never by relationship count."
+  [db]
+  (mapv (fn [datom]
+          (let [[resource-type _relation-name subject-type] (:v datom)]
+            [resource-type (:e datom) subject-type]))
+        (d/datoms db :aevt :eacl.relation/resource-type+relation-name+subject-type)))
+
+(defn- relationship-pair-retractions
+  "Both halves of one relationship, as retraction ops."
+  [subject-type subject-eid relation-eid resource-type resource-eid]
+  [[:db/retract subject-eid forward-relationship-attr
+    [subject-type relation-eid resource-type resource-eid]]
+   [:db/retract resource-eid reverse-relationship-attr
+    [resource-type relation-eid subject-type subject-eid]]])
+
+(defn tx-delete-object
+  "Retraction tx-data removing every EACL relationship that touches `object-id`,
+  in BOTH directions — including the halves stored on the peer entities.
+
+  `object-id` is resolved the same way reads resolve object ids (string ->
+  [:eacl/id ...], anything else -> d/entid), so it also accepts the raw eid of
+  an entity that was already retracted the bare Datomic way. Returns [] for an
+  id that does not resolve.
+
+  Finds relationships two ways, so it is complete whether or not the object's
+  own datoms still exist:
+    - the object's own halves, via :eavt on the object; and
+    - the peers' halves that NAME the object, via one exact :avet lookup per
+      Relation in the schema (both indexes are :db/index true).
+  Retracting a datom that is already absent is a no-op, so the overlap between
+  the two is harmless and this is idempotent.
+
+  Retracts relationships only; retracting the entity itself is yours to do."
+  [db object-id]
+  (if-let [eid (impl.indexed/object-eid db object-id)]
+    (let [triples (relation-triples db)]
+      (vec
+       (distinct
+        (concat
+         ;; The object's own halves. Needed on top of the index lookups below
+         ;; because a half whose peer is already missing is only visible here.
+         (mapcat (fn [datom]
+                   (let [[subject-type relation-eid resource-type resource-eid] (:v datom)]
+                     (relationship-pair-retractions subject-type eid relation-eid
+                                                    resource-type resource-eid)))
+                 (d/datoms db :eavt eid forward-relationship-attr))
+         (mapcat (fn [datom]
+                   (let [[resource-type relation-eid subject-type subject-eid] (:v datom)]
+                     (relationship-pair-retractions subject-type subject-eid relation-eid
+                                                    resource-type eid)))
+                 (d/datoms db :eavt eid reverse-relationship-attr))
+         ;; Peers naming this object as the SUBJECT (halves stored on resources).
+         (mapcat (fn [[resource-type relation-eid subject-type]]
+                   (mapcat (fn [datom]
+                             (relationship-pair-retractions subject-type eid relation-eid
+                                                            resource-type (:e datom)))
+                           (d/datoms db :avet reverse-relationship-attr
+                                     [resource-type relation-eid subject-type eid])))
+                 triples)
+         ;; Peers naming this object as the RESOURCE (halves stored on subjects).
+         (mapcat (fn [[resource-type relation-eid subject-type]]
+                   (mapcat (fn [datom]
+                             (relationship-pair-retractions subject-type (:e datom) relation-eid
+                                                            resource-type eid))
+                           (d/datoms db :avet forward-relationship-attr
+                                     [subject-type relation-eid resource-type eid])))
+                 triples)))))
+    []))
+
+(defn orphaned-relationship-halves
+  "Lazy seq of relationship halves whose peer half is absent — the residue of
+  entities retracted without tx-delete-object.
+
+  Scans both relationship indexes and probes for each peer, so this is an
+  offline maintenance operation, O(number of relationships). Pass a plain db
+  value (not history/filter)."
+  [db]
+  (concat
+   (for [datom (d/datoms db :aevt forward-relationship-attr)
+         :let  [subject-eid (:e datom)
+                [subject-type relation-eid resource-type resource-eid] (:v datom)]
+         :when (empty? (d/datoms db :eavt resource-eid reverse-relationship-attr
+                                 [resource-type relation-eid subject-type subject-eid]))]
+     {:half          :forward
+      :e             subject-eid
+      :attr          forward-relationship-attr
+      :v             (vec (:v datom))
+      :subject-eid   subject-eid
+      :resource-eid  resource-eid
+      :relation-eid  relation-eid})
+   (for [datom (d/datoms db :aevt reverse-relationship-attr)
+         :let  [resource-eid (:e datom)
+                [resource-type relation-eid subject-type subject-eid] (:v datom)]
+         :when (empty? (d/datoms db :eavt subject-eid forward-relationship-attr
+                                 [subject-type relation-eid resource-type resource-eid]))]
+     {:half          :reverse
+      :e             resource-eid
+      :attr          reverse-relationship-attr
+      :v             (vec (:v datom))
+      :subject-eid   subject-eid
+      :resource-eid  resource-eid
+      :relation-eid  relation-eid})))
+
+(defn tx-retract-orphaned-relationships
+  "Retraction tx-data for orphaned-relationship-halves. Fails closed: an
+  orphan means one endpoint is gone, so the survivor should stop granting.
+  Transact in batches on large databases."
+  [db]
+  (mapv (fn [{:keys [e attr v]}] [:db/retract e attr v])
+        (orphaned-relationship-halves db)))
 
 (defn tx-relationship
   "Translate relationship data into v7 tuple writes.
@@ -489,12 +663,17 @@
 
       :create
       (if exists?
-        (throw (Exception. ":create relationship conflicts with existing tuple relationship"))
+        (throw (ex-info ":create conflicts with an existing relationship. Use :touch for idempotent writes."
+                 {:type :eacl/relationship-conflict
+                  :relationship relationship}))
         (add-relationship-txes resolved))
 
+      ;; Unconditional: Datomic ignores retraction of an absent datom, and
+      ;; skipping on a not-exists? check left a surviving half-pair in place.
       :delete
-      (when exists?
-        (retract-relationship-txes resolved))
+      (retract-relationship-txes resolved)
 
       :unspecified
-      (throw (Exception. ":unspecified relationship update not supported.")))))
+      (throw (ex-info ":unspecified relationship update is not supported. Use :create, :touch or :delete."
+               {:type :eacl/unsupported-operation
+                :operation :unspecified})))))

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -1,6 +1,5 @@
 (ns eacl.datomic.impl.indexed
-  (:require [clojure.core.cache :as cache]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [datomic.api :as d]
             [eacl.core :refer [spice-object]]
             [eacl.lazy-merge-sort :as lazy-sort])
@@ -299,173 +298,79 @@
                    :relation-name target-relation-name})
         []))))
 
-;; --- Schema-scoped permission-path cache (issue #74) -------------------------
+;; --- Client-lifecycle permission-path cache (issue #74) ----------------------
 ;;
-;; Two levels:
+;; EACL has one supported schema mutation boundary: eacl/write-schema!. A
+;; connection-backed client reads :eacl/schema-version ONCE when it is created
+;; and owns one generation of resolved permission paths for its lifetime.
+;; Ordinary Datomic transactions may produce a new db value for every request;
+;; they do not cause a version read, definition scan, cache-key change or db
+;; value retention.
 ;;
-;;   schema-scope-cache : db value        -> schema scope   (LRU, few entries)
-;;   permission-paths-cache : [scope resource-type permission-name] -> paths
+;; write-schema! through that client replaces the entire generation under the
+;; client's schema write lock. Other clients/processes must be recreated after
+;; an out-of-band schema write. Low-level functions in this namespace are
+;; intentionally uncached unless a client binds *schema-cache*: arbitrary
+;; d/with/filter/as-of values therefore cannot publish paths into a live
+;; connection-backed client's cache.
 ;;
-;; The scope is an exact fingerprint of the EACL *definition* datoms visible in
-;; that db value, so two db values share a paths entry only when their schemas
-;; are identical. That closes two holes in the previous
-;; [database-uuid schema-version] scope, both of which produced silently wrong
-;; authorization answers:
-;;
-;;   1. A d/with speculative database inherits the database uuid, reads as
-;;      :plain (is-filtered/as-of-t/since-t are all false/nil on it) and does
-;;      not bump :eacl/schema-version. Evaluating a permission against a
-;;      speculative schema change therefore published the speculative paths
-;;      under the LIVE database's key, granting permissions the committed
-;;      schema does not define — until the process restarted.
-;;   2. Databases that never called write-schema! (programmatic Relation /
-;;      Permission writes, or migrate! without :schema) have a nil version
-;;      stamp, so their scope was constant for the life of the database and no
-;;      definition change was ever visible to the cache.
-;;
-;; Issue #74's requirement is preserved: the fingerprint is computed once per
-;; db VALUE and memoised on the db itself. Datomic returns an identical object
-;; for repeated (d/db conn) at the same basis, and db equality is
-;; content-sensitive (a d/with db is never = to a committed db at the same t),
-;; so the memo is both exact and ~free on the hot path. An unrelated d/transact
-;; produces a new db value but the SAME fingerprint, so relationship write load
-;; re-verifies the (small) definition index once and every permission-path
-;; entry still hits. Nothing recomputes paths unless the definitions changed.
+;; An unstamped database (normally a fresh v7 database before its first schema
+;; write) is never latched: paths are resolved from the supplied db value on
+;; every call until write-schema! establishes a version. This is not a v6
+;; compatibility path.
 
-(def ^:private schema-scope-cache-threshold
-  "How many distinct db values keep a memoised schema scope. Each entry pins one
-  Datomic db value, so this is deliberately small; it only needs to cover the
-  db values in flight (one per request, plus one per in-progress paginated walk
-  pinned to d/as-of)."
-  64)
+(def ^:dynamic *schema-cache*
+  "The client-owned schema cache bound by eacl.datomic.core.
 
-(def ^:private permission-paths-cache-threshold 1000)
-
-(defn- fresh-lru [threshold]
-  (cache/lru-cache-factory {} :threshold threshold))
-
-(def permission-paths-cache
-  (atom (fresh-lru permission-paths-cache-threshold)))
-
-(def schema-scope-cache
-  "db value -> schema scope. A plain map rather than an LRU: this is read on
-  every get-permission-paths call, and a bare map lookup is ~6x cheaper than
-  LRU hit bookkeeping. It memoises a pure function whose recomputation costs
-  microseconds, so dropping the whole map when it outgrows its bound is an
-  acceptable eviction policy — and it keeps the number of retained Datomic db
-  values (and therefore index roots) hard-bounded."
-  (atom {}))
-
-(def traversal-permission-cache
-  (atom (fresh-lru permission-paths-cache-threshold)))
-
-(defn evict-permission-paths-cache!
-  "Clears the permission-path caches. Correctness no longer depends on calling
-  this: the cache scope is an exact fingerprint of the definition datoms in the
-  queried db value, so any definition change — through write-schema! or not —
-  already yields a different cache key. write-schema! still calls it to release
-  entries for schema eras that can no longer be queried."
-  []
-  (reset! permission-paths-cache (fresh-lru permission-paths-cache-threshold))
-  (reset! schema-scope-cache {})
-  (reset! traversal-permission-cache (fresh-lru permission-paths-cache-threshold)))
+  nil means raw/arbitrary-db evaluation and is deliberately uncached."
+  nil)
 
 (def schema-version-attr
-  "Installed by eacl.datomic.schema/v7-schema; asserted by write-schema!.
-  Informational since the path cache moved to content fingerprints: it records
-  which write-schema! call a database is on, and gives d/as-of views a readable
-  schema generation."
+  "Installed by eacl.datomic.schema/v7-schema; asserted by write-schema!."
   :eacl/schema-version)
 
 (defn schema-version
   "The schema-version squuid asserted by the most recent write-schema! visible
-  in this db value, or nil for databases that predate versioned schema writes.
-  A single AVET lookup on a one-datom attribute."
+  in this db value, or nil before the first supported schema write. Reads only
+  the canonical schema-string entity."
   [db]
-  (when (d/entid db schema-version-attr)
-    (:v (first (d/datoms db :avet schema-version-attr)))))
-
-(defn- classified-view
-  "Positively classifies a db value: :plain, :as-of, or nil for a view whose
-  :eacl/schema-version stamp is not a meaningful schema generation. d/filter
-  predicates are arbitrary and may hide definition datoms without hiding the
-  version datom; d/since views hide old schema; history views are not
-  queryable schema states. Only schema-version-stamp consults this — the path
-  cache fingerprints definition content and is exact on every view."
-  [db]
-  (cond
-    (d/is-history db)      nil
-    (d/is-filtered db)     nil
-    (some? (d/since-t db)) nil
-    (some? (d/as-of-t db)) :as-of
-    :else                  :plain))
+  (when (d/entid db :eacl/id)
+    (some-> (d/entity db [:eacl/id "schema-string"])
+            schema-version-attr)))
 
 (defn schema-version-stamp
-  "String form of the schema version for this db value, or nil when no version
-  has been written yet or the view is one the stamp does not describe (filter,
-  since, history — see classified-view). Informational only."
+  "String form of the version visible in db. This is an explicit diagnostic;
+  connection-backed authorization calls do not invoke it."
   [db]
-  (when (classified-view db)
-    (some-> (schema-version db) str)))
+  (some-> (schema-version db) str))
 
-(def ^:private relation-identity-attr
-  :eacl.relation/resource-type+relation-name+subject-type)
+(defn make-schema-cache
+  "Creates the one schema generation owned by an EACL client.
 
-(def ^:private permission-identity-attr
-  :eacl.permission/resource-type+source-relation-name+target-type+target-name+permission-name)
-
-(defn- attr-fingerprint
-  "[count entity-hash max-tx] over an attribute's AEVT range.
-
-  Both attributes fingerprinted here are :db.unique/identity composite tuples.
-  Datomic re-asserts a composite tuple with a fresh tx whenever ANY of its
-  component attributes changes, so max-tx detects in-place definition edits,
-  while count and entity-hash detect additions, retractions and excisions.
-  O(number of definitions) — never O(number of relationships). Iterated
-  directly rather than through a seq: this runs once per new db value on the
-  hot authz path, and skipping the seq allocation halves it."
-  [db attr]
-  (let [it (.iterator ^Iterable (d/datoms db :aevt attr))]
-    (loop [n      0
-           h      1
-           max-tx 0]
-      (if (.hasNext it)
-        (let [^datomic.Datom datom (.next it)
-              tx (long (.tx datom))]
-          (recur (unchecked-inc n)
-                 (unchecked-add (unchecked-multiply 31 h) (long (.e datom)))
-                 (if (> tx max-tx) tx max-tx)))
-        [n h max-tx]))))
-
-(defn- calc-schema-scope
-  "Exact identity of the EACL definitions visible in this db value. The database
-  id is required because two freshly created databases can hold byte-identical
-  definitions at identical eids and tx ids."
-  [db]
-  [(str (.id ^datomic.Database db))
-   (attr-fingerprint db relation-identity-attr)
-   (attr-fingerprint db permission-identity-attr)])
-
-(defn schema-scope
-  "Memoised calc-schema-scope, keyed on the db value itself.
-
-  Datomic returns an identical object for repeated (d/db conn) at the same
-  basis and its db equality is content-sensitive, so this hits for every query
-  against a db value already seen and is exact for one that has not been.
-  A db value the memo has not seen costs one O(number-of-definitions) scan;
-  that is the price of never sharing a cache slot between two schemas."
-  [db]
-  (or (get @schema-scope-cache db)
-      (let [scope (calc-schema-scope db)]
-        (swap! schema-scope-cache
-               (fn [m]
-                 (assoc (if (> (count m) schema-scope-cache-threshold) {} m)
-                        db scope)))
-        scope)))
+  This is the only automatic :eacl/schema-version read. A nil version marks a
+  fresh/unstamped database and deliberately disables latching/caching."
+  ([db]
+   (make-schema-cache db (schema-version db)))
+  ([db known-schema-version]
+   {:database-id (str (.id ^datomic.Database db))
+    :schema-version known-schema-version
+    :permission-paths (atom {})
+    :traversal-permissions (atom {})}))
 
 (defn- permission-paths-cache-key
-  [scope resource-type permission-name]
-  (conj scope resource-type permission-name))
+  [resource-type permission-name]
+  [resource-type permission-name])
+
+(defn evict-permission-paths-cache!
+  "Clears one client generation's derived entries without rereading schema.
+  With no bound/provided client cache this is intentionally a no-op."
+  ([]
+   (when *schema-cache*
+     (evict-permission-paths-cache! *schema-cache*)))
+  ([schema-cache]
+   (reset! (:permission-paths schema-cache) {})
+   (reset! (:traversal-permissions schema-cache) {})
+   nil))
 
 (defn calc-permission-paths
   "Returns path maps with resolved relation eids.
@@ -524,15 +429,19 @@
 
 (defn get-permission-paths
   [db resource-type permission-name]
-  (let [cache-key (permission-paths-cache-key (schema-scope db) resource-type permission-name)
-        cache     @permission-paths-cache]
-    (if (cache/has? cache cache-key)
-      (do
-        (swap! permission-paths-cache cache/hit cache-key)
-        (cache/lookup cache cache-key))
-      (let [paths (calc-permission-paths db resource-type permission-name)]
-        (swap! permission-paths-cache cache/miss cache-key paths)
-        paths))))
+  (if-not (some? (:schema-version *schema-cache*))
+    (calc-permission-paths db resource-type permission-name)
+    (let [cache-key (permission-paths-cache-key resource-type permission-name)
+          cache-atom (:permission-paths *schema-cache*)
+          snapshot @cache-atom]
+      (if (contains? snapshot cache-key)
+        (get snapshot cache-key)
+        (let [paths (calc-permission-paths db resource-type permission-name)]
+          (get (swap! cache-atom
+                      #(if (contains? % cache-key)
+                         %
+                         (assoc % cache-key paths)))
+               cache-key))))))
 
 (defn- frontier-permission-paths
   "Expands same-resource permission aliases into independently resumable paths.
@@ -665,19 +574,22 @@
   These roots cannot be proven page-bounded in eid order without materialized
   grants, so list APIs evaluate them in deterministic traversal order.
 
-  Every list API calls this on every page, and answering it walks the whole
-  permission dependency graph, so it is memoised under the same schema scope as
-  the paths it is derived from."
+  A stamped connection-backed client memoises this once in its single schema
+  generation. Raw db evaluation and unstamped clients recompute it."
   [db resource-type permission-name]
-  (let [cache-key (permission-paths-cache-key (schema-scope db) resource-type permission-name)
-        cache     @traversal-permission-cache]
-    (if (cache/has? cache cache-key)
-      (do
-        (swap! traversal-permission-cache cache/hit cache-key)
-        (cache/lookup cache cache-key))
-      (let [recursive? (recursive-permission-query? db resource-type permission-name)]
-        (swap! traversal-permission-cache cache/miss cache-key recursive?)
-        recursive?))))
+  (if-not (some? (:schema-version *schema-cache*))
+    (recursive-permission-query? db resource-type permission-name)
+    (let [cache-key (permission-paths-cache-key resource-type permission-name)
+          cache-atom (:traversal-permissions *schema-cache*)
+          snapshot @cache-atom]
+      (if (contains? snapshot cache-key)
+        (get snapshot cache-key)
+        (let [recursive? (recursive-permission-query? db resource-type permission-name)]
+          (get (swap! cache-atom
+                      #(if (contains? % cache-key)
+                         %
+                         (assoc % cache-key recursive?)))
+               cache-key))))))
 
 (defn traversal-nodes
   [db]
@@ -698,9 +610,9 @@
   permission whose grant set approaches :max-derived-grants therefore starts
   failing on DEEP pages while page 1 still succeeds.
 
-  Raise them for large recursive grant sets with make-client's
-  :recursive-traversal-limits (they are a memory bound: the traversal keeps a
-  seen-grants set of this size), or model the permission acyclically."
+  These are host-JVM memory bounds, not ordinary pagination controls. Use
+  :count-limit for bounded counts, model large permissions acyclically, or tune
+  :recursive-traversal-limits only after representative heap/load tests."
   {:max-derived-grants 100000
    :max-advanced-datoms 100000
    :max-queued-work 100000})
@@ -727,8 +639,9 @@
       (recursive-traversal-error!
        (str "Recursive traversal safety limit exceeded (" (name counter-key) " > " limit ")."
             " Deep pages of a recursive permission replay the traversal prefix, so this trips"
-            " on later pages of a large grant set. Raise it with make-client's"
-            " :recursive-traversal-limits, or model the permission acyclically.")
+            " on later pages of a large grant set. Use :count-limit for bounded counts,"
+            " model the permission acyclically, or tune make-client's"
+            " :recursive-traversal-limits only after heap/load testing.")
        {:eacl/error :eacl.recursive-traversal/limit-exceeded
         :limit-kind counter-key
         :limit limit}))
@@ -1163,51 +1076,34 @@
                  (if trim? (pop ring') ring')
                  (if trim? (inc size) ring-count')))))))
 
-(defn- collect-trailing-items
-  "Bare :last: exhausts a traversal keeping only the trailing size+1 items.
-  next-item is (fn [state] [state' item-or-nil]).
-
-  Acyclic lookups have always accepted bare :last, and whether a permission is
-  recursive is a property of the schema that callers cannot see — so rejecting
-  it here turned adding `parent->read` to a schema into a runtime break for
-  every :last caller. This costs a full traversal, the same as count-resources."
-  [next-item state size]
-  (loop [state state
-         ring clojure.lang.PersistentQueue/EMPTY
-         ring-count 0]
-    (let [[state' item] (next-item state)]
-      (if (nil? item)
-        (let [items (vec ring)
-              has-sentinel? (> (count items) size)]
-          {:items (if has-sentinel?
-                    (subvec items (- (count items) size))
-                    items)
-           :has-sentinel? has-sentinel?})
-        (let [ring' (conj ring item)
-              ring-count' (inc ring-count)
-              trim? (> ring-count' (inc size))]
-          (recur state'
-                 (if trim? (pop ring') ring')
-                 (if trim? (inc size) ring-count')))))))
-
 (defn- count-traversal-items
-  "Number of results a traversal emits, in ONE pass.
+  "Counts results emitted by one traversal, stopping after `limit` when set.
 
   The paged alternative (repeatedly asking for the next max-page-size page)
   replays the whole traversal prefix per page, which is O(N^2) and trips
   :max-derived-grants long before a large grant set is counted."
-  [next-item state]
+  [next-item state limit]
   (loop [state state
          n 0]
     (let [[state' item] (next-item state)]
-      (if item
-        (recur state' (unchecked-inc n))
-        n))))
+      (cond
+        (nil? item)
+        {:count n :truncated? false}
+
+        (and limit (>= n limit))
+        {:count n :truncated? true}
+
+        :else
+        (recur state' (unchecked-inc n))))))
 
 (defn- recursive-forward-page
   [db query]
   (let [{:keys [direction size bound]} (normalize-page-request query)
         _ (validate-recursive-bound! bound :forward :resource)
+        _ (when (and (= :desc direction) (nil? bound))
+            (page-error! "Bare :last is not supported for recursive traversal pagination because it requires a full closure traversal."
+                         {:eacl/error :eacl.pagination/unsupported-recursive-last
+                          :reason :requires-full-traversal}))
         {:keys [subject permission]} query
         subject-type (:type subject)
         subject-eid (object-eid db (:id subject))
@@ -1230,11 +1126,9 @@
 
         :desc
         (let [{:keys [items has-sentinel?]}
-              (if bound
-                (collect-forward-before db root-node result-type state bound size)
-                (collect-trailing-items #(next-forward-item db root-node result-type %) state size))]
+              (collect-forward-before db root-node result-type state bound size)]
           (page-response {:items items
-                          :has-next? (boolean bound)
+                          :has-next? true
                           :has-previous? has-sentinel?}))))))
 
 (defn- rules-by-node
@@ -1516,6 +1410,10 @@
                   :filter :subject/relation}))
   (let [{:keys [direction size bound]} (normalize-page-request query)
         _ (validate-recursive-bound! bound :reverse :subject)
+        _ (when (and (= :desc direction) (nil? bound))
+            (page-error! "Bare :last is not supported for recursive traversal pagination because it requires a full closure traversal."
+                         {:eacl/error :eacl.pagination/unsupported-recursive-last
+                          :reason :requires-full-traversal}))
         {:keys [resource permission]} query
         resource-type (:type resource)
         resource-eid (object-eid db (:id resource))
@@ -1538,11 +1436,9 @@
 
         :desc
         (let [{:keys [items has-sentinel?]}
-              (if bound
-                (collect-reverse-before db root-node resource-eid subject-type state bound size)
-                (collect-trailing-items #(next-reverse-item db root-node resource-eid subject-type %) state size))]
+              (collect-reverse-before db root-node resource-eid subject-type state bound size)]
           (page-response {:items items
-                          :has-next? (boolean bound)
+                          :has-next? true
                           :has-previous? has-sentinel?}))))))
 
 (declare traverse-permission-path lookup-subject-eids* can*)
@@ -1934,31 +1830,60 @@
     (page-error! (str op " does not use list pagination keys.")
                  (select-keys query count-pagination-keys))))
 
+(defn- query-count-limit
+  [query]
+  (when (contains? query :count-limit)
+    (let [limit (:count-limit query)]
+      (when-not (and (integer? limit) (not (neg? limit)))
+        (page-error! ":count-limit must be a non-negative integer."
+                     {:eacl/error :eacl.count/invalid-limit
+                      :count-limit limit}))
+      limit)))
+
+(defn- count-response
+  [{:keys [count truncated?]} limit]
+  (cond-> {:count count
+           :limit (or limit -1)}
+    (some? limit) (assoc :truncated? truncated?)))
+
 (defn- count-lazy-results
-  "Counts without retaining the head: doall bound the whole realized seq to a
-  local, so counting a broad permission held every result eid in memory for the
-  duration."
-  [results]
-  (reduce (fn [n _] (unchecked-inc n)) 0 results))
+  "Counts without retaining the head, and stops after `limit` when set.
+
+  The old doall implementation bound the whole realized seq to a local, so
+  counting a broad permission held every result eid in memory."
+  [results limit]
+  (loop [remaining (seq results)
+         n 0]
+    (cond
+      (nil? remaining)
+      {:count n :truncated? false}
+
+      (and limit (>= n limit))
+      {:count n :truncated? true}
+
+      :else
+      (recur (next remaining) (unchecked-inc n)))))
 
 (defn count-resources
   [db {:as query}]
   (reject-count-pagination-keys! "count-resources" query)
-  (if (traversal-permission? db (:resource/type query) (:permission query))
-    (let [{:keys [subject permission]} query
-          subject-eid (object-eid db (:id subject))
-          result-type (:resource/type query)
-          root-node   (permission-query-node result-type permission)]
-      {:count (if-not subject-eid
-                0
-                (count-traversal-items
-                 #(next-forward-item db root-node result-type %)
-                 (initial-forward-state db (:type subject) subject-eid root-node)))
-       :limit -1})
-    (let [page-req {:direction :asc :bound nil}
-          {:keys [results]} (lazy-merged-lookup db forward-direction query page-req)]
-      {:count (count-lazy-results results)
-       :limit -1})))
+  (let [limit (query-count-limit query)]
+    (if (traversal-permission? db (:resource/type query) (:permission query))
+      (let [{:keys [subject permission]} query
+            subject-eid (object-eid db (:id subject))
+            result-type (:resource/type query)
+            root-node   (permission-query-node result-type permission)]
+        (count-response
+         (if-not subject-eid
+           {:count 0 :truncated? false}
+           (count-traversal-items
+            #(next-forward-item db root-node result-type %)
+            (initial-forward-state db (:type subject) subject-eid root-node)
+            limit))
+         limit))
+      (let [page-req {:direction :asc :bound nil}
+            {:keys [results]} (lazy-merged-lookup db forward-direction query page-req)]
+        (count-response (count-lazy-results results limit) limit)))))
 
 (defn count-subjects
   [db {:as query}]
@@ -1967,18 +1892,20 @@
     (page-error! ":subject/relation is not supported by count-subjects."
                  {:eacl/error :eacl.pagination/unsupported-filter
                   :filter :subject/relation}))
-  (if (traversal-permission? db (:type (:resource query)) (:permission query))
-    (let [{:keys [resource permission]} query
-          resource-eid (object-eid db (:id resource))
-          subject-type (:subject/type query)
-          root-node    (permission-query-node (:type resource) permission)]
-      {:count (if-not resource-eid
-                0
-                (count-traversal-items
-                 #(next-reverse-item db root-node resource-eid subject-type %)
-                 (initial-reverse-state db subject-type root-node resource-eid)))
-       :limit -1})
-    (let [page-req {:direction :asc :bound nil}
-          {:keys [results]} (lazy-merged-lookup db reverse-direction query page-req)]
-      {:count (count-lazy-results results)
-       :limit -1})))
+  (let [limit (query-count-limit query)]
+    (if (traversal-permission? db (:type (:resource query)) (:permission query))
+      (let [{:keys [resource permission]} query
+            resource-eid (object-eid db (:id resource))
+            subject-type (:subject/type query)
+            root-node    (permission-query-node (:type resource) permission)]
+        (count-response
+         (if-not resource-eid
+           {:count 0 :truncated? false}
+           (count-traversal-items
+            #(next-reverse-item db root-node resource-eid subject-type %)
+            (initial-reverse-state db subject-type root-node resource-eid)
+            limit))
+         limit))
+      (let [page-req {:direction :asc :bound nil}
+            {:keys [results]} (lazy-merged-lookup db reverse-direction query page-req)]
+        (count-response (count-lazy-results results limit) limit)))))

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -18,7 +18,7 @@
 (def ^:private max-page-size 10000)
 (def ^:private lookup-frontier-version 1)
 
-(defn- object-eid
+(defn object-eid
   "Resolves an object id to an eid for read paths. String ids resolve via the
   canonical [:eacl/id ...] identity — d/entid on a bare string throws a raw
   IllegalArgumentException, which leaked out of can?/lookups for raw-impl
@@ -63,7 +63,21 @@
       (page-error! ":after is valid only with :first." {:after (:after query)})
 
       (and has-before? (not has-last?))
-      (page-error! ":before is valid only with :last." {:before (:before query)}))
+      (page-error! ":before is valid only with :last." {:before (:before query)})
+
+      ;; A present-but-nil boundary used to mean "start over", so a client
+      ;; looping on a page-info that carried a nil cursor silently restarted at
+      ;; page 1 forever. Absent means first page; nil means the caller lost
+      ;; their cursor and must be told.
+      (and has-after? (nil? (:after query)))
+      (page-error! ":after was passed as nil. Omit it for the first page."
+                   {:eacl/error :eacl.pagination/invalid-cursor
+                    :key :after})
+
+      (and has-before? (nil? (:before query)))
+      (page-error! ":before was passed as nil. Omit it for the last page."
+                   {:eacl/error :eacl.pagination/invalid-cursor
+                    :key :before}))
 
     (let [direction (if has-last? :desc :asc)
           size (or (when has-first? (:first query))
@@ -152,11 +166,15 @@
    :has-previous-page? (boolean has-previous?)})
 
 (defn- page-response
+  "An empty page carries no cursors, so it can advertise neither direction:
+  `has-next-page? true` with a nil `end-cursor` gave clients a loop they could
+  not exit. Both flags are therefore clamped to false when there are no items."
   [{:keys [items has-next? has-previous?]}]
-  {:data (mapv :node items)
-   :page-info (page-info {:items items
-                          :has-next? has-next?
-                          :has-previous? has-previous?})})
+  (let [any? (boolean (seq items))]
+    {:data (mapv :node items)
+     :page-info (page-info {:items items
+                            :has-next? (and any? has-next?)
+                            :has-previous? (and any? has-previous?)})}))
 
 (defn- lookup-items
   [result-type eids frontier-direction path-frontiers]
@@ -177,17 +195,21 @@
                             :desc (or bound-eid Long/MAX_VALUE)))
         datoms      (case direction
                       :asc (d/seek-datoms db :eavt subject-eid attr-eid start-tuple)
-                      :desc (d/rseek-datoms db :eavt subject-eid attr-eid start-tuple))]
+                      :desc (d/rseek-datoms db :eavt subject-eid attr-eid start-tuple))
+        skip-bound? (boolean (and bound-eid (not inclusive-bound?)))]
     (->> datoms
+         ;; Element-wise prefix comparison. `(= prefix (subvec (vec v) 0 3))`
+         ;; allocated two vectors for every datom scanned, in the innermost
+         ;; loop of the whole engine; the semantics are identical.
          (take-while
           (fn [datom]
             (let [v (:v datom)]
               (and (== subject-eid (:e datom))
                    (== attr-eid (:a datom))
-                   (= prefix (subvec (vec v) 0 3))))))
-         (drop-while #(and bound-eid
-                           (not inclusive-bound?)
-                           (= bound-eid (nth (:v %) 3))))
+                   (= subject-type (nth v 0))
+                   (= relation-eid (nth v 1))
+                   (= resource-type (nth v 2))))))
+         (drop-while #(and skip-bound? (= bound-eid (nth (:v %) 3))))
          (map (fn [datom] (nth (:v datom) 3))))))
 
 (defn resource->subjects
@@ -202,17 +224,20 @@
                             :desc (or bound-eid Long/MAX_VALUE)))
         datoms      (case direction
                       :asc (d/seek-datoms db :eavt resource-eid attr-eid start-tuple)
-                      :desc (d/rseek-datoms db :eavt resource-eid attr-eid start-tuple))]
+                      :desc (d/rseek-datoms db :eavt resource-eid attr-eid start-tuple))
+        skip-bound? (boolean (and bound-eid (not inclusive-bound?)))]
     (->> datoms
+         ;; See subject->resources: element-wise prefix comparison, no per-datom
+         ;; vector allocation.
          (take-while
           (fn [datom]
             (let [v (:v datom)]
               (and (== resource-eid (:e datom))
                    (== attr-eid (:a datom))
-                   (= prefix (subvec (vec v) 0 3))))))
-         (drop-while #(and bound-eid
-                           (not inclusive-bound?)
-                           (= bound-eid (nth (:v %) 3))))
+                   (= resource-type (nth v 0))
+                   (= relation-eid (nth v 1))
+                   (= subject-type (nth v 2))))))
+         (drop-while #(and skip-bound? (= bound-eid (nth (:v %) 3))))
          (map (fn [datom] (nth (:v datom) 3))))))
 
 (defn relation-datoms
@@ -274,42 +299,82 @@
                    :relation-name target-relation-name})
         []))))
 
+;; --- Schema-scoped permission-path cache (issue #74) -------------------------
+;;
+;; Two levels:
+;;
+;;   schema-scope-cache : db value        -> schema scope   (LRU, few entries)
+;;   permission-paths-cache : [scope resource-type permission-name] -> paths
+;;
+;; The scope is an exact fingerprint of the EACL *definition* datoms visible in
+;; that db value, so two db values share a paths entry only when their schemas
+;; are identical. That closes two holes in the previous
+;; [database-uuid schema-version] scope, both of which produced silently wrong
+;; authorization answers:
+;;
+;;   1. A d/with speculative database inherits the database uuid, reads as
+;;      :plain (is-filtered/as-of-t/since-t are all false/nil on it) and does
+;;      not bump :eacl/schema-version. Evaluating a permission against a
+;;      speculative schema change therefore published the speculative paths
+;;      under the LIVE database's key, granting permissions the committed
+;;      schema does not define — until the process restarted.
+;;   2. Databases that never called write-schema! (programmatic Relation /
+;;      Permission writes, or migrate! without :schema) have a nil version
+;;      stamp, so their scope was constant for the life of the database and no
+;;      definition change was ever visible to the cache.
+;;
+;; Issue #74's requirement is preserved: the fingerprint is computed once per
+;; db VALUE and memoised on the db itself. Datomic returns an identical object
+;; for repeated (d/db conn) at the same basis, and db equality is
+;; content-sensitive (a d/with db is never = to a committed db at the same t),
+;; so the memo is both exact and ~free on the hot path. An unrelated d/transact
+;; produces a new db value but the SAME fingerprint, so relationship write load
+;; re-verifies the (small) definition index once and every permission-path
+;; entry still hits. Nothing recomputes paths unless the definitions changed.
+
+(def ^:private schema-scope-cache-threshold
+  "How many distinct db values keep a memoised schema scope. Each entry pins one
+  Datomic db value, so this is deliberately small; it only needs to cover the
+  db values in flight (one per request, plus one per in-progress paginated walk
+  pinned to d/as-of)."
+  64)
+
+(def ^:private permission-paths-cache-threshold 1000)
+
+(defn- fresh-lru [threshold]
+  (cache/lru-cache-factory {} :threshold threshold))
+
 (def permission-paths-cache
-  (atom (cache/lru-cache-factory {} :threshold 1000)))
+  (atom (fresh-lru permission-paths-cache-threshold)))
+
+(def schema-scope-cache
+  "db value -> schema scope. A plain map rather than an LRU: this is read on
+  every get-permission-paths call, and a bare map lookup is ~6x cheaper than
+  LRU hit bookkeeping. It memoises a pure function whose recomputation costs
+  microseconds, so dropping the whole map when it outgrows its bound is an
+  acceptable eviction policy — and it keeps the number of retained Datomic db
+  values (and therefore index roots) hard-bounded."
+  (atom {}))
+
+(def traversal-permission-cache
+  (atom (fresh-lru permission-paths-cache-threshold)))
 
 (defn evict-permission-paths-cache!
-  "Manual override that clears the permission-path cache. write-schema! calls
-  it for immediate local hygiene; cross-peer and as-of correctness rely on the
-  :eacl/schema-version cache key, not on this. It is also the recovery hatch
-  after unsupported programmatic schema edits."
+  "Clears the permission-path caches. Correctness no longer depends on calling
+  this: the cache scope is an exact fingerprint of the definition datoms in the
+  queried db value, so any definition change — through write-schema! or not —
+  already yields a different cache key. write-schema! still calls it to release
+  entries for schema eras that can no longer be queried."
   []
-  (reset! permission-paths-cache (cache/lru-cache-factory {} :threshold 1000)))
-
-;; --- Schema-version cache scope (issue #74) ---------------------------------
-;;
-;; The path cache is invalidated ONLY by eacl.datomic.schema/write-schema!,
-;; which asserts a fresh :eacl/schema-version squuid on the schema singleton in
-;; the same transaction as any definition change. Reading the stamp is a single
-;; AVET lookup — O(log N), no per-call schema-datom scans — and unrelated
-;; d/transact calls leave it (and therefore every cache key) untouched, so
-;; relationship write load can never evict or recompute paths. (The previous
-;; design derived a digest from the schema datoms on every lookup — issue #74.)
-;;
-;; Contract: permission schema mutations MUST go through write-schema!.
-;; Programmatic edits of relation/permission datoms (raw d/transact, d/with,
-;; excision) do not bump the version, so caches may serve paths computed from
-;; the pre-edit schema until the next write-schema! or a manual
-;; evict-permission-paths-cache!. That trade-off is by design.
-;;
-;; The stamp lives in the database, not in peer memory, so:
-;;  - write-schema! on any peer invalidates every peer (the stored value changes);
-;;  - d/as-of views read the version that was current at that basis, giving
-;;    historic views their own cache slots;
-;;  - a squuid can never be re-asserted to an unchanged value by a concurrent
-;;    writer (no counter-elision race).
+  (reset! permission-paths-cache (fresh-lru permission-paths-cache-threshold))
+  (reset! schema-scope-cache {})
+  (reset! traversal-permission-cache (fresh-lru permission-paths-cache-threshold)))
 
 (def schema-version-attr
-  "Installed by eacl.datomic.schema/v7-schema; asserted by write-schema!."
+  "Installed by eacl.datomic.schema/v7-schema; asserted by write-schema!.
+  Informational since the path cache moved to content fingerprints: it records
+  which write-schema! call a database is on, and gives d/as-of views a readable
+  schema generation."
   :eacl/schema-version)
 
 (defn schema-version
@@ -320,14 +385,13 @@
   (when (d/entid db schema-version-attr)
     (:v (first (d/datoms db :avet schema-version-attr)))))
 
-(def ^:private uncached-scope [::uncached])
-
 (defn- classified-view
-  "Positively classifies a db value: :plain, :as-of, or nil for any view the
-  version stamp cannot be trusted on. d/filter views are excluded because their
-  predicates are arbitrary functions that may hide definition datoms without
-  hiding the version datom; d/since views hide old schema and are pointless to
-  cache; history views are not queryable schema states."
+  "Positively classifies a db value: :plain, :as-of, or nil for a view whose
+  :eacl/schema-version stamp is not a meaningful schema generation. d/filter
+  predicates are arbitrary and may hide definition datoms without hiding the
+  version datom; d/since views hide old schema; history views are not
+  queryable schema states. Only schema-version-stamp consults this — the path
+  cache fingerprints definition content and is exact on every view."
   [db]
   (cond
     (d/is-history db)      nil
@@ -336,29 +400,68 @@
     (some? (d/as-of-t db)) :as-of
     :else                  :plain))
 
-(defn- schema-cache-scope
-  "Returns [database-id schema-version-string] for positively classified
-  plain/as-of db values, or a sentinel scope for anything else (filter, since,
-  history, unrecognized views) and for ANY failure. Sentinel scopes bypass the
-  cache entirely: every failure mode degrades to recomputation from the
-  queried db value — never to serving a stale entry."
-  [db]
-  (or (try
-        (when (classified-view db)
-          [(str (.id db)) (some-> (schema-version db) str)])
-        (catch Throwable _ nil))
-      uncached-scope))
-
-(defn- uncached-scope? [scope]
-  (identical? uncached-scope scope))
-
 (defn schema-version-stamp
   "String form of the schema version for this db value, or nil when no version
-  has been written yet or the view cannot be classified (see schema-cache-scope)."
+  has been written yet or the view is one the stamp does not describe (filter,
+  since, history — see classified-view). Informational only."
   [db]
-  (let [scope (schema-cache-scope db)]
-    (when-not (uncached-scope? scope)
-      (second scope))))
+  (when (classified-view db)
+    (some-> (schema-version db) str)))
+
+(def ^:private relation-identity-attr
+  :eacl.relation/resource-type+relation-name+subject-type)
+
+(def ^:private permission-identity-attr
+  :eacl.permission/resource-type+source-relation-name+target-type+target-name+permission-name)
+
+(defn- attr-fingerprint
+  "[count entity-hash max-tx] over an attribute's AEVT range.
+
+  Both attributes fingerprinted here are :db.unique/identity composite tuples.
+  Datomic re-asserts a composite tuple with a fresh tx whenever ANY of its
+  component attributes changes, so max-tx detects in-place definition edits,
+  while count and entity-hash detect additions, retractions and excisions.
+  O(number of definitions) — never O(number of relationships). Iterated
+  directly rather than through a seq: this runs once per new db value on the
+  hot authz path, and skipping the seq allocation halves it."
+  [db attr]
+  (let [it (.iterator ^Iterable (d/datoms db :aevt attr))]
+    (loop [n      0
+           h      1
+           max-tx 0]
+      (if (.hasNext it)
+        (let [^datomic.Datom datom (.next it)
+              tx (long (.tx datom))]
+          (recur (unchecked-inc n)
+                 (unchecked-add (unchecked-multiply 31 h) (long (.e datom)))
+                 (if (> tx max-tx) tx max-tx)))
+        [n h max-tx]))))
+
+(defn- calc-schema-scope
+  "Exact identity of the EACL definitions visible in this db value. The database
+  id is required because two freshly created databases can hold byte-identical
+  definitions at identical eids and tx ids."
+  [db]
+  [(str (.id ^datomic.Database db))
+   (attr-fingerprint db relation-identity-attr)
+   (attr-fingerprint db permission-identity-attr)])
+
+(defn schema-scope
+  "Memoised calc-schema-scope, keyed on the db value itself.
+
+  Datomic returns an identical object for repeated (d/db conn) at the same
+  basis and its db equality is content-sensitive, so this hits for every query
+  against a db value already seen and is exact for one that has not been.
+  A db value the memo has not seen costs one O(number-of-definitions) scan;
+  that is the price of never sharing a cache slot between two schemas."
+  [db]
+  (or (get @schema-scope-cache db)
+      (let [scope (calc-schema-scope db)]
+        (swap! schema-scope-cache
+               (fn [m]
+                 (assoc (if (> (count m) schema-scope-cache-threshold) {} m)
+                        db scope)))
+        scope)))
 
 (defn- permission-paths-cache-key
   [scope resource-type permission-name]
@@ -421,20 +524,15 @@
 
 (defn get-permission-paths
   [db resource-type permission-name]
-  (let [scope (schema-cache-scope db)]
-    (if (uncached-scope? scope)
-      ;; Unclassifiable view (filter/since/history) or scope failure:
-      ;; compute fresh from this db value; never share cache entries.
-      (calc-permission-paths db resource-type permission-name)
-      (let [cache @permission-paths-cache
-            cache-key (permission-paths-cache-key scope resource-type permission-name)]
-        (if (cache/has? cache cache-key)
-          (do
-            (swap! permission-paths-cache cache/hit cache-key)
-            (cache/lookup cache cache-key))
-          (let [paths (calc-permission-paths db resource-type permission-name)]
-            (swap! permission-paths-cache cache/miss cache-key paths)
-            paths))))))
+  (let [cache-key (permission-paths-cache-key (schema-scope db) resource-type permission-name)
+        cache     @permission-paths-cache]
+    (if (cache/has? cache cache-key)
+      (do
+        (swap! permission-paths-cache cache/hit cache-key)
+        (cache/lookup cache cache-key))
+      (let [paths (calc-permission-paths db resource-type permission-name)]
+        (swap! permission-paths-cache cache/miss cache-key paths)
+        paths))))
 
 (defn- frontier-permission-paths
   "Expands same-resource permission aliases into independently resumable paths.
@@ -453,7 +551,18 @@
                               (expand (:target-permission path) visited-nodes')
                               [path]))
                           (get-permission-paths db resource-type permission-name))))))]
-    (vec (expand permission-name #{}))))
+    ;; `permission view = owner + admin` where `permission admin = owner`
+    ;; expands to the same relation path twice: scanned twice, and both
+    ;; collapsing onto one path-frontier-key anyway.
+    (->> (expand permission-name #{})
+         (reduce (fn [{:keys [seen paths] :as acc} path]
+                   (let [k (path-frontier-identity path)]
+                     (if (contains? seen k)
+                       acc
+                       {:seen (conj seen k)
+                        :paths (conj paths path)})))
+                 {:seen #{} :paths []})
+         :paths)))
 
 (defn- permission-query-node
   [resource-type permission-name]
@@ -554,9 +663,21 @@
 (defn traversal-permission?
   "True when a permission root transitively depends on a recursive permission SCC.
   These roots cannot be proven page-bounded in eid order without materialized
-  grants, so list APIs evaluate them in deterministic traversal order."
+  grants, so list APIs evaluate them in deterministic traversal order.
+
+  Every list API calls this on every page, and answering it walks the whole
+  permission dependency graph, so it is memoised under the same schema scope as
+  the paths it is derived from."
   [db resource-type permission-name]
-  (recursive-permission-query? db resource-type permission-name))
+  (let [cache-key (permission-paths-cache-key (schema-scope db) resource-type permission-name)
+        cache     @traversal-permission-cache]
+    (if (cache/has? cache cache-key)
+      (do
+        (swap! traversal-permission-cache cache/hit cache-key)
+        (cache/lookup cache cache-key))
+      (let [recursive? (recursive-permission-query? db resource-type permission-name)]
+        (swap! traversal-permission-cache cache/miss cache-key recursive?)
+        recursive?))))
 
 (defn traversal-nodes
   [db]
@@ -567,10 +688,25 @@
 
 (def ^:private recursive-engine-version 1)
 
-(def ^:dynamic *recursive-traversal-limits*
+(def default-recursive-traversal-limits
+  "Safety ceilings for one recursive traversal.
+
+  These bound a SINGLE page computation. Recursive pages resume by replaying
+  the traversal prefix and discarding results up to the cursor's ordinal, so
+  work — and :derived-grants — grows with the page's offset: enumerating N
+  results needs roughly N derived grants on the last page. A recursive
+  permission whose grant set approaches :max-derived-grants therefore starts
+  failing on DEEP pages while page 1 still succeeds.
+
+  Raise them for large recursive grant sets with make-client's
+  :recursive-traversal-limits (they are a memory bound: the traversal keeps a
+  seen-grants set of this size), or model the permission acyclically."
   {:max-derived-grants 100000
    :max-advanced-datoms 100000
    :max-queued-work 100000})
+
+(def ^:dynamic *recursive-traversal-limits*
+  default-recursive-traversal-limits)
 
 (def ^:dynamic *recursive-traversal-stats* nil)
 
@@ -589,7 +725,10 @@
         limit (get *recursive-traversal-limits* limit-key)]
     (when (and limit (> n limit))
       (recursive-traversal-error!
-       "Recursive traversal safety limit exceeded."
+       (str "Recursive traversal safety limit exceeded (" (name counter-key) " > " limit ")."
+            " Deep pages of a recursive permission replay the traversal prefix, so this trips"
+            " on later pages of a large grant set. Raise it with make-client's"
+            " :recursive-traversal-limits, or model the permission acyclically.")
        {:eacl/error :eacl.recursive-traversal/limit-exceeded
         :limit-kind counter-key
         :limit limit}))
@@ -1024,14 +1163,51 @@
                  (if trim? (pop ring') ring')
                  (if trim? (inc size) ring-count')))))))
 
+(defn- collect-trailing-items
+  "Bare :last: exhausts a traversal keeping only the trailing size+1 items.
+  next-item is (fn [state] [state' item-or-nil]).
+
+  Acyclic lookups have always accepted bare :last, and whether a permission is
+  recursive is a property of the schema that callers cannot see — so rejecting
+  it here turned adding `parent->read` to a schema into a runtime break for
+  every :last caller. This costs a full traversal, the same as count-resources."
+  [next-item state size]
+  (loop [state state
+         ring clojure.lang.PersistentQueue/EMPTY
+         ring-count 0]
+    (let [[state' item] (next-item state)]
+      (if (nil? item)
+        (let [items (vec ring)
+              has-sentinel? (> (count items) size)]
+          {:items (if has-sentinel?
+                    (subvec items (- (count items) size))
+                    items)
+           :has-sentinel? has-sentinel?})
+        (let [ring' (conj ring item)
+              ring-count' (inc ring-count)
+              trim? (> ring-count' (inc size))]
+          (recur state'
+                 (if trim? (pop ring') ring')
+                 (if trim? (inc size) ring-count')))))))
+
+(defn- count-traversal-items
+  "Number of results a traversal emits, in ONE pass.
+
+  The paged alternative (repeatedly asking for the next max-page-size page)
+  replays the whole traversal prefix per page, which is O(N^2) and trips
+  :max-derived-grants long before a large grant set is counted."
+  [next-item state]
+  (loop [state state
+         n 0]
+    (let [[state' item] (next-item state)]
+      (if item
+        (recur state' (unchecked-inc n))
+        n))))
+
 (defn- recursive-forward-page
   [db query]
   (let [{:keys [direction size bound]} (normalize-page-request query)
         _ (validate-recursive-bound! bound :forward :resource)
-        _ (when (and (= :desc direction) (nil? bound))
-            (page-error! "Bare :last is not supported for recursive traversal pagination."
-                         {:eacl/error :eacl.pagination/unsupported-recursive-last
-                          :reason :requires-full-traversal}))
         {:keys [subject permission]} query
         subject-type (:type subject)
         subject-eid (object-eid db (:id subject))
@@ -1053,9 +1229,12 @@
                           :has-previous? (boolean bound)}))
 
         :desc
-        (let [{:keys [items has-sentinel?]} (collect-forward-before db root-node result-type state bound size)]
+        (let [{:keys [items has-sentinel?]}
+              (if bound
+                (collect-forward-before db root-node result-type state bound size)
+                (collect-trailing-items #(next-forward-item db root-node result-type %) state size))]
           (page-response {:items items
-                          :has-next? true
+                          :has-next? (boolean bound)
                           :has-previous? has-sentinel?}))))))
 
 (defn- rules-by-node
@@ -1337,10 +1516,6 @@
                   :filter :subject/relation}))
   (let [{:keys [direction size bound]} (normalize-page-request query)
         _ (validate-recursive-bound! bound :reverse :subject)
-        _ (when (and (= :desc direction) (nil? bound))
-            (page-error! "Bare :last is not supported for recursive traversal pagination."
-                         {:eacl/error :eacl.pagination/unsupported-recursive-last
-                          :reason :requires-full-traversal}))
         {:keys [resource permission]} query
         resource-type (:type resource)
         resource-eid (object-eid db (:id resource))
@@ -1362,9 +1537,12 @@
                           :has-previous? (boolean bound)}))
 
         :desc
-        (let [{:keys [items has-sentinel?]} (collect-reverse-before db root-node resource-eid subject-type state bound size)]
+        (let [{:keys [items has-sentinel?]}
+              (if bound
+                (collect-reverse-before db root-node resource-eid subject-type state bound size)
+                (collect-trailing-items #(next-reverse-item db root-node resource-eid subject-type %) state size))]
           (page-response {:items items
-                          :has-next? true
+                          :has-next? (boolean bound)
                           :has-previous? has-sentinel?}))))))
 
 (declare traverse-permission-path lookup-subject-eids* can*)
@@ -1747,62 +1925,60 @@
     (recursive-reverse-page db query)
     (lookup db reverse-direction query)))
 
+(def ^:private count-pagination-keys
+  [:cursor :limit :first :last :before :after])
+
+(defn- reject-count-pagination-keys!
+  [op query]
+  (when (some #(contains? query %) count-pagination-keys)
+    (page-error! (str op " does not use list pagination keys.")
+                 (select-keys query count-pagination-keys))))
+
+(defn- count-lazy-results
+  "Counts without retaining the head: doall bound the whole realized seq to a
+  local, so counting a broad permission held every result eid in memory for the
+  duration."
+  [results]
+  (reduce (fn [n _] (unchecked-inc n)) 0 results))
+
 (defn count-resources
   [db {:as query}]
-  (when (or (contains? query :cursor)
-            (contains? query :limit)
-            (contains? query :first)
-            (contains? query :last)
-            (contains? query :before)
-            (contains? query :after))
-    (page-error! "count-resources does not use list pagination keys."
-                 (select-keys query [:cursor :limit :first :last :before :after])))
+  (reject-count-pagination-keys! "count-resources" query)
   (if (traversal-permission? db (:resource/type query) (:permission query))
-    (let [page (recursive-forward-page db (assoc query :first max-page-size))]
-      {:count (loop [counted (count (:data page))
-                     cursor (get-in page [:page-info :end-cursor])
-                     has-next? (get-in page [:page-info :has-next-page?])]
-                (if-not has-next?
-                  counted
-                  (let [next-page (recursive-forward-page db (assoc query
-                                                                    :first max-page-size
-                                                                    :after cursor))]
-                    (recur (+ counted (count (:data next-page)))
-                           (get-in next-page [:page-info :end-cursor])
-                           (get-in next-page [:page-info :has-next-page?])))))
+    (let [{:keys [subject permission]} query
+          subject-eid (object-eid db (:id subject))
+          result-type (:resource/type query)
+          root-node   (permission-query-node result-type permission)]
+      {:count (if-not subject-eid
+                0
+                (count-traversal-items
+                 #(next-forward-item db root-node result-type %)
+                 (initial-forward-state db (:type subject) subject-eid root-node)))
        :limit -1})
-    (let [page-req {:direction :asc :size max-page-size :bound nil}
-          {:keys [results]} (lazy-merged-lookup db forward-direction query page-req)
-          counted (doall results)]
-      {:count (count counted)
+    (let [page-req {:direction :asc :bound nil}
+          {:keys [results]} (lazy-merged-lookup db forward-direction query page-req)]
+      {:count (count-lazy-results results)
        :limit -1})))
 
 (defn count-subjects
   [db {:as query}]
-  (when (or (contains? query :cursor)
-            (contains? query :limit)
-            (contains? query :first)
-            (contains? query :last)
-            (contains? query :before)
-            (contains? query :after))
-    (page-error! "count-subjects does not use list pagination keys."
-                 (select-keys query [:cursor :limit :first :last :before :after])))
+  (reject-count-pagination-keys! "count-subjects" query)
+  (when (:subject/relation query)
+    (page-error! ":subject/relation is not supported by count-subjects."
+                 {:eacl/error :eacl.pagination/unsupported-filter
+                  :filter :subject/relation}))
   (if (traversal-permission? db (:type (:resource query)) (:permission query))
-    (let [page (recursive-reverse-page db (assoc query :first max-page-size))]
-      {:count (loop [counted (count (:data page))
-                     cursor (get-in page [:page-info :end-cursor])
-                     has-next? (get-in page [:page-info :has-next-page?])]
-                (if-not has-next?
-                  counted
-                  (let [next-page (recursive-reverse-page db (assoc query
-                                                                    :first max-page-size
-                                                                    :after cursor))]
-                    (recur (+ counted (count (:data next-page)))
-                           (get-in next-page [:page-info :end-cursor])
-                           (get-in next-page [:page-info :has-next-page?])))))
+    (let [{:keys [resource permission]} query
+          resource-eid (object-eid db (:id resource))
+          subject-type (:subject/type query)
+          root-node    (permission-query-node (:type resource) permission)]
+      {:count (if-not resource-eid
+                0
+                (count-traversal-items
+                 #(next-reverse-item db root-node resource-eid subject-type %)
+                 (initial-reverse-state db subject-type root-node resource-eid)))
        :limit -1})
-    (let [page-req {:direction :asc :size max-page-size :bound nil}
-          {:keys [results]} (lazy-merged-lookup db reverse-direction query page-req)
-          counted (doall results)]
-      {:count (count counted)
+    (let [page-req {:direction :asc :bound nil}
+          {:keys [results]} (lazy-merged-lookup db reverse-direction query page-req)]
+      {:count (count-lazy-results results)
        :limit -1})))

--- a/src/eacl/datomic/integrity.clj
+++ b/src/eacl/datomic/integrity.clj
@@ -1,0 +1,81 @@
+(ns eacl.datomic.integrity
+  "Explicit, offline integrity diagnostics.
+
+  Nothing in this namespace runs on EACL's authorization hot path. Callers
+  choose when to pay for a database scan or a schema-version read."
+  (:require [datomic.api :as d]
+            [eacl.datomic.impl :as impl]
+            [eacl.datomic.impl.indexed :as indexed]))
+
+(defn client-schema-status
+  "Reads the connection's current :eacl/schema-version once and compares it
+  with the generation captured when `client` was created (or last changed via
+  that client's write-schema!).
+
+  This is an explicit diagnostic for detecting out-of-band schema writes. EACL
+  deliberately does not perform this read for every authorization operation.
+  Recreate an :outdated client; do not reuse its cached permission paths."
+  [client]
+  (let [cached-version  (some-> client :schema-state deref :schema-version)
+        current-version (some-> client :conn d/db indexed/schema-version)
+        status          (cond
+                          (and (nil? cached-version) (nil? current-version)) :unstamped
+                          (= cached-version current-version) :current
+                          :else :outdated)]
+    {:status status
+     :current? (= :current status)
+     :cache-enabled? (some? cached-version)
+     :client-schema-version (some-> cached-version str)
+     :database-schema-version (some-> current-version str)}))
+
+(defn dangling-relationship-halves
+  "Returns a lazy sequence of relationship halves whose matching peer half is
+  absent. This is an offline O(number-of-relationships) database scan."
+  [db]
+  (impl/orphaned-relationship-halves db))
+
+(defn dangling-relationship-report
+  "Scans dangling relationship halves without retaining the scan head.
+
+  Returns the total count, counts by half, and at most `:sample-size` examples
+  (default 20). This is an offline O(number-of-relationships) operation."
+  ([db]
+   (dangling-relationship-report db {}))
+  ([db {:keys [sample-size] :or {sample-size 20}}]
+   (when-not (and (integer? sample-size) (not (neg? sample-size)))
+     (throw (ex-info ":sample-size must be a non-negative integer."
+                     {:type :eacl.integrity/invalid-options
+                      :sample-size sample-size})))
+   (let [{:keys [count by-half sample]}
+         (reduce (fn [{:keys [count] :as report} half]
+                   (cond-> (-> report
+                               (assoc :count (unchecked-inc count))
+                               (update-in [:by-half (:half half)] (fnil unchecked-inc 0)))
+                     (< count sample-size) (update :sample conj half)))
+                 {:count 0 :by-half {:forward 0 :reverse 0} :sample []}
+                 (dangling-relationship-halves db))]
+     {:valid? (zero? count)
+      :dangling-count count
+      :by-half by-half
+      :sample sample})))
+
+(defn repair-tx-data
+  "Lazily converts dangling-half maps into Datomic retractions."
+  [dangling-halves]
+  (map (fn [{:keys [e attr v]}]
+         [:db/retract e attr v])
+       dangling-halves))
+
+(defn repair-tx-batches
+  "Returns lazy Datomic transaction batches for all dangling halves visible in
+  `db`. The default batch size is 1000, keeping repair memory bounded."
+  ([db]
+   (repair-tx-batches db {}))
+  ([db {:keys [batch-size] :or {batch-size 1000}}]
+   (when-not (and (integer? batch-size) (pos? batch-size))
+     (throw (ex-info ":batch-size must be a positive integer."
+                     {:type :eacl.integrity/invalid-options
+                      :batch-size batch-size})))
+   (map vec
+        (partition-all batch-size
+                       (repair-tx-data (dangling-relationship-halves db))))))

--- a/src/eacl/datomic/schema.clj
+++ b/src/eacl/datomic/schema.clj
@@ -37,14 +37,13 @@
 ;  [:or DirectPermission ArrowPermission])
 
 (def schema-version-attr-definition
-  "Cache-invalidation stamp. write-schema! asserts a fresh squuid here in the
-  same transaction as any definition change; EACL's permission-path caches and
-  cursor fingerprints key on it, so ONLY write-schema! invalidates them (#74).
-  A squuid (not a counter) so two concurrent writers can never assert the same
-  value and elide each other's invalidation. Do not edit EACL definitions
-  outside write-schema! — the stamp will not change and caches will be stale."
+  "Schema-generation stamp. write-schema! asserts a fresh squuid here in the
+  same transaction as any definition change. A connection-backed EACL client
+  reads it once at construction and replaces its one cached generation when
+  write-schema! is invoked through that client. Do not edit EACL definitions
+  outside write-schema!."
   {:db/ident       :eacl/schema-version
-   :db/doc         "Squuid bumped by write-schema! whenever definitions change. Path caches and cursor fingerprints key on it."
+   :db/doc         "Squuid bumped by write-schema! whenever definitions change. EACL clients latch one generation at construction."
    :db/valueType   :db.type/uuid
    :db/cardinality :db.cardinality/one
    :db/index       true})
@@ -205,11 +204,11 @@
     (if-not relation-eid
       0
       (reduce (fn [n _] (inc n))
-        0
-        (d/index-range db
-          :eacl.v7.relationship/subject-type+relation+resource-type+resource
-          [subject-type relation-eid resource-type 0]
-          [subject-type relation-eid resource-type Long/MAX_VALUE])))))
+              0
+              (d/index-range db
+                             :eacl.v7.relationship/subject-type+relation+resource-type+resource
+                             [subject-type relation-eid resource-type 0]
+                             [subject-type relation-eid resource-type Long/MAX_VALUE])))))
 
 (defn read-relations
   "Enumerates all EACL Relation schema entities in DB and returns pull maps."
@@ -220,7 +219,7 @@
                                  :eacl.relation/relation-name]) ...]
          :where
          [?relation :eacl.relation/relation-name ?relation-name]]
-    db))
+       db))
 
 (defn read-permissions
   "Enumerates all EACL permission schema entities in DB and returns maps."
@@ -233,7 +232,7 @@
                              :eacl.permission/target-name]) ...]
          :where
          [?perm :eacl.permission/permission-name]]
-    db))
+       db))
 
 (defn read-schema
   "Enumerates all EACL permission schema entities in DB and returns maps."
@@ -259,25 +258,25 @@
         permissions-by-type (group-by :eacl.permission/resource-type permissions)
 
         relation-names-by-type
-                            (into {} (for [[rt rels] relations-by-type]
-                                       [rt (set (map :eacl.relation/relation-name rels))]))
+        (into {} (for [[rt rels] relations-by-type]
+                   [rt (set (map :eacl.relation/relation-name rels))]))
 
         permission-names-by-type
-                            (into {} (for [[rt perms] permissions-by-type]
-                                       [rt (set (map :eacl.permission/permission-name perms))]))
+        (into {} (for [[rt perms] permissions-by-type]
+                   [rt (set (map :eacl.permission/permission-name perms))]))
 
         ;; Subject types for each relation as full SETS (for arrow target validation).
         ;; Multi-type relations (relation owner: user | group) expand to one entry per
         ;; type; keeping a set makes validation independent of declaration order.
         relation-subject-types
-                            (reduce (fn [acc rel]
-                                      (update acc
-                                        [(:eacl.relation/resource-type rel)
-                                         (:eacl.relation/relation-name rel)]
-                                        (fnil conj #{})
-                                        (:eacl.relation/subject-type rel)))
-                              {}
-                              relations)
+        (reduce (fn [acc rel]
+                  (update acc
+                          [(:eacl.relation/resource-type rel)
+                           (:eacl.relation/relation-name rel)]
+                          (fnil conj #{})
+                          (:eacl.relation/subject-type rel)))
+                {}
+                relations)
 
         errors              (atom [])]
 
@@ -294,30 +293,30 @@
             ;; Self -> relation: validate relation exists on this resource type
             (when-not (contains? (get relation-names-by-type res-type) target-name)
               (swap! errors conj
-                {:type       :invalid-self-relation
-                 :permission (str (name res-type) "/" (name perm-name))
-                 :target     target-name
-                 :message    (str "Permission " (name res-type) "/" (name perm-name)
-                              " references non-existent relation: " (name target-name))}))
+                     {:type       :invalid-self-relation
+                      :permission (str (name res-type) "/" (name perm-name))
+                      :target     target-name
+                      :message    (str "Permission " (name res-type) "/" (name perm-name)
+                                       " references non-existent relation: " (name target-name))}))
             ;; Self -> permission: validate permission exists on this resource type
             (when-not (contains? (get permission-names-by-type res-type) target-name)
               (swap! errors conj
-                {:type       :invalid-self-permission
-                 :permission (str (name res-type) "/" (name perm-name))
-                 :target     target-name
-                 :message    (str "Permission " (name res-type) "/" (name perm-name)
-                              " references non-existent permission: " (name target-name))})))
+                     {:type       :invalid-self-permission
+                      :permission (str (name res-type) "/" (name perm-name))
+                      :target     target-name
+                      :message    (str "Permission " (name res-type) "/" (name perm-name)
+                                       " references non-existent permission: " (name target-name))})))
 
           ;; For arrow permissions (source-rel != :self)
           (do
             ;; Validate source relation exists on this resource type
             (when-not (contains? (get relation-names-by-type res-type) source-rel)
               (swap! errors conj
-                {:type       :missing-source-relation
-                 :permission (str (name res-type) "/" (name perm-name))
-                 :relation   source-rel
-                 :message    (str "Permission " (name res-type) "/" (name perm-name)
-                              " references non-existent relation: " (name source-rel))}))
+                     {:type       :missing-source-relation
+                      :permission (str (name res-type) "/" (name perm-name))
+                      :relation   source-rel
+                      :message    (str "Permission " (name res-type) "/" (name perm-name)
+                                       " references non-existent relation: " (name source-rel))}))
 
             ;; If source relation exists, validate the target exists on EVERY subject
             ;; type of the source relation. Anything else is declaration-order-dependent,
@@ -328,30 +327,30 @@
                   ;; Arrow to relation: validate relation exists on target type
                   (when-not (contains? (get relation-names-by-type target-res-type) target-name)
                     (swap! errors conj
-                      {:type        :invalid-arrow-target-relation
-                       :permission  (str (name res-type) "/" (name perm-name))
-                       :arrow-via   source-rel
-                       :target-type target-res-type
-                       :target      target-name
-                       :message     (str "Permission " (name res-type) "/" (name perm-name)
-                                     " arrow via " (name source-rel) "->" (name target-name)
-                                     " - relation '" (name target-name) "' does not exist on " (name target-res-type))}))
+                           {:type        :invalid-arrow-target-relation
+                            :permission  (str (name res-type) "/" (name perm-name))
+                            :arrow-via   source-rel
+                            :target-type target-res-type
+                            :target      target-name
+                            :message     (str "Permission " (name res-type) "/" (name perm-name)
+                                              " arrow via " (name source-rel) "->" (name target-name)
+                                              " - relation '" (name target-name) "' does not exist on " (name target-res-type))}))
                   ;; Arrow to permission: validate permission exists on target type
                   (when-not (contains? (get permission-names-by-type target-res-type) target-name)
                     (swap! errors conj
-                      {:type        :invalid-arrow-target-permission
-                       :permission  (str (name res-type) "/" (name perm-name))
-                       :arrow-via   source-rel
-                       :target-type target-res-type
-                       :target      target-name
-                       :message     (str "Permission " (name res-type) "/" (name perm-name)
-                                     " arrow via " (name source-rel) "->" (name target-name)
-                                     " - permission '" (name target-name) "' does not exist on " (name target-res-type))})))))))))
+                           {:type        :invalid-arrow-target-permission
+                            :permission  (str (name res-type) "/" (name perm-name))
+                            :arrow-via   source-rel
+                            :target-type target-res-type
+                            :target      target-name
+                            :message     (str "Permission " (name res-type) "/" (name perm-name)
+                                              " arrow via " (name source-rel) "->" (name target-name)
+                                              " - permission '" (name target-name) "' does not exist on " (name target-res-type))})))))))))
 
     (when (seq @errors)
       (throw (ex-info "Invalid schema: reference validation failed"
-               {:errors      @errors
-                :error-count (count @errors)})))
+                      {:errors      @errors
+                       :error-count (count @errors)})))
     nil))
 
 ; now we have to do a diff of relations and permissions
@@ -376,17 +375,17 @@
   ; when can we ditch the setval :db/id?
   (let [before-relations-set   (->> before-relations
                                  ;(S/setval [S/ALL :db/id] S/NONE) ; no longer needed.
-                                   (set))
+                                    (set))
         after-relations-set    (->> after-relations
                                     ;(S/setval [S/ALL :db/id] S/NONE)
                                     (set))
 
         before-permissions-set (->> before-permissions
                                  ;(S/setval [S/ALL :db/id] S/NONE)
-                                 (set))
+                                    (set))
         after-permissions-set  (->> after-permissions
                                  ;(S/setval [S/ALL :db/id] S/NONE)
-                                  (set))]
+                                    (set))]
     {:relations   (calc-set-deltas before-relations-set after-relations-set)
      :permissions (calc-set-deltas before-permissions-set after-permissions-set)}))
 
@@ -402,8 +401,11 @@
   {:allow-empty-schema? true} to explicitly wipe the stored schema."
   ([conn schema-string]
    (write-schema! conn schema-string {}))
-  ([conn schema-string {:keys [allow-empty-schema?]}]
-   ;; Upgrade path: databases installed before :eacl/schema-version existed.
+  ([conn schema-string opts]
+   (write-schema! conn schema-string opts ::read-current-version))
+  ([conn schema-string {:keys [allow-empty-schema?]} known-schema-version]
+   ;; Fresh/partially installed v7 databases may not have the stamp attribute
+   ;; yet. This is schema installation, not a v6 cache-compatibility path.
    (when-not (d/entid (d/db conn) :eacl/schema-version)
      @(d/transact conn [schema-version-attr-definition]))
    (let [new-schema-map         (parser/->eacl-schema (parser/parse-schema schema-string))
@@ -417,28 +419,37 @@
                                                (seq (:permissions existing-schema))))
                                   (throw (ex-info (str "Refusing to replace a non-empty schema with zero definitions."
                                                        " Pass {:allow-empty-schema? true} to write-schema! if this is intentional.")
-                                           {:type :eacl.schema/empty-schema-guard
-                                            :existing {:relations (count (:relations existing-schema))
-                                                       :permissions (count (:permissions existing-schema))}})))
+                                                  {:type :eacl.schema/empty-schema-guard
+                                                   :existing {:relations (count (:relations existing-schema))
+                                                              :permissions (count (:permissions existing-schema))}})))
          deltas                 (compare-schema existing-schema new-schema-map)
          {:keys [relations permissions]} deltas
          relation-retractions   (:retractions relations)
          permission-retractions (:retractions permissions)]
 
     ;; Check for orphaned relationships
-    (doseq [rel relation-retractions]
-      (let [cnt (count-relationships-using-relation db rel)]
-        (when (pos? cnt)
-          (throw (ex-info (str "Cannot delete relation " (:eacl.relation/relation-name rel)
-                            " because it is used by " cnt " relationships.")
-                   {:relation rel :count cnt})))))
+     (doseq [rel relation-retractions]
+       (let [cnt (count-relationships-using-relation db rel)]
+         (when (pos? cnt)
+           (throw (ex-info (str "Cannot delete relation " (:eacl.relation/relation-name rel)
+                                " because it is used by " cnt " relationships.")
+                           {:relation rel :count cnt})))))
 
     ;; Transact changes
-    (let [schema-changed? (boolean (or (seq (:additions relations))
-                                       (seq relation-retractions)
-                                       (seq (:additions permissions))
-                                       (seq permission-retractions)))
-          tx-data (concat
+     (let [schema-changed?  (boolean (or (seq (:additions relations))
+                                         (seq relation-retractions)
+                                         (seq (:additions permissions))
+                                         (seq permission-retractions)))
+          ;; The connection-backed client passes its construction-time value,
+          ;; avoiding another DB read. Direct low-level callers pay the
+          ;; explicit diagnostic read here.
+           current-version  (if (= ::read-current-version known-schema-version)
+                              (impl.indexed/schema-version db)
+                              known-schema-version)
+           stamp-missing?   (nil? current-version)
+           stamp-schema?    (or schema-changed? stamp-missing?)
+           next-version     (if stamp-schema? (d/squuid) current-version)
+           tx-data (concat
                     ;; Additions
                     (:additions relations)
                     (:additions permissions)
@@ -447,13 +458,11 @@
                       [:db.fn/retractEntity [:eacl/id (:eacl/id rel)]])
                     (for [perm permission-retractions]
                       [:db.fn/retractEntity [:eacl/id (:eacl/id perm)]])
-                     ;; Store schema string + bump the version stamp when
-                     ;; definitions changed. The stamp is what invalidates the
-                     ;; path caches and cursor fingerprints — on every peer,
-                     ;; and correctly for d/as-of views (issue #74).
+                     ;; Store schema string + establish/bump the version stamp.
+                     ;; An identical first write on an unstamped database must
+                     ;; still establish a cacheable client generation.
                     [(cond-> {:eacl/id            "schema-string"
                               :eacl/schema-string schema-string}
-                       schema-changed? (assoc :eacl/schema-version (d/squuid)))])]
-      @(d/transact conn tx-data)
-      (impl.indexed/evict-permission-paths-cache!)
-      deltas))))
+                       stamp-schema? (assoc :eacl/schema-version next-version))])]
+       @(d/transact conn tx-data)
+       (with-meta deltas {:eacl/schema-version next-version})))))

--- a/test/eacl/bench/pagination_test.clj
+++ b/test/eacl/bench/pagination_test.clj
@@ -523,3 +523,49 @@
             "second page replays a deeper traversal prefix")
         (is (< (:advanced-stream-datoms @stats2) 200)
             "second page work should still be bounded by the reachable prefix")))))
+
+;; --- Permission-check hot path ----------------------------------------------
+;;
+;; can? is the highest-frequency EACL call, and the permission-path cache scope
+;; sits directly on it. The scope is a fingerprint of the schema's definition
+;; datoms — exact against d/with, filtered and unstamped databases — memoised
+;; on the db VALUE, so it costs one O(number-of-definitions) scan per db value
+;; observed and nothing thereafter.
+;;
+;; Two numbers matter and both are reported:
+;;   warm  — repeated checks against one db value (the normal shape)
+;;   cold  — every check against a db value the memo has not seen, i.e. the
+;;           database advancing between every single check. This is the price
+;;           of exact scoping; it is bounded by schema size, not by data size.
+
+(def ^:private can-warm-threshold-us 25)
+(def ^:private can-cold-threshold-us 250)
+
+(deftest ^:benchmark permission-check-benchmark
+  (testing "can? throughput, warm and cold cache scope"
+    (with-mem-conn [conn []]
+      (let [acl     (seed-multipath! conn {:num-accounts     5
+                                           :teams-per-acct   2
+                                           :vpcs-per-acct    1
+                                           :servers-per-acct 20})
+            subject (->user "super-user")
+            server  (->server "server-1-1")
+            check   #(eacl/can? acl subject :view server)]
+
+        (run-timed 2000 check)                              ; warm JIT + caches
+
+        (let [warm-us (* 1000.0 (median (run-timed 5000 check)))]
+          (println (format "can? warm: median=%.2fus" warm-us))
+          (is (< warm-us can-warm-threshold-us)
+              (format "REGRESSION: warm can? median %.2fus exceeds %dus" warm-us can-warm-threshold-us)))
+
+        (testing "with a fingerprint scan forced on every call"
+          (let [cold-us (* 1000.0
+                           (median (run-timed 500
+                                              (fn []
+                                                (impl.indexed/evict-permission-paths-cache!)
+                                                (check)))))]
+            (println (format "can? cold scope + cold paths: median=%.2fus" cold-us))
+            (is (< cold-us can-cold-threshold-us)
+                (format "REGRESSION: cold can? median %.2fus exceeds %dus; the schema fingerprint or path calc got more expensive"
+                        cold-us can-cold-threshold-us))))))))

--- a/test/eacl/bench/pagination_test.clj
+++ b/test/eacl/bench/pagination_test.clj
@@ -526,23 +526,19 @@
 
 ;; --- Permission-check hot path ----------------------------------------------
 ;;
-;; can? is the highest-frequency EACL call, and the permission-path cache scope
-;; sits directly on it. The scope is a fingerprint of the schema's definition
-;; datoms — exact against d/with, filtered and unstamped databases — memoised
-;; on the db VALUE, so it costs one O(number-of-definitions) scan per db value
-;; observed and nothing thereafter.
+;; can? is the highest-frequency EACL call. A connection-backed client reads
+;; its schema generation once at construction, then new db values caused by
+;; unrelated transactions do no schema reads or definition scans.
 ;;
 ;; Two numbers matter and both are reported:
-;;   warm  — repeated checks against one db value (the normal shape)
-;;   cold  — every check against a db value the memo has not seen, i.e. the
-;;           database advancing between every single check. This is the price
-;;           of exact scoping; it is bounded by schema size, not by data size.
+;;   warm — repeated checks against the client generation
+;;   cold — explicit cache eviction before each call (path-resolution cost)
 
 (def ^:private can-warm-threshold-us 25)
 (def ^:private can-cold-threshold-us 250)
 
 (deftest ^:benchmark permission-check-benchmark
-  (testing "can? throughput, warm and cold cache scope"
+  (testing "can? throughput, warm and cold permission paths"
     (with-mem-conn [conn []]
       (let [acl     (seed-multipath! conn {:num-accounts     5
                                            :teams-per-acct   2
@@ -559,13 +555,14 @@
           (is (< warm-us can-warm-threshold-us)
               (format "REGRESSION: warm can? median %.2fus exceeds %dus" warm-us can-warm-threshold-us)))
 
-        (testing "with a fingerprint scan forced on every call"
+        (testing "with permission paths forced cold on every call"
           (let [cold-us (* 1000.0
                            (median (run-timed 500
                                               (fn []
-                                                (impl.indexed/evict-permission-paths-cache!)
+                                                (impl.indexed/evict-permission-paths-cache!
+                                                 @(:schema-state acl))
                                                 (check)))))]
-            (println (format "can? cold scope + cold paths: median=%.2fus" cold-us))
+            (println (format "can? cold paths: median=%.2fus" cold-us))
             (is (< cold-us can-cold-threshold-us)
-                (format "REGRESSION: cold can? median %.2fus exceeds %dus; the schema fingerprint or path calc got more expensive"
+                (format "REGRESSION: cold can? median %.2fus exceeds %dus; path calculation got more expensive"
                         cold-us can-cold-threshold-us))))))))

--- a/test/eacl/datomic/api_contract_test.clj
+++ b/test/eacl/datomic/api_contract_test.clj
@@ -1,0 +1,268 @@
+(ns eacl.datomic.api-contract-test
+  "Regressions for API-surface bugs found in the 2026-07-29 full-source hunt:
+  nil-valued anchor filters, nil page cursors, empty-page flags, the broken
+  impl/can? map arity, untyped write exceptions, and recursive traversal
+  limits/counting."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datomic.api :as d]
+            [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datomic.core :as core]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
+            [eacl.datomic.impl :as impl :refer [Relationship]]
+            [eacl.datomic.impl.indexed :as idx]
+            [eacl.datomic.schema :as schema]))
+
+(def ^:private acyclic-schema
+  "definition user {}
+   definition account { relation owner: user
+                        permission admin = owner }")
+
+(def ^:private recursive-schema
+  "definition user {}
+   definition folder { relation parent: folder
+                       relation reader: user
+                       permission read = reader + parent->read }")
+
+(defn- ents [ids] (mapv (fn [id] {:eacl/id id}) ids))
+
+(defn- ex-data-of [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(defn- seed-acyclic!
+  "n accounts, all owned by user u."
+  [conn n]
+  (schema/write-schema! conn acyclic-schema)
+  @(d/transact conn (ents (cons "u" (map #(str "a-" %) (range n)))))
+  (let [db (d/db conn)]
+    @(d/transact conn (into [] (mapcat #(impl/tx-relationship db %))
+                            (for [i (range n)]
+                              (Relationship (spice-object :user "u")
+                                            :owner
+                                            (spice-object :account (str "a-" i)))))))
+  (let [db (d/db conn)]
+    {:db db :u (d/entid db [:eacl/id "u"])}))
+
+(defn- seed-recursive!
+  "A flat tree: `n` folders under one root the user reads."
+  [conn n]
+  (schema/write-schema! conn recursive-schema)
+  @(d/transact conn (ents (concat ["u" "root"] (map #(str "f-" %) (range n)))))
+  (let [db (d/db conn)]
+    @(d/transact conn (into [] (mapcat #(impl/tx-relationship db %))
+                            (cons (Relationship (spice-object :user "u") :reader (spice-object :folder "root"))
+                                  (for [i (range n)]
+                                    (Relationship (spice-object :folder "root")
+                                                  :parent
+                                                  (spice-object :folder (str "f-" i))))))))
+  (let [db (d/db conn)]
+    {:db db :u (d/entid db [:eacl/id "u"])}))
+
+;; --- read-relationships anchors ---------------------------------------------
+
+(deftest nil-anchor-filters-are-rejected-test
+  ;; The guard used contains?, which is key PRESENCE. {:subject/id nil} — the
+  ;; shape you get from {:subject/id (get-in req [:params :user-id])} when the
+  ;; param is missing — satisfied it while every consumer treated the value as
+  ;; absent, degrading the read to the global index scan the guard exists to
+  ;; prevent.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db]} (seed-acyclic! conn 3)]
+      (doseq [k [:subject/id :resource/id :subject/type :resource/type :resource/relation]]
+        (let [data (ex-data-of #(impl/read-relationships db {k nil :first 5}))]
+          (is (= :eacl.filters/missing-anchor (:eacl/error data))
+              (str k " => nil must not count as an anchor"))
+          (is (= [k] (:nil-anchor-keys data))
+              "the error names the key that was passed as nil")))
+
+      (testing "a real anchor still works, and an absent filter map still throws"
+        (is (= 3 (count (:data (impl/read-relationships db {:resource/type :account :first 10})))))
+        (is (= :eacl.filters/missing-anchor
+               (:eacl/error (ex-data-of #(impl/read-relationships db {:first 5})))))))))
+
+;; --- page cursors ------------------------------------------------------------
+
+(deftest nil-page-cursors-are-rejected-test
+  ;; :after nil used to mean "start over", so a client looping on a page-info
+  ;; that carried a nil cursor silently restarted at page 1 forever.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-acyclic! conn 5)
+          query {:subject (spice-object :user u) :permission :admin :resource/type :account}]
+      (is (= :eacl.pagination/invalid-cursor
+             (:eacl/error (ex-data-of #(idx/lookup-resources db (assoc query :first 2 :after nil))))))
+      (is (= :eacl.pagination/invalid-cursor
+             (:eacl/error (ex-data-of #(idx/lookup-resources db (assoc query :last 2 :before nil))))))
+
+      (testing "an omitted cursor is still the first/last page"
+        (is (= 2 (count (:data (idx/lookup-resources db (assoc query :first 2))))))
+        (is (= 2 (count (:data (idx/lookup-resources db (assoc query :last 2))))))))))
+
+(deftest empty-pages-advertise-no-further-pages-test
+  ;; has-next-page? true alongside a nil end-cursor is a loop with no exit.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-acyclic! conn 4)
+          query   {:subject (spice-object :user u) :permission :admin :resource/type :account}
+          all     (idx/lookup-resources db (assoc query :first 10))
+          past-end (idx/lookup-resources db (assoc query :first 10
+                                                  :after (get-in all [:page-info :end-cursor])))
+          before-start (idx/lookup-resources db (assoc query :last 10
+                                                       :before (get-in all [:page-info :start-cursor])))]
+      (doseq [[label page] [["past the end" past-end] ["before the start" before-start]]]
+        (is (empty? (:data page)) label)
+        (is (nil? (get-in page [:page-info :start-cursor])) label)
+        (is (nil? (get-in page [:page-info :end-cursor])) label)
+        (is (false? (get-in page [:page-info :has-next-page?])) label)
+        (is (false? (get-in page [:page-info :has-previous-page?])) label))
+
+      (testing "and the same for relationship reads"
+        (let [rels  (impl/read-relationships db {:resource/type :account :first 10})
+              past  (impl/read-relationships db {:resource/type :account :first 10
+                                                 :after (get-in rels [:page-info :end-cursor])})]
+          (is (empty? (:data past)))
+          (is (false? (get-in past [:page-info :has-next-page?])))
+          (is (false? (get-in past [:page-info :has-previous-page?]))))))))
+
+(deftest page-info-cursor-invariant-holds-across-a-full-walk-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-acyclic! conn 7)
+          query {:subject (spice-object :user u) :permission :admin :resource/type :account}]
+      (doseq [page-size [1 2 3]]
+        (loop [cursor nil, seen 0, guard 0]
+          (is (< guard 50) "a page walk must terminate")
+          (let [page (idx/lookup-resources db (cond-> (assoc query :first page-size)
+                                                cursor (assoc :after cursor)))
+                {:keys [has-next-page? has-previous-page? start-cursor end-cursor]} (:page-info page)]
+            (when has-next-page?
+              (is (some? end-cursor) "has-next-page? must imply a usable end-cursor"))
+            (when has-previous-page?
+              (is (some? start-cursor) "has-previous-page? must imply a usable start-cursor"))
+            (if has-next-page?
+              (recur end-cursor (+ seen (count (:data page))) (inc guard))
+              (is (= 7 (+ seen (count (:data page))))))))))))
+
+;; --- impl/can? arities & typed errors ---------------------------------------
+
+(deftest impl-can-map-arity-test
+  ;; The map arity forwarded to a 2-arity impl.indexed/can? that does not
+  ;; exist, so it threw ArityException on every call.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-acyclic! conn 1)
+          a (d/entid db [:eacl/id "a-0"])]
+      (is (true? (impl/can? db {:subject    (spice-object :user u)
+                                :permission :admin
+                                :resource   (spice-object :account a)})))
+      (is (false? (impl/can? db {:subject    (spice-object :user u)
+                                 :permission :nonexistent
+                                 :resource   (spice-object :account a)})))
+      (is (= (impl/can? db (spice-object :user u) :admin (spice-object :account a))
+             (impl/can? db {:subject (spice-object :user u)
+                            :permission :admin
+                            :resource (spice-object :account a)}))))))
+
+(deftest write-errors-are-typed-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-acyclic! conn 1)
+          a   (d/entid db [:eacl/id "a-0"])
+          rel (Relationship (spice-object :user "u") :owner (spice-object :account "a-0"))]
+      (testing ":create on an existing relationship"
+        (is (= :eacl/relationship-conflict
+               (:type (ex-data-of #(impl/tx-update-relationship (d/db conn)
+                                                                {:operation :create :relationship rel}))))))
+      (testing ":unspecified"
+        (is (= :eacl/unsupported-operation
+               (:type (ex-data-of #(impl/tx-update-relationship (d/db conn)
+                                                                {:operation :unspecified :relationship rel}))))))
+      (testing "can!"
+        (is (true? (impl/can! db (spice-object :user u) :admin (spice-object :account a))))
+        (is (= :eacl/unauthorized
+               (:type (ex-data-of #(impl/can! db (spice-object :user u) :nope (spice-object :account a))))))))))
+
+;; --- recursive traversal: limits, counting, subjects -------------------------
+
+(deftest recursive-count-does-not-replay-the-traversal-test
+  ;; count-resources used to page with :first max-page-size and :after, and
+  ;; each page replayed the whole prefix — O(N^2), and it tripped
+  ;; :max-derived-grants long before a large grant set was counted.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-recursive! conn 60)
+          query {:subject (spice-object :user u) :permission :read :resource/type :folder}]
+      (is (true? (idx/traversal-permission? db :folder :read)))
+      (is (= 61 (:count (idx/count-resources db query))) "root + 60 children")
+
+      (testing "counting derives each grant once"
+        (let [stats (atom {})]
+          (binding [idx/*recursive-traversal-stats* stats]
+            (idx/count-resources db query))
+          (is (<= (:derived-grants @stats) 70)
+              (str "one pass over 61 results, got " (:derived-grants @stats)))))
+
+      (testing "a limit far below N^2 but above N no longer breaks counting"
+        (binding [idx/*recursive-traversal-limits* {:max-derived-grants 200
+                                                    :max-advanced-datoms 100000
+                                                    :max-queued-work 100000}]
+          (is (= 61 (:count (idx/count-resources db query))))))
+
+      (testing "the limit still fires, and says how to raise it"
+        (binding [idx/*recursive-traversal-limits* {:max-derived-grants 5
+                                                    :max-advanced-datoms 100000
+                                                    :max-queued-work 100000}]
+          (let [data (ex-data-of #(idx/count-resources db query))]
+            (is (= :eacl.recursive-traversal/limit-exceeded (:eacl/error data)))
+            (is (= :derived-grants (:limit-kind data)))))))))
+
+(deftest recursive-traversal-limits-are-configurable-test
+  (with-mem-conn [conn schema/v7-schema]
+    (seed-recursive! conn 40)
+    (testing "a client can raise the ceiling"
+      (let [tight (core/make-client conn {:recursive-traversal-limits {:max-derived-grants 3}})
+            roomy (core/make-client conn {:recursive-traversal-limits {:max-derived-grants 100000}})
+            query {:subject (spice-object :user "u") :permission :read :resource/type :folder :first 10}]
+        (is (= :eacl.recursive-traversal/limit-exceeded
+               (:eacl/error (ex-data-of #(eacl/lookup-resources tight query)))))
+        (is (= 10 (count (:data (eacl/lookup-resources roomy query)))))))
+
+    (testing "a partial override keeps the other defaults instead of disabling them"
+      (let [client (core/make-client conn {:recursive-traversal-limits {:max-derived-grants 3}})]
+        (is (= :eacl.recursive-traversal/limit-exceeded
+               (:eacl/error (ex-data-of #(eacl/lookup-resources
+                                          client
+                                          {:subject (spice-object :user "u")
+                                           :permission :read
+                                           :resource/type :folder
+                                           :first 10})))))))
+
+    (testing "a malformed limits map is rejected at construction"
+      (doseq [bad [{:no-such-limit 1} {:max-derived-grants 0} {:max-derived-grants "many"} :not-a-map]]
+        (is (= :eacl/invalid-config
+               (:type (ex-data-of #(core/make-client conn {:recursive-traversal-limits bad}))))
+            (pr-str bad))))))
+
+(deftest recursive-bare-last-and-count-subjects-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-recursive! conn 5)
+          root  (d/entid db [:eacl/id "root"])
+          leaf  (d/entid db [:eacl/id "f-0"])
+          query {:subject (spice-object :user u) :permission :read :resource/type :folder}
+          all   (mapv :id (:data (idx/lookup-resources db (assoc query :first 100))))]
+
+      (testing "bare :last on a recursive permission returns the trailing window"
+        (let [tail (idx/lookup-resources db (assoc query :last 2))]
+          (is (= (vec (take-last 2 all)) (mapv :id (:data tail))))
+          (is (false? (get-in tail [:page-info :has-next-page?])))
+          (is (true? (get-in tail [:page-info :has-previous-page?])))))
+
+      (testing "count-subjects agrees with lookup-subjects on a recursive permission"
+        (doseq [[label resource] [["root" root] ["leaf" leaf]]]
+          (let [q {:resource (spice-object :folder resource)
+                   :permission :read
+                   :subject/type :user}]
+            (is (= (count (:data (idx/lookup-subjects db (assoc q :first 100))))
+                   (:count (idx/count-subjects db q)))
+                label)
+            (is (= 1 (:count (idx/count-subjects db q))) label))))
+
+      (testing "count-subjects rejects the filters lookup-subjects rejects"
+        (is (= :eacl.pagination/unsupported-filter
+               (:eacl/error (ex-data-of #(idx/count-subjects db {:resource (spice-object :folder root)
+                                                                 :permission :read
+                                                                 :subject/type :user
+                                                                 :subject/relation :member})))))))))

--- a/test/eacl/datomic/api_contract_test.clj
+++ b/test/eacl/datomic/api_contract_test.clj
@@ -236,19 +236,17 @@
                (:type (ex-data-of #(core/make-client conn {:recursive-traversal-limits bad}))))
             (pr-str bad))))))
 
-(deftest recursive-bare-last-and-count-subjects-test
+(deftest recursive-last-and-count-subjects-test
   (with-mem-conn [conn schema/v7-schema]
     (let [{:keys [db u]} (seed-recursive! conn 5)
           root  (d/entid db [:eacl/id "root"])
           leaf  (d/entid db [:eacl/id "f-0"])
-          query {:subject (spice-object :user u) :permission :read :resource/type :folder}
-          all   (mapv :id (:data (idx/lookup-resources db (assoc query :first 100))))]
+          query {:subject (spice-object :user u) :permission :read :resource/type :folder}]
 
-      (testing "bare :last on a recursive permission returns the trailing window"
-        (let [tail (idx/lookup-resources db (assoc query :last 2))]
-          (is (= (vec (take-last 2 all)) (mapv :id (:data tail))))
-          (is (false? (get-in tail [:page-info :has-next-page?])))
-          (is (true? (get-in tail [:page-info :has-previous-page?])))))
+      (testing "bare :last rejects the implicit full recursive traversal"
+        (is (= :eacl.pagination/unsupported-recursive-last
+               (:eacl/error
+                (ex-data-of #(idx/lookup-resources db (assoc query :last 2)))))))
 
       (testing "count-subjects agrees with lookup-subjects on a recursive permission"
         (doseq [[label resource] [["root" root] ["leaf" leaf]]]
@@ -266,3 +264,34 @@
                                                                  :permission :read
                                                                  :subject/type :user
                                                                  :subject/relation :member})))))))))
+
+(deftest bounded-counts-stop-before-a-full-recursive-traversal-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [db u]} (seed-recursive! conn 60)
+          root   (d/entid db [:eacl/id "root"])
+          client (core/make-client conn {})
+          forward-query {:subject (spice-object :user u)
+                         :permission :read
+                         :resource/type :folder}
+          reverse-query {:resource (spice-object :folder root)
+                         :permission :read
+                         :subject/type :user}]
+      (is (= {:count 5 :limit 5 :truncated? true}
+             (idx/count-resources db (assoc forward-query :count-limit 5))))
+      (is (= {:count 61 :limit 100 :truncated? false}
+             (idx/count-resources db (assoc forward-query :count-limit 100))))
+      (is (= {:count 0 :limit 0 :truncated? true}
+             (idx/count-resources db (assoc forward-query :count-limit 0))))
+
+      (testing "count-subjects is exposed on the public client"
+        (is (= {:count 1 :limit 1 :truncated? false}
+               (eacl/count-subjects
+                client
+                (-> reverse-query
+                    (assoc :resource (spice-object :folder "root"))
+                    (assoc :count-limit 1))))))
+
+      (testing "invalid limits are typed"
+        (is (= :eacl.count/invalid-limit
+               (:eacl/error
+                (ex-data-of #(idx/count-subjects db (assoc reverse-query :count-limit -1))))))))))

--- a/test/eacl/datomic/differential_test.clj
+++ b/test/eacl/datomic/differential_test.clj
@@ -138,10 +138,20 @@
     (doseq [page-size [1 3]]
       (is (= subjects (collect-subjects-paged db query page-size))
           (str label ": forward subject pagination at page size " page-size
-               " must equal the full enumeration"))
-      (is (= subjects (collect-paged-backward idx/lookup-subjects db query page-size))
-          (str label ": reverse subject pagination at page size " page-size
                " must equal the full enumeration")))
+    (if (idx/traversal-permission? db (:type resource) permission)
+      (is (= :eacl.pagination/unsupported-recursive-last
+             (:eacl/error
+              (try
+                (idx/lookup-subjects db (assoc query :last 1))
+                nil
+                (catch clojure.lang.ExceptionInfo e
+                  (ex-data e)))))
+          (str label ": recursive reverse pagination requires a :before boundary"))
+      (doseq [page-size [1 3]]
+        (is (= subjects (collect-paged-backward idx/lookup-subjects db query page-size))
+            (str label ": reverse subject pagination at page size " page-size
+                 " must equal the full enumeration"))))
     (is (= (count subjects) (:count (idx/count-subjects db query)))
         (str label ": count-subjects must agree"))))
 

--- a/test/eacl/datomic/differential_test.clj
+++ b/test/eacl/datomic/differential_test.clj
@@ -141,7 +141,9 @@
                " must equal the full enumeration"))
       (is (= subjects (collect-paged-backward idx/lookup-subjects db query page-size))
           (str label ": reverse subject pagination at page size " page-size
-               " must equal the full enumeration")))))
+               " must equal the full enumeration")))
+    (is (= (count subjects) (:count (idx/count-subjects db query)))
+        (str label ": count-subjects must agree"))))
 
 (deftest differential-nonrecursive-test
   (doseq [seed [7 23 42 1337]]
@@ -219,9 +221,17 @@
                       (Relationship (spice-object :user u) :reader (spice-object :folder f))))]
           @(d/transact conn (into [] (mapcat #(impl/tx-relationship db0 %)) rels)))
         (let [db          (d/db conn)
-              folder-eids (mapv #(eid-of db %) folders)]
+              folder-eids (mapv #(eid-of db %) folders)
+              user-eids   (mapv #(eid-of db %) users)]
           (testing (str "seed " seed ": recursive forward invariants (stable discovery order, exact dedup)")
             (doseq [u users]
               (check-forward-invariants! db (str "seed " seed " user " u " :read :folder")
                                          (spice-object :user (eid-of db u))
-                                         :read :folder folder-eids false))))))))
+                                         :read :folder folder-eids false)))
+          ;; The recursive REVERSE engine had no differential coverage at all —
+          ;; differential-recursive-test only checked lookup-resources.
+          (testing (str "seed " seed ": recursive reverse invariants for every folder")
+            (doseq [f folders]
+              (check-reverse-invariants! db (str "seed " seed " folder " f)
+                                         (spice-object :folder (eid-of db f))
+                                         :read :user user-eids))))))))

--- a/test/eacl/datomic/impl/indexed_test.clj
+++ b/test/eacl/datomic/impl/indexed_test.clj
@@ -1388,33 +1388,14 @@
                                                        :resource/type :account
                                                        :first         2})))))))
 
-      ;; Regression: bare :last used to throw :eacl.pagination/unsupported-recursive-last
-      ;; while the acyclic engine accepted it, so adding `parent->read` to a
-      ;; schema turned every existing {:last n} caller into a runtime error.
-      ;; It now exhausts the traversal into a trailing window, like count-*.
-      (testing "bare recursive :last returns the trailing page, matching the acyclic contract"
-        (let [all  (paginated->spice db (lookup-resources db {:subject       user
-                                                              :permission    :read
-                                                              :resource/type :account
-                                                              :first         100}))
-              tail (lookup-resources db {:subject       user
-                                         :permission    :read
-                                         :resource/type :account
-                                         :last          2})]
-          (is (= (vec (take-last 2 all)) (paginated->spice db tail))
-              "bare :last is the last window of the traversal order")
-          (is (false? (get-in tail [:page-info :has-next-page?]))
-              "nothing follows the last page")
-          (is (true? (get-in tail [:page-info :has-previous-page?]))
-              "3 results, page size 2: an earlier page exists")
-          (testing "and :before composes backwards from it"
-            (is (= (vec (drop-last 2 all))
-                   (paginated->spice db
-                                     (lookup-resources db {:subject       user
-                                                           :permission    :read
-                                                           :resource/type :account
-                                                           :last          2
-                                                           :before        (page-start-cursor tail)})))))))
+      (testing "bare recursive :last rejects its implicit full-closure traversal"
+        (is (= :eacl.pagination/unsupported-recursive-last
+               (:eacl/error
+                (thrown-ex-data
+                 #(lookup-resources db {:subject       user
+                                        :permission    :read
+                                        :resource/type :account
+                                        :last          2}))))))
 
       (testing "wrong cursor kind is rejected by recursive lookup"
         (is (= :eacl.pagination/wrong-cursor-kind
@@ -1479,34 +1460,35 @@
 
 (deftest permission-paths-caching-test
   (let [db (d/db *conn*)]
-    (testing "Caching of permission paths"
-      (impl.indexed/evict-permission-paths-cache!)
-
+    (testing "A client generation caches permission paths"
       (let [calc-calls (atom 0)
-            orig-calc impl.indexed/calc-permission-paths]
-        (with-redefs [impl.indexed/calc-permission-paths (fn [& args]
-                                                           (swap! calc-calls inc)
-                                                           (apply orig-calc args))]
-          ;; First call - should compute
-          (let [paths1 (impl.indexed/get-permission-paths db :account :view)]
-            (is (pos? (count paths1)))
-            (is (pos? @calc-calls) "Should have called calc-permission-paths")
+            orig-calc impl.indexed/calc-permission-paths
+            client-cache (assoc (impl.indexed/make-schema-cache db)
+                                :schema-version (d/squuid))]
+        (binding [impl.indexed/*schema-cache* client-cache]
+          (with-redefs [impl.indexed/calc-permission-paths (fn [& args]
+                                                             (swap! calc-calls inc)
+                                                             (apply orig-calc args))]
+            ;; First call - should compute
+            (let [paths1 (impl.indexed/get-permission-paths db :account :view)]
+              (is (pos? (count paths1)))
+              (is (pos? @calc-calls) "Should have called calc-permission-paths")
 
-            (reset! calc-calls 0)
+              (reset! calc-calls 0)
 
-            ;; Second call - should be cached
-            (let [paths2 (impl.indexed/get-permission-paths db :account :view)]
-              (is (pos? (count paths2)))
-              (is (= paths1 paths2))
-              (is (zero? @calc-calls) "Should use cache, not call calc-permission-paths")
+              ;; Second call - should be cached
+              (let [paths2 (impl.indexed/get-permission-paths db :account :view)]
+                (is (pos? (count paths2)))
+                (is (= paths1 paths2))
+                (is (zero? @calc-calls) "Should use cache, not call calc-permission-paths")
 
-              ;; Evict cache
-              (impl.indexed/evict-permission-paths-cache!)
+                ;; Evict this client generation
+                (impl.indexed/evict-permission-paths-cache!)
 
-              ;; Third call - should recompute
-              (let [paths3 (impl.indexed/get-permission-paths db :account :view)]
-                (is (pos? (count paths3)))
-                (is (pos? @calc-calls) "Should call calc-permission-paths after eviction")))))))))
+                ;; Third call - should recompute
+                (let [paths3 (impl.indexed/get-permission-paths db :account :view)]
+                  (is (pos? (count paths3)))
+                  (is (pos? @calc-calls) "Should call calc-permission-paths after eviction"))))))))))
 
 (deftest permission-paths-cache-is-scoped-per-database-test
   (with-mem-conn [conn1 schema/v7-schema]
@@ -1516,37 +1498,45 @@
       @(d/transact conn2 fixtures/relations+permissions)
       @(d/transact conn2 fixtures/entity-fixtures)
 
-      (impl.indexed/evict-permission-paths-cache!)
-
-      (impl.indexed/get-permission-paths (d/db conn1) :server :view)
-      (impl.indexed/get-permission-paths (d/db conn2) :server :view)
-
-      (is (= 2 (count @impl.indexed/permission-paths-cache))
-          "Permission path caching must not leak DB-specific relation eids across databases"))))
+      (let [db1 (d/db conn1)
+            db2 (d/db conn2)
+            cache1 (assoc (impl.indexed/make-schema-cache db1) :schema-version (d/squuid))
+            cache2 (assoc (impl.indexed/make-schema-cache db2) :schema-version (d/squuid))
+            paths1 (binding [impl.indexed/*schema-cache* cache1]
+                     (impl.indexed/get-permission-paths db1 :server :view))
+            paths2 (binding [impl.indexed/*schema-cache* cache2]
+                     (impl.indexed/get-permission-paths db2 :server :view))]
+        (is (= (count paths1) (count paths2)))
+        (is (not= (:database-id cache1) (:database-id cache2)))
+        (is (not (identical? (:permission-paths cache1)
+                             (:permission-paths cache2)))
+            "separate clients own separate cache generations")))))
 
 (deftest permission-paths-cache-is-scoped-per-schema-test
-  ;; Issue #74 contract: ONLY write-schema! invalidates the path cache — it
-  ;; bumps the :eacl/schema-version stamp the cache keys on, giving each
-  ;; schema era (including as-of views) its own cache slot. Programmatic
-  ;; edits of relation/permission datoms are deliberately NOT detected; they
-  ;; require write-schema! or a manual evict-permission-paths-cache!.
+  ;; Each client owns one generation. A client write swaps that generation;
+  ;; historic db values are evaluated only with an explicitly matching cache
+  ;; (or uncached through the low-level API).
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn "definition user {}
        definition account { relation owner: user  relation viewer: user
                             permission view = owner + viewer }")
-    (impl.indexed/evict-permission-paths-cache!)
     (let [db-before    (d/db conn)
-          before-paths (impl.indexed/get-permission-paths db-before :account :view)]
+          cache-before (impl.indexed/make-schema-cache db-before)
+          before-paths (binding [impl.indexed/*schema-cache* cache-before]
+                         (impl.indexed/get-permission-paths db-before :account :view))]
       (schema/write-schema! conn "definition user {}
          definition account { relation owner: user  relation viewer: user  relation auditor: user
                               permission view = owner + viewer + auditor }")
       (let [db-after         (d/db conn)
-            after-paths      (impl.indexed/get-permission-paths db-after :account :view)
-            historical-paths (impl.indexed/get-permission-paths db-before :account :view)]
+            cache-after      (impl.indexed/make-schema-cache db-after)
+            after-paths      (binding [impl.indexed/*schema-cache* cache-after]
+                               (impl.indexed/get-permission-paths db-after :account :view))
+            historical-paths (binding [impl.indexed/*schema-cache* cache-before]
+                               (impl.indexed/get-permission-paths db-before :account :view))]
         (is (< (count before-paths) (count after-paths)))
         (is (= before-paths historical-paths))
-        (is (= 2 (count @impl.indexed/permission-paths-cache))
-            "each schema-version era gets its own cache slot; an older db value must not see live-schema paths")))))
+        (is (not= (:schema-version cache-before) (:schema-version cache-after))
+            "write-schema! created a new generation stamp")))))
 
 (deftest string-object-id-resolution-test
   ;; d/entid on a bare string throws a raw IllegalArgumentException, which

--- a/test/eacl/datomic/impl/indexed_test.clj
+++ b/test/eacl/datomic/impl/indexed_test.clj
@@ -724,8 +724,12 @@
             (is (empty? (paginated->spice db' empty-page)))
             (is (nil? (page-start-cursor empty-page)))
             (is (nil? (page-end-cursor empty-page)))
+            ;; A page with no items carries no cursors, so it can advertise
+            ;; neither direction: has-*-page? true alongside a nil cursor gave
+            ;; clients a loop with no exit (and :after nil silently restarted
+            ;; at page 1). Both flags are clamped to false on an empty page.
             (is (false? (get-in empty-page [:page-info :has-next-page?])))
-            (is (true? (get-in empty-page [:page-info :has-previous-page?])))))
+            (is (false? (get-in empty-page [:page-info :has-previous-page?])))))
 
         (testing "forward pages compose with :after end-cursor"
           (let [both-pages (lookup-resources db' {:first 5
@@ -1384,14 +1388,33 @@
                                                        :resource/type :account
                                                        :first         2})))))))
 
-      (testing "bare recursive :last is rejected because it requires full traversal"
-        (is (= :eacl.pagination/unsupported-recursive-last
-               (:eacl/error
-                (thrown-ex-data
-                 #(lookup-resources db {:subject       user
-                                        :permission    :read
-                                        :resource/type :account
-                                        :last          2}))))))
+      ;; Regression: bare :last used to throw :eacl.pagination/unsupported-recursive-last
+      ;; while the acyclic engine accepted it, so adding `parent->read` to a
+      ;; schema turned every existing {:last n} caller into a runtime error.
+      ;; It now exhausts the traversal into a trailing window, like count-*.
+      (testing "bare recursive :last returns the trailing page, matching the acyclic contract"
+        (let [all  (paginated->spice db (lookup-resources db {:subject       user
+                                                              :permission    :read
+                                                              :resource/type :account
+                                                              :first         100}))
+              tail (lookup-resources db {:subject       user
+                                         :permission    :read
+                                         :resource/type :account
+                                         :last          2})]
+          (is (= (vec (take-last 2 all)) (paginated->spice db tail))
+              "bare :last is the last window of the traversal order")
+          (is (false? (get-in tail [:page-info :has-next-page?]))
+              "nothing follows the last page")
+          (is (true? (get-in tail [:page-info :has-previous-page?]))
+              "3 results, page size 2: an earlier page exists")
+          (testing "and :before composes backwards from it"
+            (is (= (vec (drop-last 2 all))
+                   (paginated->spice db
+                                     (lookup-resources db {:subject       user
+                                                           :permission    :read
+                                                           :resource/type :account
+                                                           :last          2
+                                                           :before        (page-start-cursor tail)})))))))
 
       (testing "wrong cursor kind is rejected by recursive lookup"
         (is (= :eacl.pagination/wrong-cursor-kind

--- a/test/eacl/datomic/object_deletion_test.clj
+++ b/test/eacl/datomic/object_deletion_test.clj
@@ -19,6 +19,7 @@
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
             [eacl.datomic.impl :as impl :refer [Relationship]]
             [eacl.datomic.impl.indexed :as idx]
+            [eacl.datomic.integrity :as integrity]
             [eacl.datomic.schema :as schema]))
 
 (def ^:private test-schema
@@ -145,6 +146,31 @@
                                                :subject/type :user
                                                :first        10})))))))
 
+(deftest public-integrity-audit-is-explicit-and-bounded-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [u]} (seed! conn)
+          acl (core/make-client conn {})]
+      (is (= :current (:status (integrity/client-schema-status acl))))
+
+      @(d/transact conn [[:db.fn/retractEntity u]])
+
+      (is (= {:valid? false
+              :dangling-count 1
+              :by-half {:forward 0 :reverse 1}
+              :sample []}
+             (integrity/dangling-relationship-report (d/db conn) {:sample-size 0})))
+
+      (let [batches (integrity/repair-tx-batches (d/db conn) {:batch-size 1})]
+        (is (= 1 (count batches)))
+        (doseq [batch batches]
+          @(d/transact conn batch)))
+
+      (is (= {:valid? true
+              :dangling-count 0
+              :by-half {:forward 0 :reverse 0}
+              :sample []}
+             (integrity/dangling-relationship-report (d/db conn)))))))
+
 (deftest half-written-relationships-are-repairable-test
   ;; relationship-exists? consulted only the forward index, so a surviving
   ;; reverse half read as "already there" to :touch and "nothing to do" to
@@ -183,9 +209,11 @@
         (is (= 1 (reverse-count (d/db conn) a)))
         (is (= 1 (forward-count (d/db conn) u)))))))
 
-(deftest public-can-does-not-grant-on-a-retracted-entity-test
-  ;; With the README-documented eid-as-external-id coercion, d/entid passes any
-  ;; long through unchanged, so can? answered from the surviving forward half.
+(deftest bare-retract-can-leave-a-detectable-ghost-test
+  ;; With eid-as-external-id coercion, d/entid passes any long through
+  ;; unchanged. EACL deliberately does not add entity-existence probes to every
+  ;; can?; the consumer deletion contract and explicit integrity auditor own
+  ;; this failure mode.
   (with-mem-conn [conn schema/v7-schema]
     (let [{:keys [u a]} (seed! conn)
           acl (core/make-client conn {:object-id->ident identity
@@ -195,8 +223,12 @@
       @(d/transact conn [[:db.fn/retractEntity a]])
 
       (is (= 1 (forward-count (d/db conn) u)) "the orphan is still there…")
-      (is (false? (eacl/can? acl (spice-object :user u) :admin (spice-object :account a)))
-          "…but a retracted object grants nothing")
+      (is (true? (eacl/can? acl (spice-object :user u) :admin (spice-object :account a)))
+          "…and raw eid identity can still address the surviving tuple")
+      (is (= 1 (:dangling-count
+                (integrity/dangling-relationship-report (d/db conn)))))
 
-      (testing "and the same holds for a retracted subject"
-        (is (false? (eacl/can? acl (spice-object :user 99999999) :admin (spice-object :account a))))))))
+      (doseq [batch (integrity/repair-tx-batches (d/db conn))]
+        @(d/transact conn batch))
+      (is (false? (eacl/can? acl (spice-object :user u) :admin (spice-object :account a)))
+          "repair removes the ghost grant"))))

--- a/test/eacl/datomic/object_deletion_test.clj
+++ b/test/eacl/datomic/object_deletion_test.clj
@@ -1,0 +1,202 @@
+(ns eacl.datomic.object-deletion-test
+  "Regressions for dangling relationship halves.
+
+  A v7 relationship is two datoms on two different entities, each naming its
+  peer inside a tuple VALUE. Datomic's :db.fn/retractEntity follows
+  :db.type/ref ATTRIBUTES, not ref-typed components of a heterogeneous tuple,
+  so retracting a permissioned entity the ordinary Datomic way leaves the
+  peer's half behind — where it keeps answering queries, and where
+  write-relationships! can no longer reach it (resolving either endpoint now
+  throws :eacl/unknown-object).
+
+  eacl/delete-object! (impl/tx-delete-object) is the supported deletion path;
+  impl/orphaned-relationship-halves + impl/tx-retract-orphaned-relationships
+  repair databases that already contain orphans."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datomic.api :as d]
+            [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datomic.core :as core]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
+            [eacl.datomic.impl :as impl :refer [Relationship]]
+            [eacl.datomic.impl.indexed :as idx]
+            [eacl.datomic.schema :as schema]))
+
+(def ^:private test-schema
+  "definition user {}
+   definition account { relation owner: user
+                        permission admin = owner }")
+
+(defn- seed!
+  "user u owns account a."
+  [conn]
+  (schema/write-schema! conn test-schema)
+  @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
+  @(d/transact conn (impl/tx-relationship (d/db conn)
+                      (Relationship (spice-object :user [:eacl/id "u"])
+                                    :owner
+                                    (spice-object :account [:eacl/id "a"]))))
+  (let [db (d/db conn)]
+    {:u (d/entid db [:eacl/id "u"])
+     :a (d/entid db [:eacl/id "a"])}))
+
+(defn- forward-count [db eid]
+  (count (seq (d/datoms db :eavt eid :eacl.v7.relationship/subject-type+relation+resource-type+resource))))
+
+(defn- reverse-count [db eid]
+  (count (seq (d/datoms db :eavt eid :eacl.v7.relationship/resource-type+relation+subject-type+subject))))
+
+(deftest retract-entity-leaves-orphans-that-delete-object-prevents-test
+  (testing "deleting the RESOURCE: the subject's forward half used to keep granting"
+    (with-mem-conn [conn schema/v7-schema]
+      (let [{:keys [u a]} (seed! conn)]
+        (is (true? (idx/can? (d/db conn) (spice-object :user u) :admin (spice-object :account a))))
+
+        ;; the supported path: drop the relationships, then the entity
+        @(d/transact conn (impl/tx-delete-object (d/db conn) a))
+        @(d/transact conn [[:db.fn/retractEntity a]])
+
+        (let [db (d/db conn)]
+          (is (zero? (forward-count db u)) "the subject's half is gone too")
+          (is (false? (idx/can? db (spice-object :user u) :admin (spice-object :account a))))
+          (is (empty? (:data (idx/lookup-resources db {:subject       (spice-object :user u)
+                                                       :permission    :admin
+                                                       :resource/type :account
+                                                       :first         10}))))
+          (is (zero? (:count (idx/count-resources db {:subject       (spice-object :user u)
+                                                      :permission    :admin
+                                                      :resource/type :account}))))))))
+
+  (testing "deleting the SUBJECT: the resource's reverse half used to keep listing it"
+    (with-mem-conn [conn schema/v7-schema]
+      (let [{:keys [u a]} (seed! conn)]
+        @(d/transact conn (impl/tx-delete-object (d/db conn) u))
+        @(d/transact conn [[:db.fn/retractEntity u]])
+
+        (let [db (d/db conn)]
+          (is (zero? (reverse-count db a)) "the resource's half is gone too")
+          (is (empty? (:data (idx/lookup-subjects db {:resource     (spice-object :account a)
+                                                      :permission   :admin
+                                                      :subject/type :user
+                                                      :first        10}))))
+          (is (zero? (:count (idx/count-subjects db {:resource     (spice-object :account a)
+                                                     :permission   :admin
+                                                     :subject/type :user})))))))))
+
+(deftest delete-object-through-the-client-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [u a]} (seed! conn)
+          acl (core/make-client conn {})]
+      (is (true? (eacl/can? acl (spice-object :user "u") :admin (spice-object :account "a"))))
+
+      (let [result (eacl/delete-object! acl (spice-object :account "a"))]
+        (is (= 2 (:retracted-datoms result)) "both halves of the one relationship")
+        (is (some? (:zed/token result))))
+
+      (is (false? (eacl/can? acl (spice-object :user "u") :admin (spice-object :account "a"))))
+      (is (zero? (forward-count (d/db conn) u)))
+      (is (zero? (reverse-count (d/db conn) a)))
+
+      (testing "it is idempotent"
+        (is (= 0 (:retracted-datoms (eacl/delete-object! acl (spice-object :account "a"))))))
+
+      (testing "the entities themselves are untouched — retracting them is the caller's business"
+        (is (seq (d/datoms (d/db conn) :eavt a)))))))
+
+(deftest delete-object-accepts-a-raw-eid-after-the-entity-is-gone-test
+  ;; The cleanup path for an entity already retracted the bare Datomic way:
+  ;; its :eacl/id no longer resolves, but the eid still identifies the orphans.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [u a]} (seed! conn)
+          acl (core/make-client conn {})]
+      @(d/transact conn [[:db.fn/retractEntity u]])
+      (is (= 1 (reverse-count (d/db conn) a)) "orphan present before repair")
+
+      (let [result (eacl/delete-object! acl (spice-object :user u))]
+        (is (pos? (:retracted-datoms result))))
+
+      (is (zero? (reverse-count (d/db conn) a)))
+      (is (empty? (:data (idx/lookup-subjects (d/db conn)
+                                              {:resource     (spice-object :account a)
+                                               :permission   :admin
+                                               :subject/type :user
+                                               :first        10})))))))
+
+(deftest orphan-detection-and-repair-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [u a]} (seed! conn)]
+      (is (empty? (impl/orphaned-relationship-halves (d/db conn)))
+          "a well-formed database has no orphans")
+
+      @(d/transact conn [[:db.fn/retractEntity u]])
+
+      (let [orphans (vec (impl/orphaned-relationship-halves (d/db conn)))]
+        (is (= 1 (count orphans)))
+        (is (= :reverse (:half (first orphans))))
+        (is (= a (:e (first orphans))))
+        (is (= u (:subject-eid (first orphans)))))
+
+      @(d/transact conn (impl/tx-retract-orphaned-relationships (d/db conn)))
+
+      (is (empty? (impl/orphaned-relationship-halves (d/db conn))))
+      (is (zero? (reverse-count (d/db conn) a)))
+      (is (empty? (:data (idx/lookup-subjects (d/db conn)
+                                              {:resource     (spice-object :account a)
+                                               :permission   :admin
+                                               :subject/type :user
+                                               :first        10})))))))
+
+(deftest half-written-relationships-are-repairable-test
+  ;; relationship-exists? consulted only the forward index, so a surviving
+  ;; reverse half read as "already there" to :touch and "nothing to do" to
+  ;; :delete — permanently unrepairable through the write API.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [u a]} (seed! conn)
+          acl (core/make-client conn {})
+          rel (Relationship (spice-object :user "u") :owner (spice-object :account "a"))]
+
+      (testing ":delete removes both halves even when only one is present"
+        ;; hand-retract the forward half only, simulating a partial write
+        (let [forward (first (d/datoms (d/db conn) :eavt u
+                                       :eacl.v7.relationship/subject-type+relation+resource-type+resource))]
+          @(d/transact conn [[:db/retract u
+                              :eacl.v7.relationship/subject-type+relation+resource-type+resource
+                              (vec (:v forward))]]))
+        (is (= 1 (reverse-count (d/db conn) a)) "reverse half survives")
+
+        (eacl/delete-relationship! acl rel)
+        (is (zero? (reverse-count (d/db conn) a)) "…and :delete can now clear it")))
+
+    (let [{:keys [u a]} (seed! conn)]
+      (testing ":touch re-asserts a missing half instead of reporting it present"
+        (let [reverse-datom (first (d/datoms (d/db conn) :eavt a
+                                             :eacl.v7.relationship/resource-type+relation+subject-type+subject))]
+          @(d/transact conn [[:db/retract a
+                              :eacl.v7.relationship/resource-type+relation+subject-type+subject
+                              (vec (:v reverse-datom))]]))
+        (is (zero? (reverse-count (d/db conn) a)))
+
+        (eacl/write-relationship! (core/make-client conn {})
+                                  {:operation :touch
+                                   :subject   (spice-object :user "u")
+                                   :relation  :owner
+                                   :resource  (spice-object :account "a")})
+        (is (= 1 (reverse-count (d/db conn) a)))
+        (is (= 1 (forward-count (d/db conn) u)))))))
+
+(deftest public-can-does-not-grant-on-a-retracted-entity-test
+  ;; With the README-documented eid-as-external-id coercion, d/entid passes any
+  ;; long through unchanged, so can? answered from the surviving forward half.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [{:keys [u a]} (seed! conn)
+          acl (core/make-client conn {:object-id->ident identity
+                                      :entid->object-id (fn [_db eid] eid)})]
+      (is (true? (eacl/can? acl (spice-object :user u) :admin (spice-object :account a))))
+
+      @(d/transact conn [[:db.fn/retractEntity a]])
+
+      (is (= 1 (forward-count (d/db conn) u)) "the orphan is still there…")
+      (is (false? (eacl/can? acl (spice-object :user u) :admin (spice-object :account a)))
+          "…but a retracted object grants nothing")
+
+      (testing "and the same holds for a retracted subject"
+        (is (false? (eacl/can? acl (spice-object :user 99999999) :admin (spice-object :account a))))))))

--- a/test/eacl/datomic/schema_basis_test.clj
+++ b/test/eacl/datomic/schema_basis_test.clj
@@ -1,23 +1,18 @@
 (ns eacl.datomic.schema-basis-test
-  "Pins the permission-path cache-scoping contract and the Datomic facts it
-  relies on, plus the audit §3 regression (no cache-slot sharing across db
-  bases).
+  "Pins the v7.4 client-lifecycle schema-cache contract.
 
-  The contract: the cache scope is an exact fingerprint of the EACL definition
-  datoms visible in the queried db value, so two db values share a cached path
-  set only when their schemas are identical — however the schema changed
-  (write-schema!, raw d/transact, d/with, excision) and whether or not
-  :eacl/schema-version was bumped.
-
-  Issue #74's requirement still holds and is pinned here: the fingerprint is
-  memoised per db VALUE, so relationship and application writes never recompute
-  permission paths."
-  (:require [clojure.test :refer [deftest testing is]]
+  A connection-backed client reads :eacl/schema-version once at construction
+  and owns exactly one cache generation. New Datomic db values never trigger a
+  schema read or definition scan. write-schema! through the client swaps that
+  generation; arbitrary-db internals are uncached and cannot mutate it."
+  (:require [clojure.test :refer [deftest is testing]]
             [datomic.api :as d]
-            [eacl.core :refer [spice-object]]
+            [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datomic.core :as core]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
-            [eacl.datomic.impl :as impl :refer [Relation Permission Relationship]]
+            [eacl.datomic.impl :as impl :refer [Permission Relation Relationship]]
             [eacl.datomic.impl.indexed :as idx]
+            [eacl.datomic.integrity :as integrity]
             [eacl.datomic.schema :as schema]))
 
 (def ^:private schema-v1
@@ -31,269 +26,172 @@
                         relation viewer: user
                         permission admin = owner + viewer }")
 
-(deftest pinned-datomic-behaviors-test
+(defn- seed-owner!
+  [conn]
+  @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
+  @(d/transact conn
+               (impl/tx-relationship
+                (d/db conn)
+                (Relationship (spice-object :user [:eacl/id "u"])
+                              :owner
+                              (spice-object :account [:eacl/id "a"])))))
+
+(deftest client-schema-is-read-once-not-on-every-db-value-test
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn schema-v1)
-    (let [db1 (d/db conn)
-          _   (schema/write-schema! conn schema-v2)
-          db2 (d/db conn)]
+    (seed-owner! conn)
+    (let [version-reads (atom 0)
+          path-calcs   (atom 0)
+          version-fn   idx/schema-version
+          calc-fn      idx/calc-permission-paths]
+      (with-redefs [idx/schema-version (fn [db]
+                                        (swap! version-reads inc)
+                                        (version-fn db))
+                    idx/calc-permission-paths (fn [& args]
+                                                (swap! path-calcs inc)
+                                                (apply calc-fn args))]
+        (let [acl (core/make-client conn {})
+              u   (spice-object :user "u")
+              a   (spice-object :account "a")]
+          (is (= 1 @version-reads) "make-client performs the one automatic stamp read")
+          (is (true? (eacl/can? acl u :admin a)))
+          (is (= 1 @path-calcs) "first permission use populates the client generation")
 
-      (testing ".id returns the same database UUID on plain/as-of/with views (scope key component)"
-        (is (= (str (.id db2))
-               (str (.id (d/as-of db2 (d/basis-t db1))))
-               (str (.id (:db-after (d/with db2 [])))))))
+          (dotimes [n 50]
+            @(d/transact conn [{:eacl/id (str "unrelated-" n)}])
+            (is (true? (eacl/can? acl u :admin a))))
 
-      (testing "view classification predicates identify their views; with-dbs read as plain"
-        (is (false? (d/is-filtered db2)))
-        (is (false? (d/is-filtered (d/as-of db2 (d/basis-t db1)))))
-        (is (false? (d/is-filtered (d/since db2 (d/basis-t db1)))))
-        (is (true?  (d/is-filtered (d/filter db2 (fn [_ _] true)))))
-        (is (true?  (d/is-history (d/history db2))))
-        (is (false? (d/is-history db2)))
-        (is (nil?   (d/as-of-t (:db-after (d/with db2 [])))))
-        (is (nil?   (d/since-t (:db-after (d/with db2 [])))))
-        (is (some?  (d/since-t (d/since db2 (d/basis-t db1))))))
+          (eacl/write-schema! acl schema-v1)
+          (is (= 1 @version-reads)
+              "new db values and client schema writes reuse the construction-time version")
+          (is (= 1 @path-calcs)
+              "unrelated and identical schema transactions never recompute permission paths"))))))
 
-      (testing "the version datom is a plain cardinality-one assert: as-of views read their era's value"
-        (is (some? (idx/schema-version db1)))
-        (is (not= (idx/schema-version db1) (idx/schema-version db2)))
-        (is (= (idx/schema-version db1)
-               (idx/schema-version (d/as-of db2 (d/basis-t db1)))))))))
-
-(deftest write-schema-invalidation-test
-  ;; Audit §3 regression, reworked for issue #74: invalidation is signaled by
-  ;; write-schema!'s version bump (visible to every peer via the db), not
-  ;; derived from db content and not dependent on the local eviction.
+(deftest write-schema-through-client-replaces-one-generation-test
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn schema-v1)
-    @(d/transact conn [{:db/id "u" :eacl/id "u"} {:db/id "a" :eacl/id "a"}])
-    @(d/transact conn (impl/tx-relationship (d/db conn)
-                        (Relationship (spice-object :user [:eacl/id "u"])
-                                      :owner
-                                      (spice-object :account [:eacl/id "a"]))))
-    (idx/evict-permission-paths-cache!)
-    (let [db1 (d/db conn)
-          u   (spice-object :user [:eacl/id "u"])
-          a   (spice-object :account [:eacl/id "a"])]
-      (is (true? (idx/can? db1 u :admin a)))
-      (is (= 1 (count (idx/get-permission-paths db1 :account :admin))) "cache populated")
+    (seed-owner! conn)
+    @(d/transact conn [{:eacl/id "viewer"}])
+    (let [acl       (core/make-client conn {:page-token-key "schema-generation-test"})
+          owner     (spice-object :user "u")
+          viewer    (spice-object :user "viewer")
+          account   (spice-object :account "a")
+          path-calcs (atom 0)
+          calc-fn   idx/calc-permission-paths]
+      (with-redefs [idx/calc-permission-paths
+                    (fn [& args]
+                      (swap! path-calcs inc)
+                      (apply calc-fn args))]
+        (is (true? (eacl/can? acl owner :admin account)))
+        (is (= 1 @path-calcs))
 
-      (testing "write-schema! invalidates via the version key alone — no local eviction needed (the cross-peer story)"
-        (with-redefs [idx/evict-permission-paths-cache! (fn [] nil)]
-          (schema/write-schema! conn schema-v2))
-        (let [db2 (d/db conn)]
-          (is (= 2 (count (idx/get-permission-paths db2 :account :admin)))
-              "new version, new cache slot: paths recomputed without eviction")
-          (is (true? (idx/can? db2 u :admin a)))
+        (eacl/write-schema! acl schema-v2)
+        (eacl/create-relationship! acl viewer :viewer account)
 
-          (testing "as-of at the pre-change basis resolves the HISTORICAL paths, even after both were cached"
-            (is (= 1 (count (idx/get-permission-paths (d/as-of db2 (d/basis-t db1)) :account :admin))))
-            (is (= 2 (count (idx/get-permission-paths db2 :account :admin)))))))
+        (is (true? (eacl/can? acl viewer :admin account)))
+        (is (= 2 @path-calcs) "the new generation computes admin once")
 
-      ;; This used to assert the opposite — that a programmatic edit served
-      ;; stale paths until write-schema! or a manual eviction. The scope is now
-      ;; a fingerprint of the definition datoms themselves, so it does not
-      ;; matter how the definitions changed.
-      (testing "programmatic schema edits are visible to the caches without a version bump"
-        ;; a viewer-only subject: their access depends solely on the
-        ;; `admin = … + viewer` row that is about to be retracted.
-        @(d/transact conn [{:eacl/id "v"}])
-        @(d/transact conn (impl/tx-relationship (d/db conn)
-                            (Relationship (spice-object :user [:eacl/id "v"])
-                                          :viewer
-                                          (spice-object :account [:eacl/id "a"]))))
-        (let [v               (spice-object :user [:eacl/id "v"])
-              viewer-perm-eid (d/q '[:find ?e .
-                                     :where
-                                     [?e :eacl.permission/resource-type :account]
-                                     [?e :eacl.permission/permission-name :admin]
-                                     [?e :eacl.permission/target-name :viewer]]
-                                   (d/db conn))
-              version-before  (idx/schema-version (d/db conn))]
-          (is (true? (idx/can? (d/db conn) v :admin a))
-              "viewer grants :admin under schema-v2, and this caches it")
-          @(d/transact conn [[:db.fn/retractEntity viewer-perm-eid]])
-          (is (= version-before (idx/schema-version (d/db conn)))
-              "raw d/transact does not bump :eacl/schema-version")
-          (is (= 1 (count (idx/get-permission-paths (d/db conn) :account :admin)))
-              "the retracted permission row is gone from the paths anyway")
-          (is (false? (idx/can? (d/db conn) v :admin a))
-              "…so the access it granted is revoked immediately")
-          (is (true? (idx/can? (d/db conn) u :admin a))
-              "while the surviving `admin = owner` row still grants"))))))
+        (testing "an identical write neither bumps the stamp nor discards paths"
+          (let [before (idx/schema-version (d/db conn))]
+            (eacl/write-schema! acl schema-v2)
+            (is (= before (idx/schema-version (d/db conn))))
+            (is (true? (eacl/can? acl viewer :admin account)))
+            (is (= 2 @path-calcs))))))))
 
-(deftest speculative-db-cannot-poison-live-cache-test
-  ;; A d/with database inherits the database uuid, reads as :plain
-  ;; (is-filtered/as-of-t/since-t are all false/nil on it) and does not bump
-  ;; :eacl/schema-version — so under the old [database-uuid schema-version]
-  ;; scope it shared a cache slot with the committed database. Evaluating a
-  ;; permission against a speculative schema change published the speculative
-  ;; paths under the LIVE key and granted a permission the committed schema
-  ;; does not define, for the life of the process.
+(deftest page-token-does-not-time-travel-across-schema-generations-test
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn schema-v1)
-    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
-    @(d/transact conn (impl/tx-relationship (d/db conn)
-                        (Relationship (spice-object :user [:eacl/id "u"])
-                                      :owner
-                                      (spice-object :account [:eacl/id "a"]))))
-    (idx/evict-permission-paths-cache!)
-    (let [db  (d/db conn)
-          u   (spice-object :user [:eacl/id "u"])
-          a   (spice-object :account [:eacl/id "a"])]
+    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a-1"} {:eacl/id "a-2"}])
+    (doseq [account ["a-1" "a-2"]]
+      @(d/transact conn
+                   (impl/tx-relationship
+                    (d/db conn)
+                    (Relationship (spice-object :user [:eacl/id "u"])
+                                  :owner
+                                  (spice-object :account [:eacl/id account])))))
+    (let [acl   (core/make-client conn {:page-token-key "stale-schema-token"})
+          query {:subject (spice-object :user "u")
+                 :permission :admin
+                 :resource/type :account
+                 :first 1}
+          page1 (eacl/lookup-resources acl query)
+          cursor (get-in page1 [:page-info :end-cursor])]
+      (is (some? cursor))
+      (eacl/write-schema! acl schema-v2)
+      (try
+        (eacl/lookup-resources acl (assoc query :after cursor))
+        (is false "a token may not evaluate a historical schema")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :eacl.pagination/stale-schema (:type (ex-data e)))))))))
 
-      (testing "a speculative ADDITION does not leak into the committed database"
-        (let [speculative (:db-after (d/with db [(Permission :account :view {:relation :owner})]))]
-          (is (true? (idx/can? speculative u :view a))
-              "the speculative db sees its own new permission")
-          (is (false? (idx/can? db u :view a))
-              "the committed db must not: :view does not exist there")
-          (is (empty? (idx/get-permission-paths db :account :view)))
-          (is (empty? (:data (idx/lookup-resources db {:subject       u
-                                                       :permission    :view
-                                                       :resource/type :account
-                                                       :first         10}))))))
+(deftest arbitrary-db-evaluation-is-uncached-and-isolated-test
+  (with-mem-conn [conn schema/v7-schema]
+    (schema/write-schema! conn schema-v1)
+    (seed-owner! conn)
+    (let [acl (core/make-client conn {})
+          db  (d/db conn)
+          internal-u (spice-object :user (d/entid db [:eacl/id "u"]))
+          internal-a (spice-object :account (d/entid db [:eacl/id "a"]))
+          public-u   (spice-object :user "u")
+          public-a   (spice-object :account "a")]
+      (is (true? (eacl/can? acl public-u :admin public-a)))
 
-      (testing "a speculative RETRACTION does not leak either (the false-denial direction)"
-        (let [perm-eid    (d/q '[:find ?e .
-                                 :where
-                                 [?e :eacl.permission/resource-type :account]
-                                 [?e :eacl.permission/permission-name :admin]]
-                               db)
-              speculative (:db-after (d/with db [[:db.fn/retractEntity perm-eid]]))]
-          (is (false? (idx/can? speculative u :admin a)))
-          (is (true? (idx/can? db u :admin a))
-              "the committed db still grants :admin"))))))
+      (testing "a speculative addition can be evaluated explicitly but cannot publish into the client"
+        (let [speculative (:db-after
+                           (d/with db [(Permission :account :view {:relation :owner})]))]
+          (is (true? (idx/can? speculative internal-u :view internal-a)))
+          (is (false? (eacl/can? acl public-u :view public-a)))))
 
-(deftest unstamped-database-cache-is-still-exact-test
-  ;; :eacl/schema-version is only written by write-schema!, so a database built
-  ;; with programmatic Relation/Permission maps (or migrated with no :schema)
-  ;; had a nil stamp and therefore a scope that never changed: definitions
-  ;; added after the first query stayed invisible for the life of the process.
+      (testing "a speculative retraction cannot narrow the client generation"
+        (let [permission-eid
+              (d/q '[:find ?e .
+                     :where
+                     [?e :eacl.permission/resource-type :account]
+                     [?e :eacl.permission/permission-name :admin]]
+                   db)
+              speculative (:db-after
+                           (d/with db [[:db.fn/retractEntity permission-eid]]))]
+          (is (false? (idx/can? speculative internal-u :admin internal-a)))
+          (is (true? (eacl/can? acl public-u :admin public-a))))))))
+
+(deftest unstamped-client-does-not-latch-schema-test
   (with-mem-conn [conn schema/v7-schema]
     @(d/transact conn [(Relation :account :owner :user)])
-    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
-    @(d/transact conn (impl/tx-relationship (d/db conn)
-                        (Relationship (spice-object :user [:eacl/id "u"])
-                                      :owner
-                                      (spice-object :account [:eacl/id "a"]))))
-    (idx/evict-permission-paths-cache!)
-    (let [u (spice-object :user [:eacl/id "u"])
-          a (spice-object :account [:eacl/id "a"])]
-      (is (nil? (idx/schema-version (d/db conn)))
-          "no write-schema! has run: there is no version stamp to key on")
-      (is (false? (idx/can? (d/db conn) u :admin a))
-          "populates the cache with the pre-change (empty) paths")
+    (seed-owner! conn)
+    (let [acl (core/make-client conn {})
+          u   (spice-object :user "u")
+          a   (spice-object :account "a")]
+      (is (nil? (idx/schema-version (d/db conn))))
+      (is (false? (eacl/can? acl u :admin a)))
 
-      (testing "a permission added programmatically afterwards takes effect"
-        @(d/transact conn [(Permission :account :admin {:relation :owner})])
-        (is (nil? (idx/schema-version (d/db conn))))
-        (is (true? (idx/can? (d/db conn) u :admin a))))
+      @(d/transact conn [(Permission :account :admin {:relation :owner})])
+      (is (true? (eacl/can? acl u :admin a))
+          "without a stamp, paths are recomputed rather than latched")
 
-      (testing "and retracting it programmatically takes effect too"
-        @(d/transact conn [[:db.fn/retractEntity
-                            (d/q '[:find ?e .
-                                   :where [?e :eacl.permission/permission-name :admin]]
-                                 (d/db conn))]])
-        (is (false? (idx/can? (d/db conn) u :admin a)))))))
+      (testing "the first supported write establishes a stamp even for a zero delta"
+        (eacl/write-schema! acl schema-v1)
+        (is (some? (idx/schema-version (d/db conn))))
+        (is (true? (eacl/can? acl u :admin a)))))))
 
-(deftest unrelated-transact-keeps-cache-test
-  ;; Issue #74 itself: relationship/application writes must not bust the path
-  ;; cache — neither before any write-schema! (nil version) nor after one.
-  (with-mem-conn [conn schema/v7-schema]
-    @(d/transact conn [(Relation :account :owner :user)
-                       (Permission :account :admin {:relation :owner})])
-    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
-    (idx/evict-permission-paths-cache!)
-    (let [calls (atom 0)
-          orig  idx/calc-permission-paths]
-      (with-redefs [idx/calc-permission-paths (fn [& args]
-                                                (swap! calls inc)
-                                                (apply orig args))]
-        (testing "pre-version databases (no write-schema! yet) still cache across unrelated writes"
-          (idx/get-permission-paths (d/db conn) :account :admin)
-          (is (= 1 @calls))
-          @(d/transact conn (impl/tx-relationship (d/db conn)
-                              (Relationship (spice-object :user [:eacl/id "u"])
-                                            :owner
-                                            (spice-object :account [:eacl/id "a"]))))
-          (idx/get-permission-paths (d/db conn) :account :admin)
-          (is (= 1 @calls)
-              "unchanged schema across relationship writes must hit the cache"))
-
-        (testing "after write-schema!, the version stays put across unrelated writes: cache stays hot"
-          (schema/write-schema! conn schema-v1)
-          (idx/get-permission-paths (d/db conn) :account :admin)
-          (let [warm @calls]
-            @(d/transact conn [{:eacl/id "unrelated-entity"}])
-            @(d/transact conn (impl/tx-relationship (d/db conn)
-                                (Relationship (spice-object :user [:eacl/id "u"])
-                                              :owner
-                                              (spice-object :account [:eacl/id "unrelated-entity"]))))
-            (idx/get-permission-paths (d/db conn) :account :admin)
-            (is (= warm @calls)
-                "d/transact of relationships/entities must not recompute paths (issue #74)")))))))
-
-(deftest schema-scope-is-computed-once-per-db-value-test
-  ;; The scope is now a fingerprint of the definition datoms, which costs one
-  ;; O(number-of-definitions) scan. That is only affordable because it is
-  ;; memoised on the db VALUE: computing it per get-permission-paths call (or
-  ;; per can?) would put a schema-sized scan on the hottest path in EACL.
+(deftest out-of-band-schema-write-requires-a-new-client-test
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn schema-v1)
-    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
-    @(d/transact conn (impl/tx-relationship (d/db conn)
-                        (Relationship (spice-object :user [:eacl/id "u"])
-                                      :owner
-                                      (spice-object :account [:eacl/id "a"]))))
-    (idx/evict-permission-paths-cache!)
-    (let [scans (atom 0)
-          orig  @#'idx/calc-schema-scope
-          u     (spice-object :user [:eacl/id "u"])
-          a     (spice-object :account [:eacl/id "a"])]
-      (with-redefs [idx/calc-schema-scope (fn [db] (swap! scans inc) (orig db))]
-        (let [db (d/db conn)]
-          (testing "many checks against one db value fingerprint it once"
-            (dotimes [_ 50]
-              (is (true? (idx/can? db u :admin a)))
-              (idx/lookup-resources db {:subject u :permission :admin
-                                        :resource/type :account :first 10}))
-            (is (= 1 @scans)
-                (str "expected one fingerprint scan for one db value, got " @scans)))
+    (seed-owner! conn)
+    @(d/transact conn [{:eacl/id "viewer"}])
+    (let [old-client (core/make-client conn {})
+          viewer     (spice-object :user "viewer")
+          account    (spice-object :account "a")]
+      ;; Warm and therefore latch the old admin path.
+      (is (false? (eacl/can? old-client viewer :admin account)))
+      (is (= :current (:status (integrity/client-schema-status old-client))))
 
-          (testing "d/db at an unchanged basis is the same value and still hits"
-            (idx/can? (d/db conn) u :admin a)
-            (is (= 1 @scans)))
+      ;; Deliberately bypass the client. The lifecycle contract requires
+      ;; recreating other clients/processes after such a schema write.
+      (schema/write-schema! conn schema-v2)
+      (is (= :outdated (:status (integrity/client-schema-status old-client)))
+          "the optional one-datom diagnostic detects the mismatch")
+      (let [writer (core/make-client conn {})]
+        (eacl/create-relationship! writer viewer :viewer account))
 
-          (testing "a new db value costs exactly one more scan, however many calls follow"
-            @(d/transact conn [{:eacl/id "unrelated"}])
-            (let [db2 (d/db conn)]
-              (dotimes [_ 20] (idx/can? db2 u :admin a))
-              (is (= 2 @scans)))))))))
-
-(deftest filtered-views-cannot-poison-cache-test
-  (with-mem-conn [conn schema/v7-schema]
-    (schema/write-schema! conn schema-v1)
-    (let [db       (d/db conn)
-          perm-eid (d/q '[:find ?e .
-                          :where
-                          [?e :eacl.permission/resource-type :account]
-                          [?e :eacl.permission/permission-name :admin]]
-                        db)]
-      (testing "a d/filter db hiding the permission cannot publish empty paths under the plain db's key"
-        (idx/evict-permission-paths-cache!)
-        (let [filtered   (d/filter db (fn [_db datom] (not= perm-eid (:e datom))))
-              filt-paths (idx/get-permission-paths filtered :account :admin)]
-          (is (= 0 (count filt-paths)) "the filtered view itself must not see the permission")
-          (is (= 1 (count (idx/get-permission-paths db :account :admin)))
-              "the plain db, queried AFTER the filtered view, must still see it")
-          (is (nil? (idx/schema-version-stamp filtered))
-              "the version stamp does not describe a filter view")
-          (is (not= (idx/schema-scope filtered) (idx/schema-scope db))
-              "and the filtered view fingerprints to its own cache scope")))
-
-      (testing "since and history views have no meaningful version stamp"
-        (is (nil? (idx/schema-version-stamp (d/since db 0))))
-        (is (nil? (idx/schema-version-stamp (d/history db))))
-        (is (some? (idx/schema-version-stamp db)))
-        (is (some? (idx/schema-version-stamp (d/as-of db (d/basis-t db)))))))))
+      (is (false? (eacl/can? old-client viewer :admin account)))
+      (is (true? (eacl/can? (core/make-client conn {}) viewer :admin account))))))

--- a/test/eacl/datomic/schema_basis_test.clj
+++ b/test/eacl/datomic/schema_basis_test.clj
@@ -1,13 +1,17 @@
 (ns eacl.datomic.schema-basis-test
-  "Pins the write-schema!-driven cache-invalidation contract (issue #74) and
-  the Datomic view-classification facts the cache scope relies on, plus the
-  audit §3 regression (no cache-slot sharing across db bases).
+  "Pins the permission-path cache-scoping contract and the Datomic facts it
+  relies on, plus the audit §3 regression (no cache-slot sharing across db
+  bases).
 
-  The contract: ONLY eacl.datomic.schema/write-schema! invalidates the
-  permission-path caches — it bumps :eacl/schema-version in the same
-  transaction as any definition change. Unrelated d/transact calls must leave
-  every cache key untouched. Programmatic edits of relation/permission datoms
-  bypass the stamp and are explicitly unsupported (issue #74)."
+  The contract: the cache scope is an exact fingerprint of the EACL definition
+  datoms visible in the queried db value, so two db values share a cached path
+  set only when their schemas are identical — however the schema changed
+  (write-schema!, raw d/transact, d/with, excision) and whether or not
+  :eacl/schema-version was bumped.
+
+  Issue #74's requirement still holds and is pinned here: the fingerprint is
+  memoised per db VALUE, so relationship and application writes never recompute
+  permission paths."
   (:require [clojure.test :refer [deftest testing is]]
             [datomic.api :as d]
             [eacl.core :refer [spice-object]]
@@ -86,19 +90,112 @@
             (is (= 1 (count (idx/get-permission-paths (d/as-of db2 (d/basis-t db1)) :account :admin))))
             (is (= 2 (count (idx/get-permission-paths db2 :account :admin)))))))
 
-      (testing "programmatic schema edits are invisible to the caches — by design (issue #74)"
-        (let [viewer-perm-eid (d/q '[:find ?e .
+      ;; This used to assert the opposite — that a programmatic edit served
+      ;; stale paths until write-schema! or a manual eviction. The scope is now
+      ;; a fingerprint of the definition datoms themselves, so it does not
+      ;; matter how the definitions changed.
+      (testing "programmatic schema edits are visible to the caches without a version bump"
+        ;; a viewer-only subject: their access depends solely on the
+        ;; `admin = … + viewer` row that is about to be retracted.
+        @(d/transact conn [{:eacl/id "v"}])
+        @(d/transact conn (impl/tx-relationship (d/db conn)
+                            (Relationship (spice-object :user [:eacl/id "v"])
+                                          :viewer
+                                          (spice-object :account [:eacl/id "a"]))))
+        (let [v               (spice-object :user [:eacl/id "v"])
+              viewer-perm-eid (d/q '[:find ?e .
                                      :where
                                      [?e :eacl.permission/resource-type :account]
                                      [?e :eacl.permission/permission-name :admin]
                                      [?e :eacl.permission/target-name :viewer]]
-                                   (d/db conn))]
+                                   (d/db conn))
+              version-before  (idx/schema-version (d/db conn))]
+          (is (true? (idx/can? (d/db conn) v :admin a))
+              "viewer grants :admin under schema-v2, and this caches it")
           @(d/transact conn [[:db.fn/retractEntity viewer-perm-eid]])
-          (is (= 2 (count (idx/get-permission-paths (d/db conn) :account :admin)))
-              "raw d/transact did not bump the version: stale paths served until the next write-schema!")
-          (idx/evict-permission-paths-cache!)
+          (is (= version-before (idx/schema-version (d/db conn)))
+              "raw d/transact does not bump :eacl/schema-version")
           (is (= 1 (count (idx/get-permission-paths (d/db conn) :account :admin)))
-              "manual evict-permission-paths-cache! is the recovery hatch"))))))
+              "the retracted permission row is gone from the paths anyway")
+          (is (false? (idx/can? (d/db conn) v :admin a))
+              "…so the access it granted is revoked immediately")
+          (is (true? (idx/can? (d/db conn) u :admin a))
+              "while the surviving `admin = owner` row still grants"))))))
+
+(deftest speculative-db-cannot-poison-live-cache-test
+  ;; A d/with database inherits the database uuid, reads as :plain
+  ;; (is-filtered/as-of-t/since-t are all false/nil on it) and does not bump
+  ;; :eacl/schema-version — so under the old [database-uuid schema-version]
+  ;; scope it shared a cache slot with the committed database. Evaluating a
+  ;; permission against a speculative schema change published the speculative
+  ;; paths under the LIVE key and granted a permission the committed schema
+  ;; does not define, for the life of the process.
+  (with-mem-conn [conn schema/v7-schema]
+    (schema/write-schema! conn schema-v1)
+    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
+    @(d/transact conn (impl/tx-relationship (d/db conn)
+                        (Relationship (spice-object :user [:eacl/id "u"])
+                                      :owner
+                                      (spice-object :account [:eacl/id "a"]))))
+    (idx/evict-permission-paths-cache!)
+    (let [db  (d/db conn)
+          u   (spice-object :user [:eacl/id "u"])
+          a   (spice-object :account [:eacl/id "a"])]
+
+      (testing "a speculative ADDITION does not leak into the committed database"
+        (let [speculative (:db-after (d/with db [(Permission :account :view {:relation :owner})]))]
+          (is (true? (idx/can? speculative u :view a))
+              "the speculative db sees its own new permission")
+          (is (false? (idx/can? db u :view a))
+              "the committed db must not: :view does not exist there")
+          (is (empty? (idx/get-permission-paths db :account :view)))
+          (is (empty? (:data (idx/lookup-resources db {:subject       u
+                                                       :permission    :view
+                                                       :resource/type :account
+                                                       :first         10}))))))
+
+      (testing "a speculative RETRACTION does not leak either (the false-denial direction)"
+        (let [perm-eid    (d/q '[:find ?e .
+                                 :where
+                                 [?e :eacl.permission/resource-type :account]
+                                 [?e :eacl.permission/permission-name :admin]]
+                               db)
+              speculative (:db-after (d/with db [[:db.fn/retractEntity perm-eid]]))]
+          (is (false? (idx/can? speculative u :admin a)))
+          (is (true? (idx/can? db u :admin a))
+              "the committed db still grants :admin"))))))
+
+(deftest unstamped-database-cache-is-still-exact-test
+  ;; :eacl/schema-version is only written by write-schema!, so a database built
+  ;; with programmatic Relation/Permission maps (or migrated with no :schema)
+  ;; had a nil stamp and therefore a scope that never changed: definitions
+  ;; added after the first query stayed invisible for the life of the process.
+  (with-mem-conn [conn schema/v7-schema]
+    @(d/transact conn [(Relation :account :owner :user)])
+    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
+    @(d/transact conn (impl/tx-relationship (d/db conn)
+                        (Relationship (spice-object :user [:eacl/id "u"])
+                                      :owner
+                                      (spice-object :account [:eacl/id "a"]))))
+    (idx/evict-permission-paths-cache!)
+    (let [u (spice-object :user [:eacl/id "u"])
+          a (spice-object :account [:eacl/id "a"])]
+      (is (nil? (idx/schema-version (d/db conn)))
+          "no write-schema! has run: there is no version stamp to key on")
+      (is (false? (idx/can? (d/db conn) u :admin a))
+          "populates the cache with the pre-change (empty) paths")
+
+      (testing "a permission added programmatically afterwards takes effect"
+        @(d/transact conn [(Permission :account :admin {:relation :owner})])
+        (is (nil? (idx/schema-version (d/db conn))))
+        (is (true? (idx/can? (d/db conn) u :admin a))))
+
+      (testing "and retracting it programmatically takes effect too"
+        @(d/transact conn [[:db.fn/retractEntity
+                            (d/q '[:find ?e .
+                                   :where [?e :eacl.permission/permission-name :admin]]
+                                 (d/db conn))]])
+        (is (false? (idx/can? (d/db conn) u :admin a)))))))
 
 (deftest unrelated-transact-keeps-cache-test
   ;; Issue #74 itself: relationship/application writes must not bust the path
@@ -137,6 +234,43 @@
             (is (= warm @calls)
                 "d/transact of relationships/entities must not recompute paths (issue #74)")))))))
 
+(deftest schema-scope-is-computed-once-per-db-value-test
+  ;; The scope is now a fingerprint of the definition datoms, which costs one
+  ;; O(number-of-definitions) scan. That is only affordable because it is
+  ;; memoised on the db VALUE: computing it per get-permission-paths call (or
+  ;; per can?) would put a schema-sized scan on the hottest path in EACL.
+  (with-mem-conn [conn schema/v7-schema]
+    (schema/write-schema! conn schema-v1)
+    @(d/transact conn [{:eacl/id "u"} {:eacl/id "a"}])
+    @(d/transact conn (impl/tx-relationship (d/db conn)
+                        (Relationship (spice-object :user [:eacl/id "u"])
+                                      :owner
+                                      (spice-object :account [:eacl/id "a"]))))
+    (idx/evict-permission-paths-cache!)
+    (let [scans (atom 0)
+          orig  @#'idx/calc-schema-scope
+          u     (spice-object :user [:eacl/id "u"])
+          a     (spice-object :account [:eacl/id "a"])]
+      (with-redefs [idx/calc-schema-scope (fn [db] (swap! scans inc) (orig db))]
+        (let [db (d/db conn)]
+          (testing "many checks against one db value fingerprint it once"
+            (dotimes [_ 50]
+              (is (true? (idx/can? db u :admin a)))
+              (idx/lookup-resources db {:subject u :permission :admin
+                                        :resource/type :account :first 10}))
+            (is (= 1 @scans)
+                (str "expected one fingerprint scan for one db value, got " @scans)))
+
+          (testing "d/db at an unchanged basis is the same value and still hits"
+            (idx/can? (d/db conn) u :admin a)
+            (is (= 1 @scans)))
+
+          (testing "a new db value costs exactly one more scan, however many calls follow"
+            @(d/transact conn [{:eacl/id "unrelated"}])
+            (let [db2 (d/db conn)]
+              (dotimes [_ 20] (idx/can? db2 u :admin a))
+              (is (= 2 @scans)))))))))
+
 (deftest filtered-views-cannot-poison-cache-test
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn schema-v1)
@@ -154,9 +288,11 @@
           (is (= 1 (count (idx/get-permission-paths db :account :admin)))
               "the plain db, queried AFTER the filtered view, must still see it")
           (is (nil? (idx/schema-version-stamp filtered))
-              "filter views are unclassifiable and never share the cache")))
+              "the version stamp does not describe a filter view")
+          (is (not= (idx/schema-scope filtered) (idx/schema-scope db))
+              "and the filtered view fingerprints to its own cache scope")))
 
-      (testing "since and history views are likewise unclassifiable"
+      (testing "since and history views have no meaningful version stamp"
         (is (nil? (idx/schema-version-stamp (d/since db 0))))
         (is (nil? (idx/schema-version-stamp (d/history db))))
         (is (some? (idx/schema-version-stamp db)))


### PR DESCRIPTION
Revises the EACL v7.3 bug-hunt fixes after operator review. The detailed finding-by-finding record and benchmark protocol live in [the updated report](docs/reports/2026-07-29-eacl-full-source-bug-hunt.md).

## Schema-cache contract

- A connection-backed client reads `:eacl/schema-version` once at construction and owns one permission-path cache generation.
- Ordinary authorization calls do not reread schema, scan definitions, key by `db`, or retain Datomic database values—even when the connection advances on every request.
- Schema changes must go through `eacl/write-schema!`. A client schema write atomically swaps its generation; an identical write keeps it hot.
- Arbitrary `db`, `d/with`, filtered, and historic low-level evaluation is uncached and cannot poison a live client. Time travel is not a connection-client goal.
- Other clients/processes must be recreated after an out-of-band schema write. `eacl.datomic.integrity/client-schema-status` is an explicit one-entity mismatch diagnostic, never a hot-path check.
- Fresh unstamped v7 databases stay uncached until their first supported schema write; this is not a v6 compatibility mode.

## Tuple integrity

Consumers remain responsible for deleting relationships before `:db.fn/retractEntity`. `eacl/delete-object!` remains a convenience helper, not an interception mechanism. Per-call entity-existence probes were removed.

A new public `eacl.datomic.integrity` namespace provides:

- bounded-memory dangling-half reports;
- lazy batched repair transactions;
- explicit client/schema-generation status.

## Recursive traversal and counts

- `count-resources` and the newly public `count-subjects` use one traversal instead of page replay.
- Both accept `:count-limit` and report `:truncated?`, allowing situated AuthZ callers to bound work.
- Count implementations do not retain a realized lazy-seq head; recursive request state remains hard-capped.
- Bare recursive `:last` is rejected because it implies a full closure traversal. `:last` with `:before` still supports previous-page navigation.
- Recursive page enumeration still replays its prefix and remains `O(N²/page-size)`. Eliminating that while keeping stateless bounded tokens requires the persisted effective-grant index already designed in `docs/plans/2026-05-17-recursive-pagination-effective-grants-plan.md`; this PR documents rather than disguises that boundary.

## Verification

- Fresh nREPL: **92 tests, 1,656 assertions, 0 failures/errors**
- Heavy benchmark suite: **3 tests, 3,227 assertions, 0 failures/errors**
- 15,000-resource pagination: flat versus v7.3 within run-to-run noise; traversal counts identical
- Public hot `can?`: **42–44% faster** than v7.3 in the comparison harness
- New connection value before every `can?`: median **26–43% faster**, with no schema-size-dependent scan