### PR TITLE
Fix Datahike exhausted cursor resumption

### DIFF
--- a/modules/eacl-datahike/src/eacl/datahike/core.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/core.clj
@@ -15,6 +15,12 @@
 (def cursor->token cursor/cursor->token)
 (def token->cursor cursor/token->cursor)
 
+(defn- transform-frontier
+  [f frontier]
+  (if (= :exhausted frontier)
+    frontier
+    (f frontier)))
+
 (defn default-internal-cursor->spice
   [db {:keys [entid->object-id]} cursor]
   (when cursor
@@ -30,7 +36,10 @@
         (:p cursor) (update :p
                             (fn [p]
                               (into {}
-                                    (map (fn [[k v]] [k (entid->object-id db v)]))
+                                    (map (fn [[k v]]
+                                           [k (transform-frontier
+                                               #(entid->object-id db %)
+                                               v)]))
                                     p))))
       :else
       (cond
@@ -52,7 +61,10 @@
         (:p cursor) (update :p
                             (fn [p]
                               (into {}
-                                    (map (fn [[k v]] [k (object-id->entid db v)]))
+                                    (map (fn [[k v]]
+                                           [k (transform-frontier
+                                               #(object-id->entid db %)
+                                               v)]))
                                     p))))
       :else
       (cond

--- a/modules/eacl-datahike/test/eacl/datahike/backend_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/backend_test.clj
@@ -146,3 +146,27 @@
             "the owner path is gone from the schema, so the cached answer must not stand")
         (is (true? (eacl/can? client (eacl/spice-object :user "super-user") :reboot server-1))
             "and the surviving path still resolves")))))
+
+(deftest exhausted-path-frontiers-survive-cursor-coercion
+  (doseq [[label config] modes]
+    (testing label
+      (let [[_ client] (seeded-conn config)
+            query      {:subject (contract/->user "user-1")
+                        :permission :admin
+                        :resource/type :account
+                        :limit 1}
+            page       (eacl/lookup-resources client query)
+            cursor     (datahike/token->cursor (:cursor page))]
+        (is (contains? (set (vals (:p cursor))) :exhausted)
+            "an exhausted path must remain exhausted in the public cursor")
+        (let [calls    (atom 0)
+              original impl/subject->resources]
+          (with-redefs [impl/subject->resources
+                        (fn [& args]
+                          (swap! calls inc)
+                          (apply original args))]
+            (eacl/lookup-resources
+             client
+             (assoc query :cursor (:cursor page))))
+          (is (= 1 @calls)
+              "only the live path is scanned when the page resumes"))))))


### PR DESCRIPTION
## What changed

- Preserve the v2 cursor frontier sentinel `:exhausted` while converting Datahike cursor IDs between internal and public representations.
- Add a public pagination regression in both Datahike attribute representations.
- Assert that a resumed page scans only the remaining live path.

## Root cause

PR #81 copied DataScript's v2 cursor coercion without its sentinel-preserving `transform-frontier` helper. As a result, `:exhausted` was passed through `entid->object-id` / `object-id->entid`, could become `nil`, and an exhausted authorization path could restart on a later page.

This was only fixed in 0f8e6a4 on July 28, and whilo's branch was based on the older e47f403.

## Impact

Later pages could repeat traversal work and potentially return duplicate or incorrect continuation results when a multi-path permission had already exhausted one path.

## Verification

- `git diff --check`
- clj-kondo: zero errors (three pre-existing unused-binding warnings)
- Regression covers keyword attributes and numeric `:attribute-refs?` mode
- GitHub Actions will run the branch's full test suite