### PR TITLE
Redesign cross-backend freshness and authorization caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,26 @@ Situated AuthZ offers some advantages for typical use-cases:
   can retain valid entries without treating `basis-t` or a listener as proof.
 - EACL derives permission paths from the one immutable snapshot selected for
   the request and keys compiled state by its complete schema proof.
-  - `eacl/write-schema!` is the required schema mutation boundary. Calling it through a client atomically swaps that client's generation after the schema transaction. An identical write keeps the existing generation hot.
-  - Schema writes from another client or process change the selected
-    snapshot's schema proof, so existing clients rederive the permission graph.
-    `eacl.datomic.integrity/client-schema-status` remains an optional
-    operational diagnostic.
+  - Under `:coherence-authority :managed`, `eacl/write-schema!` is the required
+    schema mutation boundary and atomically publishes the schema mutation
+    identity. An identical write keeps the existing generation hot.
+  - Under the default `:unknown` authority, schema writes from another client,
+    process, or low-level transaction change the selected snapshot's complete
+    content proof, so existing clients rederive the permission graph without
+    trusting a listener. Detecting arbitrary out-of-band writes requires a
+    complete schema read; content mode is the conservative interoperability
+    path, not the low-latency configuration.
   - Low-level calls against arbitrary `db`, `d/as-of`, `d/with`, or filtered values are deliberately uncached. Connection-backed cursor and exact reads build request-scoped schema state from their historical DB; they do not publish paths into the client's live schema cache.
-  - A fresh database with no schema stamp remains uncached until its first `write-schema!`; this is not a v6 compatibility mode. A client constructed against such a database adopts the generation the first time one is visible — including one written by another client or process — so it does not stay permanently uncached, and its cursors stay valid across that transition. That `:eacl/schema-version` read happens only while the client is still unstamped.
+  - Permission paths, dependency closures, and recursive routing are compiled
+    lazily and memoized within a schema-proof generation. Recursive
+    classification has an `O(V(V+E))` cold upper bound for `V` reachable
+    permission nodes and `E` permission edges, but the cached decision is not
+    recomputed on each authorization call.
+  - Managed proof reads are dependency-sized. Unknown-writer content proofs
+    currently perform graph-wide collection/filtering before hashing the
+    dependency relations. See the
+    [proof-cost review](docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md)
+    for measured costs and exact methodology.
 - Acyclic lookup cursors retain a per-permission-path intermediate frontier. Later pages resume each arrow path at the earliest intermediate that can still contribute, and permanently skip paths exhausted in that scan direction. This prevents deep pages from repeatedly scanning intermediates that were already proved irrelevant.
 - Acyclic lookup performance should scale roughly with permission graph complexity * `O(logN)` for `N` resources in terminal resource Relationship indices. Recursive lookup pages are deterministic traversal-order pages with request-local dedupe. Continuation hits make a sequential walk approximately linear in traversed work; a proof-equivalent miss is slower but correct because it replays the prefix. Counts consume bounded frontier pages (at most 16,384 EIDs at once) or one explicit recursive state machine; they never retain an entire broad lazy result head. Subjects are typically sparse compared to resources, i.e. 1k users will have access to 1M resources – rarely the other way around.
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ Situated AuthZ offers some advantages for typical use-cases:
     complete schema read; content mode is the conservative interoperability
     path, not the low-latency configuration.
   - Low-level calls against arbitrary `db`, `d/as-of`, `d/with`, or filtered values are deliberately uncached. Connection-backed cursor and exact reads build request-scoped schema state from their historical DB; they do not publish paths into the client's live schema cache.
-  - Permission paths, dependency closures, and recursive routing are compiled
-    lazily and memoized within a schema-proof generation. Recursive
-    classification has an `O(V(V+E))` cold upper bound for `V` reachable
-    permission nodes and `E` permission edges, but the cached decision is not
-    recomputed on each authorization call.
+  - Permission paths and dependency closures are compiled lazily and memoized
+    within a schema-proof generation. Recursive routing for all permission
+    nodes shares one generation analysis. Iterative SCC and reverse-reachability
+    passes make the graph-analysis portion `O(V+E)` cold work for `V` permission
+    nodes and `E` permission edges once their paths are materialized; another
+    first-read permission root reuses the result.
   - Managed proof reads are dependency-sized. Unknown-writer content proofs
     currently perform graph-wide collection/filtering before hashing the
     dependency relations. See the

--- a/README.md
+++ b/README.md
@@ -43,31 +43,32 @@ Situated AuthZ offers some advantages for typical use-cases:
 - EACL is internally benchmarked against ~800k permissioned resources with good latency (5-30ms per query). You can scale Datomic Peers horizontally and dedicate peers to EACL as needed.
 - The performance goal for EACL is to handle 10M permissioned entities with real-time performance.
 - EACL does not support all SpiceDB features. Please refer to the [limitations section](#limitations-deficiencies--gotchas) to decide if EACL is right for you.
-- EACL has one optional, bounded ephemeral authorization cache for `can?`, lookup pages, counts,
-  exact snapshots, and recursive continuations. A continuation hit advances recursive pagination
-  from its saved frontier, removing repeated-prefix `O(N²/page-size)` work. If a continuation is
-  unavailable, EACL reconstructs the cursor's authenticated historical Datomic basis and safely
-  recomputes the deterministic prefix. Relevant relationship or schema changes after page one do
-  not alter later pages.
-- Completed `can?`, lookup, and count answers are kept once the same check recurs. Keys use the
-  definitions in the compiled permission graph and the change stamps of only the relations that
-  permission actually reads — not every Datomic `basis-t` — so unrelated application
-  transactions, schema definitions, and relationship writes outside that dependency set leave
-  entries hot. No coordination between clients or processes is needed or configurable.
-- EACL caches resolved *permission paths* for one client schema generation. `make-client` reads `:eacl/schema-version` once from the schema entity; ordinary authorization calls do not reread it, scan definitions, key by `db`, or retain Datomic database values. Unrelated transactions therefore leave a hot client cache untouched even when the connection advances for every request.
+- EACL has one optional, bounded ephemeral completed-answer cache for `can?`,
+  lookup pages, and counts. Entries are authenticated v3 envelopes and can
+  lift across snapshots only after causal-anchor and complete dependency-proof
+  validation. The old process-local recursive-continuation side cache is not
+  trusted; cursors replay deterministic authenticated frontiers.
+- Completed answers are keyed by semantic query/configuration identity.
+  Mutation-identity or canonical content proofs cover exactly the compiled
+  schema and relationship closure the permission reads, so unrelated writes
+  can retain valid entries without treating `basis-t` or a listener as proof.
+- EACL derives permission paths from the one immutable snapshot selected for
+  the request and keys compiled state by its complete schema proof.
   - `eacl/write-schema!` is the required schema mutation boundary. Calling it through a client atomically swaps that client's generation after the schema transaction. An identical write keeps the existing generation hot.
-  - If another client or process changes schema, recreate existing clients. `eacl.datomic.integrity/client-schema-status` is an explicit one-entity diagnostic for detecting an outdated client; it is never invoked on the authorization hot path.
+  - Schema writes from another client or process change the selected
+    snapshot's schema proof, so existing clients rederive the permission graph.
+    `eacl.datomic.integrity/client-schema-status` remains an optional
+    operational diagnostic.
   - Low-level calls against arbitrary `db`, `d/as-of`, `d/with`, or filtered values are deliberately uncached. Connection-backed cursor and exact reads build request-scoped schema state from their historical DB; they do not publish paths into the client's live schema cache.
   - A fresh database with no schema stamp remains uncached until its first `write-schema!`; this is not a v6 compatibility mode. A client constructed against such a database adopts the generation the first time one is visible — including one written by another client or process — so it does not stay permanently uncached, and its cursors stay valid across that transition. That `:eacl/schema-version` read happens only while the client is still unstamped.
 - Acyclic lookup cursors retain a per-permission-path intermediate frontier. Later pages resume each arrow path at the earliest intermediate that can still contribute, and permanently skip paths exhausted in that scan direction. This prevents deep pages from repeatedly scanning intermediates that were already proved irrelevant.
 - Acyclic lookup performance should scale roughly with permission graph complexity * `O(logN)` for `N` resources in terminal resource Relationship indices. Recursive lookup pages are deterministic traversal-order pages with request-local dedupe. Continuation hits make a sequential walk approximately linear in traversed work; a proof-equivalent miss is slower but correct because it replays the prefix. Counts consume bounded frontier pages (at most 16,384 EIDs at once) or one explicit recursive state machine; they never retain an entire broad lazy result head. Subjects are typically sparse compared to resources, i.e. 1k users will have access to 1M resources – rarely the other way around.
 
-EACL page tokens pin the database identity, historical basis, operation, query, ordering, and
-schema semantics selected by page one. A matching cached page or continuation is an accelerator;
-on a miss, eviction, disabled cache, or recoverable provider failure, EACL uses `d/as-of` and
-replays from the pinned basis. It never silently falls forward to live relationship or schema
-state. A typed snapshot-unavailable/cursor-expired error is reserved for invalid, expired, or
-genuinely unreconstructable history.
+EACL page tokens bind database/source identity, graph head and exact locator,
+operation, query, ordering, configuration, and complete dependency/proof
+digests. Page two continues on a newer selected snapshot when the complete
+proof is equal. Only a proof mismatch falls back to the authenticated original
+exact value; a newer incompatible freshness floor returns a typed conflict.
 
 The authenticated database identity is checked before EACL selects a cursor basis or resolves
 query inputs. Sharing a stable page-token key across backend instances does not make a cursor
@@ -92,7 +93,7 @@ caller already handles for expiry.
 > [!WARNING]
 > EACL is under active development.
 > I try hard not to introduce breaking changes, but if data structures change, the major version will increment.
-> The changes on this branch are the [v8.0 candidate](docs/release-notes-v8.0.md). The major version increments because v8.0 adds a Datomic schema attribute, `:eacl/relation-version`, and upgrades the DataScript and Datahike list/count APIs to the v8 Relay contract. `write-schema!` installs the Datomic attribute, so there is no persisted-data migration from v7. DataScript/Datahike callers must migrate pagination requests and responses as described in the [v8 backend and upgrade guide](docs/v8-backend-modules-and-upgrade.md). Releases are not tagged yet, so pin the Git SHA.
+> The changes on this branch are the [v8.0 candidate](docs/release-notes-v8.0.md). v8 adds an additive database-visible mutation journal, authenticated v3 causal/cache/cursor formats, and upgrades the DataScript and Datahike list/count APIs to the Relay contract. Client construction performs the idempotent additive migration; v7 relationship storage remains unchanged. See the [v8 backend and upgrade guide](docs/v8-backend-modules-and-upgrade.md) and [consistency/cache operations guide](docs/v8-consistency-cache-operations.md). Releases are not tagged yet, so pin the Git SHA.
 > Upgrading from v6? The relationship storage model changed — follow the [v6 → v7 migration guide](docs/migration-v6-to-v7.md).
 
 ## Modules
@@ -208,11 +209,11 @@ Pass `:count-limit n` to either count operation to bound work. The result then i
 ### Relationship Maintenance
 
 - `(eacl/read-relationships acl filters) => {:data [relationships...] :page-info {...}}`
-- `(eacl/write-relationships! acl updates) => {:zed/token "eacl_z2_..."}`,
+- `(eacl/write-relationships! acl updates) => {:zed/token "eacl_z3_..."}`,
   - where `updates` is a collection of `[operation relationship]`, and `operation` is one of `:create`, `:touch` or `:delete`.
 - `(eacl/create-relationships! acl relationships)` simply calls `write-relationships!` with `:create` operation.
 - `(eacl/delete-relationships! acl relationships)` simply calls `write-relationships!` with `:delete` operation.
-- `(eacl/delete-object! acl object) => {:zed/token "eacl_z2_...", :retracted-datoms n}` is a convenience helper that removes every relationship touching `object`, in both directions. `n` counts relationship datoms actually retracted by the committed transactions. Consumers are expected to delete relationships before retracting a permissioned entity — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
+- `(eacl/delete-object! acl object) => {:zed/token "eacl_z3_...", :retracted-datoms n}` is a convenience helper that removes every relationship touching `object`, in both directions. `n` counts relationship datoms actually retracted by the committed transactions. Consumers are expected to delete relationships before retracting a permissioned entity — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
 
 All list APIs use the v8 Relay pagination contract:
 
@@ -629,10 +630,10 @@ The default options are to use the built-in EACL string attr `:eacl/id`, but you
 
 ### Lookup cache configuration
 
-Recursive cursor continuations use a bounded local store by default, and a finished answer is kept
-once the same check has been asked twice. The store's default admission budget is 16,777,216
-estimated weight units; this is not a measured 16 MiB heap guarantee. Disable all result and
-continuation caching without changing authorization answers:
+Completed answers use bounded authenticated v3 cache envelopes. Cursor
+continuation does not trust the old process-local recursive/frontier side
+cache; it replays from authenticated proof context. Disable completed-answer
+retention without changing authorization semantics:
 
 ```clojure
 (require '[eacl.datomic.cache :as eacl-cache])
@@ -654,58 +655,20 @@ Capacity and lifetime can be tuned, though most consumers do not need to:
             :ttl-ms 300000}}))
 ```
 
-Exact entries are keyed by a **cache epoch** rather than Datomic's `basis-t`. Keying on `basis-t`
-meant any unrelated application write minted a new key: a 0% hit rate, and slower than running with
-no cache at all.
-
-EACL's relationship write helpers publish what they changed. Every one of them appends
-`[:db/add <relation-eid> :eacl/relation-version "datomic.tx"]` to the tx-data it returns, stamping
-each affected relation with the transaction that changed it. An answer's epoch is the greatest
-stamp over the relations that answer actually depends on, so it moves for a write that can change
-the answer and stays put for one that cannot.
-
-Three properties make that sound. The stamp is transacted **with** the relationship datoms, so no
-db value can show one without the other, whichever connection or process wrote them. Its value is
-the transaction entity, whose id increases monotonically with `t`, so any new write to a dependency
-is strictly greater and a max can never miss it. And the dependency set is fixed for a schema
-generation, which is already part of every cache key.
-
-Because the value is the transaction rather than a fresh id, the assertion is idempotent: a
-transaction touching a thousand relationships of one relation emits one datom, and callers may
-freely `concat` the output of several helpers into a single transaction. The attribute is
-`:db/noHistory`, so only the current stamp is retained.
-
-Relation and permission **definitions** are not covered by stamps; they move only through
-`write-schema!`, which bumps `:eacl/schema-version` — already a cache-key component.
-
-Reading an epoch costs one index seek per relation in the dependency set — typically one to four —
-and is independent of database size. A database that predates `:eacl/relation-version` retains no
-answers until its next `write-schema!` installs the attribute, after which caching begins.
-
-Reads pinned to a historical basis — cursors and `at-exact-snapshot` — key on that basis instead,
-and are deliberately not made hot. Stamps are `:db/noHistory`, so `d/as-of` resolves them only
-until the database indexes and collects the superseded values; after that every historical basis
-would read "no stamp" and collide on one key. EACL targets the current database, and a cache per
-point in time is a non-goal.
+The cache selects one immutable request snapshot before lookup. A candidate
+computed elsewhere is reusable only when the selected history contains its
+authenticated mutation anchor and its complete dependency closure, schema
+proof, and relationship proof match. `:proof-mode :mutation` requires complete
+managed-writer authority; `:proof-mode :content` detects relevant out-of-band
+writes. Datomic content proof covers both physical relationship halves and
+endpoint identity mappings. `basis-t`, listener counts, TTL, and “latest”
+pointers are never validity evidence.
 
 Entry admission includes a conservative estimate of
-the retained key and result/traversal shape; the weight settings are estimates, not literal JVM
+the retained key and result shape; the weight settings are estimates, not literal JVM
 bytes or a heap guarantee. Oversized entries are rejected rather than allowed to threaten the
 host heap. `:kind-max-weight` and `:two-hit-kinds` keep high-cardinality permission checks from
-displacing every expensive lookup or continuation.
-
-Continuation state contains only internal traversal structures. Pending relationship-index scans
-are stored as scalar descriptors plus at most 64 materialized internal EIDs; no Datomic DB value or
-lazy index sequence is retained. TTL is checked on the requested key, without scanning every cache
-entry on each hot operation. Expired entries remain subject to the same global weight and entry
-bounds until reclaimed. Recursive state is keyed by the relationship proof rather than general
-`basis-t`, so unrelated application transactions do not make a fresh identical recursive walk
-cold.
-
-Reverse continuations also retain their compiled rule graph; its scalar rule and node counts are
-included in admission weight without walking that graph for every page. Recursive physical keys
-include `:cache :namespace`, so clients sharing a provider cannot read or overwrite another
-namespace's pages or continuations, and targeted cleanup cannot remove another namespace's state.
+displacing every expensive lookup.
 
 `:cache` names the cache adapter the client uses. Omit it and EACL builds a default client-local
 one; that is what most consumers want.
@@ -760,10 +723,9 @@ query map for `lookup-resources`, `lookup-subjects`, `count-resources`, `count-s
 unaffected: a page token is minted and validated from the request rather than from the cache, so a
 cursor minted with the bypass is usable without it and vice versa.
 
-There is nothing to coordinate between clients or processes, no entry types to configure, and no
-coherence scope to wire up. Invalidation rides on the `:eacl/relation-version` stamps described
-above, which are transacted with the relationship datoms themselves, so every reader of the
-database observes every write.
+There is no process-local listener/coordinator correctness path. Managed
+writers publish database-visible random mutation identities atomically;
+unknown-writer deployments use selected-snapshot content proof.
 
 A configuration map may be supplied in place of an adapter for capacity tuning and tests —
 `:store`, `:max-weight`, `:max-entry-weight`, `:max-entries`, `:ttl-ms`, `:namespace`,
@@ -771,20 +733,17 @@ A configuration map may be supplied in place of an adapter for capacity tuning a
 These are deliberately not part of the API most consumers need. `:remember-answers` defaults to
 `:on-repeat`, which keeps a finished answer only once the same check has been asked twice.
 
-Entries do not expire on a timer. A cached answer stops being usable because a relation it depends
-on was written, not because time passed, so the only reason to remove one is capacity — which
-`:max-weight` and `:max-entries` handle by evicting the least recently used entry. Set `:ttl-ms` if
-you want an expiry anyway.
+TTL and capacity govern resource retention only. Every hit still authenticates
+the entry and revalidates causal ancestry plus complete dependency proofs.
 
 Unrelated Datomic transactions, relationship no-ops, and changes to relations outside a cached
 permission's dependency set do not expire an entry.
 
-All result keys and values contain internal EIDs, never external object IDs. A *query input* naming
-an unknown external ID returns the ordinary false/empty boundary result and is not cached. EACL
-assumes the external-ID mapping for an entity is stable for that entity's lifetime. When a stale or
-freshness-floor mode selects an older cached lookup page, coercion runs against that answer's
-historical basis; deleting the live entity therefore does not turn an otherwise valid cached
-snapshot into a boundary error.
+Result values contain internal IDs and are externalized against the request's
+selected immutable snapshot. A query input naming an unknown external ID
+returns the ordinary false/empty boundary result and is not cached. Content
+proof includes endpoint identity mappings; managed deployments must publish
+identity mutations through the v3 journal.
 
 A *result* object that has no external ID in the database it was evaluated against is a different
 matter, and `lookup-resources`/`lookup-subjects` raise `{:type :eacl/unresolvable-object}` listing
@@ -816,22 +775,24 @@ No cache data or derived tuples are written to the consumer's Datomic database.
 
 ### Consistency and Zed tokens
 
-Relationship writes return an authenticated v2 `:zed/token` whose revision is the exact committed
-Datomic basis `t`. The token is bound to one logical database and signed with HMAC-SHA-256. Read
-operations accept these descriptors:
+Under `:coherence-authority :managed`, graph writes and reads return an
+authenticated v3 `:zed/token` bound to backend, native source/store identity,
+causal family/branch, random graph mutation anchor, order hint, exact locator,
+issue time, and expiry. Transaction counters are hints, never ancestry proof.
+Read operations accept these descriptors:
 
 ```clojure
 (require '[eacl.spicedb.consistency :as consistency])
 (require '[eacl.datomic.core :as eacl-datomic])
 
-;; Current locally observed DB and matching relationship proof. This is the default.
+;; Authoritative backend barrier. This is the default.
 (eacl/can? acl subject :view resource consistency/fully-consistent)
 
-;; Newest usable cached result, otherwise the current local DB.
+;; Current complete local snapshot, with normal proof-validated cache lookup.
 (eacl/can? acl subject :view resource consistency/minimize-latency)
 
-;; Never older than the exact write/read token. Only this mode may perform
-;; targeted (d/sync conn T), and only when the local Peer is behind T.
+;; Select a snapshot containing the token's mutation anchor. Datomic may use
+;; targeted (d/sync conn T) as a bounded waiting hint.
 (eacl/can? acl subject :view resource
            (consistency/at-least-as-fresh write-token))
 
@@ -844,12 +805,12 @@ operations accept these descriptors:
 (def now-token (eacl-datomic/current-zed-token acl))
 ```
 
-`fully-consistent` means the current DB visible to the local Peer; EACL does not force
-zero-argument `d/sync`. Callers that require the Peer to observe transactor head may synchronize
-before calling EACL. Targeted waits for `at-least-as-fresh`, exact history, cursor history, and a
-shared coordinator's published floor are bounded by `:consistency-sync-timeout-ms` (30,000 ms by
-default). A timeout returns `:eacl.consistency/freshness-unavailable` with requested, observed, and
-timeout revisions; EACL does not fall back to an older DB.
+Datomic `fully-consistent` performs a bounded zero-argument `d/sync`
+authoritative barrier. At-least waits and exact/cursor reconstruction are
+bounded by `:consistency-sync-timeout-ms` (30,000 ms by default). Failure
+returns a typed error; it never falls back to an older or incomparable graph.
+DataScript and Datahike advertise only the modes their configured source can
+actually establish.
 
 Zed-token authentication prevents a frontend from changing the database or revision, but it does
 not make a valid token single-use, bind it to an end user, prevent replay, or authorize historical
@@ -865,7 +826,8 @@ doing arithmetic on `t`:
 (def acl
   (eacl.datomic.core/make-client
    conn
-   {:cache {:checkpoints true}}))
+   {:coherence-authority :managed
+    :cache {:checkpoints true}}))
 
 (def lower-bound
   (eacl-datomic/zed-token-at-least-seconds-ago acl 30))
@@ -889,12 +851,13 @@ These are heap-protection limits, not ordinary page-size controls. Prefer `:coun
 situated authorization counts; raise traversal ceilings only after load-testing the host JVM.
 
 For multi-peer deployments, configure stable shared page- and Zed-token keys so `eacl4_...`
-cursors and frontend-returned `eacl_z2_...` tokens survive restarts and can be verified by every
+cursors and frontend-returned `eacl_z3_...` tokens survive restarts and can be verified by every
 backend:
 
 ```clojure
 (def acl (eacl.datomic.core/make-client conn
-           {:page-token-key "32+ bytes of shared secret key material"
+           {:coherence-authority :managed
+            :page-token-key "32+ bytes of shared secret key material"
             :page-token-kid :page-2026-07
             :zed-token-keyring {:zed-2026-06 old-zed-root
                                 :zed-2026-07 current-zed-root}
@@ -1062,11 +1025,13 @@ Now you can transact relationships. The usual way is `eacl/create-relationships!
 - You need to specify a `Permission` for each relation in a sum-type permission. In future this can be shortened.
 - `subject.relation` is not currently supported. It's useful for group memberships.
 - `expand-permission-tree` is not implemented yet.
-- *Cache invalidation follows EACL's own writes:* every relationship helper stamps
-  `:eacl/relation-version` on the relations it changes, inside the same transaction, so any writer
-  using those helpers publishes the change — including a caller who transacts `tx-relationship`
-  output itself. Hand-written relationship tuples that bypass the helpers are outside this
-  contract and will not invalidate cached results.
+- *Mutation-proof caching requires complete writer authority:* managed EACL
+  writes atomically publish a v3 mutation record, graph head, and affected
+  relation identities. Set `:coherence-authority :managed` only when every
+  schema, relationship, mutable identity, caveat, and custom-dependency writer
+  follows that protocol. Mixed or hand-written writers must use the default
+  `:unknown` authority, where `:proof-mode :auto` selects complete content
+  proofs and detects database-visible changes without listener coordination.
 - *Deleting entities:* `:db.fn/retractEntity` does not remove an entity's relationships. Consumers should delete relationships first; `delete-object!` is a convenience helper, and `eacl.datomic.integrity` provides explicit detection/repair — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
 - *Recursive cursors benefit from their continuation:* a permission that transitively depends on itself
   (`permission read = reader + parent->read`) is evaluated in traversal order. Sequential cache

--- a/README.md
+++ b/README.md
@@ -699,9 +699,13 @@ custom or shared store needs no backend dependency in EACL core.
 `eacl.datomic.cache/no-cache` is the adapter that caches nothing. `nil`, or omitting `:cache`
 entirely, gives you the default in-memory adapter.
 
-Reach for `no-cache` when the same permission check is essentially never asked twice — a batch job
-sweeping distinct resources, say. A read then pays for a cache lookup it can never benefit from.
-When checks do recur, the cache is the faster path.
+Reach for `no-cache` when the same permission check is essentially never asked
+twice — a batch job sweeping distinct resources, say — or when direct
+evaluation is cheaper than authenticated completed-answer validation. Repeated
+checks do not by themselves guarantee a latency win: the avoided authorization
+work must exceed the proof/envelope hit cost. See the
+[cache proof cost review](docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md)
+for measured break-even examples.
 
 Lookups and counts report where their answer came from:
 

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -1,10 +1,11 @@
 # EACL v8.0 candidate
 
-The major version increments because v8.0 adds a Datomic schema attribute and
-moves the DataScript/Datahike ports to the v8 Relay list/count contract. The
-relationship storage model is unchanged (`:eacl/storage-version` stays at 7,
-and v8.0 reads a v7 database as-is), and there is no persisted-data migration
-step — `write-schema!` installs the new Datomic attribute.
+The major version increments because v8.0 adds the database-visible v3 mutation
+journal and authenticated causal tokens/cache entries/cursors, and moves the
+DataScript/Datahike ports to the v8 Relay list/count contract. The relationship
+storage model is unchanged (`:eacl/storage-version` stays at 7). Client
+construction performs an idempotent additive migration that creates the graph
+family/head, schema mutation identity, and identities for existing relations.
 
 ## Modular artifacts
 
@@ -19,11 +20,14 @@ EACL v8.0 is a workspace with independently consumable modules:
 
 Existing Datomic namespace imports do not change. Consumers replace the root
 Git dependency with `:deps/root "modules/eacl-datomic"`; this packaging change
-does not alter persisted schema or Datomic cursor formats. The original
-six-function SPI remains compatible for v7 third-party adapters. The three
-built-in v8 adapters use the validated v8 operation/capability contract and
-share permission compilation, recursive traversal, pagination, counting, and
-portable cache validation.
+does not alter v7 relationship storage. Tokens, cursors, cache envelopes, and
+the additive mutation-journal schema are deliberately new v8 formats; no
+downgrade or dual-format cache/token mode is provided. The original
+six-function SPI remains compatible for third-party adapters, but it does not
+advertise v8 causal selection or proof lifting. The three built-in adapters use
+the validated v8 operation/capability contract and share permission
+compilation, recursive traversal, pagination, counting, and portable cache
+validation.
 
 DataScript and Datahike now expose the v8 Relay list/count API and portable
 cache; this is a breaking request/response change from their v7 ports. See the
@@ -32,129 +36,122 @@ cache; this is a breaking request/response change from their v7 ports. See the
 Published module dependency maps do not select Logback or another logging
 implementation. Applications own their logging backend and configuration.
 
-It adds one Datomic schema attribute, `:eacl/relation-version`, one small
-transactor-side relation-removal guard, and no permanent cache tuples.
-The attribute holds one `:db/noHistory` datom per relation naming the transaction that last changed
-a relationship using it; this is what lets a cached answer survive writes to relations it does not
-read. `write-schema!` installs it when a database predates it, so there is no migration step. Until
-it exists, exact-result retention is simply off.
+It adds mutation-journal, graph-head, schema-proof, and per-relation mutation
+identity attributes plus the existing transactor-side relation-removal guard.
+No authorization answers are persisted in the application database. A managed
+graph mutation appends its random mutation record and updates graph/schema/
+relation identities atomically, so answers survive writes outside their
+complete dependency closure without relying on listener state or transaction
+number equality.
 
 ## Authorization cache
 
-- One typed store serves `can?`, both lookup directions, both counts, exact results, and recursive
-  continuations.
-- Recursive continuations use the bounded local store by default. Completed exact-result retention
-  follows the same store.
-- Cache keys and values contain internal EIDs. Missing external IDs are resolved at the boundary
-  and are not cached.
-- Older cached lookup answers resolve those EIDs against the answer's own historical basis, so a
-  later live entity deletion does not break `minimize-latency` or freshness-floor reads.
-- `make-client` takes `:cache <adapter>` — any `CacheStore` implementation. Omitted or `nil` builds
-  a default client-local adapter; `eacl.datomic.cache/no-cache` disables caching. Booleans are
-  rejected: whatever is passed must BE a cache, so that `nil` is unambiguous and the option does not
-  read as a flag. A single call bypasses the
-  configured cache with `:cache? false` on the request. `:cache` names WHICH cache, `:cache?` says
-  WHETHER to use it, so the two are deliberately different keys. There is nothing else to decide
-  and nothing to coordinate between clients or processes: invalidation rides on the
-  `:eacl/relation-version` stamps EACL's own write helpers transact, so every reader of the
-  database observes every write.
-- Turn it off when the same check is essentially never asked twice; a read then pays for a lookup
-  it cannot benefit from. Measured on entirely distinct checks: 7.9us off against 11.8us on. When
-  checks recur it inverts — 8.0us against 4.3us for an arrow permission.
-- A map may be supplied instead of an adapter for capacity tuning and tests. `:remember-answers`
-  (`false` | `true` | `:on-repeat`, default `:on-repeat`) lives there. `:on-repeat` keeps a
-  finished answer only once the same check has been seen twice and measured no slower than `true`
-  in any workload tested, which is why it is the default rather than a consumer decision.
-- A single read can opt out with a per-request `:cache? false` — on the map arity of `can?`, and in
-  the query map for lookups, counts and `read-relationships`.
-- `lookup-resources`, `lookup-subjects`, `count-resources` and `count-subjects` report `:cached?`
-  and `:cache-basis` — the Datomic `t` the answer was computed at. `eacl.datomic.core/basis-instant`
-  resolves that to a wall-clock time, so a caller can say how old an answer is. `can?` returns a
-  bare boolean and carries neither; that would be a breaking change to its return type.
-- Cache entries no longer expire on a timer. Relation stamps are the staleness bound, so age is not
-  a reason to drop an entry; capacity is, and `:max-weight`/`:max-entries` handle it by evicting the
-  least recently used. The previous default applied a ttl capped to the page-token lifetime, which
-  discarded hot entries on a clock. `:ttl-ms` is still available for callers who want an expiry.
-- Relationship helpers publish exactly which relations they changed; unrelated application
-  transactions, no-op writes, and unrelated relation changes do not invalidate hot entries.
-- Public relationship writes use per-relation compare-and-swap stamps and bounded retry, so
-  concurrent `:create` calls preserve the promised single-winner/conflict result. Schema
-  replacements compare-and-swap the schema generation, and relation removal is rechecked inside
-  the transactor transaction, preventing concurrent schema writers from merging and preventing
-  relationship creation from racing a relation out of existence.
-- The built-in memory store has hard total-weight, entry-weight, entry-count, TTL, per-kind, and
-  optional two-hit admission limits.
-- Custom portable stores can be implemented without adding backend dependencies to EACL core.
-- Cache lookup, capability, publication, metrics, and provider-error failures are contained as
-  misses or rejected admissions and never replace authoritative authorization outcomes.
+- Completed answers use versioned authenticated v3 envelopes. The semantic
+  key binds source scope, backend/engine/configuration identity, operation,
+  public and internal query identity, result kind, and complete dependencies.
+- A candidate is reusable only when the selected snapshot contains its
+  computation mutation anchor and its complete schema/relationship proof is
+  equal. Numeric transaction ordering, listener observations, TTLs, and
+  “latest” pointers are never correctness evidence.
+- `:proof-mode :mutation` compares atomically published mutation identities and
+  requires `:coherence-authority :managed`. `:proof-mode :content` commits
+  canonical selected-snapshot content and remains safe with out-of-band
+  writers. Datomic content proof includes both physical relationship halves
+  and endpoint identity mappings.
+- Cache/provider corruption, races, format mismatch, or proof failure become a
+  miss on the already selected immutable snapshot. Token/freshness/exact
+  failures remain request errors.
+- `:cache? false` bypasses retention for one request. Use
+  `eacl.cache/no-cache` for portable adapters or
+  `eacl.datomic.cache/no-cache` for Datomic to disable it globally.
+- The v7 process-local recursive-continuation and latest-result side caches are
+  not trusted by v8. Recursive pages replay deterministically from the
+  authenticated cursor until continuation state is protected by the same v3
+  proof envelope.
 
 ## Recursive pagination and counts
 
-- Recursive pages resume bounded continuation state instead of replaying every preceding prefix.
-- Continuations retain scalar scan descriptors and bounded internal-EID chunks, not Datomic DB
-  values or lazy index sequences.
-- Recursive state is keyed by its relationship proof rather than general Datomic basis churn.
-- A cursor pins its database identity, basis, operation, query, ordering, and schema semantics.
-  A missing continuation or exact page reconstructs `d/as-of` and replays its deterministic prefix,
-  even when caching is disabled or live relationships/schema have changed.
+- A cursor authenticates source/branch scope, graph head and exact locator,
+  operation/query/configuration identity, complete dependency/proof digests,
+  stable position, and expiry.
+- Continuation first rederives the full closure and proof on the request's
+  selected snapshot. Equal proof continues there and rebases the next cursor;
+  changed proof uses the authenticated original exact value only when a newer
+  at-least floor does not forbid moving backward.
+- A missing exact value is a typed snapshot-expired failure. A changed proof
+  plus an incompatible newer floor is a typed cursor-consistency conflict.
 - Database identity is authenticated and rejected before historical selection; shared page-token
   keys do not permit cursor replay against another logical Datomic database.
-- Recursive physical keys include the configured cache namespace, and continuation admission
-  accounts for retained reverse-rule graphs.
 - Acyclic count misses advance through bounded frontier pages; recursive counts use one explicit,
   hard-capped traversal state. Neither count direction retains a full-cardinality lazy result head.
 
 ## Consistency
 
-- Write tokens are bounded, database-bound v2 envelopes authenticated with a domain-separated
-  HMAC-SHA-256 tag over their exact encoded claims. The unreleased unsigned v1 format is rejected.
+- Read and write tokens are bounded v3 envelopes authenticated with
+  domain-separated keys. They bind backend, database/store identity, causal
+  family, Datahike branch, random graph mutation anchor, order hint, exact
+  locator, issue time, and expiry. Older listener/revision token formats are
+  rejected.
 - Authorization reads support `fully-consistent`, `minimize-latency`, `at-least-as-fresh`, and
   historical `at-exact-snapshot`.
-- Ordinary reads do not call zero-argument `d/sync`. Targeted revision waits are bounded by the new
-  positive `:consistency-sync-timeout-ms` option (30 seconds by default) and return typed
-  freshness-unavailable diagnostics rather than using an older DB.
+- Datomic `fully-consistent` performs a bounded zero-argument `d/sync`
+  authoritative barrier. At-least uses bounded two-argument `d/sync` only as a
+  waiting hint, then requires the selected DB to contain the token mutation
+  anchor.
 - Exact cache entries remain accelerators; on a miss or provider failure, exact reads evaluate
-  against `d/as-of` with schema state reconstructed at the requested basis.
+  against verified `d/as-of` with schema state reconstructed at the requested
+  basis and the expected graph identity.
 - Optional bounded revision checkpoints construct age-based lower-bound tokens without arithmetic
   on `t`, background timers, retained DB values, or implicit synchronization.
 - `:zed-token-key`, `:zed-token-keyring`, and `:zed-token-kid` support stable multi-instance keys
   and overlap-based rotation. When omitted, domain-separated signing keys derive from the page-token
   keyring; the random default is deliberately client-instance-local.
-- Token authentication prevents database/revision forgery but not replay and is not authorization.
-  Backends should normally apply frontend-echoed tokens as `at-least-as-fresh`; choosing exact
-  historical access must remain a backend-controlled decision.
+- Token authentication prevents claim forgery but not replay and is not
+  authorization. Numeric basis/order equality never substitutes for mutation
+  anchor membership.
 
 ## Schema and mutation lifecycle
 
-- A client reads `:eacl/schema-version` once at construction. Hot reads do not rescan schema when
-  unrelated transactions advance the connection.
-- `write-schema!` rotates that client's immutable schema generation only after a successful write.
-- An unstamped database remains usable but result caching stays disabled until `write-schema!`
-  establishes a generation; this is not a v6 compatibility mode.
-- Exact result entries are keyed by the relations they depend on, stamped by EACL's own write
-  helpers, so direct transactions of EACL relationship or schema data — from this process, another
-  process, or raw `d/transact` of `tx-relationship` output — DO invalidate them, and writes to
-  relations an answer does not read do not.
-- Every relationship-producing helper stamps `:eacl/relation-version` on the relations it touches,
-  including `tx-relationship`, `tx-update-relationship`, `tx-delete-object`,
-  `tx-retract-orphaned-relationships` and `eacl.datomic.integrity/repair-tx-data`. A caller that transacts one of these directly publishes the
-  change without knowing the cache exists. The stamp's value is the transaction entity, so repeated
-  or concatenated helper output collapses to one datom instead of conflicting.
-- `delete-object!` transacts in batches and re-stamps each batch with the relations that batch
-  retracts. `tx-delete-object` deduplicates its output, which keeps only the first stamp per
-  relation, so any caller slicing that output into separate transactions must run
-  `eacl.datomic.impl/stamp-relation-versions` over each slice.
-  `integrity/repair-tx-batches` partitions by dangling half rather than by op for the same reason,
-  so a retraction and the stamp that publishes it always share a transaction.
+- Client construction idempotently establishes one causal family and mutation
+  graph when absent. Concurrent migrations converge through transactional
+  compare-and-swap.
+- `write-schema!` publishes the schema mutation identity and graph head in the
+  same committed transaction as the schema delta.
+- Completed answers are keyed by their complete semantic identity and carry
+  authenticated computation/validation points, dependency closure, and
+  schema/relation proof. A selected snapshot can lift an older answer only
+  when it contains the computation mutation and all complete proofs match.
+- `:coherence-authority :managed` means every schema, relationship, mutable
+  identity, caveat, and custom dependency writer participates in the mutation
+  protocol. Unknown or mixed writers must remain `:unknown`; `:proof-mode
+  :auto` then uses full-content proof rather than mutation identity.
+- Every managed relationship helper publishes one v3 mutation record, advances
+  the graph head, and stamps every affected relation mutation identity in the
+  same transaction as the tuple change. Batched deletion does this separately
+  for each committed batch and mints its response token from the final
+  `db-after`.
+- Datomic still emits `:eacl/relation-version` CAS datoms to serialize
+  competing relationship writes against the existing storage schema. They are
+  not a v3 cache proof. Mutation mode trusts only the declared v3 writer
+  protocol; content mode hashes complete scoped tuples and endpoint identities.
+- `integrity/repair-tx-batches` keeps each dangling-half repair and its
+  dependency publication in one transaction. Custom repair or relationship
+  writers must either use the v3 mutation builder or keep
+  `:coherence-authority :unknown`.
 - Consumers should call `delete-relationships!` before retracting an entity.
   `eacl.datomic.integrity/dangling-relationship-report` detects reverse ghost tuples left by an
   incorrect deletion sequence.
 - Relationship update operations are validated before endpoint resolution. `delete-object!`
   reports actual committed relationship-datom retractions across all batches.
 
-The cache can be disabled with `{:cache eacl.datomic.cache/no-cache}`. Authorization remains correct and usable, with
-the expected loss of cache-dependent performance; cursors and exact reads still use reconstructable
-Datomic history.
+The cache can be disabled with `{:cache eacl.datomic.cache/no-cache}`.
+Authorization remains correct and usable, with the expected loss of
+cache-dependent performance. This does not create causal writer authority:
+at-least/exact token guarantees still require `:coherence-authority :managed`.
+
+Operational retention, writer-authority configuration, key rotation, cursor
+proof lifting, failure containment, and typed diagnostics are documented in the
+[v8 consistency and cache guide](v8-consistency-cache-operations.md).
 
 ## Fixes from the 2026-07-31 adversarial review
 
@@ -173,50 +170,23 @@ All of these were found in this candidate and fixed before release.
   offending eid, instead of a cache-flavoured `:eacl.consistency/snapshot-unavailable` naming one.
 - `delete-object!` takes the relationship barrier per batch, so a large deletion no longer blocks
   concurrent lookups for its whole multi-transaction run.
-- `fully-consistent` reads use a matching epoch-keyed entry, so remembering answers accelerates the
-  default consistency mode rather than being write-only cost.
+- `fully-consistent` performs its authoritative selection barrier before
+  validating any candidate answer.
 - Page tokens are length-bounded, reject hostile EDN without escaping a `StackOverflowError`, and
   report every cursor rejection as `:eacl.pagination/invalid-cursor` with a `:reason`.
 - Cursor pages no longer publish live entries and latest-result pointers that nothing can read.
-- Exact result entries are keyed by per-relation change stamps instead of Datomic `basis-t`, so
-  neither an unrelated application write nor a write to an EACL relation the answer does not read
-  invalidates them. Under one unrelated transaction per read, `can?` went from 320 evaluations per
-  300 reads to 1 (26.9us -> 12.1us, and 13.9us with no cache at all); `lookup-resources`
-  101.8us -> 49.2us.
-
-  Scanning `d/tx-range` for EACL datoms was the first design and shipped briefly. It is sound, but
-  it can only ever establish THAT something changed, never WHAT, so every EACL write invalidated
-  every cached answer. On a schema where `doc/view` and `folder/editor` share nothing, writing
-  folder relationships between reads measured (same process, 400 reads each):
-
-  | `can?`, arrow fan-out 400 | us/read | evaluations |
-  |---|---|---|
-  | no cache | 19.2 | 400/400 |
-  | cache, global epoch | 102.4 | 340/400 |
-  | cache, per-relation | 6.9 | 0/400 |
-
-  | `lookup-resources {:first 50}` | us/read | evaluations |
-  |---|---|---|
-  | no cache | 106.2 | 400/400 |
-  | cache, global epoch | 158.4 | 340/400 |
-  | cache, per-relation | 53.3 | 0/400 |
-
-  A global epoch was therefore WORSE than no cache under EACL write traffic: every read paid a
-  publication it could never read back, and the store thrashed on entries nothing would match. With
-  no churn at all the per-relation cache still wins — `can?` 8.9us -> 5.4us, lookups
-  83.0us -> 45.7us — so the epoch's cost (one index seek per dependency, ~0.8us) is absorbed.
-
-  Stamps are written by EACL's own tx-data helpers, so they observe writes from another connection,
-  another process, and raw `d/transact` of `tx-relationship` output — none of which a coordinator
-  can see — and `d/log` is no longer used at all. A database without `:eacl/relation-version`
-  retains nothing rather than reverting to basis keying, which measured worse than no cache; its
-  next `write-schema!` installs the attribute.
-- Forward acyclic pages resume from cached per-intermediate stream heads. Every page previously
-  opened an index scan for each of the subject's intermediates just to learn where each stream
-  starts; a page now re-opens only the streams it actually drew from. A full walk over 4000
-  intermediates: 591ms -> 199ms; on the multipath benchmark, forward pagination 1.3ms -> 0.85ms per
-  page. Still super-linear — see the report for what remains — and a miss falls back to the
-  existing frontier replay, so nothing depends on the cache for correctness.
+- The churn benchmark compares mutation-identity proof, complete-content
+  proof, global invalidation, and no-cache under both unrelated and relevant
+  writes. Proof validation is intentionally retained even where the small
+  fixture makes uncached evaluation faster: correctness is the gate, not a
+  benchmark-selected consistency model.
+- Datomic content proofs are fixed-size streaming digests over deterministic
+  schema records, both relationship tuple halves, and endpoint identities.
+  Proof size therefore does not grow cursor or cache envelopes with graph
+  cardinality.
+- The old cached per-intermediate stream-head optimization is disabled because
+  its state was outside the authenticated v3 envelope. Acyclic and recursive
+  cursor pages deterministically replay the authenticated frontier.
 - `can?` answers an arrow by intersecting two sorted intermediate streams instead of scanning the
   resource's side in full, so it no longer scales with arrow fan-out. A doc attached to N teams
   where the user belongs to one of them: 133us -> 13us at N=100, 1.34ms -> 13us at N=1000,
@@ -238,12 +208,10 @@ All of these were found in this candidate and fixed before release.
 barriers, and the bounded reader catch-up loop. Both keys now throw `:eacl/invalid-config` rather
 than being silently ignored.
 
-Per-relation stamps made the coordinator redundant and then strictly worse. It was reachable in
-exactly one consistency mode — `:fully-consistent`, where the epoch-keyed entry was already the
-fallback — and it was consulted FIRST, so a coordinator that had missed a write served a stale
-answer where an epoch-keyed read would correctly have missed. A coordinator can only observe writes
-made through a client sharing it; a stamp is transacted with the relationship datoms, so every
-reader of the database observes it.
+Database-visible mutation identities and selected-snapshot content proofs make
+the coordinator redundant. A process-local coordinator can observe only
+participating writers and cannot prove an authoritative head, causal ancestry,
+or dependency equality.
 
 Migration: replace `:cache (assoc (cache/local-context) :live-results? true)` with
 `:cache <adapter>` (or just omit it), and delete any coordinator plumbing. A writer-only client

--- a/docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md
+++ b/docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md
@@ -79,18 +79,46 @@ A synthetic permission chain measured the first
 | 200 | 42,753.2 | 0.113 |
 | 400 | 83,726.8 | 0.113 |
 
-The implementation computes a reachability closure for each reachable node, so
-its cold upper bound is `O(V(V+E))`. The benchmark confirms that this is
-generation compilation, not per-call proof work: after compilation, lookup is
-constant-time at measurement resolution.
+The measured implementation computed a reachability closure for each permission
+node, so its cold upper bound was `O(V(V+E))`. The review also found that this
+result was memoized per root, allowing different first-read roots to repeat the
+quadratic calculation. The follow-up implementation replaces the closure matrix
+with iterative strongly connected component and reverse-reachability passes:
+`O(V+E)` graph-analysis time and memory once permission paths are materialized,
+once per schema generation. Adapter path materialization and its deterministic
+sorting are additional backend-dependent work. A shared delay makes concurrent
+first reads single-flight. After compilation, any root lookup is constant-time.
+The earlier intermediate fix (still using the quadratic compiler) took 21,789.5
+µs for a warmed 200-node generation and 607.5 µs to read all 200 roots
+afterward; it is retained here only as audit history, not as a measurement of
+the final linear compiler.
+
+The final implementation was then measured with nine fresh-generation samples
+per size in the same warmed JVM:
+
+| Permission nodes | Final cold median (µs) | Warm root median (µs) |
+| ---: | ---: | ---: |
+| 10 | 587.3 | 0.075 |
+| 25 | 907.0 | 0.088 |
+| 50 | 1,478.8 | 0.075 |
+| 100 | 3,291.0 | 0.075 |
+| 200 | 7,206.0 | 0.071 |
+| 400 | 18,249.5 | 0.071 |
+| 1,000 | 73,856.9 | 0.088 |
+
+These end-to-end cold numbers include adapter schema-path materialization and
+do not empirically claim linear wall-clock scaling. The important bound is that
+the graph proof no longer constructs a quadratic closure matrix or repeats it
+per root. The measured steady lookup is constant at this resolution.
 
 ## Conclusions
 
 1. The redesigned managed proof system does not have graph- or schema-wide
    proof cost per call. Its backend proof work is dependency-sized and remained
    flat in this benchmark.
-2. Recursive classification has a potentially quadratic cold compilation cost,
-   but it is memoized per permission root and schema generation.
+2. Recursive classification uses `O(V+E)` graph analysis once for all
+   permission roots in a schema generation after permission-path
+   materialization, and constant-time lookups afterward.
 3. Unknown-writer content mode is intentionally conservative and is not
    constant-time. It pays complete-schema and relationship-content work because
    it refuses to trust writer-maintained mutation identities.

--- a/docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md
+++ b/docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md
@@ -1,0 +1,103 @@
+# EACL v8 cache-proof cost review
+
+Date: 2026-08-02
+
+## Scope
+
+This review compares the cache immediately before the v3 freshness redesign
+(`8bf9244`) with the redesigned implementation (`ac9d06f`). It separates:
+
+1. backend proof construction;
+2. one-time recursive-schema compilation; and
+3. a completed `can?` cache hit, including snapshot selection, authenticated
+   token/cache-envelope work, proof validation, and cache telemetry.
+
+The old Datomic result is not a correctness-equivalent alternative: it used a
+process-local epoch/listener mechanism. The old DataScript and Datahike paths
+used database content but returned proof material rather than authenticated,
+fixed-size digests.
+
+## Method
+
+- Apple M3 Pro, macOS 26.5.1
+- OpenJDK 22.0.1, Clojure 1.11.4
+- in-memory Datomic, Datahike, and DataScript databases
+- one target permission depending on one relation
+- added schema definitions and relationships were unrelated to the target
+- completed-hit numbers are the median of 51 samples of 10 calls after 100
+  warm-up calls
+- direct proof numbers are the median of 31 samples of 5 calls after 20 warm-up
+  calls
+- times are microseconds per call
+
+These are comparative microbenchmarks, not production latency promises.
+
+## Completed cache-hit results
+
+| Backend / workload | Pre-v3 | v3 content | v3 managed mutation |
+| --- | ---: | ---: | ---: |
+| Datomic, minimal | 106.6 | 2,132.9 | 1,539.5 |
+| Datomic, +200 schema definitions | 53.9 | 7,281.0 | 1,529.9 |
+| Datomic, +5,000 unrelated relationships | 40.3 | 4,033.7 | 1,524.6 |
+| Datahike, minimal | 111.3 | 1,936.5 | 1,695.0 |
+| Datahike, +200 schema definitions | 2,129.3 | 7,518.5 | 1,686.6 |
+| Datahike, +5,000 unrelated relationships | 327.2 | 1,967.3 | 1,672.8 |
+| DataScript, minimal | 179.8 | 1,968.2 | 1,523.4 |
+| DataScript, +200 schema definitions | 337.9 | 3,652.0 | 1,521.2 |
+| DataScript, +5,000 unrelated relationships | 4,660.5 | 6,308.1 | 1,513.0 |
+
+The managed column stays flat as unrelated schema and graph data grow. The
+approximately 1.5–1.7 ms floor is not backend proof construction: it includes
+the redesigned consistency selection and authenticated token/cache-envelope
+path.
+
+## Direct proof results
+
+| Backend | v3 content: complete schema at +200 defs | v3 content: scoped schema at +200 defs | v3 content: relation proof at +5,000 unrelated edges | v3 managed proof operations |
+| --- | ---: | ---: | ---: | ---: |
+| Datomic | 2,783.0 | 13.6 | 616.3 | 0.5–1.2 |
+| Datahike | 3,637.1 | 2,114.0 | 266.5 | 0.8–1.6 |
+| DataScript | 1,693.5 | 242.9 | 4,767.3 | 0.6–0.8 |
+
+The complete schema proof is invoked to select a safe derived-schema generation.
+It is why content-mode cache hits grow with unrelated schema even when the
+query's scoped schema proof is cheap. Removing it without another authoritative
+schema-change identity would reintroduce stale compiled permission paths under
+out-of-band schema writers.
+
+## Recursive-schema compilation
+
+A synthetic permission chain measured the first
+`traversal-permission?` classification and the cached lookup:
+
+| Reachable permission nodes | Cold compilation (µs) | Warm lookup (µs) |
+| ---: | ---: | ---: |
+| 10 | 1,965.6 | 0.425 |
+| 25 | 2,136.6 | 0.117 |
+| 50 | 4,275.3 | 0.113 |
+| 100 | 12,189.5 | 0.113 |
+| 200 | 42,753.2 | 0.113 |
+| 400 | 83,726.8 | 0.113 |
+
+The implementation computes a reachability closure for each reachable node, so
+its cold upper bound is `O(V(V+E))`. The benchmark confirms that this is
+generation compilation, not per-call proof work: after compilation, lookup is
+constant-time at measurement resolution.
+
+## Conclusions
+
+1. The redesigned managed proof system does not have graph- or schema-wide
+   proof cost per call. Its backend proof work is dependency-sized and remained
+   flat in this benchmark.
+2. Recursive classification has a potentially quadratic cold compilation cost,
+   but it is memoized per permission root and schema generation.
+3. Unknown-writer content mode is intentionally conservative and is not
+   constant-time. It pays complete-schema and relationship-content work because
+   it refuses to trust writer-maintained mutation identities.
+4. “Streaming digest” means fixed output and incremental hashing. It must not be
+   read as a claim that collecting, sorting, or reading proof records is
+   constant-time or constant-memory end to end.
+5. The authenticated v3 path has a material fixed latency floor even in managed
+   mode. Further optimization should profile token and cache-envelope
+   encode/decode separately; weakening proof or authentication semantics is not
+   an acceptable benchmark optimization.

--- a/docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md
+++ b/docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md
@@ -51,6 +51,56 @@ approximately 1.5–1.7 ms floor is not backend proof construction: it includes
 the redesigned consistency selection and authenticated token/cache-envelope
 path.
 
+## Proofed cache hit versus no completed-result cache
+
+The old/new comparison does not answer the most important operational question:
+whether a proofed completed-answer hit is faster than evaluating the
+authorization with result caching disabled. The same public `can?` call was
+therefore measured under both writer-authority modes, first with a warmed
+completed-answer cache and then through a client using `cache/no-cache`. Both
+clients used the same database and had their derived schema state warmed before
+measurement.
+
+For the benchmark's cheap one-relation permission, both the optimized managed
+mode and the default unknown-writer content mode were measured:
+
+| Backend / authority | Proofed cache hit (µs) | No cache (µs) | Cache / no-cache |
+| --- | ---: | ---: | ---: |
+| Datomic / managed | 1,625.5 | 1,580.0 | 1.03× |
+| Datahike / managed | 1,810.3 | 155.3 | 11.66× |
+| DataScript / managed | 1,694.1 | 202.8 | 8.35× |
+| Datomic / unknown | 1,923.7 | 1,821.1 | 1.06× |
+| Datahike / unknown | 1,813.9 | 69.6 | 26.05× |
+| DataScript / unknown | 1,642.7 | 111.4 | 14.74× |
+
+The proofed cache is not faster for this workload. Datomic is effectively at
+parity at this measurement scale; Datahike and DataScript are substantially
+slower because their uncached direct evaluation is much cheaper than the fixed
+authenticated cache path.
+
+A recursive folder chain demonstrates the break-even behavior. The cached
+answer still validates the same dependency-sized proof; the uncached call must
+traverse an increasing number of relationship edges:
+
+| Backend / chain depth | Proofed cache hit (µs) | No cache (µs) | Speedup |
+| --- | ---: | ---: | ---: |
+| Datahike / 100 | 1,733.4 | 1,018.2 | 0.59× |
+| Datahike / 200 | 1,765.2 | 1,720.0 | 0.97× |
+| Datahike / 400 | 1,726.7 | 4,260.6 | 2.47× |
+| Datahike / 800 | 1,799.3 | 6,346.4 | 3.53× |
+| DataScript / 50 | 1,629.4 | 729.9 | 0.45× |
+| DataScript / 100 | 1,623.7 | 1,837.1 | 1.13× |
+| DataScript / 400 | 1,594.8 | 11,275.8 | 7.07× |
+| DataScript / 800 | 1,578.6 | 24,857.4 | 15.75× |
+| Datomic / 50 | 1,618.0 | 1,622.8 | 1.00× |
+| Datomic / 400 | 1,654.5 | 1,742.0 | 1.05× |
+
+The exact crossover is hardware-, backend-, schema-, and query-dependent.
+These rows establish only the governing rule: completed-result caching wins
+when avoided authorization work exceeds the roughly 1.6–1.8 ms fixed
+proof/envelope hit cost. It is a correctness-preserving latency trade, not a
+universal optimization.
+
 ## Direct proof results
 
 | Backend | v3 content: complete schema at +200 defs | v3 content: scoped schema at +200 defs | v3 content: relation proof at +5,000 unrelated edges | v3 managed proof operations |
@@ -126,6 +176,8 @@ per root. The measured steady lookup is constant at this resolution.
    read as a claim that collecting, sorting, or reading proof records is
    constant-time or constant-memory end to end.
 5. The authenticated v3 path has a material fixed latency floor even in managed
-   mode. Further optimization should profile token and cache-envelope
-   encode/decode separately; weakening proof or authentication semantics is not
-   an acceptable benchmark optimization.
+   mode. It is slower than uncached direct evaluation on Datahike and DataScript
+   and only pays off for sufficiently expensive/repeated authorization work.
+   Further optimization should profile token and cache-envelope encode/decode
+   separately; weakening proof or authentication semantics is not an acceptable
+   benchmark optimization.

--- a/docs/v8-backend-adapter-boundary.md
+++ b/docs/v8-backend-adapter-boundary.md
@@ -9,7 +9,7 @@ database mechanics; shared code must not import an adapter namespace.
 | Concern | Current Datomic implementation | V8 owner |
 | --- | --- | --- |
 | Public request and error contract | `eacl.datomic.core/spiceomic-*` and `eacl.datomic.impl.indexed/normalize-page-request` | Shared engine, except backend capability rejection |
-| Consistency descriptor selection | `eacl.datomic.core/capture-result-context` and `eacl.datomic.consistency` | Shared capability validation; adapter selects the promised snapshot |
+| Consistency descriptor selection | `eacl.consistency/select-snapshot` and `eacl.datomic.backend` | Shared capability validation; adapter selects the promised snapshot |
 | Historical/current snapshot | `d/db`, `d/as-of`, `d/sync` in `eacl.datomic.core` | Adapter |
 | Object ID resolution | `object-id->entid`, `entid->object-id`, `object-eid` | Adapter |
 | Relation and permission definitions | `relation-datoms`, `find-permission-defs` | Adapter returns normalized definitions |
@@ -21,9 +21,9 @@ database mechanics; shared code must not import an adapter namespace.
 | Relay windowing and count limits | `normalize-page-request`, `page-response`, `count-*` | Shared engine |
 | Cursor traversal state | path frontiers and recursive continuation maps | Shared engine, versioned |
 | Cursor protection and runtime encoding | AES-GCM page tokens in `eacl.datomic.core` | Adapter/runtime |
-| Schema proof | `:eacl/schema-version` | Adapter, opaque to shared code |
-| Relationship proof | `eacl.datomic.watermark/safe-epoch-for` | Adapter, opaque to shared code |
-| Cache store, entries, and validation | `eacl.datomic.cache` and result-cache helpers in `core` | Shared cache contract |
+| Schema proof | v3 schema mutation identity or canonical content digest | Adapter, opaque to shared code |
+| Relationship proof | v3 per-relation mutation identities or canonical content digest including endpoint identities | Adapter, opaque to shared code |
+| Cache store, entries, and validation | Provider adaptation in `eacl.datomic.cache`; authenticated entries and proof lifting in `eacl.cache` | Shared cache contract |
 | Schema parsing/model validation | `eacl.spicedb.parser`, `eacl.schema.model` | Shared |
 | Schema persistence | `eacl.datomic.schema` | Adapter |
 | Relationship reads and transactions | `eacl.datomic.impl` | Adapter |
@@ -56,7 +56,8 @@ transaction, proof, and runtime capabilities it provides.
 Unsupported guarantees fail with `:eacl/unsupported-capability` before
 authorization work begins. Datomic declares all four v8 consistency modes,
 historical snapshots, authenticated encrypted cursors, schema/relationship
-transactions, deletion, and database-visible proofs. DataScript and Datahike
-will declare only the guarantees implemented by their immutable snapshot and
-runtime APIs; shared code must not silently map an unsupported request to a
-weaker mode.
+transactions, deletion, and database-visible proofs. DataScript provides a
+serialized local head and optional bounded exact registry. Datahike derives
+authoritative-head and exact-history capabilities from the active writer,
+commit-graph, and history configuration. Shared code never maps an unsupported
+request to a weaker mode.

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -9,17 +9,20 @@ the core module.
 
 | Module | Runtime | Consistency and snapshots | Cursors | Cache proof |
 | --- | --- | --- | --- | --- |
-| `eacl-datomic` | Clojure/JVM | current, minimized-latency, freshness floor, and exact/historical | authenticated and encrypted; reconstructs the pinned historical basis | scoped schema definitions and per-relation transaction stamps |
-| `eacl-datascript` | Clojure and ClojureScript | `:fully-consistent` current immutable DB only | synchronous opaque token; query- and snapshot-bound | exact schema and relevant relationship content in the selected DB |
-| `eacl-datahike` | Clojure/JVM | `:fully-consistent` current immutable DB only | synchronous opaque token; query- and snapshot-bound | exact schema and relevant relationship content visible across connections |
+| `eacl-datomic` | Clojure/JVM | authoritative barrier, local current, causal floor, and exact `d/as-of` | authenticated and encrypted; proof-equivalent current continuation with exact fallback | mutation identity or canonical content over scoped schema and both relationship halves |
+| `eacl-datascript` | Clojure and ClojureScript | serialized local head, local current, causal-anchor wait; optional bounded exact registry | authenticated synchronous cursor; proof-equivalent continuation and optional exact fallback | mutation identity or canonical selected-DB content |
+| `eacl-datahike` | Clojure/JVM | authoritative direct branch head, local current, causal-anchor wait, retained commit/temporal exact | authenticated synchronous cursor; proof-equivalent continuation and exact fallback | mutation identity or canonical store-visible content |
 | `eacl` | Clojure and ClojureScript | supplied by an adapter | supplied by an adapter | portable store/entry validation contract |
 
-DataScript and Datahike reject unsupported consistency or historical promises
-with `:eacl/unsupported-capability` before running authorization. Their cursors
-cannot reconstruct history: after the database snapshot changes, a cursor
-raises `:eacl.pagination/invalid-cursor` with reason `:snapshot-changed`.
-Datomic instead evaluates a valid cursor against its authenticated historical
-basis.
+Capabilities are configuration-specific. DataScript exact reads require
+`:exact-snapshot-registry-size`; Datahike exact reads require a retained commit
+graph or temporal history; a lagging Datahike source without a branch-head
+barrier rejects `:fully-consistent`. All adapters continue a cursor on a newer
+proof-equivalent snapshot and use the authenticated original exact snapshot
+only after a proof mismatch.
+
+See [the consistency and cache operations guide](v8-consistency-cache-operations.md)
+for authority, retention, token, cursor, cache, and failure-diagnostic rules.
 
 ## DataScript and Datahike v7-to-v8 API migration
 
@@ -98,19 +101,12 @@ object deletion force a miss. A missing, throwing, or corrupt store and any
 proof/decoding failure safely recompute from the DB.
 
 Prefer `write-schema!`, `create-relationship!`, `write-relationships!`,
-`delete-relationships!`, and `delete-object!`. DataScript/Datahike proofs are
-derived from canonical database contents, so a raw transaction is visible
-only if it atomically maintains every canonical schema or relationship datom
-and tuple the adapter reads. If application code cannot make that guarantee,
-use `cache/no-cache` for all clients that may observe those out-of-band
-writes.
-
-Datomic uses database-visible relation-version stamps instead. Raw Datomic
-relationship transactions must come from EACL transaction helpers or include
-the corresponding `eacl.datomic.impl/stamp-relation-versions` data in the same
-transaction. A custom raw writer that cannot publish those stamps must use
-`eacl.datomic.cache/no-cache`. See the Datomic-specific lifecycle section in
-the [v8 release notes](release-notes-v8.0.md#schema-and-mutation-lifecycle).
+`delete-relationships!`, and `delete-object!`. Configure
+`:coherence-authority :managed` only when every answer-affecting writer uses
+the v3 atomic mutation protocol. Otherwise keep authority `:unknown`; the
+default `:proof-mode :auto` then uses canonical full-content proof. Disabling
+the cache is sufficient for answer reuse, but it does not manufacture the
+causal ancestry required to issue or consume at-least/exact tokens.
 
 ## Recursive permissions and safety controls
 

--- a/docs/v8-consistency-cache-operations.md
+++ b/docs/v8-consistency-cache-operations.md
@@ -1,0 +1,171 @@
+# EACL v8 consistency, cache, and rollout operations
+
+EACL v8 separates two questions that transaction counters cannot safely
+collapse:
+
+1. Which immutable database value satisfies the request's consistency mode?
+2. Is an answer or cursor created on another value observationally equivalent
+   on the selected value?
+
+Snapshot selection uses an authenticated causal mutation identity.
+Cross-revision reuse uses a complete schema and relationship proof. Datomic
+`basis-t` and DataScript/Datahike `:max-tx` are order and waiting hints only;
+they are never proof of ancestry or authorization equality.
+
+## Consistency modes and backend capabilities
+
+Every mode selects one immutable database value before resolving object ids,
+deriving dependencies, reading a cache, or evaluating authorization.
+
+| Backend | `:fully-consistent` | `:minimize-latency` | `:at-least-as-fresh` | `:at-exact-snapshot` |
+| --- | --- | --- | --- | --- |
+| Datomic | bounded zero-argument `d/sync` barrier | current local Peer DB | bounded `d/sync conn t`, then mandatory mutation-anchor lookup | `d/as-of` at the authenticated basis, then graph-head verification |
+| DataScript | current immutable value of the supplied serialized connection | current connection value | bounded polling of that same connection, then anchor lookup; no replication is implied | only when `:exact-snapshot-registry-size` configures a bounded immutable-DB registry |
+| Datahike | current authoritative branch head only for a direct `:self` writer | current complete local value | bounded branch refresh/polling, then anchor lookup | retained `commit-as-db`, or temporal `as-of` when the commit graph is disabled and `:keep-history? true` |
+
+A Datahike streaming or replicated reader without an authoritative branch-head
+barrier does not advertise `:fully-consistent`. A DataScript connection cannot
+catch itself up from another process; its at-least mode waits only for the
+caller-supplied connection to acquire the mutation anchor. Unsupported
+configuration/mode combinations fail before authorization.
+
+Tokens are scoped to backend, native database/store identity, causal family,
+and Datahike branch. A branch, restore, clone, or `reset-conn!` that reuses a
+numeric transaction position does not pass unless it contains the token's
+random mutation identity. Datahike merge parents and commit locators are
+metadata for lineage and exact reconstruction; `:max-tx` is not lineage.
+
+## Writer authority and proof modes
+
+Configure `:coherence-authority` explicitly:
+
+- `:managed` asserts that every write capable of changing an authorization
+  result participates in EACL's atomic v3 mutation protocol. This includes
+  schema, relationships, object identity, caveat inputs, and declared custom
+  dependencies. Managed clients may issue read/write Zed tokens and use
+  mutation-identity proofs.
+- `:unknown` makes no causal-writer claim. It does not issue read tokens or
+  offer causal/exact token modes. Cache validation defaults to canonical
+  full-content proofs, which detect relevant out-of-band writes but cannot
+  reconstruct missing ancestry.
+
+`:proof-mode :auto` selects `:mutation` under managed authority and `:content`
+otherwise. `:mutation` is rejected without managed authority. `:content`
+commits all scoped schema definitions and relationship tuples, including both
+physical Datomic relationship halves. `:none` evaluates without retaining
+completed answers.
+
+Listeners are not part of any correctness argument. They may feed metrics, but
+listener counts never appear in tokens, schema keys, dependency proofs, cache
+validity, or freshness selection.
+
+## Token keys, lifetime, and retention
+
+Portable DataScript/Datahike clients use `:security-key` or
+`:security-keyring`; Datomic uses `:zed-token-key` or
+`:zed-token-keyring`. Configure stable shared key material in every process
+that must accept the same token or cursor. Use the keyring plus current key id
+for overlap-based rotation.
+
+The default token lifetime is 3,600 seconds. Mutation records carry an
+additional 300-second retention grace by default. Override these with
+`:token-ttl-seconds` and `:retention-grace-seconds`. Do not prune a mutation
+record before its encoded expiry. The backend-specific
+`eacl.<backend>.mutation/prune-expired!` removes expired non-head records;
+schedule it only after clocks, configured TTLs, and the grace window have been
+accounted for.
+
+Database retention is a separate constraint:
+
+- Datomic must retain the basis needed for exact `d/as-of`.
+- DataScript retains only the configured number of immutable registry values.
+- Datahike must retain commit records, or temporal history when that fallback
+  is enabled. Branch deletion and storage GC can expire old commits.
+
+A valid token with a missing causal anchor never falls back to transaction
+number comparison. A cursor whose proof changed and whose exact database value
+has expired returns `:eacl.consistency/snapshot-expired`.
+
+## Cache theorem and proof lifting
+
+The cache first selects snapshot `S`. A candidate computed at `C` is reusable
+only when:
+
+- its authenticated semantic key, source/branch scope, engine and adapter
+  fingerprints, result kind, query identities, and configuration match;
+- `S` contains `C`'s computation mutation anchor, preventing backward or
+  sibling-history lifting;
+- the complete dependency closure and selected schema/relationship proofs
+  match; and
+- the value shape and entry authenticator validate.
+
+Every cross-revision hit recomputes the proof on `S`. `validated-at` is
+telemetry, not a lease. `computed-at` remains the original computation point;
+the response token identifies `S`.
+
+Provider failures, corrupt or old entries, proof errors, and missing proofs
+become misses evaluated on the already selected snapshot. Token
+authentication, causal freshness, scope, and exact-snapshot failures remain
+request errors. `eacl.cache/stats` exposes exact hits, causal lifts, proof
+mismatches, future-history rejections, unauthenticated entries, no-proof
+bypasses, and provider failures.
+
+Use `eacl.cache/no-cache` for portable adapters or
+`eacl.datomic.cache/no-cache` for Datomic to disable retention without changing
+authorization semantics. A request-level `:cache? false` bypasses the
+configured store for that call.
+
+## Proof-equivalent cursors
+
+Cursors are authenticated; Datomic cursors are additionally AES-GCM
+encrypted. They bind the query, source scope, graph anchor, exact locator,
+adapter/configuration identity, complete dependency-scope and proof digests,
+stable position, and expiry.
+
+Continuation follows this order:
+
+1. select a snapshot satisfying the request, including any newer at-least
+   floor;
+2. rederive the complete dependency closure and proof;
+3. continue on that selected snapshot when the proof equals the cursor proof,
+   rebasing new cursors to its graph;
+4. on a mismatch, use the verified original exact snapshot only when no newer
+   at-least floor forbids moving backward; otherwise return
+   `:eacl.consistency/cursor-consistency-conflict`.
+
+Cursor failures are intentionally distinguishable:
+
+- `:eacl.pagination/invalid-cursor` — authentication, scope, query, format, or
+  configuration mismatch;
+- `:eacl.pagination/expired-cursor` — authenticated envelope lifetime elapsed;
+- `:eacl.pagination/stale-cursor` — proof changed and exact fallback is not
+  supported;
+- `:eacl.consistency/snapshot-expired` — the exact locator is no longer
+  reconstructable;
+- `:eacl.consistency/cursor-consistency-conflict` — a newer causal floor has a
+  different proof.
+
+## Initial v8 configuration
+
+The v3 token, cursor, and cache formats have no downgrade or dual-format mode.
+Portable tokens use `eacl_z3_`, portable cursors use `eacl_c3_`, and portable
+completed entries use `eacl_ce3_`. Datomic retains the `eacl4_` encrypted
+prefix, but payloads without v3 proof context are rejected.
+
+Client construction performs the idempotent mutation-journal migration. Use
+`:coherence-authority :managed` only when every schema, relationship,
+object-identity, caveat, and custom-data writer uses EACL helpers or the
+exported mutation transaction-data builders. Otherwise keep authority
+`:unknown`; `:proof-mode :auto` then uses complete content proofs.
+
+During key rotation, publish the new current key while retaining old read keys
+until all tokens and cursors issued under them have expired. Mutation pruning
+and backend history/commit garbage collection must respect the configured
+token and cursor lifetime.
+
+## Failure diagnostics
+
+For incidents, record the typed error plus backend, source/branch, requested
+and observed order hints, graph anchor, exact locator, proof mode, coherence
+authority, cache metric, and key id. Never log opaque token/cursor contents or
+signing/encryption key material.

--- a/docs/v8-consistency-cache-operations.md
+++ b/docs/v8-consistency-cache-operations.md
@@ -79,13 +79,15 @@ Mutation and content proofs have deliberately different cost models:
   is fixed-size and hashing is incremental; that is a size/memory property, not
   a constant-time claim.
 
-Permission paths, relation dependencies, and recursive-routing decisions are
-memoized within a selected schema-proof generation. The current recursive
-classification computes reachability closures iteratively and has an
-`O(V(V+E))` cold upper bound for `V` reachable permission nodes and `E`
-permission edges. It is not paid on every authorization call: the result is
-cached per permission root and schema generation. Schema writes are rare, but
-large recursive schemas should account for this first-read compilation latency.
+Permission paths and relation dependencies are memoized within a selected
+schema-proof generation. Recursive routing for all permission nodes shares one
+generation analysis. Iterative strongly connected component and reverse
+reachability passes make the graph-analysis portion `O(V+E)` cold work and
+memory for `V` permission nodes and `E` permission edges once adapter permission
+paths are materialized. The analysis is published through one shared delay, so
+concurrent first readers do not duplicate it. Another permission root then
+performs a constant-time lookup. Schema writes are rare, but large recursive
+schemas should account for this first-read generation-compilation latency.
 
 Use managed mutation proofs for the normal EACL-only writer contract. Content
 mode is the conservative interoperability fallback for unknown writers, not the

--- a/docs/v8-consistency-cache-operations.md
+++ b/docs/v8-consistency-cache-operations.md
@@ -59,6 +59,38 @@ Listeners are not part of any correctness argument. They may feed metrics, but
 listener counts never appear in tokens, schema keys, dependency proofs, cache
 validity, or freshness selection.
 
+### Proof cost and schema compilation
+
+Mutation and content proofs have deliberately different cost models:
+
+- Managed mutation schema proof is one indexed identity read. A relation proof
+  reads one mutation identity for each relation in the compiled dependency
+  closure, so it is `O(K log D + K log K)` for `K` dependent relations in a
+  database of `D` datoms. It does not grow with unrelated schema definitions or
+  relationships.
+- Unknown-writer content mode must detect arbitrary database-visible schema
+  changes without trusting an EACL-maintained stamp. The derived-schema
+  generation key therefore commits the complete schema. Its current worst-case
+  work is `O(S log S)` for `S` definition records.
+- Content relationship proofs are complete but currently collect/filter the
+  backend's relationship storage before hashing the dependency relations.
+  Their worst-case work is `O(G + M log M)`, where `G` is total relationship
+  storage scanned and `M` is the matching proof record count. The digest output
+  is fixed-size and hashing is incremental; that is a size/memory property, not
+  a constant-time claim.
+
+Permission paths, relation dependencies, and recursive-routing decisions are
+memoized within a selected schema-proof generation. The current recursive
+classification computes reachability closures iteratively and has an
+`O(V(V+E))` cold upper bound for `V` reachable permission nodes and `E`
+permission edges. It is not paid on every authorization call: the result is
+cached per permission root and schema generation. Schema writes are rare, but
+large recursive schemas should account for this first-read compilation latency.
+
+Use managed mutation proofs for the normal EACL-only writer contract. Content
+mode is the conservative interoperability fallback for unknown writers, not the
+low-latency configuration.
+
 ## Token keys, lifetime, and retention
 
 Portable DataScript/Datahike clients use `:security-key` or

--- a/modules/eacl-datahike/README.md
+++ b/modules/eacl-datahike/README.md
@@ -12,12 +12,15 @@ Responsibilities:
 - Datahike schema installation and relationship transactions
 - current immutable-snapshot selection and object/reference conversion
 - ordered adjacency in both keyword and numeric `:attribute-refs?` modes
-- snapshot-bound opaque Relay cursors
-- database-visible schema and relation cache proofs across connections
+- proof-equivalent authenticated Relay cursors with exact fallback
+- database-visible mutation identities plus schema/relation proofs
 - `delete-object!` relationship cleanup
 
-Only `:fully-consistent` current-snapshot reads are supported. Unsupported
-consistency or historical promises fail with `:eacl/unsupported-capability`.
+Datahike supports local `:minimize-latency`, managed causal at-least selection,
+and exact reconstruction from retained commits or temporal history. It
+advertises `:fully-consistent` only for a direct `:self` writer with an
+authoritative branch-head barrier; lagging/replicated sources reject it.
+Unsupported configuration/mode combinations fail before authorization.
 The v7 `:limit`/`:cursor` API is replaced by v8 `:first`/`:after` and
 `:last`/`:before`; see the
 [upgrade guide](../../docs/v8-backend-modules-and-upgrade.md).

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -4,15 +4,83 @@
             [eacl.backend.v8 :as backend]
             [eacl.datahike.db :as ddb]
             [eacl.datahike.impl :as impl]
-            [eacl.datahike.schema :as schema]))
+            [eacl.datahike.mutation :as journal]
+            [eacl.datahike.schema :as schema]
+            [eacl.mutation :as mutation]
+            [eacl.secure-format :as secure])
+  (:import [java.util UUID]))
 
 (def capabilities
-  {:consistency #{:fully-consistent}
-   :snapshots #{:current}
+  {:consistency #{:fully-consistent
+                  :minimize-latency
+                  :at-least-as-fresh
+                  :at-exact-snapshot}
+   :snapshots #{:current :authoritative :causal :exact}
+   :source #{:stable-scope :graph-head :anchor-membership :order-hint}
    :cursor #{:forward :reverse :opaque}
    :transactions #{:schema :relationships :object-deletion}
    :cache-proofs #{:schema :relations :snapshot-bound :database-visible}
    :runtime #{:clj}})
+
+(defn- direct-writer?
+  [db]
+  (= :self (get-in db [:config :writer :backend])))
+
+(defn- exact-commits?
+  [db]
+  (not (false? (get-in db [:config :commit-graph?] true))))
+
+(defn- temporal-history?
+  [db]
+  (true? (get-in db [:config :keep-history?])))
+
+(defn- exact-reconstruction?
+  [db]
+  (or (exact-commits? db)
+      (temporal-history? db)))
+
+(defn- commit-locator
+  [db]
+  (some-> (get-in db [:meta :datahike/commit-id]) str))
+
+(defn- parent-locators
+  [db]
+  (->> (get-in db [:meta :datahike/parents])
+       (map str)
+       sort
+       vec))
+
+(defn- freshness-timeout!
+  [token-data timeout-ms observed]
+  (throw
+   (ex-info
+    "Datahike branch did not acquire the requested mutation anchor."
+    {:type :eacl.consistency/freshness-unavailable
+     :eacl/error :eacl.consistency/freshness-unavailable
+     :reason :freshness-timeout
+     :requested-order-hint (:order-hint token-data)
+     :observed-order-hint (:max-tx observed)
+     :timeout-ms timeout-ms})))
+
+(defn- await-anchor-db
+  [conn fallback token-data timeout-ms]
+  (let [timeout-ms (or timeout-ms 30000)
+        deadline (+ (System/nanoTime)
+                    (* 1000000 timeout-ms))]
+    (loop []
+      (let [candidate (if conn (d/db conn) fallback)]
+        (cond
+          (journal/contains-anchor?
+           candidate (:graph-anchor token-data))
+          candidate
+
+          (>= (System/nanoTime) deadline)
+          (freshness-timeout! token-data timeout-ms candidate)
+
+          :else
+          (do
+            (Thread/sleep 2)
+            (recur)))))))
 
 (defn- normalized-permission
   [permission]
@@ -43,7 +111,7 @@
     (cond->> (filter within-bound? ordered)
       (= :desc direction) reverse)))
 
-(defn- schema-proof
+(defn- schema-proof-records
   [db {:keys [permission-nodes relation-ids] :as scope}]
   (let [{:keys [relation-defs permission-defs]}
         (impl/build-schema-catalog db)
@@ -55,110 +123,255 @@
         (if scope
           (mapcat #(get permission-defs % []) permission-nodes)
           (mapcat identity (vals permission-defs)))]
-    {:relations
+    (concat
      (->> scoped-relations
-          (sort-by (juxt :resource-type :relation-name :subject-type))
-          vec)
-     :permissions
+          (map (fn [relation]
+                 [:relation
+                  (:relation-id relation)
+                  (:resource-type relation)
+                  (:relation-name relation)
+                  (:subject-type relation)]))
+          sort)
      (->> scoped-permissions
           (map normalized-permission)
-          (sort-by (juxt :resource-type
-                         :permission-name
-                         :source-relation-name
-                         :target-type
-                         :target-name))
-          vec)}))
+          (map (fn [permission]
+                 [:permission
+                  (:permission-id permission)
+                  (:resource-type permission)
+                  (:permission-name permission)
+                  (:source-relation-name permission)
+                  (:target-type permission)
+                  (:target-name permission)]))
+          sort))))
 
-(defn- relation-proof
-  [db relation-ids]
+(defn- content-schema-proof
+  [db scope]
+  {:content-digest
+   (secure/canonical-records-digest
+    "eacl/datahike/schema-content-proof/v3"
+    (schema-proof-records db scope))})
+
+(defn- content-relation-proof
+  [db relation-ids external-id]
   (let [wanted (set relation-ids)]
-    (->> (d/q '[:find ?relation ?subject-type ?subject
-                 ?resource-type ?resource
-                 :where
-                 [?relationship :eacl.relationship/relation ?relation]
-                 [?relationship :eacl.relationship/subject-type ?subject-type]
-                 [?relationship :eacl.relationship/subject ?subject]
-                 [?relationship :eacl.relationship/resource-type ?resource-type]
-                 [?relationship :eacl.relationship/resource ?resource]]
-               db)
-         (filter #(contains? wanted (nth % 0)))
-         sort
-         vec)))
+    {:content-digest
+     (secure/canonical-records-digest
+      "eacl/datahike/relationship-content-proof/v3"
+      (->> (d/q '[:find ?relation ?subject-type ?subject
+                  ?resource-type ?resource
+                  :where
+                  [?relationship :eacl.relationship/relation ?relation]
+                  [?relationship :eacl.relationship/subject-type ?subject-type]
+                  [?relationship :eacl.relationship/subject ?subject]
+                  [?relationship :eacl.relationship/resource-type ?resource-type]
+                  [?relationship :eacl.relationship/resource ?resource]]
+                db)
+           (filter #(contains? wanted (nth % 0)))
+           sort
+           (map (fn [[relation subject-type subject
+                      resource-type resource]]
+                  [:relationship relation
+                   subject-type subject (external-id db subject)
+                   resource-type resource (external-id db resource)]))))}))
+
+(defn- mutation-schema-proof
+  [db]
+  (some-> (d/entity db [:eacl/id mutation/schema-entity-id])
+          (get mutation/schema-mutation-id-attr)))
+
+(defn- mutation-relation-proof
+  [db relation-ids]
+  (let [proof
+        (mapv (fn [relation-id]
+                [relation-id
+                 (get (d/entity db relation-id)
+                      mutation/relation-mutation-id-attr)])
+              (sort relation-ids))]
+    (when (every? (comp some? second) proof)
+      proof)))
 
 (defn snapshot-adapter
   "Creates a v8 adapter bound to one immutable Datahike db value."
-  [db {:keys [object-id->entid entid->object-id]}]
-  (backend/make-adapter
-   {:id :datahike
-    :capabilities capabilities
-    :state {:db db}
-    :operations
-    {:snapshot-id
-     (fn []
-       {:database-id (select-keys (:config db)
-                                  [:store :attribute-refs?])
-        :basis-t (:max-tx db)})
+  [db {:keys [object-id->entid entid->object-id conn
+              coherence-authority proof-mode]
+       :or {proof-mode :content}
+       :as opts}]
+  (let [source-scope
+        (or (:source-scope opts)
+            (let [{:keys [backend id]} (get-in db [:config :store])]
+              {:source-id
+               {:store-backend backend
+                :store-id (str id)
+                :family-id (:family-id (journal/graph-state db))}
+               :branch (get-in db [:config :branch])}))
+        opts' (assoc opts :source-scope source-scope)]
+    (backend/make-adapter
+     {:id :datahike
+      :fingerprint (:adapter-fingerprint opts)
+      :deterministic? (:adapter-deterministic? opts)
+      :identity-contract
+      (:identity-contract opts
+                          :selected-internal/current-external-v1)
+      :capabilities
+      (cond-> capabilities
+        (not= :managed coherence-authority)
+        (update :consistency disj :at-least-as-fresh :at-exact-snapshot)
 
-     :object-id->internal
-     (fn [object-id]
-       (if (number? object-id)
-         object-id
-         (object-id->entid db object-id)))
+        (or (nil? conn)
+            (not (direct-writer? db)))
+        (update :consistency disj :fully-consistent)
 
-     :internal-id->object
-     (fn [internal-id]
-       (entid->object-id db internal-id))
+        (or (nil? conn)
+            (not (exact-reconstruction? db)))
+        (update :consistency disj :at-exact-snapshot))
+      :state {:db db
+              :commit-id (commit-locator db)
+              :parent-commit-ids (parent-locators db)}
+      :operations
+      {:snapshot-id
+       (fn []
+         {:database-id
+          {:store
+           (update (:store (:config db)) :id str)}
+          :attribute-refs? (boolean
+                            (:attribute-refs? (:config db)))
+          :basis-t (:max-tx db)})
 
-     :relation-defs
-     (fn [resource-type relation-name]
-       (mapv (fn [{:keys [e v]}]
-               {:relation-id e
-                :resource-type resource-type
-                :relation-name relation-name
-                :subject-type (nth v 2)})
-             (impl/relation-datoms db resource-type relation-name)))
+       :source-scope
+       (fn [] source-scope)
 
-     :permission-defs
-     (fn [resource-type permission-name]
-       (mapv normalized-permission
-             (impl/find-permission-defs
-              db resource-type permission-name)))
+       :graph-head
+       (fn []
+         {:graph-anchor (:head-id (journal/graph-state db))
+          :order-hint (:max-tx db)
+          :exact-locator (commit-locator db)})
 
-     :subject->resources
-     (fn [subject-type subject-id relation-id resource-type options]
-       (apply-scan-window
-        (impl/subject->resources
-         db subject-type subject-id relation-id resource-type nil)
-        options))
+       :contains-anchor?
+       (fn [anchor]
+         (journal/contains-anchor? db anchor))
 
-     :resource->subjects
-     (fn [resource-type resource-id relation-id subject-type options]
-       (apply-scan-window
-        (impl/resource->subjects
-         db resource-type resource-id relation-id subject-type nil)
-        options))
+       :order-hint (fn [] (:max-tx db))
 
-     :direct-match?
-     (fn [subject-type subject-id relation-id resource-type resource-id]
-       (boolean
-        (ddb/entid
-         db
-         [schema/relationship-full-key-attr
-          [subject-type subject-id relation-id resource-type resource-id]])))
+       :select-current
+       (fn []
+         (snapshot-adapter (if conn (d/db conn) db) opts'))
 
-     :all-permission-nodes
-     (fn []
-       (->> (ddb/avet-datoms db schema/permission-key-attr)
-            (map :v)
-            set))
+       :select-authoritative
+       (fn [_timeout-ms]
+         (when-not (direct-writer? db)
+           (throw
+            (ex-info
+             "Datahike source has no authoritative branch-head barrier."
+             {:type :eacl/unsupported-capability
+              :eacl/error :eacl/unsupported-capability
+              :backend :datahike
+              :capability :consistency
+              :requested :fully-consistent})))
+         (snapshot-adapter (if conn (d/db conn) db) opts'))
 
-     :frontier-key pr-str
+       :select-at-least
+       (fn [token-data timeout-ms]
+         (snapshot-adapter
+          (await-anchor-db conn db token-data timeout-ms)
+          opts'))
 
-     :schema-proof
-     (fn
-       ([] (schema-proof db nil))
-       ([scope] (schema-proof db scope)))
+       :exact-locator (fn [] (commit-locator db))
 
-     :relation-proof
-     (fn [relation-ids]
-       (relation-proof db relation-ids))}}))
+       :select-exact
+       (fn [token-data _timeout-ms]
+         (when (and conn
+                    (:exact-locator token-data))
+           (try
+             (let [commit-db
+                   (when (exact-commits? db)
+                     (d/commit-as-db
+                      conn
+                      (UUID/fromString
+                       (:exact-locator token-data))))
+                   temporal-db
+                   (when (and (nil? commit-db)
+                              (temporal-history? db)
+                              (integer? (:order-hint token-data))
+                              (<= (:order-hint token-data)
+                                  (:max-tx (d/db conn))))
+                     (d/as-of (d/db conn)
+                              (:order-hint token-data)))]
+               (some-> (or commit-db temporal-db)
+                       (snapshot-adapter opts')))
+             (catch Throwable _
+               nil))))
+
+       :object-id->internal
+       (fn [object-id]
+         (if (number? object-id)
+           object-id
+           (object-id->entid db object-id)))
+
+       :internal-id->object
+       (fn [internal-id]
+         (entid->object-id db internal-id))
+
+       :relation-defs
+       (fn [resource-type relation-name]
+         (mapv (fn [{:keys [e v]}]
+                 {:relation-id e
+                  :resource-type resource-type
+                  :relation-name relation-name
+                  :subject-type (nth v 2)})
+               (impl/relation-datoms db resource-type relation-name)))
+
+       :permission-defs
+       (fn [resource-type permission-name]
+         (mapv normalized-permission
+               (impl/find-permission-defs
+                db resource-type permission-name)))
+
+       :subject->resources
+       (fn [subject-type subject-id relation-id resource-type options]
+         (apply-scan-window
+          (impl/subject->resources
+           db subject-type subject-id relation-id resource-type nil)
+          options))
+
+       :resource->subjects
+       (fn [resource-type resource-id relation-id subject-type options]
+         (apply-scan-window
+          (impl/resource->subjects
+           db resource-type resource-id relation-id subject-type nil)
+          options))
+
+       :direct-match?
+       (fn [subject-type subject-id relation-id resource-type resource-id]
+         (boolean
+          (ddb/entid
+           db
+           [schema/relationship-full-key-attr
+            [subject-type subject-id relation-id resource-type resource-id]])))
+
+       :all-permission-nodes
+       (fn []
+         (->> (ddb/avet-datoms db schema/permission-key-attr)
+              (map :v)
+              set))
+
+       :frontier-key pr-str
+
+       :schema-proof
+       (fn
+         ([]
+          (case proof-mode
+            :mutation (mutation-schema-proof db)
+            :content (content-schema-proof db nil)
+            nil))
+         ([scope]
+          (case proof-mode
+            :mutation (mutation-schema-proof db)
+            :content (content-schema-proof db scope)
+            nil)))
+
+       :relation-proof
+       (fn [relation-ids]
+         (case proof-mode
+           :mutation (mutation-relation-proof db relation-ids)
+           :content (content-relation-proof db relation-ids entid->object-id)
+           nil))}})))

--- a/modules/eacl-datahike/src/eacl/datahike/core.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/core.clj
@@ -3,6 +3,8 @@
             [datahike.api :as d]
             [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
+            [eacl.causal-token :as causal-token]
+            [eacl.consistency :as consistency-v3]
             [eacl.core :as eacl :refer [IAuthorization
                                         spice-object
                                         ->Relationship
@@ -12,11 +14,14 @@
             [eacl.datahike.backend :as datahike-backend]
             [eacl.datahike.db :as ddb]
             [eacl.datahike.impl :as impl]
+            [eacl.datahike.mutation :as journal]
             [eacl.datahike.schema :as schema]
             [eacl.engine.v8 :as engine]
+            [eacl.mutation :as mutation]
             [eacl.relay :as relay]
             [eacl.relationships.filters :as relationship-filters]
             [eacl.relationships.relay :as relationship-relay]
+            [eacl.secure-format :as secure]
             [eacl.spicedb.consistency :as consistency]))
 
 (def cursor->token cursor/cursor->token)
@@ -81,9 +86,20 @@
   [db opts]
   (datahike-backend/snapshot-adapter db opts))
 
-(defn- require-consistency!
-  [adapter value]
-  (backend/require-consistency! adapter value))
+(defn- selected-context
+  [db opts consistency-value]
+  (let [selection
+        (consistency-v3/select
+         (snapshot-adapter db opts)
+         consistency-value
+         {:format-options (:format-options opts)
+          :coherence-authority (:coherence-authority opts)
+          :issue-token? true
+          :timeout-ms (:consistency-sync-timeout-ms opts)})
+        adapter (:adapter selection)]
+    {:adapter adapter
+     :db (:db (backend/state adapter))
+     :selection selection}))
 
 (defn- permission-dependencies
   [adapter resource-type permission]
@@ -97,22 +113,71 @@
        adapter resource-type permission)
       :relation-ids relation-ids}}))
 
+(defn- cursor-options
+  [adapter opts selection resource-type permission]
+  (binding [engine/*schema-cache*
+            (engine/schema-cache-for!
+             (:derived-schema-caches opts)
+             adapter)]
+    (assoc opts
+           :cursor-dependencies
+           (permission-dependencies
+            adapter resource-type permission)
+           :cursor-consistency-mode
+           (get-in selection [:descriptor :mode])
+           :timeout-ms (:consistency-sync-timeout-ms opts))))
+
+(defn- page-context
+  [adapter opts selection operation query resource-type permission]
+  (let [current-opts
+        (cursor-options
+         adapter opts selection resource-type permission)
+        page-adapter
+        (relay/select-continuation-adapter
+         adapter current-opts operation query)
+        page-opts
+        (cursor-options
+         page-adapter opts selection resource-type permission)]
+    {:adapter page-adapter
+     :db (:db (backend/state page-adapter))
+     :opts page-opts}))
+
+(defn- pagination-snapshot-context
+  [adapter]
+  {:source-scope
+   {:backend (backend/backend-id adapter)
+    :scope (backend/invoke adapter :source-scope)}
+   :graph-head (backend/invoke adapter :graph-head)
+   :adapter-fingerprint (backend/fingerprint adapter)
+   :identity-contract (backend/identity-contract adapter)})
+
 (defn- cached-engine-result
   [adapter opts operation query resource-type permission
    valid-value? compute]
-  (let [{:keys [schema-scope relation-ids]}
-        (permission-dependencies adapter resource-type permission)]
-    (binding [engine/*recursive-traversal-limits*
-              (:recursive-traversal-limits opts)]
+  (binding [engine/*schema-cache*
+            (engine/schema-cache-for!
+             (:derived-schema-caches opts)
+             adapter)
+            engine/*recursive-traversal-limits*
+            (:recursive-traversal-limits opts)]
+    (let [{:keys [schema-scope relation-ids]}
+          (permission-dependencies adapter resource-type permission)]
       (cache/resolve!
        adapter
        (:cache-store opts)
-       [operation query]
+       {:operation operation
+        :query query
+        :engine-version engine/engine-version
+        :adapter-fingerprint (:adapter-fingerprint opts)
+        :proof-mode (:proof-mode opts)
+        :recursive-traversal-limits
+        (:recursive-traversal-limits opts)}
        operation
        schema-scope
        relation-ids
        valid-value?
-       compute))))
+       compute
+       (:format-options opts)))))
 
 (defn- with-cache-info
   [value {:keys [cached? cache-basis]}]
@@ -123,56 +188,66 @@
 (defn datahike-read-relationships
   [db
    {:as opts
-    :keys [object-id->entid
+   :keys [object-id->entid
            internal-cursor->spice
            spice-cursor->internal]}
    filters]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency filters))
+  (let [{selected-db :db adapter :adapter selection :selection}
+        (selected-context db opts (:consistency filters))
         base-filters (apply dissoc filters
                             [:first :last :after :before :consistency])
         _ (relationship-filters/validate! base-filters)
-        subject-id   (:subject/id base-filters)
-        resource-id  (:resource/id base-filters)
-        subject-eid  (when subject-id (object-id->entid db subject-id))
-        resource-eid (when resource-id (object-id->entid db resource-id))
-        missing-id?  (or (and subject-id (nil? subject-eid))
-                         (and resource-id (nil? resource-eid)))]
-    (if missing-id?
-      relay/empty-page
-      (let [filters' (cond-> base-filters
-                       subject-id (assoc :subject/id subject-eid)
-                       resource-id (assoc :resource/id resource-eid))
-            internal-relationships
-            (loop [cursor nil
-                   result []]
-              (let [page
-                    (impl/read-relationships
-                     db
-                     (cond-> (assoc filters' :limit 10000)
-                       cursor (assoc :cursor cursor)))
-                    result' (into result (:data page))
-                    next-cursor (:cursor page)]
-                (if (and next-cursor
-                         (not= cursor next-cursor)
-                         (seq (:data page)))
-                  (recur next-cursor result')
-                  result')))
-            public-relationships
-            (->> internal-relationships
-                 (sort-by
-                  (fn [{:keys [subject relation resource]}]
-                    [(:type subject) (:id subject)
-                     relation
-                     (:type resource) (:id resource)]))
-                 (map #(relationship->spice db opts %))
-                 vec)]
-        (relationship-relay/paginate
-         opts
-         :read-relationships
-         filters
-         (backend/invoke adapter :snapshot-id)
-         public-relationships)))))
+        items-for-adapter
+        (fn [page-adapter]
+          (let [page-db (:db (backend/state page-adapter))
+                subject-id (:subject/id base-filters)
+                resource-id (:resource/id base-filters)
+                subject-eid (when subject-id
+                              (object-id->entid page-db subject-id))
+                resource-eid (when resource-id
+                               (object-id->entid page-db resource-id))]
+            (if (or (and subject-id (nil? subject-eid))
+                    (and resource-id (nil? resource-eid)))
+              []
+              (let [filters'
+                    (cond-> base-filters
+                      subject-id (assoc :subject/id subject-eid)
+                      resource-id (assoc :resource/id resource-eid))
+                    internal-relationships
+                    (loop [cursor nil
+                           result []]
+                      (let [page
+                            (impl/read-relationships
+                             page-db
+                             (cond-> (assoc filters' :limit 10000)
+                               cursor (assoc :cursor cursor)))
+                            result' (into result (:data page))
+                            next-cursor (:cursor page)]
+                        (if (and next-cursor
+                                 (not= cursor next-cursor)
+                                 (seq (:data page)))
+                          (recur next-cursor result')
+                          result')))]
+                (->> internal-relationships
+                     (map #(relationship->spice page-db opts %))
+                     (sort-by
+                      (fn [{:keys [subject relation resource]}]
+                        [(:type subject) (:id subject)
+                         relation
+                         (:type resource) (:id resource)]))
+                     vec)))))
+        cursor-opts
+        (assoc opts
+               :cursor-consistency-mode
+               (get-in selection [:descriptor :mode])
+               :relationship-adapter adapter
+               :relationship-items-for-adapter items-for-adapter)]
+    (relationship-relay/paginate
+     cursor-opts
+     :read-relationships
+     filters
+     (pagination-snapshot-context adapter)
+     (items-for-adapter adapter))))
 
 (defn spice-relationship->internal
   [db {:keys [spice-object->internal]} {:keys [subject relation resource]}]
@@ -180,24 +255,71 @@
    :relation relation
    :resource (spice-object->internal db resource)})
 
+(defn- source-id
+  [db family-id]
+  (let [{:keys [backend id]} (get-in db [:config :store])]
+    {:store-backend backend
+     :store-id (str id)
+     :family-id family-id}))
+
+(defn- response-token
+  [db opts]
+  (when (= :managed (:coherence-authority opts))
+    (let [adapter (snapshot-adapter db opts)]
+      (causal-token/issue
+       (:format-options opts)
+       (merge
+        {:backend :datahike}
+        (backend/invoke adapter :source-scope)
+        (backend/invoke adapter :graph-head))))))
+
+(defn- write-response
+  [db opts]
+  (if-let [token (response-token db opts)]
+    {:zed/token token}
+    {}))
+
 (defn datahike-write-relationships!
   [conn opts updates]
-  (let [db       (d/db conn)
-        tx-stamp (:tx-stamp opts)
-        tx-data  (->> updates
-                      (S/transform [S/ALL :relationship]
-                                   #(spice-relationship->internal db opts %))
-                      (mapcat #(impl/tx-update-relationship db %))
-                      (remove nil?)
-                      (vec))]
-    (when (seq tx-data)
-      (d/transact conn tx-data))
-    {:zed/token (str @tx-stamp)}))
+  (let [db (d/db conn)
+        internal-updates
+        (S/transform [S/ALL :relationship]
+                     #(spice-relationship->internal db opts %)
+                     updates)
+        relation-ids
+        (->> internal-updates
+             (map (comp #(impl/relationship-relation-id db %)
+                        :relationship))
+             distinct
+             vec)
+        tx-data
+        (->> internal-updates
+             (mapcat #(impl/tx-update-relationship db %))
+             (remove nil?)
+             vec)]
+    (if (seq tx-data)
+      (let [report
+            (journal/transact!
+             conn
+             {:mutation-id (mutation/new-id)
+              :kind :relationships
+              :canonical-data
+              {:operation :write-relationships
+               :updates internal-updates}
+              :relation-ids relation-ids
+              :token-ttl-seconds (:token-ttl-seconds opts)
+              :retention-grace-seconds
+              (:retention-grace-seconds opts)
+              :tx-data tx-data})]
+        (write-response (:db-after report) opts))
+      (do
+        (journal/ensure-migrated! conn)
+        (write-response (d/db conn) opts)))))
 
 (defn datahike-delete-object!
   "Removes every relationship that references `object`, without retracting the
   object entity itself."
-  [conn {:keys [object->entid tx-stamp]} object]
+  [conn {:keys [object->entid] :as opts} object]
   (let [db (d/db conn)]
     (when-let [object-eid (object->entid db object)]
       (let [relationship-eids
@@ -206,13 +328,32 @@
                    :where
                    (or [?relationship :eacl.relationship/subject ?object]
                        [?relationship :eacl.relationship/resource ?object])]
-                 db object-eid)]
+                 db object-eid)
+            relation-ids
+            (d/q '[:find [?relation ...]
+                   :in $ [?relationship ...]
+                   :where
+                   [?relationship :eacl.relationship/relation ?relation]]
+                 db relationship-eids)]
         (when (seq relationship-eids)
-          (d/transact conn
-                      (mapv (fn [relationship-eid]
-                              [:db/retractEntity relationship-eid])
-                            relationship-eids))))))
-  {:zed/token (str @tx-stamp)})
+          (journal/transact!
+           conn
+           {:mutation-id (mutation/new-id)
+            :kind :object-deletion
+            :canonical-data
+            {:operation :delete-object
+             :object object
+             :relationship-eids (vec (sort relationship-eids))}
+            :relation-ids relation-ids
+            :token-ttl-seconds (:token-ttl-seconds opts)
+            :retention-grace-seconds
+            (:retention-grace-seconds opts)
+            :tx-data
+            (mapv (fn [relationship-eid]
+                    [:db/retractEntity relationship-eid])
+                  relationship-eids)})))))
+  (journal/ensure-migrated! conn)
+  (write-response (d/db conn) opts))
 
 (defn- relationship-seq
   [relationships]
@@ -223,16 +364,18 @@
 (defn datahike-can?
   [db {:keys [spice-object->internal] :as opts}
    subject permission resource consistency]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter consistency)
-        internal-subject (spice-object->internal db subject)
-        internal-resource (spice-object->internal db resource)]
+  (let [{selected-db :db adapter :adapter}
+        (selected-context db opts consistency)
+        internal-subject (spice-object->internal selected-db subject)
+        internal-resource (spice-object->internal selected-db resource)]
     (if-not (and (:id internal-subject) (:id internal-resource))
       false
       (:value
        (cached-engine-result
         adapter opts :can?
-        [internal-subject permission internal-resource]
+        {:public [subject permission resource]
+         :internal
+         [internal-subject permission internal-resource]}
         (:type internal-resource)
         permission
         boolean?
@@ -248,28 +391,34 @@
            internal-cursor->spice
            spice-cursor->internal]}
    {:as query :keys [subject]}]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-subject (spice-object->internal db subject)]
+  (let [{source-adapter :adapter selection :selection}
+        (selected-context db opts (:consistency query))
+        {adapter :adapter selected-db :db cursor-opts :opts}
+        (page-context
+         source-adapter opts selection :lookup-resources query
+         (:resource/type query) (:permission query))
+        internal-subject (spice-object->internal selected-db subject)]
     (if (nil? (:id internal-subject))
       (assoc relay/empty-page :cached? false :cache-basis nil)
       (let [internal-query
             (-> query
                 (dissoc :consistency)
                 (#(relay/internalize-page-query
-                   adapter opts :lookup-resources %))
+                   adapter cursor-opts :lookup-resources %))
                 (assoc :subject internal-subject))
             answer
             (cached-engine-result
-             adapter opts :lookup-resources internal-query
+             adapter cursor-opts :lookup-resources
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:resource/type internal-query)
              (:permission internal-query)
              #(and (map? %) (vector? (:data %))
                    (map? (:page-info %)))
              #(engine/lookup-resources adapter internal-query))]
         (with-cache-info
-          (relay/externalize-page
-           adapter opts :lookup-resources query (:value answer))
+           (relay/externalize-page
+           adapter cursor-opts :lookup-resources query (:value answer))
           answer)))))
 
 (defn datahike-count-resources
@@ -279,9 +428,9 @@
            spice-cursor->internal
            internal-cursor->spice]}
    {:as query :keys [subject]}]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-subject (spice-object->internal db subject)]
+  (let [{selected-db :db adapter :adapter selection :selection}
+        (selected-context db opts (:consistency query))
+        internal-subject (spice-object->internal selected-db subject)]
     (if-not (:id internal-subject)
       (assoc
        (cond-> {:count 0 :limit (or (:count-limit query) -1)}
@@ -293,7 +442,9 @@
                 (dissoc :consistency))
             answer
             (cached-engine-result
-             adapter opts :count-resources internal-query
+             adapter opts :count-resources
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:resource/type internal-query)
              (:permission internal-query)
              #(and (map? %) (integer? (:count %)))
@@ -308,9 +459,14 @@
            spice-cursor->internal
            internal-cursor->spice]}
    query]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-resource (spice-object->internal db (:resource query))]
+  (let [{source-adapter :adapter selection :selection}
+        (selected-context db opts (:consistency query))
+        {adapter :adapter selected-db :db cursor-opts :opts}
+        (page-context
+         source-adapter opts selection :lookup-subjects query
+         (:type (:resource query)) (:permission query))
+        internal-resource
+        (spice-object->internal selected-db (:resource query))]
     (when (contains? query :subject/relation)
       (throw (ex-info ":subject/relation is not supported by lookup-subjects."
                       {:eacl/error :eacl.pagination/unsupported-filter
@@ -321,19 +477,21 @@
             (-> query
                 (dissoc :consistency)
                 (#(relay/internalize-page-query
-                   adapter opts :lookup-subjects %))
+                   adapter cursor-opts :lookup-subjects %))
                 (assoc :resource internal-resource))
             answer
             (cached-engine-result
-             adapter opts :lookup-subjects internal-query
+             adapter cursor-opts :lookup-subjects
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:type (:resource internal-query))
              (:permission internal-query)
              #(and (map? %) (vector? (:data %))
                    (map? (:page-info %)))
              #(engine/lookup-subjects adapter internal-query))]
         (with-cache-info
-          (relay/externalize-page
-           adapter opts :lookup-subjects query (:value answer))
+           (relay/externalize-page
+           adapter cursor-opts :lookup-subjects query (:value answer))
           answer)))))
 
 (defn datahike-count-subjects
@@ -343,9 +501,10 @@
            spice-cursor->internal
            internal-cursor->spice]}
    query]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-resource (spice-object->internal db (:resource query))]
+  (let [{selected-db :db adapter :adapter}
+        (selected-context db opts (:consistency query))
+        internal-resource
+        (spice-object->internal selected-db (:resource query))]
     (if-not (:id internal-resource)
       (assoc
        (cond-> {:count 0 :limit (or (:count-limit query) -1)}
@@ -357,7 +516,9 @@
                 (dissoc :consistency))
             answer
             (cached-engine-result
-             adapter opts :count-subjects internal-query
+             adapter opts :count-subjects
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:type (:resource internal-query))
              (:permission internal-query)
              #(and (map? %) (integer? (:count %)))
@@ -377,7 +538,14 @@
   (read-schema [_]
     (schema/read-schema (d/db conn)))
   (write-schema! [_ schema-string]
-    (schema/write-schema! conn schema-string))
+    (let [result
+          (schema/write-schema!
+           conn schema-string
+           (select-keys opts
+                        [:token-ttl-seconds
+                         :retention-grace-seconds]))]
+      (merge result
+             (write-response (:eacl.mutation/db-after result) opts))))
 
   (read-relationships [_ filters]
     (datahike-read-relationships (d/db conn) opts filters))
@@ -430,66 +598,6 @@
                     {:type :eacl/not-implemented
                      :method (quote expand-permission-tree)}))))
 
-(defonce runtime-state-registry (atom {}))
-
-(defn- schema-transaction?
-  "Whether `tx-report` touched EACL's schema, and so invalidated the permission
-   paths and the schema catalog.
-
-   The ident resolution is load-bearing, not defensive: under
-   `:attribute-refs? true` a datom's `:a` is a numeric ref, so comparing it
-   against a set of keywords matches nothing and the derived caches are never
-   invalidated — a schema change would keep answering from stale permission
-   paths. `:db-after` is used because a retraction's attribute must still
-   resolve."
-  [tx-report]
-  (let [db (:db-after tx-report)]
-    (boolean
-     (some (fn [{:keys [a]}]
-             (contains? schema/schema-change-attrs (ddb/attr-ident db a)))
-           (:tx-data tx-report)))))
-
-(defn- reset-schema-derived-state!
-  [state]
-  (swap! (:schema-stamp state) inc)
-  (reset! (:permission-paths-cache state) {})
-  (reset! (:schema-catalog state) nil))
-
-(defn ensure-runtime-state!
-  [conn]
-  (if-let [state (get @runtime-state-registry conn)]
-    state
-    (let [state {:conn-id (random-uuid)
-                 :tx-stamp (atom 0)
-                 :schema-stamp (atom 0)
-                 :permission-paths-cache (atom {})
-                 :schema-catalog (atom nil)
-                 :listener-key (keyword (str "eacl-stamp-" (random-uuid)))}]
-      (d/listen conn
-                (:listener-key state)
-                (fn [tx-report]
-                  (swap! (:tx-stamp state) inc)
-                  (when (schema-transaction? tx-report)
-                    (reset-schema-derived-state! state))))
-      (get (swap! runtime-state-registry
-                  #(if (contains? % conn) % (assoc % conn state)))
-           conn))))
-
-(defn- ensure-schema-catalog!
-  [state db]
-  (let [schema-stamp @(:schema-stamp state)
-        cached       @(:schema-catalog state)]
-    (if (= schema-stamp (:schema-stamp cached))
-      (:catalog cached)
-      (let [catalog (impl/build-schema-catalog db)]
-        (-> (swap! (:schema-catalog state)
-                   (fn [entry]
-                     (if (= schema-stamp (:schema-stamp entry))
-                       entry
-                       {:schema-stamp schema-stamp
-                        :catalog      catalog})))
-            :catalog)))))
-
 (def ^:private known-client-opt-keys
   #{:entid->object-id
     :entity->object-id
@@ -498,7 +606,17 @@
     :spice-cursor->internal
     :cursor-ttl-seconds
     :cache
-    :recursive-traversal-limits})
+    :recursive-traversal-limits
+    :security-key
+    :security-keyring
+    :security-kid
+    :token-ttl-seconds
+    :retention-grace-seconds
+    :coherence-authority
+    :proof-mode
+    :adapter-fingerprint
+    :adapter-deterministic?
+    :consistency-sync-timeout-ms})
 
 (defn make-client
   "Builds an IAuthorization client over a datahike conn.
@@ -519,7 +637,17 @@
            spice-cursor->internal
            cursor-ttl-seconds
            cache
-           recursive-traversal-limits]
+           recursive-traversal-limits
+           security-key
+           security-keyring
+           security-kid
+           token-ttl-seconds
+           retention-grace-seconds
+           coherence-authority
+           proof-mode
+           adapter-fingerprint
+           adapter-deterministic?
+           consistency-sync-timeout-ms]
     :or   {object-id->lookup-ref  (fn [obj-id] [:eacl/id obj-id])
            internal-cursor->spice default-internal-cursor->spice
            spice-cursor->internal default-spice-cursor->internal}}]
@@ -533,25 +661,134 @@
     (throw (ex-info "EACL Config Error: supply only one of :entid->object-id (canonical) or :entity->object-id (deprecated alias)."
                     {:type :eacl/invalid-config
                      :conflicting-keys [:entid->object-id :entity->object-id]})))
-  (let [runtime-state    (ensure-runtime-state! conn)
+  (when (and security-key security-keyring)
+    (throw (ex-info "EACL Config Error: supply only one of :security-key or :security-keyring."
+                    {:type :eacl/invalid-config
+                     :conflicting-keys [:security-key :security-keyring]})))
+  (when-not (contains? #{nil :unknown :managed} coherence-authority)
+    (throw (ex-info "EACL Config Error: :coherence-authority must be :managed or :unknown."
+                    {:type :eacl/invalid-config
+                     :key :coherence-authority
+                     :value coherence-authority})))
+  (when-not (contains? #{nil :auto :mutation :content :none} proof-mode)
+    (throw (ex-info "EACL Config Error: unsupported :proof-mode."
+                    {:type :eacl/invalid-config
+                     :key :proof-mode
+                     :value proof-mode})))
+  (when (and (= :mutation proof-mode)
+             (not= :managed coherence-authority))
+    (throw (ex-info "EACL Config Error: mutation proof requires managed writer authority."
+                    {:type :eacl/invalid-config
+                     :key :proof-mode
+                     :value proof-mode})))
+  (when (and (contains? config-opts :adapter-deterministic?)
+             (not (boolean? adapter-deterministic?)))
+    (throw (ex-info "EACL Config Error: :adapter-deterministic? must be boolean."
+                    {:type :eacl/invalid-config
+                     :key :adapter-deterministic?
+                     :value adapter-deterministic?})))
+  (when adapter-fingerprint
+    (try
+      (secure/encode-canonical adapter-fingerprint)
+      (catch Exception error
+        (throw (ex-info "EACL Config Error: :adapter-fingerprint must be portable canonical data."
+                        {:type :eacl/invalid-config
+                         :key :adapter-fingerprint}
+                        error)))))
+  (when (and token-ttl-seconds
+             (not (and (integer? token-ttl-seconds)
+                       (pos? token-ttl-seconds))))
+    (throw (ex-info "EACL Config Error: :token-ttl-seconds must be positive."
+                    {:type :eacl/invalid-config
+                     :key :token-ttl-seconds
+                     :value token-ttl-seconds})))
+  (when (and consistency-sync-timeout-ms
+             (not (and (integer? consistency-sync-timeout-ms)
+                       (pos? consistency-sync-timeout-ms))))
+    (throw (ex-info "EACL Config Error: :consistency-sync-timeout-ms must be positive."
+                    {:type :eacl/invalid-config
+                     :key :consistency-sync-timeout-ms
+                     :value consistency-sync-timeout-ms})))
+  (let [_ (journal/ensure-migrated! conn)
+        coherence-authority (or coherence-authority :unknown)
+        proof-mode (case (or proof-mode :auto)
+                     :auto (if (= :managed coherence-authority)
+                             :mutation
+                             :content)
+                     proof-mode)
+        current-kid (or security-kid :default)
+        root-keyring
+        (cond
+          security-keyring
+          (into {} (map (fn [[kid key]]
+                          [kid (secure/normalize-key key)]))
+                security-keyring)
+
+          security-key
+          {current-kid (secure/normalize-key security-key)}
+
+          :else
+          {:default secure/default-root-key})
+        _ (when-not (get root-keyring current-kid)
+            (throw (ex-info "EACL Config Error: :security-kid is absent from :security-keyring."
+                            {:type :eacl/invalid-config
+                             :key :security-kid
+                             :value current-kid})))
+        format-options {:current-kid current-kid
+                        :keyring root-keyring
+                        :token-ttl-seconds
+                        (or token-ttl-seconds
+                            mutation/default-token-ttl-seconds)}
         object-id->entid (fn [db object-id]
                            (ddb/entid db (object-id->lookup-ref object-id)))
+        custom-codec?
+        (boolean
+         (or entid->object-id
+             entity->object-id
+             (contains? config-opts :object-id->lookup-ref)))
+        cache-eligible? (or (not custom-codec?)
+                            (and (some? adapter-fingerprint)
+                                 (true? adapter-deterministic?)))
         entid->object-id (or entid->object-id
                              (when entity->object-id
                                (fn [db eid] (entity->object-id (d/entity db eid))))
                              (fn [db eid] (:eacl/id (d/entity db eid))))
         opts             {:object-id->lookup-ref object-id->lookup-ref
-                          :cache-stamp (fn []
-                                         [(:conn-id runtime-state)
-                                          @(:schema-stamp runtime-state)])
-                          :tx-stamp (:tx-stamp runtime-state)
-                          :permission-paths-cache (:permission-paths-cache runtime-state)
-                          :schema-catalog (fn [db]
-                                            (ensure-schema-catalog! runtime-state db))
+                          :conn conn
+                          :derived-schema-caches (atom {})
+                          :adapter-fingerprint
+                          (or adapter-fingerprint
+                              {:backend :datahike
+                               :adapter-version backend/adapter-version
+                               :proof-mode proof-mode
+                               :recursive-traversal-limits
+                               recursive-traversal-limits
+                               :codec
+                               (if custom-codec?
+                                 :custom-unfingerprinted
+                                 :eacl-id-immutable-v1)})
+                          :adapter-deterministic?
+                          (if custom-codec?
+                            (true? adapter-deterministic?)
+                            true)
                           :entid->object-id entid->object-id
                           :object-id->entid object-id->entid
                           :cursor-ttl-seconds cursor-ttl-seconds
-                          :cache-store (eacl.cache/cache-store cache)
+                          :format-options format-options
+                          :coherence-authority coherence-authority
+                          :proof-mode proof-mode
+                          :consistency-sync-timeout-ms
+                          (or consistency-sync-timeout-ms 30000)
+                          :token-ttl-seconds
+                          (or token-ttl-seconds
+                              mutation/default-token-ttl-seconds)
+                          :retention-grace-seconds
+                          (or retention-grace-seconds
+                              mutation/default-retention-grace-seconds)
+                          :cache-store
+                          (if cache-eligible?
+                            (eacl.cache/cache-store cache)
+                            eacl.cache/no-cache)
                           :recursive-traversal-limits
                           (engine/normalize-recursive-traversal-limits
                            recursive-traversal-limits)

--- a/modules/eacl-datahike/src/eacl/datahike/db.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/db.clj
@@ -53,24 +53,22 @@
   "Datoms of composite-tuple attribute `attr` (of `arity` components) whose
    value begins with `prefix`.
 
-   Two datahike facts make the obvious spelling silently wrong. A partial tuple
-   is not a valid seek bound: datahike sorts vectors length-first (as DataScript
-   does — Datomic is the outlier here), so a short bound lands at the head of
-   the whole attribute and the seek returns everything. Hence the pad to full
-   arity with `nil`, which sorts lowest and positions at the exact prefix. And
-   `seek-datoms` runs off the end of the attribute into the next one, hence the
-   `:a` guard rather than just a value check."
+   Restrict the scan to the exact AVET attribute first, then filter its tuple
+   values. Datahike 0.8.1759's `AsOfDB` delegates `seek-datoms` without applying
+   the temporal wrapper's seek context: a padded composite lower bound can skip
+   the wanted historical tuple and start in the following attribute. Exact
+   `datoms` does apply that context. Relation-definition cardinality is bounded
+   by the authorization schema, so this preserves correctness on temporal
+   snapshots without widening the scan to the database."
   [db attr arity prefix]
   (let [prefix (vec prefix)
-        n      (count prefix)
-        padded (into prefix (repeat (- arity n) nil))
-        a-repr (attr-repr db attr)]
-    (->> (d/seek-datoms db {:index :avet :components [attr padded]})
-         (take-while (fn [{:keys [a v]}]
-                       (and (= a-repr a)
-                            (vector? v)
-                            (<= n (count v))
-                            (= prefix (subvec v 0 n))))))))
+        n      (count prefix)]
+    (->> (d/datoms db {:index :avet :components [attr]})
+         (filter (fn [{:keys [v]}]
+                   (and (vector? v)
+                        (= arity (count v))
+                        (<= n arity)
+                        (= prefix (subvec v 0 n))))))))
 
 (defn avet-datoms
   "Datoms of `attr`, optionally restricted to an exact value."

--- a/modules/eacl-datahike/src/eacl/datahike/impl.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/impl.clj
@@ -186,6 +186,10 @@
     (when existing
       resolved)))
 
+(defn relationship-relation-id
+  [db relationship]
+  (:relation-id (resolve-relationship db relationship)))
+
 (defn- relationship-entity
   [resolved]
   {:eacl.relationship/subject-type  (:subject-type resolved)

--- a/modules/eacl-datahike/src/eacl/datahike/mutation.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/mutation.clj
@@ -1,0 +1,149 @@
+(ns eacl.datahike.mutation
+  "Datahike storage adapter for the shared mutation journal."
+  (:require [datahike.api :as d]
+            [eacl.datahike.db :as ddb]
+            [eacl.mutation :as mutation]))
+
+(defn graph-state
+  [db]
+  (when-let [entity (d/entity db [:eacl/id mutation/graph-entity-id])]
+    (let [family-id (get entity mutation/graph-family-id-attr)
+          head-id (get entity mutation/graph-head-id-attr)
+          order (get entity mutation/graph-head-order-attr)]
+      (when (and family-id head-id)
+        {:family-id family-id
+         :head-id head-id
+         :head-order (if (number? order) order (:db/id order))
+         :max-tx (:max-tx db)}))))
+
+(defn contains-anchor?
+  [db anchor]
+  (boolean (ddb/entid db [mutation/mutation-id-attr anchor])))
+
+(defn mutation-entity
+  [db mutation-id]
+  (some-> (d/entity db [mutation/mutation-id-attr mutation-id])
+          (select-keys
+           [mutation/mutation-id-attr
+            mutation/mutation-fingerprint-attr
+            mutation/mutation-kind-attr
+            mutation/mutation-issued-at-attr
+            mutation/mutation-expires-at-attr])))
+
+(defn relation-ids
+  [db]
+  (->> (d/q '[:find [?relation ...]
+               :where
+               [?relation :eacl.relation/relation-name]]
+             db)
+       sort
+       vec))
+
+(defn- native-tx-data
+  [db tx-data]
+  (mapv
+   (fn [op]
+     (if (and (vector? op)
+              (= :db.fn/cas (first op)))
+       (assoc op 2 (ddb/attr-repr db (nth op 2)))
+       op))
+   tx-data))
+
+(defn ensure-migrated!
+  [conn]
+  (or (graph-state (d/db conn))
+      (let [_ (d/transact conn [{:eacl/id mutation/graph-entity-id}])
+            db (d/db conn)
+            {:keys [tx-data]}
+            (mutation/migration-data
+             {:relation-ids (relation-ids db)
+              :family-id (mutation/new-id)
+              :order-value :db/current-tx})]
+        (try
+          (d/transact conn (native-tx-data db tx-data))
+          (catch Throwable error
+            (when-not (graph-state (d/db conn))
+              (throw error))))
+        (graph-state (d/db conn)))))
+
+(defn mutation-transaction-data
+  [db {:keys [mutation-id kind canonical-data relation-ids dependency-ids
+              schema-change?
+              token-ttl-seconds retention-grace-seconds]}]
+  (let [{:keys [family-id head-id]} (graph-state db)]
+    (mutation/transaction-data
+     {:mutation-id mutation-id
+      :kind kind
+      :canonical-data canonical-data
+      :relation-ids relation-ids
+      :dependency-ids dependency-ids
+      :schema-change? schema-change?
+      :order-value :db/current-tx
+      :family-id family-id
+      :previous-head-id head-id
+      :token-ttl-seconds token-ttl-seconds
+      :retention-grace-seconds retention-grace-seconds})))
+
+(defn transact!
+  [conn {:keys [mutation-id canonical-data tx-data] :as mutation-options}]
+  (ensure-migrated! conn)
+  (let [db (d/db conn)]
+    (if-let [stored (mutation-entity db mutation-id)]
+      (if (mutation/mutation-data-matches?
+           stored mutation-id canonical-data)
+        {:db-before db
+         :db-after db
+         :tx-data []
+         :mutation-id mutation-id
+         :idempotent-recovery? true}
+        (throw (ex-info "EACL mutation id was reused with different data."
+                        {:type :eacl.mutation/id-reused
+                         :mutation-id mutation-id})))
+      (assoc
+       (try
+         (d/transact
+         conn
+          (native-tx-data
+           db
+           (into (vec tx-data)
+                 (mutation-transaction-data db mutation-options))))
+         (catch Throwable error
+           (if-let [stored (mutation-entity (d/db conn) mutation-id)]
+             (if (mutation/mutation-data-matches?
+                  stored mutation-id canonical-data)
+               {:db-before db
+                :db-after (d/db conn)
+                :tx-data []
+                :mutation-id mutation-id
+                :idempotent-recovery? true}
+               (throw
+                (ex-info
+                 "EACL mutation id was reused with different data."
+                 {:type :eacl.mutation/id-reused
+                  :mutation-id mutation-id}
+                 error)))
+             (throw error))))
+       :mutation-id mutation-id))))
+
+(defn prune-expired!
+  [conn now]
+  (let [db (d/db conn)
+        current-head (:head-id (graph-state db))
+        expired
+        (d/q '[:find [?mutation ...]
+               :in $ ?now
+               :where
+               [?mutation :eacl.mutation/id ?id]
+               [?mutation :eacl.mutation/expires-at ?expiry]
+               [(< ?expiry ?now)]]
+             db now)
+        retractable
+        (remove #(= current-head
+                    (get (d/entity db %) mutation/mutation-id-attr))
+                expired)]
+    (when (seq retractable)
+      (d/transact
+       conn
+       (mapv (fn [entity-id] [:db/retractEntity entity-id])
+             retractable)))
+    (count retractable)))

--- a/modules/eacl-datahike/src/eacl/datahike/schema.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/schema.clj
@@ -1,6 +1,8 @@
 (ns eacl.datahike.schema
   (:require [datahike.api :as d]
             [eacl.datahike.db :as ddb]
+            [eacl.datahike.mutation :as journal]
+            [eacl.mutation :as mutation]
             [eacl.schema.model :as model]
             [eacl.spicedb.parser :as parser]))
 
@@ -84,6 +86,51 @@
     :db/index       true}
    {:db/ident       :eacl.permission/target-name
     :db/valueType   :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+
+   {:db/ident       :eacl.mutation/id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity
+    :db/index       true}
+   {:db/ident       :eacl.mutation/fingerprint
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.mutation/kind
+    :db/valueType   :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.mutation/issued-at
+    :db/valueType   :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.mutation/expires-at
+    :db/valueType   :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.graph/family-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.graph/head-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.graph/head-order
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :eacl.schema/mutation-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.relation/mutation-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.dependency/mutation-id
+    :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one
     :db/index       true}
 
@@ -277,7 +324,8 @@
   {:allow-empty-schema? true} to wipe intentionally."
   ([conn schema-string]
    (write-schema! conn schema-string {}))
-  ([conn schema-string {:keys [allow-empty-schema?]}]
+  ([conn schema-string
+    {:keys [allow-empty-schema? token-ttl-seconds retention-grace-seconds]}]
    (let [new-schema-map  (parser/->eacl-schema (parser/parse-schema schema-string))
          _               (validate-schema-references new-schema-map)
          db              (d/db conn)
@@ -301,19 +349,56 @@
            (throw (ex-info (str "Cannot delete relation " (:eacl.relation/relation-name rel)
                                 " because it is used by " cnt " relationships.")
                            {:relation rel :count cnt})))))
-     (d/transact conn
-                 (vec
-                  (concat
-                   (:additions relations)
-                   (:additions permissions)
-                   (for [rel relation-retractions
-                         :let [eid (ddb/entid db [:eacl/id (:eacl/id rel)])]
-                         :when eid]
-                     [:db/retractEntity eid])
-                   (for [perm permission-retractions
-                         :let [eid (ddb/entid db [:eacl/id (:eacl/id perm)])]
-                         :when eid]
-                     [:db/retractEntity eid])
-                   [{:eacl/id "schema-string"
-                     :eacl/schema-string schema-string}])))
-     deltas)))
+     (let [tx-data
+           (vec
+            (concat
+             (:additions relations)
+             (:additions permissions)
+             (for [rel relation-retractions
+                   :let [eid (ddb/entid db [:eacl/id (:eacl/id rel)])]
+                   :when eid]
+               [:db/retractEntity eid])
+             (for [perm permission-retractions
+                   :let [eid (ddb/entid db [:eacl/id (:eacl/id perm)])]
+                   :when eid]
+               [:db/retractEntity eid])
+             [{:eacl/id "schema-string"
+               :eacl/schema-string schema-string}]))
+           stored-string
+           (some-> (d/entity db [:eacl/id "schema-string"])
+                   :eacl/schema-string)
+           changed?
+           (or (not= stored-string schema-string)
+               (some seq
+                     [(:additions relations)
+                      (:retractions relations)
+                      (:additions permissions)
+                      (:retractions permissions)]))
+           mutation-id (mutation/new-id)
+           report
+           (if changed?
+             (journal/transact!
+              conn
+              {:mutation-id mutation-id
+               :kind :schema
+               :canonical-data
+               {:operation :write-schema
+                :schema-string schema-string
+                :deltas deltas}
+               :schema-change? true
+               :token-ttl-seconds token-ttl-seconds
+               :retention-grace-seconds retention-grace-seconds
+               :relation-ids
+               (mapv (fn [relation]
+                       [:eacl/id (:eacl/id relation)])
+                     (:additions relations))
+               :tx-data tx-data})
+             {:db-before db
+              :db-after db
+              :tx-data []
+              :mutation-id (:head-id (journal/ensure-migrated! conn))
+              :no-op? true})]
+       (assoc deltas
+              :eacl.mutation/id (:mutation-id report)
+              :eacl.mutation/db-after (:db-after report)
+              :eacl.mutation/no-op? (boolean (:no-op? report)))))))

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -1,0 +1,322 @@
+(ns eacl.datahike.consistency-v3-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [eacl.backend.v8 :as backend]
+            [eacl.core :as eacl]
+            [eacl.datahike.backend :as datahike-backend]
+            [eacl.datahike.core :as datahike]
+            [eacl.datahike.db :as ddb]
+            [eacl.spicedb.consistency :as consistency])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]
+           [java.util Date]))
+
+(def schema
+  "definition user {}
+   definition document {
+     relation reader: user
+     permission view = reader
+   }")
+
+(def security-key "01234567890123456789012345678901")
+(def user (eacl/spice-object :user "user"))
+(def document (eacl/spice-object :document "document"))
+(def relationship
+  (eacl/->Relationship user :reader document))
+
+(defn- client
+  [conn]
+  (datahike/make-client
+   conn
+   {:coherence-authority :managed
+    :security-key security-key
+    :consistency-sync-timeout-ms 5}))
+
+(defn- seed!
+  [conn authorization]
+  (eacl/write-schema! authorization schema)
+  (d/transact conn [{:eacl/id "user"}
+                    {:eacl/id "document"}]))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(deftest branch-refresh-exact-and-force-rewind-test
+  (let [conn (datahike/create-conn)
+        authorization (client conn)
+        _ (seed! conn authorization)
+        pre-write (d/db conn)
+        token
+        (:zed/token
+         (eacl/create-relationship! authorization relationship))]
+    (is (true?
+         (eacl/can?
+          authorization user :view document
+          (consistency/at-least-as-fresh token))))
+    (eacl/delete-relationship! authorization relationship)
+    (testing "retained commit reconstruction recovers the exact graph"
+      (is (true?
+           (eacl/can?
+            authorization user :view document
+            (consistency/at-exact-snapshot token)))))
+    (testing "force-moving the branch to a predecessor cannot pass by max-tx"
+      (d/force-branch!
+       pre-write
+       :db
+       #{(get-in pre-write [:meta :datahike/commit-id])})
+      ;; force-branch! deliberately makes existing writer connections stale.
+      ;; Reconnect before advancing the replacement history.
+      (d/release conn)
+      (let [rewound-conn (d/connect (:config pre-write))
+            rewound-authorization (client rewound-conn)]
+        (d/transact rewound-conn [{:eacl/id "unrelated"}])
+        (is (= :eacl.consistency/freshness-unavailable
+               (:type
+                (error-data
+                 #(eacl/can?
+                   rewound-authorization
+                   user
+                   :view
+                   document
+                   (consistency/at-least-as-fresh token))))))))))
+
+(deftest configuration-specific-head-and-history-capabilities-test
+  (let [conn (datahike/create-conn)
+        authorization (client conn)
+        adapter
+        (datahike-backend/snapshot-adapter
+         (d/db conn)
+         (:opts authorization))]
+    (is (backend/supports?
+         adapter :consistency :fully-consistent))
+    (is (backend/supports?
+         adapter :consistency :at-exact-snapshot))
+    (let [streaming-db
+          (assoc-in (d/db conn)
+                    [:config :writer]
+                    {:backend :stream})]
+      (is (not
+           (backend/supports?
+            (datahike-backend/snapshot-adapter
+             streaming-db (:opts authorization))
+            :consistency :fully-consistent)))))
+  (let [conn
+        (datahike/create-conn
+         nil
+         {:commit-graph? false
+          :keep-history? false})
+        authorization (client conn)
+        adapter
+        (datahike-backend/snapshot-adapter
+         (d/db conn)
+         (:opts authorization))]
+    (is (not
+         (backend/supports?
+          adapter :consistency :at-exact-snapshot)))))
+
+(deftest reader-branch-and-merge-metadata-test
+  (let [writer-conn (datahike/create-conn)
+        config (:config (d/db writer-conn))
+        reader-conn (d/connect config)
+        writer (client writer-conn)
+        reader (client reader-conn)
+        _ (seed! writer-conn writer)
+        token
+        (:zed/token
+         (eacl/create-relationship! writer relationship))]
+    (testing "another direct-store connection refreshes to the token anchor"
+      (is (true?
+           (eacl/can?
+            reader user :view document
+            (consistency/at-least-as-fresh token)))))
+    (d/branch! writer-conn :db :feature)
+    (let [feature-conn
+          (d/connect (assoc config :branch :feature))
+          feature (client feature-conn)
+          feature-commit
+          (str
+           (get-in (d/db feature-conn)
+                   [:meta :datahike/commit-id]))]
+      (testing "branch scope is authenticated even when the initial commit is shared"
+        (is (= :eacl.consistency/incomparable-scope
+               (:type
+                (error-data
+                 #(eacl/can?
+                   feature user :view document
+                   (consistency/at-least-as-fresh token)))))))
+      (d/merge-db
+       writer-conn
+       #{:feature}
+       [{:db/id -1 :db/doc "unrelated merge metadata"}])
+      (let [adapter
+            (datahike-backend/snapshot-adapter
+             (d/db writer-conn)
+             (:opts writer))]
+        (is (= [feature-commit]
+               (:parent-commit-ids (backend/state adapter)))))
+      (d/release feature-conn))
+    (d/release reader-conn)
+    (d/release writer-conn)))
+
+(deftest content-proofs-are-bounded-and-cover-public-identity-test
+  (let [conn (datahike/create-conn)
+        authorization
+        (datahike/make-client
+         conn
+         {:coherence-authority :managed
+          :proof-mode :content
+          :security-key security-key})
+        _ (seed! conn authorization)
+        _ (eacl/create-relationship! authorization relationship)
+        before-adapter
+        (datahike-backend/snapshot-adapter
+         (d/db conn) (:opts authorization))
+        relation-id
+        (:relation-id
+         (first
+          (backend/invoke
+           before-adapter :relation-defs :document :reader)))
+        schema-proof (backend/invoke before-adapter :schema-proof)
+        before-proof
+        (backend/invoke before-adapter :relation-proof [relation-id])
+        user-eid (ddb/entid (d/db conn) [:eacl/id "user"])]
+    (is (= #{:content-digest} (set (keys schema-proof))))
+    (is (= 43 (count (:content-digest schema-proof))))
+    (is (= #{:content-digest} (set (keys before-proof))))
+    (is (= 43 (count (:content-digest before-proof))))
+    (d/transact conn [[:db/retract user-eid :eacl/id "user"]
+                      [:db/add user-eid :eacl/id "renamed-user"]])
+    (let [after-adapter
+          (datahike-backend/snapshot-adapter
+           (d/db conn) (:opts authorization))
+          after-proof
+          (backend/invoke after-adapter :relation-proof [relation-id])]
+      (is (not= before-proof after-proof)))
+    (d/release conn)))
+
+(deftest temporal-fallback-and-commit-garbage-collection-test
+  (testing "history can reconstruct exact state when the commit graph is off"
+    (let [conn
+          (datahike/create-conn
+           nil
+           {:commit-graph? false
+            :keep-history? true})
+          authorization (client conn)
+          _ (seed! conn authorization)
+          token
+          (:zed/token
+           (eacl/create-relationship! authorization relationship))]
+      (eacl/delete-relationship! authorization relationship)
+      (is (true?
+           (eacl/can?
+            authorization user :view document
+            (consistency/at-exact-snapshot token))))
+      (d/release conn)))
+  (testing "collected commit history expires exact, not causal anchor membership"
+    ;; Datahike 0.8.1759's in-memory konserve backend cannot mark its
+    ;; persistent-set roots (`:flush-before-marking`). Exercise the public GC
+    ;; contract on the file backend, where the persisted roots are flushable.
+    (let [temp-dir
+          (Files/createTempDirectory
+           "eacl-datahike-gc-"
+           (make-array FileAttribute 0))
+          conn
+          (datahike/create-conn
+           nil
+           {:store {:backend :file
+                    :path (str temp-dir "/db")}})
+          config (:config (d/db conn))
+          authorization (client conn)
+          _ (seed! conn authorization)
+          token
+          (:zed/token
+           (eacl/create-relationship! authorization relationship))]
+      (try
+        (eacl/delete-relationship! authorization relationship)
+        (is (true?
+             (eacl/can?
+              authorization user :view document
+              (consistency/at-exact-snapshot token))))
+        @(d/gc-storage conn (Date. (+ 1000 (System/currentTimeMillis))))
+        (is (= :eacl.consistency/exact-snapshot-unavailable
+               (:type
+                (error-data
+                 #(eacl/can?
+                   authorization user :view document
+                   (consistency/at-exact-snapshot token))))))
+        (is (false?
+             (eacl/can?
+              authorization user :view document
+              (consistency/at-least-as-fresh token))))
+        (finally
+          (d/release conn)
+          (d/delete-database config))))))
+
+(deftest relationship-cursor-proof-equivalence-and-exact-fallback-test
+  (let [conn (datahike/create-conn)
+        authorization (client conn)
+        _ (eacl/write-schema! authorization schema)
+        _ (d/transact conn [{:eacl/id "user"}
+                            {:eacl/id "doc-a"}
+                            {:eacl/id "doc-b"}
+                            {:eacl/id "doc-c"}])
+        documents
+        (mapv #(eacl/spice-object :document %)
+              ["doc-a" "doc-b" "doc-c"])
+        relationships
+        (mapv #(eacl/->Relationship user :reader %) documents)
+        _ (doseq [value relationships]
+            (eacl/create-relationship! authorization value))
+        query {:subject/id "user" :first 1}
+        page-1 (eacl/read-relationships authorization query)
+        cursor (get-in page-1 [:page-info :end-cursor])
+        cursor-data
+        (datahike/token->cursor cursor (:opts authorization))]
+    (try
+      (d/transact conn [{:eacl/id "unrelated-cursor-churn"}])
+      (testing "an equal complete result proof rebases to the current commit"
+        (let [page-2
+              (eacl/read-relationships
+               authorization
+               (assoc query :after cursor))
+              rebased
+              (datahike/token->cursor
+               (get-in page-2 [:page-info :end-cursor])
+               (:opts authorization))]
+          (is (= [(second relationships)] (:data page-2)))
+          (is (< (get-in cursor-data [:graph-head :order-hint])
+                 (get-in rebased [:graph-head :order-hint])))))
+      (let [fresh-page-1
+            (eacl/read-relationships authorization query)
+            fresh-cursor
+            (get-in fresh-page-1 [:page-info :end-cursor])
+            delete-token
+            (:zed/token
+             (eacl/delete-relationship!
+              authorization
+              (second relationships)))]
+        (testing "a changed proof falls back to the retained original commit"
+          (is (= [(second relationships)]
+                 (:data
+                  (eacl/read-relationships
+                   authorization
+                   (assoc query :after fresh-cursor))))))
+        (testing "a newer at-least floor forbids exact fallback"
+          (is (= :eacl.consistency/cursor-consistency-conflict
+                 (:type
+                  (error-data
+                   #(eacl/read-relationships
+                     authorization
+                     (assoc
+                      query
+                      :after fresh-cursor
+                      :consistency
+                      (consistency/at-least-as-fresh
+                       delete-token)))))))))
+      (finally
+        (d/release conn)))))

--- a/modules/eacl-datahike/test/eacl/datahike/mutation_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/mutation_test.clj
@@ -1,0 +1,191 @@
+(ns eacl.datahike.mutation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [eacl.causal-token :as causal-token]
+            [eacl.core :as eacl]
+            [eacl.datahike.core :as datahike]
+            [eacl.datahike.db :as ddb]
+            [eacl.datahike.mutation :as journal]
+            [eacl.datahike.schema :as schema]
+            [eacl.mutation :as mutation]
+            [eacl.schema.model :as model]))
+
+(def test-schema
+  "definition user {}
+   definition folder {
+     relation owner: user
+     relation viewer: user
+     permission view = owner + viewer
+   }")
+
+(def security-key
+  "01234567890123456789012345678901")
+
+(defn- relation-eid
+  [db relation-name]
+  (ddb/entid
+   db
+   [:eacl/id
+    (model/->relation-id :folder relation-name :user)]))
+
+(deftest managed-writes-publish-one-committed-mutation-test
+  (let [conn (schema/create-conn)
+        client (datahike/make-client
+                conn
+                {:coherence-authority :managed
+                 :security-key security-key})
+        schema-result (eacl/write-schema! client test-schema)
+        first-payload
+        (causal-token/token-data
+         (get-in client [:opts :format-options])
+         (:zed/token schema-result))
+        first-head (:head-id (journal/graph-state (d/db conn)))
+        no-op-result (eacl/write-schema! client test-schema)
+        no-op-payload
+        (causal-token/token-data
+         (get-in client [:opts :format-options])
+         (:zed/token no-op-result))]
+    (testing "schema tokens name the committed graph head and branch"
+      (is (= first-head (:graph-anchor first-payload)))
+      (is (= (:max-tx (d/db conn)) (:order-hint first-payload)))
+      (is (= :db (:branch first-payload))))
+    (testing "a schema no-op keeps the graph head"
+      (is (= first-head (:head-id (journal/graph-state (d/db conn)))))
+      (is (= first-head (:graph-anchor no-op-payload))))
+
+    (d/transact conn [{:eacl/id "user-1"}
+                      {:eacl/id "folder-1"}
+                      {:eacl/id "folder-2"}])
+    (let [write-result
+          (eacl/create-relationships!
+           client
+           [(eacl/->Relationship
+             (eacl/spice-object :user "user-1")
+             :owner
+             (eacl/spice-object :folder "folder-1"))
+            (eacl/->Relationship
+             (eacl/spice-object :user "user-1")
+             :viewer
+             (eacl/spice-object :folder "folder-2"))])
+          db (d/db conn)
+          owner-stamp
+          (get (d/entity db (relation-eid db :owner))
+               mutation/relation-mutation-id-attr)
+          viewer-stamp
+          (get (d/entity db (relation-eid db :viewer))
+               mutation/relation-mutation-id-attr)
+          payload
+          (causal-token/token-data
+           (get-in client [:opts :format-options])
+           (:zed/token write-result))]
+      (testing "one batch stamps both affected relation identities"
+        (is (= owner-stamp viewer-stamp))
+        (is (= owner-stamp (:graph-anchor payload))))
+      (let [delete-result
+            (eacl/delete-object!
+             client
+             (eacl/spice-object :user "user-1"))
+            db-after (d/db conn)
+            owner-delete-stamp
+            (get (d/entity db-after (relation-eid db-after :owner))
+                 mutation/relation-mutation-id-attr)
+            viewer-delete-stamp
+            (get (d/entity db-after (relation-eid db-after :viewer))
+                 mutation/relation-mutation-id-attr)
+            delete-payload
+            (causal-token/token-data
+             (get-in client [:opts :format-options])
+             (:zed/token delete-result))]
+        (testing "cascade deletion stamps every affected relation"
+          (is (= owner-delete-stamp viewer-delete-stamp))
+          (is (not= owner-stamp owner-delete-stamp))
+          (is (= owner-delete-stamp
+                 (:graph-anchor delete-payload))))))))
+
+(deftest cross-connection-writer-and-migration-race-test
+  (let [conn-1 (schema/create-conn)
+        _ (d/transact
+           conn-1
+           [{:eacl/id "legacy-relation"
+             :eacl.relation/relation-name :member}])
+        config (:config (d/db conn-1))
+        conn-2 (d/connect config)
+        attempts
+        (doall
+         (for [conn [conn-1 conn-2]]
+           (future (journal/ensure-migrated! conn))))
+        states (mapv deref attempts)
+        state (journal/graph-state (d/db conn-1))]
+    (is (every? #(= (:family-id state) (:family-id %)) states))
+    (is (every? #(= (:head-id state) (:head-id %)) states))
+    (is (= (:head-id state)
+           (get (d/entity (d/db conn-1)
+                          [:eacl/id "legacy-relation"])
+                mutation/relation-mutation-id-attr)))
+    (let [first-id (mutation/new-id)
+          second-id (mutation/new-id)]
+      (journal/transact!
+       conn-1
+       {:mutation-id first-id
+        :kind :custom
+        :canonical-data {:writer 1}
+        :tx-data []})
+      (journal/transact!
+       conn-2
+       {:mutation-id second-id
+        :kind :custom
+        :canonical-data {:writer 2}
+        :tx-data []})
+      (is (journal/contains-anchor? (d/db conn-1) first-id))
+      (is (journal/contains-anchor? (d/db conn-1) second-id))
+      (is (= second-id
+             (:head-id (journal/graph-state (d/db conn-1))))))))
+
+(deftest idempotency-custom-dependency-and-expiry-test
+  (let [conn (schema/create-conn)
+        _ (journal/ensure-migrated! conn)
+        _ (d/transact conn [{:eacl/id "identity-1"}])
+        mutation-id (mutation/new-id)
+        options
+        {:mutation-id mutation-id
+         :kind :caveat-input
+         :canonical-data {:operation :caveat-input
+                          :id "identity-1"
+                          :value true}
+         :dependency-ids [[:eacl/id "identity-1"]]
+         :token-ttl-seconds 1
+         :retention-grace-seconds 0
+         :tx-data [[:db/add
+                    [:eacl/id "identity-1"]
+                    :eacl/schema-string
+                    "true"]]}
+        report (journal/transact! conn options)
+        recovered (journal/transact! conn options)]
+    (is (not (:idempotent-recovery? report)))
+    (is (true? (:idempotent-recovery? recovered)))
+    (is (= mutation-id
+           (get (d/entity (d/db conn) [:eacl/id "identity-1"])
+                mutation/dependency-mutation-id-attr)))
+    (is (= :eacl.mutation/id-reused
+           (try
+             (journal/transact!
+              conn
+              (assoc options :canonical-data {:different true}))
+             nil
+             (catch clojure.lang.ExceptionInfo error
+               (:type (ex-data error))))))
+    (let [old-head (:head-id (journal/graph-state (d/db conn)))
+          next-id (mutation/new-id)]
+      (journal/transact!
+       conn
+       {:mutation-id next-id
+        :kind :custom
+        :canonical-data {:operation :next}
+        :token-ttl-seconds 1
+        :retention-grace-seconds 0
+        :tx-data []})
+      (is (pos? (journal/prune-expired!
+                 conn
+                 (+ 2 (mutation/now-seconds)))))
+      (is (false? (journal/contains-anchor? (d/db conn) old-head)))
+      (is (true? (journal/contains-anchor? (d/db conn) next-id))))))

--- a/modules/eacl-datascript/README.md
+++ b/modules/eacl-datascript/README.md
@@ -13,13 +13,16 @@ Responsibilities:
 - DataScript schema installation and canonical schema storage
 - DataScript SPI implementation for CLJ and CLJS
 - current immutable-snapshot selection and object/reference conversion
-- snapshot-bound opaque Relay cursors
-- database-visible schema and relation cache proofs
-- portable authorization caching and recursive continuations
+- proof-equivalent authenticated Relay cursors with optional exact fallback
+- database-visible mutation identities plus schema/relation content proofs
+- portable authenticated completed-answer caching
 - DataScript contract tests and adapter-specific edge cases
 
-Only `:fully-consistent` current-snapshot reads are supported. Unsupported
-consistency or historical promises fail with `:eacl/unsupported-capability`.
+DataScript supports serialized connection-head `:fully-consistent`, local
+`:minimize-latency`, and managed causal at-least selection. Exact selection is
+advertised only when `:exact-snapshot-registry-size` configures a bounded
+immutable-DB registry. It does not claim an external replication mechanism.
+Unsupported configuration/mode combinations fail before authorization.
 The v7 `:limit`/`:cursor` API is replaced by v8 `:first`/`:after` and
 `:last`/`:before`; see the
 [upgrade guide](../../docs/v8-backend-modules-and-upgrade.md).

--- a/modules/eacl-datascript/src/eacl/datascript/backend.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/backend.cljc
@@ -3,15 +3,67 @@
   (:require [datascript.core :as ds]
             [eacl.backend.v8 :as backend]
             [eacl.datascript.impl :as impl]
-            [eacl.datascript.schema :as schema]))
+            [eacl.datascript.mutation :as journal]
+            [eacl.datascript.schema :as schema]
+            [eacl.mutation :as mutation]
+            [eacl.secure-format :as secure]))
 
 (def capabilities
-  {:consistency #{:fully-consistent}
-   :snapshots #{:current}
+  {:consistency #{:fully-consistent
+                  :minimize-latency
+                  :at-least-as-fresh
+                  :at-exact-snapshot}
+   :snapshots #{:current :authoritative :causal}
+   :source #{:stable-scope :graph-head :anchor-membership :order-hint}
    :cursor #{:forward :reverse :opaque}
    :transactions #{:schema :relationships :object-deletion}
    :cache-proofs #{:schema :relations :snapshot-bound :database-visible}
    :runtime #{:clj :cljs}})
+
+(defn- freshness-timeout!
+  [token-data timeout-ms observed]
+  (throw
+   (ex-info
+    "DataScript connection did not acquire the requested mutation anchor."
+    {:type :eacl.consistency/freshness-unavailable
+     :eacl/error :eacl.consistency/freshness-unavailable
+     :reason :freshness-timeout
+     :requested-order-hint (:order-hint token-data)
+     :observed-order-hint (:max-tx observed)
+     :timeout-ms timeout-ms})))
+
+(defn- await-anchor-db
+  [conn fallback token-data timeout-ms]
+  (let [timeout-ms (or timeout-ms 30000)]
+    #?(:clj
+       (let [deadline (+ (System/nanoTime)
+                         (* 1000000 timeout-ms))]
+         (loop []
+           (let [candidate (if conn (ds/db conn) fallback)]
+             (cond
+               (journal/contains-anchor?
+                candidate (:graph-anchor token-data))
+               candidate
+
+               (>= (System/nanoTime) deadline)
+               (freshness-timeout!
+                token-data timeout-ms candidate)
+
+               :else
+               (do
+                 (Thread/sleep 2)
+                 (recur))))))
+       :cljs
+       (let [candidate (if conn (ds/db conn) fallback)]
+         (if (journal/contains-anchor?
+              candidate (:graph-anchor token-data))
+           candidate
+           ;; A synchronous browser API cannot yield to an asynchronous writer
+           ;; while preserving this call's return type. It therefore reports
+           ;; the unavailable floor immediately rather than busy-waiting and
+           ;; pretending to provide replication.
+           (freshness-timeout!
+            token-data timeout-ms candidate))))))
 
 (defn- normalized-permission
   [permission]
@@ -42,7 +94,7 @@
     (cond->> (filter within-bound? ordered)
       (= :desc direction) reverse)))
 
-(defn- schema-proof
+(defn- schema-proof-records
   [db {:keys [permission-nodes relation-ids] :as scope}]
   (let [{:keys [relation-defs permission-defs]}
         (impl/build-schema-catalog db)
@@ -54,110 +106,242 @@
         (if scope
           (mapcat #(get permission-defs % []) permission-nodes)
           (mapcat identity (vals permission-defs)))]
-    {:relations
+    (concat
      (->> scoped-relations
-          (sort-by (juxt :resource-type :relation-name :subject-type))
-          vec)
-     :permissions
+          (map (fn [relation]
+                 [:relation
+                  (:relation-id relation)
+                  (:resource-type relation)
+                  (:relation-name relation)
+                  (:subject-type relation)]))
+          sort)
      (->> scoped-permissions
           (map normalized-permission)
-          (sort-by (juxt :resource-type
-                         :permission-name
-                         :source-relation-name
-                         :target-type
-                         :target-name))
-          vec)}))
+          (map (fn [permission]
+                 [:permission
+                  (:permission-id permission)
+                  (:resource-type permission)
+                  (:permission-name permission)
+                  (:source-relation-name permission)
+                  (:target-type permission)
+                  (:target-name permission)]))
+          sort))))
 
-(defn- relation-proof
-  [db relation-ids]
+(defn- content-schema-proof
+  [db scope]
+  {:content-digest
+   (secure/canonical-records-digest
+    "eacl/datascript/schema-content-proof/v3"
+    (schema-proof-records db scope))})
+
+(defn- content-relation-proof
+  [db relation-ids external-id]
   (let [wanted (set relation-ids)]
-    (->> (ds/q '[:find ?relation ?subject-type ?subject
-                 ?resource-type ?resource
-                 :where
-                 [?relationship :eacl.relationship/relation ?relation]
-                 [?relationship :eacl.relationship/subject-type ?subject-type]
-                 [?relationship :eacl.relationship/subject ?subject]
-                 [?relationship :eacl.relationship/resource-type ?resource-type]
-                 [?relationship :eacl.relationship/resource ?resource]]
-               db)
-         (filter #(contains? wanted (nth % 0)))
-         sort
-         vec)))
+    {:content-digest
+     (secure/canonical-records-digest
+      "eacl/datascript/relationship-content-proof/v3"
+      (->> (ds/q '[:find ?relation ?subject-type ?subject
+                   ?resource-type ?resource
+                   :where
+                   [?relationship :eacl.relationship/relation ?relation]
+                   [?relationship :eacl.relationship/subject-type ?subject-type]
+                   [?relationship :eacl.relationship/subject ?subject]
+                   [?relationship :eacl.relationship/resource-type ?resource-type]
+                   [?relationship :eacl.relationship/resource ?resource]]
+                 db)
+           (filter #(contains? wanted (nth % 0)))
+           sort
+           (map (fn [[relation subject-type subject
+                      resource-type resource]]
+                  [:relationship relation
+                   subject-type subject (external-id db subject)
+                   resource-type resource (external-id db resource)]))))}))
+
+(defn- mutation-schema-proof
+  [db]
+  (some-> (ds/entity db [:eacl/id mutation/schema-entity-id])
+          (get mutation/schema-mutation-id-attr)))
+
+(defn- mutation-relation-proof
+  [db relation-ids]
+  (let [proof
+        (mapv (fn [relation-id]
+                [relation-id
+                 (get (ds/entity db relation-id)
+                      mutation/relation-mutation-id-attr)])
+              (sort relation-ids))]
+    (when (every? (comp some? second) proof)
+      proof)))
+
+(defn remember-snapshot!
+  [registry limit db]
+  (when registry
+    (let [handle (:head-id (journal/graph-state db))]
+      (swap! registry
+             (fn [{:keys [order snapshots]}]
+               (if (contains? snapshots handle)
+                 {:order order :snapshots snapshots}
+                 (let [order' (conj (vec order) handle)
+                       snapshots' (assoc snapshots handle db)
+                       overflow (- (count order') limit)
+                       evicted (when (pos? overflow)
+                                 (take overflow order'))]
+                   {:order (if (pos? overflow)
+                             (vec (drop overflow order'))
+                             order')
+                    :snapshots (apply dissoc snapshots' evicted)})))))
+    db))
 
 (defn snapshot-adapter
   "Creates a v8 adapter bound to one immutable DataScript db value."
-  [db {:keys [object-id->entid entid->object-id]}]
-  (backend/make-adapter
-   {:id :datascript
-    :capabilities capabilities
-    :state {:db db}
-    :operations
-    {:snapshot-id
-     (fn []
-       {:database-id :datascript
-        :basis-t (:max-tx db)})
+  [db {:keys [object-id->entid entid->object-id conn
+              coherence-authority proof-mode exact-registry]
+       :or {proof-mode :content}
+       :as opts}]
+  (let [_ (when exact-registry
+            (remember-snapshot!
+             exact-registry
+             (:exact-registry-limit opts)
+             db))]
+    (backend/make-adapter
+     {:id :datascript
+      :fingerprint (:adapter-fingerprint opts)
+      :deterministic? (:adapter-deterministic? opts)
+      :identity-contract
+      (:identity-contract opts
+                          :selected-internal/current-external-v1)
+      :capabilities
+      (cond-> capabilities
+        (not= :managed coherence-authority)
+        (update :consistency disj :at-least-as-fresh :at-exact-snapshot)
 
-     :object-id->internal
-     (fn [object-id]
-       (if (number? object-id)
-         object-id
-         (object-id->entid db object-id)))
+        (nil? exact-registry)
+        (update :consistency disj :at-exact-snapshot))
+      :state {:db db}
+      :operations
+      {:snapshot-id
+       (fn []
+         {:database-id :datascript
+          :basis-t (:max-tx db)})
 
-     :internal-id->object
-     (fn [internal-id]
-       (entid->object-id db internal-id))
+       :source-scope
+       (fn []
+         {:source-id (:family-id (journal/graph-state db))
+          :branch nil})
 
-     :relation-defs
-     (fn [resource-type relation-name]
-       (mapv (fn [{:keys [e v]}]
-               {:relation-id e
-                :resource-type resource-type
-                :relation-name relation-name
-                :subject-type (nth v 2)})
-             (impl/relation-datoms db resource-type relation-name)))
+       :graph-head
+       (fn []
+         {:graph-anchor (:head-id (journal/graph-state db))
+          :order-hint (:max-tx db)
+          :exact-locator
+          (when exact-registry
+            (:head-id (journal/graph-state db)))})
 
-     :permission-defs
-     (fn [resource-type permission-name]
-       (mapv normalized-permission
-             (impl/find-permission-defs
-              db resource-type permission-name)))
+       :contains-anchor?
+       (fn [anchor]
+         (journal/contains-anchor? db anchor))
 
-     :subject->resources
-     (fn [subject-type subject-id relation-id resource-type options]
-       (apply-scan-window
-        (impl/subject->resources
-         db subject-type subject-id relation-id resource-type nil)
-        options))
+       :order-hint (fn [] (:max-tx db))
 
-     :resource->subjects
-     (fn [resource-type resource-id relation-id subject-type options]
-       (apply-scan-window
-        (impl/resource->subjects
-         db resource-type resource-id relation-id subject-type nil)
-        options))
+       :select-current
+       (fn []
+         (snapshot-adapter (if conn (ds/db conn) db) opts))
 
-     :direct-match?
-     (fn [subject-type subject-id relation-id resource-type resource-id]
-       (boolean
-        (ds/entid
-         db
-         [schema/relationship-full-key-attr
-          [subject-type subject-id relation-id resource-type resource-id]])))
+       :select-authoritative
+       (fn [_timeout-ms]
+         (snapshot-adapter (if conn (ds/db conn) db) opts))
 
-     :all-permission-nodes
-     (fn []
-       (->> (ds/datoms
-             db :avet :eacl.permission/resource-type+permission-name)
-            (map :v)
-            set))
+       :select-at-least
+       (fn [token-data timeout-ms]
+         (snapshot-adapter
+          (await-anchor-db conn db token-data timeout-ms)
+          opts))
 
-     :frontier-key pr-str
+       :exact-locator
+       (fn []
+         (when exact-registry
+           (:head-id (journal/graph-state db))))
 
-     :schema-proof
-     (fn
-       ([] (schema-proof db nil))
-       ([scope] (schema-proof db scope)))
+       :select-exact
+       (fn [token-data _timeout-ms]
+         (some-> exact-registry
+                 deref
+                 :snapshots
+                 (get (:exact-locator token-data))
+                 (snapshot-adapter opts)))
 
-     :relation-proof
-     (fn [relation-ids]
-       (relation-proof db relation-ids))}}))
+       :object-id->internal
+       (fn [object-id]
+         (if (number? object-id)
+           object-id
+           (object-id->entid db object-id)))
+
+       :internal-id->object
+       (fn [internal-id]
+         (entid->object-id db internal-id))
+
+       :relation-defs
+       (fn [resource-type relation-name]
+         (mapv (fn [{:keys [e v]}]
+                 {:relation-id e
+                  :resource-type resource-type
+                  :relation-name relation-name
+                  :subject-type (nth v 2)})
+               (impl/relation-datoms db resource-type relation-name)))
+
+       :permission-defs
+       (fn [resource-type permission-name]
+         (mapv normalized-permission
+               (impl/find-permission-defs
+                db resource-type permission-name)))
+
+       :subject->resources
+       (fn [subject-type subject-id relation-id resource-type options]
+         (apply-scan-window
+          (impl/subject->resources
+           db subject-type subject-id relation-id resource-type nil)
+          options))
+
+       :resource->subjects
+       (fn [resource-type resource-id relation-id subject-type options]
+         (apply-scan-window
+          (impl/resource->subjects
+           db resource-type resource-id relation-id subject-type nil)
+          options))
+
+       :direct-match?
+       (fn [subject-type subject-id relation-id resource-type resource-id]
+         (boolean
+          (ds/entid
+           db
+           [schema/relationship-full-key-attr
+            [subject-type subject-id relation-id resource-type resource-id]])))
+
+       :all-permission-nodes
+       (fn []
+         (->> (ds/datoms
+               db :avet :eacl.permission/resource-type+permission-name)
+              (map :v)
+              set))
+
+       :frontier-key pr-str
+
+       :schema-proof
+       (fn
+         ([]
+          (case proof-mode
+            :mutation (mutation-schema-proof db)
+            :content (content-schema-proof db nil)
+            nil))
+         ([scope]
+          (case proof-mode
+            :mutation (mutation-schema-proof db)
+            :content (content-schema-proof db scope)
+            nil)))
+
+       :relation-proof
+       (fn [relation-ids]
+         (case proof-mode
+           :mutation (mutation-relation-proof db relation-ids)
+           :content (content-relation-proof db relation-ids entid->object-id)
+           nil))}})))

--- a/modules/eacl-datascript/src/eacl/datascript/core.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/core.cljc
@@ -3,6 +3,8 @@
             [datascript.core :as ds]
             [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
+            [eacl.causal-token :as causal-token]
+            [eacl.consistency :as consistency-v3]
             [eacl.cursor :as cursor]
             [eacl.core :as eacl :refer [IAuthorization
                                         spice-object
@@ -11,11 +13,14 @@
                                         map->Relationship]]
             [eacl.datascript.backend :as datascript-backend]
             [eacl.datascript.impl :as impl]
+            [eacl.datascript.mutation :as journal]
             [eacl.datascript.schema :as schema]
             [eacl.engine.v8 :as engine]
+            [eacl.mutation :as mutation]
             [eacl.relay :as relay]
             [eacl.relationships.filters :as relationship-filters]
             [eacl.relationships.relay :as relationship-relay]
+            [eacl.secure-format :as secure]
             [eacl.spicedb.consistency :as consistency]))
 
 (def cursor->token cursor/cursor->token)
@@ -92,9 +97,20 @@
   [db opts]
   (datascript-backend/snapshot-adapter db opts))
 
-(defn- require-consistency!
-  [adapter value]
-  (backend/require-consistency! adapter value))
+(defn- selected-context
+  [db opts consistency-value]
+  (let [selection
+        (consistency-v3/select
+         (snapshot-adapter db opts)
+         consistency-value
+         {:format-options (:format-options opts)
+          :coherence-authority (:coherence-authority opts)
+          :issue-token? true
+          :timeout-ms (:consistency-sync-timeout-ms opts)})
+        adapter (:adapter selection)]
+    {:adapter adapter
+     :db (:db (backend/state adapter))
+     :selection selection}))
 
 (defn- permission-dependencies
   [adapter resource-type permission]
@@ -108,22 +124,71 @@
        adapter resource-type permission)
       :relation-ids relation-ids}}))
 
+(defn- cursor-options
+  [adapter opts selection resource-type permission]
+  (binding [engine/*schema-cache*
+            (engine/schema-cache-for!
+             (:derived-schema-caches opts)
+             adapter)]
+    (assoc opts
+           :cursor-dependencies
+           (permission-dependencies
+            adapter resource-type permission)
+           :cursor-consistency-mode
+           (get-in selection [:descriptor :mode])
+           :timeout-ms (:consistency-sync-timeout-ms opts))))
+
+(defn- page-context
+  [adapter opts selection operation query resource-type permission]
+  (let [current-opts
+        (cursor-options
+         adapter opts selection resource-type permission)
+        page-adapter
+        (relay/select-continuation-adapter
+         adapter current-opts operation query)
+        page-opts
+        (cursor-options
+         page-adapter opts selection resource-type permission)]
+    {:adapter page-adapter
+     :db (:db (backend/state page-adapter))
+     :opts page-opts}))
+
+(defn- pagination-snapshot-context
+  [adapter]
+  {:source-scope
+   {:backend (backend/backend-id adapter)
+    :scope (backend/invoke adapter :source-scope)}
+   :graph-head (backend/invoke adapter :graph-head)
+   :adapter-fingerprint (backend/fingerprint adapter)
+   :identity-contract (backend/identity-contract adapter)})
+
 (defn- cached-engine-result
   [adapter opts operation query resource-type permission
    valid-value? compute]
-  (let [{:keys [schema-scope relation-ids]}
-        (permission-dependencies adapter resource-type permission)]
-    (binding [engine/*recursive-traversal-limits*
-              (:recursive-traversal-limits opts)]
+  (binding [engine/*schema-cache*
+            (engine/schema-cache-for!
+             (:derived-schema-caches opts)
+             adapter)
+            engine/*recursive-traversal-limits*
+            (:recursive-traversal-limits opts)]
+    (let [{:keys [schema-scope relation-ids]}
+          (permission-dependencies adapter resource-type permission)]
       (cache/resolve!
        adapter
        (:cache-store opts)
-       [operation query]
+       {:operation operation
+        :query query
+        :engine-version engine/engine-version
+        :adapter-fingerprint (:adapter-fingerprint opts)
+        :proof-mode (:proof-mode opts)
+        :recursive-traversal-limits
+        (:recursive-traversal-limits opts)}
        operation
        schema-scope
        relation-ids
        valid-value?
-       compute))))
+       compute
+       (:format-options opts)))))
 
 (defn- with-cache-info
   [value {:keys [cached? cache-basis]}]
@@ -134,56 +199,66 @@
 (defn datascript-read-relationships
   [db
    {:as opts
-    :keys [object-id->entid
+   :keys [object-id->entid
            internal-cursor->spice
            spice-cursor->internal]}
    filters]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency filters))
+  (let [{selected-db :db adapter :adapter selection :selection}
+        (selected-context db opts (:consistency filters))
         base-filters (apply dissoc filters
                             [:first :last :after :before :consistency])
         _ (relationship-filters/validate! base-filters)
-        subject-id   (:subject/id base-filters)
-        resource-id  (:resource/id filters)
-        subject-eid  (when subject-id (object-id->entid db subject-id))
-        resource-eid (when resource-id (object-id->entid db resource-id))
-        missing-id?  (or (and subject-id (nil? subject-eid))
-                         (and resource-id (nil? resource-eid)))]
-    (if missing-id?
-      relay/empty-page
-      (let [filters' (cond-> base-filters
-                       subject-id (assoc :subject/id subject-eid)
-                       resource-id (assoc :resource/id resource-eid))
-            internal-relationships
-            (loop [cursor nil
-                   result []]
-              (let [page
-                    (impl/read-relationships
-                     db
-                     (cond-> (assoc filters' :limit 10000)
-                       cursor (assoc :cursor cursor)))
-                    result' (into result (:data page))
-                    next-cursor (:cursor page)]
-                (if (and next-cursor
-                         (not= cursor next-cursor)
-                         (seq (:data page)))
-                  (recur next-cursor result')
-                  result')))
-            public-relationships
-            (->> internal-relationships
-                 (sort-by
-                  (fn [{:keys [subject relation resource]}]
-                    [(:type subject) (:id subject)
-                     relation
-                     (:type resource) (:id resource)]))
-                 (map #(relationship->spice db opts %))
-                 vec)]
-        (relationship-relay/paginate
-         opts
-         :read-relationships
-         filters
-         (backend/invoke adapter :snapshot-id)
-         public-relationships)))))
+        items-for-adapter
+        (fn [page-adapter]
+          (let [page-db (:db (backend/state page-adapter))
+                subject-id (:subject/id base-filters)
+                resource-id (:resource/id base-filters)
+                subject-eid (when subject-id
+                              (object-id->entid page-db subject-id))
+                resource-eid (when resource-id
+                               (object-id->entid page-db resource-id))]
+            (if (or (and subject-id (nil? subject-eid))
+                    (and resource-id (nil? resource-eid)))
+              []
+              (let [filters'
+                    (cond-> base-filters
+                      subject-id (assoc :subject/id subject-eid)
+                      resource-id (assoc :resource/id resource-eid))
+                    internal-relationships
+                    (loop [cursor nil
+                           result []]
+                      (let [page
+                            (impl/read-relationships
+                             page-db
+                             (cond-> (assoc filters' :limit 10000)
+                               cursor (assoc :cursor cursor)))
+                            result' (into result (:data page))
+                            next-cursor (:cursor page)]
+                        (if (and next-cursor
+                                 (not= cursor next-cursor)
+                                 (seq (:data page)))
+                          (recur next-cursor result')
+                          result')))]
+                (->> internal-relationships
+                     (map #(relationship->spice page-db opts %))
+                     (sort-by
+                      (fn [{:keys [subject relation resource]}]
+                        [(:type subject) (:id subject)
+                         relation
+                         (:type resource) (:id resource)]))
+                     vec)))))
+        cursor-opts
+        (assoc opts
+               :cursor-consistency-mode
+               (get-in selection [:descriptor :mode])
+               :relationship-adapter adapter
+               :relationship-items-for-adapter items-for-adapter)]
+    (relationship-relay/paginate
+     cursor-opts
+     :read-relationships
+     filters
+     (pagination-snapshot-context adapter)
+     (items-for-adapter adapter))))
 
 (defn spice-relationship->internal
   [db {:keys [spice-object->internal]} {:keys [subject relation resource]}]
@@ -191,23 +266,64 @@
    :relation relation
    :resource (spice-object->internal db resource)})
 
+(defn- response-token
+  [db opts]
+  (when (= :managed (:coherence-authority opts))
+    (let [adapter (snapshot-adapter db opts)]
+      (causal-token/issue
+       (:format-options opts)
+       (merge
+        {:backend :datascript}
+        (backend/invoke adapter :source-scope)
+        (backend/invoke adapter :graph-head))))))
+
+(defn- write-response
+  [db opts]
+  (if-let [token (response-token db opts)]
+    {:zed/token token}
+    {}))
+
 (defn datascript-write-relationships!
   [conn opts updates]
   (let [db      (ds/db conn)
-        tx-stamp (:tx-stamp opts)
-        tx-data (->> updates
-                     (S/transform [S/ALL :relationship]
-                                  #(spice-relationship->internal db opts %))
+        internal-updates
+        (S/transform [S/ALL :relationship]
+                     #(spice-relationship->internal db opts %)
+                     updates)
+        relation-ids
+        (->> internal-updates
+             (map (comp #(impl/relationship-relation-id db %)
+                        :relationship))
+             distinct
+             vec)
+        tx-data (->> internal-updates
                      (mapcat #(impl/tx-update-relationship db %))
-                     (remove nil?))]
-    (when (seq tx-data)
-      (ds/transact! conn tx-data))
-    {:zed/token (str @tx-stamp)}))
+                     (remove nil?)
+                     vec)]
+    (if (seq tx-data)
+      (let [mutation-id (mutation/new-id)
+            report
+            (journal/transact!
+             conn
+             {:mutation-id mutation-id
+              :kind :relationships
+              :canonical-data
+              {:operation :write-relationships
+               :updates internal-updates}
+              :relation-ids relation-ids
+              :token-ttl-seconds (:token-ttl-seconds opts)
+              :retention-grace-seconds
+              (:retention-grace-seconds opts)
+              :tx-data tx-data})]
+        (write-response (:db-after report) opts))
+      (do
+        (journal/ensure-migrated! conn)
+        (write-response (ds/db conn) opts)))))
 
 (defn datascript-delete-object!
   "Removes every relationship that references `object`, without retracting the
   object entity itself."
-  [conn {:keys [object->entid tx-stamp]} object]
+  [conn {:keys [object->entid] :as opts} object]
   (let [db (ds/db conn)]
     (when-let [object-eid (object->entid db object)]
       (let [relationship-eids
@@ -216,13 +332,32 @@
                     :where
                     (or [?relationship :eacl.relationship/subject ?object]
                         [?relationship :eacl.relationship/resource ?object])]
-                  db object-eid)]
+                  db object-eid)
+            relation-ids
+            (ds/q '[:find [?relation ...]
+                    :in $ [?relationship ...]
+                    :where
+                    [?relationship :eacl.relationship/relation ?relation]]
+                  db relationship-eids)]
         (when (seq relationship-eids)
-          (ds/transact! conn
-                        (mapv (fn [relationship-eid]
-                                [:db/retractEntity relationship-eid])
-                              relationship-eids))))))
-  {:zed/token (str @tx-stamp)})
+          (journal/transact!
+           conn
+           {:mutation-id (mutation/new-id)
+            :kind :object-deletion
+            :canonical-data
+            {:operation :delete-object
+             :object object
+            :relationship-eids (vec (sort relationship-eids))}
+            :relation-ids relation-ids
+            :token-ttl-seconds (:token-ttl-seconds opts)
+            :retention-grace-seconds
+            (:retention-grace-seconds opts)
+            :tx-data
+            (mapv (fn [relationship-eid]
+                    [:db/retractEntity relationship-eid])
+                  relationship-eids)})))))
+  (journal/ensure-migrated! conn)
+  (write-response (ds/db conn) opts))
 
 (defn- relationship-seq
   [relationships]
@@ -233,16 +368,18 @@
 (defn datascript-can?
   [db {:keys [spice-object->internal] :as opts}
    subject permission resource consistency]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter consistency)
-        internal-subject (spice-object->internal db subject)
-        internal-resource (spice-object->internal db resource)]
+  (let [{selected-db :db adapter :adapter}
+        (selected-context db opts consistency)
+        internal-subject (spice-object->internal selected-db subject)
+        internal-resource (spice-object->internal selected-db resource)]
     (if-not (and (:id internal-subject) (:id internal-resource))
       false
       (:value
        (cached-engine-result
         adapter opts :can?
-        [internal-subject permission internal-resource]
+        {:public [subject permission resource]
+         :internal
+         [internal-subject permission internal-resource]}
         (:type internal-resource)
         permission
         boolean?
@@ -252,34 +389,40 @@
 (defn datascript-lookup-resources
   [db
    {:as opts
-    :keys [spice-object->internal
+   :keys [spice-object->internal
            entid->object-id
            object-id->lookup-ref
            internal-cursor->spice
            spice-cursor->internal]}
    {:as query :keys [subject]}]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-subject (spice-object->internal db subject)]
+  (let [{source-adapter :adapter selection :selection}
+        (selected-context db opts (:consistency query))
+        {adapter :adapter selected-db :db cursor-opts :opts}
+        (page-context
+         source-adapter opts selection :lookup-resources query
+         (:resource/type query) (:permission query))
+        internal-subject (spice-object->internal selected-db subject)]
     (if (nil? (:id internal-subject))
       (assoc relay/empty-page :cached? false :cache-basis nil)
       (let [internal-query
             (-> query
                 (dissoc :consistency)
                 (#(relay/internalize-page-query
-                   adapter opts :lookup-resources %))
+                   adapter cursor-opts :lookup-resources %))
                 (assoc :subject internal-subject))
             answer
             (cached-engine-result
-             adapter opts :lookup-resources internal-query
+             adapter cursor-opts :lookup-resources
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:resource/type internal-query)
              (:permission internal-query)
              #(and (map? %) (vector? (:data %))
                    (map? (:page-info %)))
              #(engine/lookup-resources adapter internal-query))]
         (with-cache-info
-          (relay/externalize-page
-           adapter opts :lookup-resources query (:value answer))
+           (relay/externalize-page
+           adapter cursor-opts :lookup-resources query (:value answer))
           answer)))))
 
 (defn datascript-count-resources
@@ -289,9 +432,9 @@
            spice-cursor->internal
            internal-cursor->spice]}
    {:as query :keys [subject]}]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-subject (spice-object->internal db subject)]
+  (let [{selected-db :db adapter :adapter selection :selection}
+        (selected-context db opts (:consistency query))
+        internal-subject (spice-object->internal selected-db subject)]
     (if-not (:id internal-subject)
       (assoc
        (cond-> {:count 0 :limit (or (:count-limit query) -1)}
@@ -303,7 +446,9 @@
                 (dissoc :consistency))
             answer
             (cached-engine-result
-             adapter opts :count-resources internal-query
+             adapter opts :count-resources
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:resource/type internal-query)
              (:permission internal-query)
              #(and (map? %) (integer? (:count %)))
@@ -318,9 +463,14 @@
            spice-cursor->internal
            internal-cursor->spice]}
    query]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-resource (spice-object->internal db (:resource query))]
+  (let [{source-adapter :adapter selection :selection}
+        (selected-context db opts (:consistency query))
+        {adapter :adapter selected-db :db cursor-opts :opts}
+        (page-context
+         source-adapter opts selection :lookup-subjects query
+         (:type (:resource query)) (:permission query))
+        internal-resource
+        (spice-object->internal selected-db (:resource query))]
     (when (contains? query :subject/relation)
       (throw (ex-info ":subject/relation is not supported by lookup-subjects."
                       {:eacl/error :eacl.pagination/unsupported-filter
@@ -331,19 +481,21 @@
             (-> query
                 (dissoc :consistency)
                 (#(relay/internalize-page-query
-                   adapter opts :lookup-subjects %))
+                   adapter cursor-opts :lookup-subjects %))
                 (assoc :resource internal-resource))
             answer
             (cached-engine-result
-             adapter opts :lookup-subjects internal-query
+             adapter cursor-opts :lookup-subjects
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:type (:resource internal-query))
              (:permission internal-query)
              #(and (map? %) (vector? (:data %))
                    (map? (:page-info %)))
              #(engine/lookup-subjects adapter internal-query))]
         (with-cache-info
-          (relay/externalize-page
-           adapter opts :lookup-subjects query (:value answer))
+           (relay/externalize-page
+           adapter cursor-opts :lookup-subjects query (:value answer))
           answer)))))
 
 (defn datascript-count-subjects
@@ -353,9 +505,10 @@
            spice-cursor->internal
            internal-cursor->spice]}
    query]
-  (let [adapter (snapshot-adapter db opts)
-        _ (require-consistency! adapter (:consistency query))
-        internal-resource (spice-object->internal db (:resource query))]
+  (let [{selected-db :db adapter :adapter}
+        (selected-context db opts (:consistency query))
+        internal-resource
+        (spice-object->internal selected-db (:resource query))]
     (if-not (:id internal-resource)
       (assoc
        (cond-> {:count 0 :limit (or (:count-limit query) -1)}
@@ -367,7 +520,9 @@
                 (dissoc :consistency))
             answer
             (cached-engine-result
-             adapter opts :count-subjects internal-query
+             adapter opts :count-subjects
+             {:public (dissoc query :consistency)
+              :internal internal-query}
              (:type (:resource internal-query))
              (:permission internal-query)
              #(and (map? %) (integer? (:count %)))
@@ -387,7 +542,14 @@
   (read-schema [_]
     (schema/read-schema (ds/db conn)))
   (write-schema! [_ schema-string]
-    (schema/write-schema! conn schema-string))
+    (let [result
+          (schema/write-schema!
+           conn schema-string
+           (select-keys opts
+                        [:token-ttl-seconds
+                         :retention-grace-seconds]))]
+      (merge result
+             (write-response (:eacl.mutation/db-after result) opts))))
 
   (read-relationships [_ filters]
     (datascript-read-relationships (ds/db conn) opts filters))
@@ -440,56 +602,6 @@
                     {:type :eacl/not-implemented
                      :method (quote expand-permission-tree)}))))
 
-(defonce runtime-state-registry (atom {}))
-
-(defn- schema-transaction?
-  [tx-report]
-  (boolean
-   (some (fn [{:keys [a]}]
-           (contains? schema/schema-change-attrs a))
-         (:tx-data tx-report))))
-
-(defn- reset-schema-derived-state!
-  [state]
-  (swap! (:schema-stamp state) inc)
-  (reset! (:permission-paths-cache state) {})
-  (reset! (:schema-catalog state) nil))
-
-(defn ensure-runtime-state!
-  [conn]
-  (if-let [state (get @runtime-state-registry conn)]
-    state
-    (let [state {:conn-id (random-uuid)
-                 :tx-stamp (atom 0)
-                 :schema-stamp (atom 0)
-                 :permission-paths-cache (atom {})
-                 :schema-catalog (atom nil)
-                 :listener-key (keyword (str "eacl-stamp-" (random-uuid)))}]
-      (ds/listen! conn
-                  (:listener-key state)
-                  (fn [tx-report]
-                    (swap! (:tx-stamp state) inc)
-                    (when (schema-transaction? tx-report)
-                      (reset-schema-derived-state! state))))
-      (get (swap! runtime-state-registry
-                  #(if (contains? % conn) % (assoc % conn state)))
-           conn))))
-
-(defn- ensure-schema-catalog!
-  [state db]
-  (let [schema-stamp @(:schema-stamp state)
-        cached       @(:schema-catalog state)]
-    (if (= schema-stamp (:schema-stamp cached))
-      (:catalog cached)
-      (let [catalog (impl/build-schema-catalog db)]
-        (-> (swap! (:schema-catalog state)
-                   (fn [entry]
-                     (if (= schema-stamp (:schema-stamp entry))
-                       entry
-                       {:schema-stamp schema-stamp
-                        :catalog      catalog})))
-            :catalog)))))
-
 (def ^:private known-client-opt-keys
   #{:entid->object-id
     :entity->object-id
@@ -498,7 +610,18 @@
     :spice-cursor->internal
     :cursor-ttl-seconds
     :cache
-    :recursive-traversal-limits})
+    :recursive-traversal-limits
+    :security-key
+    :security-keyring
+    :security-kid
+    :token-ttl-seconds
+    :retention-grace-seconds
+    :coherence-authority
+    :proof-mode
+    :adapter-fingerprint
+    :adapter-deterministic?
+    :consistency-sync-timeout-ms
+    :exact-snapshot-registry-size})
 
 (defn make-client
   "Builds an IAuthorization client over a DataScript conn.
@@ -519,7 +642,18 @@
            spice-cursor->internal
            cursor-ttl-seconds
            cache
-           recursive-traversal-limits]
+           recursive-traversal-limits
+           security-key
+           security-keyring
+           security-kid
+           token-ttl-seconds
+           retention-grace-seconds
+           coherence-authority
+           proof-mode
+           adapter-fingerprint
+           adapter-deterministic?
+           consistency-sync-timeout-ms
+           exact-snapshot-registry-size]
     :or   {object-id->lookup-ref  (fn [obj-id] [:eacl/id obj-id])
            internal-cursor->spice default-internal-cursor->spice
            spice-cursor->internal default-spice-cursor->internal}}]
@@ -533,25 +667,146 @@
     (throw (ex-info "EACL Config Error: supply only one of :entid->object-id (canonical) or :entity->object-id (deprecated alias)."
                     {:type :eacl/invalid-config
                      :conflicting-keys [:entid->object-id :entity->object-id]})))
-  (let [runtime-state   (ensure-runtime-state! conn)
+  (when (and security-key security-keyring)
+    (throw (ex-info "EACL Config Error: supply only one of :security-key or :security-keyring."
+                    {:type :eacl/invalid-config
+                     :conflicting-keys [:security-key :security-keyring]})))
+  (when-not (contains? #{nil :unknown :managed} coherence-authority)
+    (throw (ex-info "EACL Config Error: :coherence-authority must be :managed or :unknown."
+                    {:type :eacl/invalid-config
+                     :key :coherence-authority
+                     :value coherence-authority})))
+  (when-not (contains? #{nil :auto :mutation :content :none} proof-mode)
+    (throw (ex-info "EACL Config Error: unsupported :proof-mode."
+                    {:type :eacl/invalid-config
+                     :key :proof-mode
+                     :value proof-mode})))
+  (when (and (= :mutation proof-mode)
+             (not= :managed coherence-authority))
+    (throw (ex-info "EACL Config Error: mutation proof requires managed writer authority."
+                    {:type :eacl/invalid-config
+                     :key :proof-mode
+                     :value proof-mode})))
+  (when (and (contains? config-opts :adapter-deterministic?)
+             (not (boolean? adapter-deterministic?)))
+    (throw (ex-info "EACL Config Error: :adapter-deterministic? must be boolean."
+                    {:type :eacl/invalid-config
+                     :key :adapter-deterministic?
+                     :value adapter-deterministic?})))
+  (when adapter-fingerprint
+    (try
+      (secure/encode-canonical adapter-fingerprint)
+      (catch #?(:clj Exception :cljs :default) error
+        (throw (ex-info "EACL Config Error: :adapter-fingerprint must be portable canonical data."
+                        {:type :eacl/invalid-config
+                         :key :adapter-fingerprint}
+                        error)))))
+  (when (and token-ttl-seconds
+             (not (and (integer? token-ttl-seconds)
+                       (pos? token-ttl-seconds))))
+    (throw (ex-info "EACL Config Error: :token-ttl-seconds must be positive."
+                    {:type :eacl/invalid-config
+                     :key :token-ttl-seconds
+                     :value token-ttl-seconds})))
+  (when (and consistency-sync-timeout-ms
+             (not (and (integer? consistency-sync-timeout-ms)
+                       (pos? consistency-sync-timeout-ms))))
+    (throw (ex-info "EACL Config Error: :consistency-sync-timeout-ms must be positive."
+                    {:type :eacl/invalid-config
+                     :key :consistency-sync-timeout-ms
+                     :value consistency-sync-timeout-ms})))
+  (when (and exact-snapshot-registry-size
+             (not (and (integer? exact-snapshot-registry-size)
+                       (pos? exact-snapshot-registry-size))))
+    (throw (ex-info "EACL Config Error: :exact-snapshot-registry-size must be positive."
+                    {:type :eacl/invalid-config
+                     :key :exact-snapshot-registry-size
+                     :value exact-snapshot-registry-size})))
+  (let [_ (journal/ensure-migrated! conn)
+        coherence-authority (or coherence-authority :unknown)
+        proof-mode (case (or proof-mode :auto)
+                     :auto (if (= :managed coherence-authority)
+                             :mutation
+                             :content)
+                     proof-mode)
+        current-kid (or security-kid :default)
+        root-keyring
+        (cond
+          security-keyring
+          (into {} (map (fn [[kid key]]
+                          [kid (secure/normalize-key key)]))
+                security-keyring)
+
+          security-key
+          {current-kid (secure/normalize-key security-key)}
+
+          :else
+          {:default secure/default-root-key})
+        _ (when-not (get root-keyring current-kid)
+            (throw (ex-info "EACL Config Error: :security-kid is absent from :security-keyring."
+                            {:type :eacl/invalid-config
+                             :key :security-kid
+                             :value current-kid})))
+        format-options {:current-kid current-kid
+                        :keyring root-keyring
+                        :token-ttl-seconds
+                        (or token-ttl-seconds
+                            mutation/default-token-ttl-seconds)}
         object-id->entid (fn [db object-id]
                            (ds/entid db (object-id->lookup-ref object-id)))
+        custom-codec?
+        (boolean
+         (or entid->object-id
+             entity->object-id
+             (contains? config-opts :object-id->lookup-ref)))
+        cache-eligible? (or (not custom-codec?)
+                            (and (some? adapter-fingerprint)
+                                 (true? adapter-deterministic?)))
         entid->object-id (or entid->object-id
                              (when entity->object-id
                                (fn [db eid] (entity->object-id (ds/entity db eid))))
                              (fn [db eid] (:eacl/id (ds/entity db eid))))
         opts             {:object-id->lookup-ref object-id->lookup-ref
-                          :cache-stamp (fn []
-                                         [(:conn-id runtime-state)
-                                          @(:schema-stamp runtime-state)])
-                          :tx-stamp (:tx-stamp runtime-state)
-                          :permission-paths-cache (:permission-paths-cache runtime-state)
-                          :schema-catalog (fn [db]
-                                            (ensure-schema-catalog! runtime-state db))
+                          :conn conn
+                          :derived-schema-caches (atom {})
+                          :adapter-fingerprint
+                          (or adapter-fingerprint
+                              {:backend :datascript
+                               :adapter-version backend/adapter-version
+                               :proof-mode proof-mode
+                               :recursive-traversal-limits
+                               recursive-traversal-limits
+                               :codec
+                               (if custom-codec?
+                                 :custom-unfingerprinted
+                                 :eacl-id-immutable-v1)})
+                          :adapter-deterministic?
+                          (if custom-codec?
+                            (true? adapter-deterministic?)
+                            true)
                           :entid->object-id entid->object-id
                           :object-id->entid object-id->entid
                           :cursor-ttl-seconds cursor-ttl-seconds
-                          :cache-store (eacl.cache/cache-store cache)
+                          :format-options format-options
+                          :coherence-authority coherence-authority
+                          :proof-mode proof-mode
+                          :consistency-sync-timeout-ms
+                          (or consistency-sync-timeout-ms 30000)
+                          :exact-registry
+                          (when exact-snapshot-registry-size
+                            (atom {:order [] :snapshots {}}))
+                          :exact-registry-limit
+                          exact-snapshot-registry-size
+                          :token-ttl-seconds
+                          (or token-ttl-seconds
+                              mutation/default-token-ttl-seconds)
+                          :retention-grace-seconds
+                          (or retention-grace-seconds
+                              mutation/default-retention-grace-seconds)
+                          :cache-store
+                          (if cache-eligible?
+                            (eacl.cache/cache-store cache)
+                            eacl.cache/no-cache)
                           :recursive-traversal-limits
                           (engine/normalize-recursive-traversal-limits
                            recursive-traversal-limits)

--- a/modules/eacl-datascript/src/eacl/datascript/impl.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/impl.cljc
@@ -202,6 +202,10 @@
     (when existing
       resolved)))
 
+(defn relationship-relation-id
+  [db relationship]
+  (:relation-id (resolve-relationship db relationship)))
+
 (defn tx-update-relationship
   [db {:keys [operation relationship]}]
   (let [resolved  (resolve-relationship db relationship)

--- a/modules/eacl-datascript/src/eacl/datascript/mutation.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/mutation.cljc
@@ -1,0 +1,155 @@
+(ns eacl.datascript.mutation
+  "DataScript storage adapter for the shared mutation journal."
+  (:require [datascript.core :as ds]
+            [eacl.mutation :as mutation]))
+
+(defn graph-state
+  [db]
+  (when-let [entity (ds/entity db [:eacl/id mutation/graph-entity-id])]
+    (let [family-id (get entity mutation/graph-family-id-attr)
+          head-id (get entity mutation/graph-head-id-attr)
+          order
+          (ds/q '[:find ?order .
+                  :in $ ?graph-id
+                  :where
+                  [?graph :eacl/id ?graph-id]
+                  [?graph :eacl.graph/head-order ?order]]
+                db mutation/graph-entity-id)]
+      (when (and family-id head-id)
+        {:family-id family-id
+         :head-id head-id
+         :head-order order
+         :max-tx (:max-tx db)}))))
+
+(defn contains-anchor?
+  [db anchor]
+  (boolean (ds/entid db [mutation/mutation-id-attr anchor])))
+
+(defn mutation-entity
+  [db mutation-id]
+  (some-> (ds/entity db [mutation/mutation-id-attr mutation-id])
+          (select-keys
+           [mutation/mutation-id-attr
+            mutation/mutation-fingerprint-attr
+            mutation/mutation-kind-attr
+            mutation/mutation-issued-at-attr
+            mutation/mutation-expires-at-attr])))
+
+(defn relation-ids
+  [db]
+  (->> (ds/q '[:find [?relation ...]
+                :where
+                [?relation :eacl.relation/relation-name]]
+              db)
+       sort
+       vec))
+
+(defn ensure-migrated!
+  [conn]
+  (or (graph-state (ds/db conn))
+      (let [_ (ds/transact! conn [{:eacl/id mutation/graph-entity-id}])
+            db (ds/db conn)
+            family-id (mutation/new-id)
+            {:keys [tx-data]}
+            (mutation/migration-data
+             {:relation-ids (relation-ids db)
+              :family-id family-id
+              :order-value nil})]
+        (try
+          (ds/transact!
+           conn
+           (conj (vec tx-data)
+                 [:db/add
+                  [:eacl/id mutation/graph-entity-id]
+                  mutation/graph-head-order-attr
+                  :db/current-tx]))
+          (catch #?(:clj Throwable :cljs :default) error
+            (when-not (graph-state (ds/db conn))
+              (throw error))))
+        (graph-state (ds/db conn)))))
+
+(defn mutation-transaction-data
+  [db {:keys [mutation-id kind canonical-data relation-ids dependency-ids
+              schema-change?
+              token-ttl-seconds retention-grace-seconds]}]
+  (let [{:keys [family-id head-id]} (graph-state db)]
+    (conj
+     (mutation/transaction-data
+      {:mutation-id mutation-id
+       :kind kind
+       :canonical-data canonical-data
+       :relation-ids relation-ids
+       :dependency-ids dependency-ids
+       :schema-change? schema-change?
+       :order-value nil
+       :family-id family-id
+       :previous-head-id head-id
+       :token-ttl-seconds token-ttl-seconds
+       :retention-grace-seconds retention-grace-seconds})
+     [:db/add
+      [:eacl/id mutation/graph-entity-id]
+      mutation/graph-head-order-attr
+      :db/current-tx])))
+
+(defn transact!
+  "Submits a logical mutation exactly once for one caller-supplied mutation id."
+  [conn {:keys [mutation-id canonical-data tx-data] :as mutation-options}]
+  (ensure-migrated! conn)
+  (let [db (ds/db conn)]
+    (if-let [stored (mutation-entity db mutation-id)]
+      (if (mutation/mutation-data-matches?
+           stored mutation-id canonical-data)
+        {:db-before db
+         :db-after db
+         :tx-data []
+         :mutation-id mutation-id
+         :idempotent-recovery? true}
+        (throw (ex-info "EACL mutation id was reused with different data."
+                        {:type :eacl.mutation/id-reused
+                         :mutation-id mutation-id})))
+      (let [report
+            (try
+              (ds/transact!
+               conn
+               (into (vec tx-data)
+                     (mutation-transaction-data db mutation-options)))
+              (catch #?(:clj Throwable :cljs :default) error
+                (if-let [stored (mutation-entity (ds/db conn) mutation-id)]
+                  (if (mutation/mutation-data-matches?
+                       stored mutation-id canonical-data)
+                    {:db-before db
+                     :db-after (ds/db conn)
+                     :tx-data []
+                     :mutation-id mutation-id
+                     :idempotent-recovery? true}
+                    (throw
+                     (ex-info
+                      "EACL mutation id was reused with different data."
+                      {:type :eacl.mutation/id-reused
+                       :mutation-id mutation-id}
+                      error)))
+                  (throw error))))]
+        (assoc report :mutation-id mutation-id)))))
+
+(defn prune-expired!
+  [conn now]
+  (let [db (ds/db conn)
+        current-head (:head-id (graph-state db))
+        expired
+        (ds/q '[:find [?mutation ...]
+                :in $ ?now
+                :where
+                [?mutation :eacl.mutation/id ?id]
+                [?mutation :eacl.mutation/expires-at ?expiry]
+                [(< ?expiry ?now)]]
+              db now)
+        retractable
+        (remove #(= current-head
+                    (get (ds/entity db %) mutation/mutation-id-attr))
+                expired)]
+    (when (seq retractable)
+      (ds/transact!
+       conn
+       (mapv (fn [entity-id] [:db/retractEntity entity-id])
+             retractable)))
+    (count retractable)))

--- a/modules/eacl-datascript/src/eacl/datascript/schema.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/schema.cljc
@@ -1,5 +1,7 @@
 (ns eacl.datascript.schema
   (:require [datascript.core :as ds]
+            [eacl.datascript.mutation :as journal]
+            [eacl.mutation :as mutation]
             [eacl.schema.model :as model]
             [eacl.spicedb.parser :as parser]))
 
@@ -66,6 +68,20 @@
                     :eacl.permission/target-name
                     :eacl.permission/permission-name]
     :db/unique :db.unique/identity}
+
+   :eacl.mutation/id
+   {:db/unique :db.unique/identity
+    :db/index true}
+   :eacl.mutation/fingerprint {:db/index true}
+   :eacl.mutation/kind {:db/index true}
+   :eacl.mutation/issued-at {:db/index true}
+   :eacl.mutation/expires-at {:db/index true}
+   :eacl.graph/family-id {:db/index true}
+   :eacl.graph/head-id {:db/index true}
+   :eacl.graph/head-order {:db/valueType :db.type/ref}
+   :eacl.schema/mutation-id {:db/index true}
+   :eacl.relation/mutation-id {:db/index true}
+   :eacl.dependency/mutation-id {:db/index true}
 
    :eacl.relationship/subject {:db/valueType :db.type/ref}
    :eacl.relationship/relation {:db/valueType :db.type/ref}
@@ -183,7 +199,8 @@
   {:allow-empty-schema? true} to wipe intentionally."
   ([conn schema-string]
    (write-schema! conn schema-string {}))
-  ([conn schema-string {:keys [allow-empty-schema?]}]
+  ([conn schema-string
+    {:keys [allow-empty-schema? token-ttl-seconds retention-grace-seconds]}]
    (let [new-schema-map  (parser/->eacl-schema (parser/parse-schema schema-string))
          _               (validate-schema-references new-schema-map)
          db              (ds/db conn)
@@ -207,18 +224,56 @@
            (throw (ex-info (str "Cannot delete relation " (:eacl.relation/relation-name rel)
                                 " because it is used by " cnt " relationships.")
                            {:relation rel :count cnt})))))
-     (ds/transact! conn
-                   (concat
-                    (:additions relations)
-                    (:additions permissions)
-                    (for [rel relation-retractions
-                          :let [eid (ds/entid db [:eacl/id (:eacl/id rel)])]
-                          :when eid]
-                      [:db/retractEntity eid])
-                    (for [perm permission-retractions
-                          :let [eid (ds/entid db [:eacl/id (:eacl/id perm)])]
-                          :when eid]
-                      [:db/retractEntity eid])
-                    [{:eacl/id "schema-string"
-                      :eacl/schema-string schema-string}]))
-     deltas)))
+     (let [tx-data
+           (vec
+            (concat
+             (:additions relations)
+             (:additions permissions)
+             (for [rel relation-retractions
+                   :let [eid (ds/entid db [:eacl/id (:eacl/id rel)])]
+                   :when eid]
+               [:db/retractEntity eid])
+             (for [perm permission-retractions
+                   :let [eid (ds/entid db [:eacl/id (:eacl/id perm)])]
+                   :when eid]
+               [:db/retractEntity eid])
+             [{:eacl/id "schema-string"
+               :eacl/schema-string schema-string}]))
+           stored-string
+           (some-> (ds/entity db [:eacl/id "schema-string"])
+                   :eacl/schema-string)
+           changed?
+           (or (not= stored-string schema-string)
+               (some seq
+                     [(:additions relations)
+                      (:retractions relations)
+                      (:additions permissions)
+                      (:retractions permissions)]))
+           mutation-id (mutation/new-id)
+           report
+           (if changed?
+             (journal/transact!
+              conn
+              {:mutation-id mutation-id
+               :kind :schema
+               :canonical-data
+               {:operation :write-schema
+                :schema-string schema-string
+                :deltas deltas}
+               :schema-change? true
+               :token-ttl-seconds token-ttl-seconds
+               :retention-grace-seconds retention-grace-seconds
+               :relation-ids
+               (mapv (fn [relation]
+                       [:eacl/id (:eacl/id relation)])
+                     (:additions relations))
+               :tx-data tx-data})
+             {:db-before db
+              :db-after db
+              :tx-data []
+              :mutation-id (:head-id (journal/ensure-migrated! conn))
+              :no-op? true})]
+       (assoc deltas
+              :eacl.mutation/id (:mutation-id report)
+              :eacl.mutation/db-after (:db-after report)
+              :eacl.mutation/no-op? (boolean (:no-op? report)))))))

--- a/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
+++ b/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
@@ -1,8 +1,15 @@
 (ns eacl.datascript.cljs-test-runner
   (:require [cljs.nodejs :as nodejs]
             [cljs.test :as t]
+            [eacl.backend.v8-test]
             [eacl.cache-test]
-            [eacl.datascript.contract-test]))
+            [eacl.causal-model-test]
+            [eacl.consistency-test]
+            [eacl.mutation-test]
+            [eacl.secure-format-test]
+            [eacl.datascript.consistency-v3-test]
+            [eacl.datascript.contract-test]
+            [eacl.datascript.mutation-test]))
 
 (nodejs/enable-util-print!)
 
@@ -16,7 +23,14 @@
     (js/process.exit failures)))
 
 (defn -main []
-  (t/run-tests 'eacl.cache-test
-               'eacl.datascript.contract-test))
+  (t/run-tests 'eacl.backend.v8-test
+               'eacl.cache-test
+               'eacl.causal-model-test
+               'eacl.consistency-test
+               'eacl.mutation-test
+               'eacl.secure-format-test
+               'eacl.datascript.consistency-v3-test
+               'eacl.datascript.contract-test
+               'eacl.datascript.mutation-test))
 
 (set! *main-cli-fn* -main)

--- a/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
@@ -1,0 +1,278 @@
+(ns eacl.datascript.consistency-v3-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [datascript.core :as ds]
+            [eacl.backend.v8 :as backend]
+            [eacl.cache :as cache]
+            [eacl.core :as eacl]
+            [eacl.datascript.backend :as datascript-backend]
+            [eacl.datascript.core :as datascript]
+            [eacl.spicedb.consistency :as consistency]))
+
+(def schema
+  "definition user {}
+   definition document {
+     relation reader: user
+     permission view = reader
+   }")
+
+(def security-key "01234567890123456789012345678901")
+
+(def user (eacl/spice-object :user "user"))
+(def document (eacl/spice-object :document "document"))
+(def relationship
+  (eacl/->Relationship user :reader document))
+
+(defn- managed-client
+  [conn options]
+  (datascript/make-client
+   conn
+   (merge {:coherence-authority :managed
+           :security-key security-key
+           :consistency-sync-timeout-ms 5}
+          options)))
+
+(defn- seed!
+  [conn client]
+  (eacl/write-schema! client schema)
+  (ds/transact! conn [{:eacl/id "user"}
+                      {:eacl/id "document"}]))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+      error
+      (ex-data error))))
+
+(deftest causal-anchor-survives-restart-and-detects-reset-test
+  (let [conn (datascript/create-conn)
+        client (managed-client conn {})
+        _ (seed! conn client)
+        pre-write (ds/db conn)
+        token
+        (:zed/token
+         (eacl/create-relationship! client relationship))]
+    (testing "a new client over the same durable family accepts the token"
+      (let [restarted (managed-client conn {})]
+        (is (true?
+             (eacl/can?
+              restarted user :view document
+              (consistency/at-least-as-fresh token))))))
+    (testing "numeric progress cannot replace the missing anchor"
+      ;; Install a same-family predecessor and advance its transaction counter
+      ;; independently. The token mutation remains absent.
+      (ds/reset-conn! conn pre-write)
+      (ds/transact! conn [{:eacl/id "unrelated"}])
+      (is (= :eacl.consistency/freshness-unavailable
+             (:type
+              (error-data
+               #(eacl/can?
+                 client user :view document
+                 (consistency/at-least-as-fresh token)))))))))
+
+(deftest bounded-exact-registry-test
+  (let [conn (datascript/create-conn)
+        client
+        (managed-client
+         conn
+         {:exact-snapshot-registry-size 2})
+        _ (seed! conn client)
+        token
+        (:zed/token
+         (eacl/create-relationship! client relationship))]
+    (is (true? (eacl/can? client user :view document)))
+    (eacl/delete-relationship! client relationship)
+    (is (false? (eacl/can? client user :view document)))
+    (is (true?
+         (eacl/can?
+          client user :view document
+          (consistency/at-exact-snapshot token))))))
+
+(deftest cloned-history-and-listener-independence-test
+  (let [original-listen! ds/listen!
+        conn (datascript/create-conn)
+        authorization (managed-client conn {})]
+    (with-redefs [ds/listen!
+                  (fn [& _]
+                    (throw
+                     (ex-info
+                      "v3 consistency must not install listeners."
+                      {:type :unexpected-listener})))]
+      (seed! conn authorization)
+      (let [pre-token-db (ds/db conn)
+            token
+            (:zed/token
+             (eacl/create-relationship! authorization relationship))
+            post-token-db (ds/db conn)
+            post-token-client
+            (managed-client (ds/conn-from-db post-token-db) {})
+            pre-token-client
+            (managed-client (ds/conn-from-db pre-token-db) {})]
+        (is (true?
+             (eacl/can?
+              post-token-client user :view document
+              (consistency/at-least-as-fresh token))))
+        (is (= :eacl.consistency/freshness-unavailable
+               (:type
+                (error-data
+                 #(eacl/can?
+                   pre-token-client user :view document
+                   (consistency/at-least-as-fresh token))))))))
+    ;; Keep the binding referenced in both runtimes so advanced compilation
+    ;; cannot consider the interop var unused.
+    (is (fn? original-listen!))))
+
+(deftest independent-same-base-divergence-test
+  (let [seed-conn (datascript/create-conn)
+        seed-client (managed-client seed-conn {})
+        _ (seed! seed-conn seed-client)
+        base (ds/db seed-conn)
+        left-conn (ds/conn-from-db base)
+        right-conn (ds/conn-from-db base)
+        left (managed-client left-conn {})
+        right (managed-client right-conn {})
+        token
+        (:zed/token
+         (eacl/create-relationship! left relationship))]
+    ;; Both branches advance once from the same base, giving them the same
+    ;; numeric max-tx while only the left contains the token anchor.
+    (ds/transact! right-conn [{:eacl/id "unrelated"}])
+    (is (= (:max-tx (ds/db left-conn))
+           (:max-tx (ds/db right-conn))))
+    (is (= :eacl.consistency/freshness-unavailable
+           (:type
+            (error-data
+             #(eacl/can?
+               right user :view document
+               (consistency/at-least-as-fresh token))))))))
+
+(deftest exact-registry-eviction-and-cache-lifting-test
+  (let [conn (datascript/create-conn)
+        store (cache/local-store)
+        authorization
+        (managed-client
+         conn
+         {:cache store
+          :exact-snapshot-registry-size 1})
+        _ (seed! conn authorization)
+        token
+        (:zed/token
+         (eacl/create-relationship! authorization relationship))
+        query {:subject user
+               :permission :view
+               :resource/type :document
+               :first 10}
+        first-page (eacl/lookup-resources authorization query)
+        exact-hit (eacl/lookup-resources authorization query)]
+    (is (false? (:cached? first-page)))
+    (is (true? (:cached? exact-hit)))
+    (ds/transact! conn [{:eacl/id "unrelated"}])
+    (is (true?
+         (:cached?
+          (eacl/lookup-resources authorization query))))
+    (eacl/delete-relationship! authorization relationship)
+    (is (= :eacl.consistency/exact-snapshot-unavailable
+           (:type
+            (error-data
+             #(eacl/can?
+               authorization user :view document
+               (consistency/at-exact-snapshot token))))))))
+
+(deftest content-proofs-are-bounded-and-cover-public-identity-test
+  (let [conn (datascript/create-conn)
+        authorization
+        (managed-client conn {:proof-mode :content})
+        _ (seed! conn authorization)
+        _ (eacl/create-relationship! authorization relationship)
+        before-adapter
+        (datascript-backend/snapshot-adapter
+         (ds/db conn) (:opts authorization))
+        relation-id
+        (:relation-id
+         (first
+          (backend/invoke
+           before-adapter :relation-defs :document :reader)))
+        schema-proof (backend/invoke before-adapter :schema-proof)
+        before-proof
+        (backend/invoke before-adapter :relation-proof [relation-id])
+        user-eid (ds/entid (ds/db conn) [:eacl/id "user"])]
+    (is (= #{:content-digest} (set (keys schema-proof))))
+    (is (= 43 (count (:content-digest schema-proof))))
+    (is (= #{:content-digest} (set (keys before-proof))))
+    (is (= 43 (count (:content-digest before-proof))))
+    ;; The stored relationship keeps the same endpoint eid. Only its public
+    ;; identity changes, so this specifically proves the identity boundary is
+    ;; part of full-content cache and cursor equivalence.
+    (ds/transact! conn [[:db/retract user-eid :eacl/id "user"]
+                        [:db/add user-eid :eacl/id "renamed-user"]])
+    (let [after-adapter
+          (datascript-backend/snapshot-adapter
+           (ds/db conn) (:opts authorization))
+          after-proof
+          (backend/invoke after-adapter :relation-proof [relation-id])]
+      (is (not= before-proof after-proof)))))
+
+(deftest relationship-cursor-proof-equivalence-and-exact-fallback-test
+  (let [conn (datascript/create-conn)
+        authorization
+        (managed-client conn {:exact-snapshot-registry-size 16})
+        _ (eacl/write-schema! authorization schema)
+        _ (ds/transact! conn [{:eacl/id "user"}
+                              {:eacl/id "doc-a"}
+                              {:eacl/id "doc-b"}
+                              {:eacl/id "doc-c"}])
+        documents
+        (mapv #(eacl/spice-object :document %)
+              ["doc-a" "doc-b" "doc-c"])
+        relationships
+        (mapv #(eacl/->Relationship user :reader %) documents)
+        _ (doseq [value relationships]
+            (eacl/create-relationship! authorization value))
+        query {:subject/id "user" :first 1}
+        page-1 (eacl/read-relationships authorization query)
+        cursor (get-in page-1 [:page-info :end-cursor])
+        cursor-data
+        (datascript/token->cursor cursor (:opts authorization))]
+    (ds/transact! conn [{:eacl/id "unrelated-cursor-churn"}])
+    (testing "an equal complete result proof rebases to the current snapshot"
+      (let [page-2
+            (eacl/read-relationships
+             authorization
+             (assoc query :after cursor))
+            rebased
+            (datascript/token->cursor
+             (get-in page-2 [:page-info :end-cursor])
+             (:opts authorization))]
+        (is (= [(second relationships)] (:data page-2)))
+        (is (< (get-in cursor-data [:graph-head :order-hint])
+               (get-in rebased [:graph-head :order-hint])))))
+    (let [fresh-page-1
+          (eacl/read-relationships authorization query)
+          fresh-cursor
+          (get-in fresh-page-1 [:page-info :end-cursor])
+          delete-token
+          (:zed/token
+           (eacl/delete-relationship!
+            authorization
+            (second relationships)))]
+      (testing "a changed proof falls back to the retained original DB"
+        (is (= [(second relationships)]
+               (:data
+                (eacl/read-relationships
+                 authorization
+                 (assoc query :after fresh-cursor))))))
+      (testing "a newer at-least floor forbids exact fallback"
+        (is (= :eacl.consistency/cursor-consistency-conflict
+               (:type
+                (error-data
+                 #(eacl/read-relationships
+                   authorization
+                   (assoc
+                    query
+                    :after fresh-cursor
+                    :consistency
+                    (consistency/at-least-as-fresh
+                     delete-token)))))))))))

--- a/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
@@ -137,15 +137,14 @@
                              {:resource/type :server
                               :resource/id-prefix "server-"}))))))
 
-    (testing "list operations reject consistency and subject filters they cannot honor"
-      (is (= :eacl/unsupported-capability
-             (:type
-              (thrown-data #(eacl/lookup-resources
-                             client
-                             {:subject (contract/->user "user-1")
-                              :permission :view
-                              :resource/type :server
-                              :consistency :minimize-latency})))))
+    (testing "list operations honor consistency but reject unsupported filters"
+      (is (map?
+           (eacl/lookup-resources
+            client
+            {:subject (contract/->user "user-1")
+             :permission :view
+             :resource/type :server
+             :consistency :minimize-latency})))
       (is (= :eacl.pagination/unsupported-filter
              (:eacl/error
               (thrown-data #(eacl/lookup-subjects
@@ -197,7 +196,7 @@
       (is (= [(contract/->server "server-1")] (:data page-1)))
       (is (= [(contract/->server "server-2")] (:data page-2)))
       (is (empty? (:data page-3)))
-      (is (= 8 (:v envelope)))
+      (is (= 9 (:v envelope)))
       (is (= :lookup-eid (get-in envelope [:edge :kind])))
       (is (= :asc (get-in envelope [:edge :frontier-direction]))))
 

--- a/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
@@ -4,7 +4,8 @@
             [eacl.core :as eacl]
             [eacl.datascript.core :as datascript]
             [eacl.datascript.impl :as impl]
-            [eacl.datascript.schema :as schema]))
+            [eacl.datascript.schema :as schema]
+            [eacl.engine.v8 :as engine]))
 
 (def scan-schema
   "definition user {}
@@ -172,72 +173,53 @@
     {:conn conn
      :client client}))
 
-(defn- backend-for-client
-  [client db]
-  (impl/indexed-backend db (:opts client)))
-
 (deftest permission-path-cache-lifecycle-test
   (let [{:keys [conn client]} (seed-permission-db)
         calc-calls            (atom 0)
-        schema-builds         (atom 0)
-        orig-calc             impl/calc-permission-paths
-        orig-build            impl/build-schema-catalog
-        cache-stamp           (:cache-stamp (:opts client))]
-    (with-redefs [impl/calc-permission-paths (fn [& args]
-                                               (swap! calc-calls inc)
-                                               (apply orig-calc args))
-                  impl/build-schema-catalog (fn [db]
-                                              (swap! schema-builds inc)
-                                              (orig-build db))]
+        orig-calc             engine/calc-permission-paths
+        subject               (spice-object :user "user-1")
+        resource              (spice-object :server "server-1")]
+    (with-redefs [engine/calc-permission-paths
+                  (fn [& args]
+                    (swap! calc-calls inc)
+                    (apply orig-calc args))]
       (testing "permission paths and schema catalog stay warm across relationship writes"
-        (let [db-before      (ds/db conn)
-              backend-before (backend-for-client client db-before)
-              stamp-before   (cache-stamp)]
-          (is (seq (impl/get-permission-paths backend-before :server :view)))
-          (is (= 1 @calc-calls))
-          (is (= 1 @schema-builds))
+        (is (false? (eacl/can? client subject :view resource)))
+        (is (= 1 @calc-calls))
 
-          (reset! calc-calls 0)
-          (eacl/create-relationship! client
-                                     (spice-object :group "group-1")
-                                     :group
-                                     (spice-object :server "server-1"))
-          (let [db-after      (ds/db conn)
-                backend-after (backend-for-client client db-after)]
-            (is (= stamp-before (cache-stamp)))
-            (is (seq (impl/get-permission-paths backend-after :server :view)))
-            (is (zero? @calc-calls))
-            (is (= 1 @schema-builds)))))
+        (reset! calc-calls 0)
+        (eacl/create-relationship! client
+                                   (spice-object :group "group-1")
+                                   :group
+                                   resource)
+        (is (false? (eacl/can? client subject :view resource)))
+        (is (zero? @calc-calls)))
 
       (testing "schema writes invalidate permission paths and compiled schema catalog"
-        (let [stamp-before (cache-stamp)]
-          (reset! calc-calls 0)
-          (eacl/write-schema! client permission-schema-v2)
-          (let [db-after      (ds/db conn)
-                backend-after (backend-for-client client db-after)]
-            (is (not= stamp-before (cache-stamp)))
-            (is (seq (impl/get-permission-paths backend-after :server :view)))
-            (is (= 1 @calc-calls))
-            (is (= 2 @schema-builds))))))))
+        (reset! calc-calls 0)
+        (eacl/write-schema! client permission-schema-v2)
+        (is (false? (eacl/can? client subject :view resource)))
+        (is (= 1 @calc-calls))))))
 
 (deftest permission-path-cache-is-connection-local-test
-  (let [{conn-1 :conn client-1 :client} (seed-permission-db)
-        {conn-2 :conn client-2 :client} (seed-permission-db)
-        calc-calls                      (atom 0)
-        orig-calc                       impl/calc-permission-paths]
-    (with-redefs [impl/calc-permission-paths (fn [& args]
-                                               (swap! calc-calls inc)
-                                               (apply orig-calc args))]
-      (let [backend-1a (backend-for-client client-1 (ds/db conn-1))
-            backend-2a (backend-for-client client-2 (ds/db conn-2))]
-        (is (not= (:permission-paths-cache (:opts client-1))
-                  (:permission-paths-cache (:opts client-2))))
-        (impl/get-permission-paths backend-1a :server :view)
-        (impl/get-permission-paths backend-2a :server :view)
+  (let [{client-1 :client} (seed-permission-db)
+        {client-2 :client} (seed-permission-db)
+        calc-calls (atom 0)
+        orig-calc engine/calc-permission-paths]
+    (with-redefs [engine/calc-permission-paths
+                  (fn [& args]
+                    (swap! calc-calls inc)
+                    (apply orig-calc args))]
+      (let [subject (spice-object :user "user-1")
+            resource (spice-object :server "server-1")]
+        (is (not= (:derived-schema-caches (:opts client-1))
+                  (:derived-schema-caches (:opts client-2))))
+        (eacl/can? client-1 subject :view resource)
+        (eacl/can? client-2 subject :view resource)
         (is (= 2 @calc-calls))
         (reset! calc-calls 0)
-        (impl/get-permission-paths (backend-for-client client-1 (ds/db conn-1)) :server :view)
-        (impl/get-permission-paths (backend-for-client client-2 (ds/db conn-2)) :server :view)
+        (eacl/can? client-1 subject :view resource)
+        (eacl/can? client-2 subject :view resource)
         (is (zero? @calc-calls))))))
 
 (deftest read-relationships-query-matrix-test
@@ -281,4 +263,5 @@
     (is (= 5 (count page-2)))
     (is (string? cursor))
     (is (= "bulk-user-0" (get-in (first page-1) [:subject :id])))
-    (is (= "bulk-user-1000" (get-in (first page-2) [:subject :id])))))
+    (is (= "bulk-user-995" (get-in (first page-2) [:subject :id]))
+        "portable relationship order is lexicographic by public object id")))

--- a/modules/eacl-datascript/test/eacl/datascript/mutation_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/mutation_test.cljc
@@ -1,0 +1,177 @@
+(ns eacl.datascript.mutation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datascript.core :as ds]
+            [eacl.causal-token :as causal-token]
+            [eacl.core :as eacl]
+            [eacl.datascript.core :as datascript]
+            [eacl.datascript.mutation :as journal]
+            [eacl.datascript.schema :as schema]
+            [eacl.mutation :as mutation]
+            [eacl.schema.model :as model]))
+
+(def test-schema
+  "definition user {}
+   definition folder {
+     relation owner: user
+     relation viewer: user
+     permission view = owner + viewer
+   }")
+
+(def security-key
+  "01234567890123456789012345678901")
+
+(defn- relation-eid
+  [db relation-name]
+  (ds/entid
+   db
+   [:eacl/id
+    (model/->relation-id :folder relation-name :user)]))
+
+(deftest managed-writes-publish-one-committed-mutation-test
+  (let [conn (schema/create-conn)
+        client (datascript/make-client
+                conn
+                {:coherence-authority :managed
+                 :security-key security-key})
+        schema-result (eacl/write-schema! client test-schema)
+        first-token (:zed/token schema-result)
+        first-payload
+        (causal-token/token-data
+         (get-in client [:opts :format-options])
+         first-token)
+        first-head (:head-id (journal/graph-state (ds/db conn)))
+        no-op-result (eacl/write-schema! client test-schema)
+        no-op-payload
+        (causal-token/token-data
+         (get-in client [:opts :format-options])
+         (:zed/token no-op-result))]
+    (testing "schema tokens name the committed graph head"
+      (is (= first-head (:graph-anchor first-payload)))
+      (is (= (:max-tx (ds/db conn)) (:order-hint first-payload))))
+    (testing "a structural and textual no-op does not advance the graph"
+      (is (= first-head (:head-id (journal/graph-state (ds/db conn)))))
+      (is (= first-head (:graph-anchor no-op-payload))))
+
+    (ds/transact! conn [{:eacl/id "user-1"}
+                        {:eacl/id "folder-1"}
+                        {:eacl/id "folder-2"}])
+    (let [write-result
+          (eacl/create-relationships!
+           client
+           [(eacl/->Relationship
+             (eacl/spice-object :user "user-1")
+             :owner
+             (eacl/spice-object :folder "folder-1"))
+            (eacl/->Relationship
+             (eacl/spice-object :user "user-1")
+             :viewer
+             (eacl/spice-object :folder "folder-2"))])
+          db (ds/db conn)
+          owner-stamp
+          (get (ds/entity db (relation-eid db :owner))
+               mutation/relation-mutation-id-attr)
+          viewer-stamp
+          (get (ds/entity db (relation-eid db :viewer))
+               mutation/relation-mutation-id-attr)
+          payload
+          (causal-token/token-data
+           (get-in client [:opts :format-options])
+           (:zed/token write-result))]
+      (testing "one batched write stamps every affected relation once"
+        (is (= owner-stamp viewer-stamp))
+        (is (= owner-stamp (:graph-anchor payload)))
+        (is (= owner-stamp
+               (:head-id (journal/graph-state db)))))
+
+      (let [delete-result
+            (eacl/delete-object!
+             client
+             (eacl/spice-object :user "user-1"))
+            db-after (ds/db conn)
+            owner-delete-stamp
+            (get (ds/entity db-after (relation-eid db-after :owner))
+                 mutation/relation-mutation-id-attr)
+            viewer-delete-stamp
+            (get (ds/entity db-after (relation-eid db-after :viewer))
+                 mutation/relation-mutation-id-attr)
+            delete-payload
+            (causal-token/token-data
+             (get-in client [:opts :format-options])
+             (:zed/token delete-result))]
+        (testing "cascade deletion stamps all affected relations atomically"
+          (is (= owner-delete-stamp viewer-delete-stamp))
+          (is (not= owner-stamp owner-delete-stamp))
+          (is (= owner-delete-stamp (:graph-anchor delete-payload))))))))
+
+(deftest mutation-idempotency-dependency-and-retention-test
+  (let [conn (schema/create-conn)
+        _ (journal/ensure-migrated! conn)
+        _ (ds/transact! conn [{:eacl/id "identity-1"}])
+        mutation-id (mutation/new-id)
+        options
+        {:mutation-id mutation-id
+         :kind :object-identity
+         :canonical-data {:operation :rename
+                          :identity "identity-1"
+                          :value "public-2"}
+         :dependency-ids [[:eacl/id "identity-1"]]
+         :token-ttl-seconds 1
+         :retention-grace-seconds 0
+         :tx-data [[:db/add
+                    [:eacl/id "identity-1"]
+                    :eacl/schema-string
+                    "public-2"]]}
+        report (journal/transact! conn options)
+        recovered (journal/transact! conn options)
+        db (ds/db conn)]
+    (is (not (:idempotent-recovery? report)))
+    (is (true? (:idempotent-recovery? recovered)))
+    (is (= mutation-id
+           (get (ds/entity db [:eacl/id "identity-1"])
+                mutation/dependency-mutation-id-attr)))
+    (is (= :eacl.mutation/id-reused
+           (try
+             (journal/transact!
+              conn
+              (assoc options :canonical-data {:different true}))
+             nil
+             (catch #?(:clj clojure.lang.ExceptionInfo
+                       :cljs cljs.core.ExceptionInfo) error
+               (:type (ex-data error))))))
+    (let [old-head (:head-id (journal/graph-state db))
+          next-id (mutation/new-id)]
+      (journal/transact!
+       conn
+       {:mutation-id next-id
+        :kind :custom
+        :canonical-data {:operation :next}
+        :token-ttl-seconds 1
+        :retention-grace-seconds 0
+        :tx-data []})
+      (is (pos? (journal/prune-expired!
+                 conn
+                 (+ 2 (mutation/now-seconds)))))
+      (is (false? (journal/contains-anchor? (ds/db conn) old-head)))
+      (is (true? (journal/contains-anchor? (ds/db conn) next-id))))))
+
+#?(:clj
+   (deftest migration-race-test
+     (let [conn (schema/create-conn)
+           _ (ds/transact!
+              conn
+              [{:eacl/id "legacy-relation"
+                :eacl.relation/relation-name :member}])
+           attempts (doall
+                     (repeatedly
+                      8
+                      #(future (journal/ensure-migrated! conn))))
+           states (mapv deref attempts)
+           final-state (journal/graph-state (ds/db conn))]
+       (is (every? #(= (:family-id final-state) (:family-id %))
+                   states))
+       (is (every? #(= (:head-id final-state) (:head-id %))
+                   states))
+       (is (= (:head-id final-state)
+              (get (ds/entity (ds/db conn)
+                              [:eacl/id "legacy-relation"])
+                   mutation/relation-mutation-id-attr))))))

--- a/modules/eacl-datomic/README.md
+++ b/modules/eacl-datomic/README.md
@@ -8,7 +8,7 @@ Responsibilities:
 - Datomic tuple/index storage implementation
 - Datomic relationship write planning and transaction execution
 - v8 consistency descriptors, Zed tokens, encrypted Relay-style pagination, and historical reads
-- v8 authorization result cache, relation-scoped invalidation, and cache-store contract
+- v8 authenticated result cache with mutation/content proofs and cache-store contract
 - v6-to-v7 migration and v8 object-deletion/integrity helpers
 - Datomic compatibility namespaces preserving the existing public surface
 - Datomic-only regression and storage-mechanics tests

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -4,7 +4,8 @@
   (:require [datomic.api :as d]
             [eacl.backend.v8 :as backend]
             [eacl.datomic.db :as ddb]
-            [eacl.datomic.watermark :as watermark])
+            [eacl.datomic.mutation :as journal]
+            [eacl.mutation :as mutation])
   (:import [java.nio.charset StandardCharsets]
            [java.security MessageDigest]
            [java.util Base64]))
@@ -15,6 +16,8 @@
                   :at-least-as-fresh
                   :at-exact-snapshot}
    :snapshots #{:current :historical}
+   :source #{:stable-scope :graph-head :anchor-membership :order-hint
+             :exact-locator}
    :cursor #{:forward :reverse :opaque :authenticated :encrypted}
    :transactions #{:schema :relationships :object-deletion}
    :cache-proofs #{:schema :relations :snapshot-bound :database-visible}
@@ -43,59 +46,295 @@
            :target-type (:eacl.permission/target-type permission)
            :target-name (:eacl.permission/target-name permission)}))))
 
-(defn- schema-proof
+(defn- digest-records
+  "Hashes an ordered sequence without materializing one giant encoding.
+
+  Each record is length framed, so concatenation cannot create ambiguous
+  proofs. Callers provide fixed-shape vectors and a domain; map print ordering
+  is therefore never part of the proof contract."
+  [domain records]
+  (let [digest (MessageDigest/getInstance "SHA-256")
+        update-bytes!
+        (fn [^bytes bytes]
+          (let [length-prefix
+                (byte-array
+                 [(unchecked-byte (bit-shift-right (alength bytes) 24))
+                  (unchecked-byte (bit-shift-right (alength bytes) 16))
+                  (unchecked-byte (bit-shift-right (alength bytes) 8))
+                  (unchecked-byte (alength bytes))])]
+            (.update digest length-prefix)
+            (.update digest bytes)))]
+    (update-bytes! (.getBytes domain StandardCharsets/UTF_8))
+    (doseq [record records]
+      (update-bytes!
+       (.getBytes (pr-str record) StandardCharsets/UTF_8)))
+    (.encodeToString
+     (.withoutPadding (Base64/getUrlEncoder))
+     (.digest digest))))
+
+(defn- schema-proof-records
   [db {:keys [permission-nodes relation-ids] :as scope}]
-  (if-not scope
-    (some-> (ddb/schema-version db) str)
-    {:relations
-     (->> relation-ids
-          (map (fn [relation-id]
-                 (let [relation (d/entity db relation-id)]
-                   {:relation-id relation-id
-                    :resource-type
-                    (:eacl.relation/resource-type relation)
-                    :relation-name
-                    (:eacl.relation/relation-name relation)
-                    :subject-type
-                    (:eacl.relation/subject-type relation)})))
-          (sort-by (juxt :resource-type :relation-name :subject-type))
-          vec)
-     :permissions
-     (->> permission-nodes
-          (mapcat (fn [[resource-type permission-name]]
-                    (permission-defs
-                     db resource-type permission-name)))
-          (sort-by (juxt :resource-type
-                         :permission-name
-                         :source-relation-name
-                         :target-type
-                         :target-name))
-          vec)}))
+  (if-not (and (d/entid db :eacl.relation/relation-name)
+               (d/entid db :eacl.permission/permission-name))
+    []
+    (let [relation-ids (if scope
+                         relation-ids
+                         (journal/relation-ids db))
+          permission-nodes (if scope
+                             permission-nodes
+                             (ddb/all-permission-nodes db))]
+      (concat
+       (->> relation-ids
+            (map (fn [relation-id]
+                   (let [relation (d/entity db relation-id)]
+                     [:relation
+                      relation-id
+                      (:eacl.relation/resource-type relation)
+                      (:eacl.relation/relation-name relation)
+                      (:eacl.relation/subject-type relation)])))
+            sort)
+       (->> permission-nodes
+            (mapcat (fn [[resource-type permission-name]]
+                      (permission-defs
+                       db resource-type permission-name)))
+            (map (fn [permission]
+                   [:permission
+                    (:permission-id permission)
+                    (:resource-type permission)
+                    (:permission-name permission)
+                    (:source-relation-name permission)
+                    (:target-type permission)
+                    (:target-name permission)]))
+            sort)))))
+
+(defn- content-schema-proof
+  [db scope]
+  {:content-digest
+   (digest-records
+    "eacl/datomic/schema-content-proof/v3"
+    (schema-proof-records db scope))})
+
+(defn- content-relation-proof
+  [db relation-ids external-id]
+  (let [wanted (set relation-ids)
+        forward-attr ddb/forward-relationship-attr
+        reverse-attr ddb/reverse-relationship-attr
+        forward
+        (when (and (seq wanted) (d/entid db forward-attr))
+          (for [{subject :e value :v}
+                (d/datoms db :aevt forward-attr)
+                :let [[subject-type relation-id
+                       resource-type resource] value]
+                :when (contains? wanted relation-id)]
+            [:forward relation-id
+             subject-type subject (external-id db subject)
+             resource-type resource (external-id db resource)]))
+        reverse
+        (when (and (seq wanted) (d/entid db reverse-attr))
+          (for [{resource :e value :v}
+                (d/datoms db :aevt reverse-attr)
+                :let [[resource-type relation-id
+                       subject-type subject] value]
+                :when (contains? wanted relation-id)]
+            [:reverse relation-id
+             subject-type subject (external-id db subject)
+             resource-type resource (external-id db resource)]))]
+    ;; Preserve both physical halves. Direct/forward evaluation reads the
+    ;; forward tuple and reverse lookup reads the reverse tuple, so a
+    ;; corruption or out-of-band half-write must invalidate whichever
+    ;; operation it can affect.
+    {:content-digest
+     (digest-records
+      "eacl/datomic/relationship-content-proof/v3"
+      (sort (concat forward reverse)))}))
+
+(defn- mutation-schema-proof
+  [db]
+  (some-> (d/entity db [:eacl/id mutation/schema-entity-id])
+          (get mutation/schema-mutation-id-attr)))
+
+(defn- mutation-relation-proof
+  [db relation-ids]
+  (let [proof
+        (mapv (fn [relation-id]
+                [relation-id
+                 (get (d/entity db relation-id)
+                      mutation/relation-mutation-id-attr)])
+              (sort relation-ids))]
+    (when (every? (comp some? second) proof)
+      proof)))
 
 (defn snapshot-adapter
   "Creates an adapter bound to one immutable Datomic db value. Proof and scan
   operations therefore cannot accidentally observe a different basis."
   ([db]
    (snapshot-adapter db {}))
-  ([db {:keys [entid->object-id cache-epoch-state
+  ([db {:keys [entid->object-id
                object-eid-fn subject->resources-fn
-               resource->subjects-fn]
+               resource->subjects-fn conn coherence-authority
+               database-id proof-mode selected-order-hint
+               selected-exact-locator]
+        :or {proof-mode :content}
         :as opts}]
-   (let [epoch-state (or cache-epoch-state
-                         (watermark/make-epoch-state))
-         external-id (or entid->object-id
+   (let [external-id (or entid->object-id
                          (fn [snapshot eid]
                            (:eacl/id (d/entity snapshot eid))))]
      (backend/make-adapter
       {:id :datomic
-       :capabilities capabilities
+       :fingerprint (:adapter-fingerprint opts)
+       :deterministic? (:adapter-deterministic? opts)
+       :identity-contract
+       (:identity-contract opts
+                           :selected-internal/current-external-v1)
+       :capabilities
+       (cond-> capabilities
+         (not= :managed coherence-authority)
+         (update :consistency disj
+                 :at-least-as-fresh
+                 :at-exact-snapshot)
+
+         (nil? conn)
+         (update :consistency disj
+                 :fully-consistent
+                 :at-exact-snapshot))
        :state {:db db
                :opts opts}
        :operations
        {:snapshot-id
         (fn []
           {:database-id (str (.id ^datomic.Database db))
-           :basis-t (d/basis-t db)})
+           :basis-t (or selected-exact-locator
+                        (d/basis-t db))})
+
+        :source-scope
+        (fn []
+          {:source-id
+           {:database-id
+            (or database-id
+                (str (.id ^datomic.Database db)))
+            :family-id (:family-id (journal/graph-state db))}
+           :branch nil})
+
+        :graph-head
+        (fn []
+          {:graph-anchor (:head-id (journal/graph-state db))
+           :order-hint (or selected-order-hint
+                           (d/basis-t db))
+           :exact-locator (or selected-exact-locator
+                              (d/basis-t db))})
+
+        :contains-anchor?
+        (fn [anchor]
+          (journal/contains-anchor? db anchor))
+
+        :order-hint
+        (fn []
+          (or selected-order-hint
+              (d/basis-t db)))
+
+        :select-current
+        (fn []
+          (snapshot-adapter (if conn (d/db conn) db) opts))
+
+        :select-authoritative
+        (fn [timeout-ms]
+          (try
+            (let [selected
+                  (if conn
+                    (deref (d/sync conn)
+                           (or timeout-ms 30000)
+                           ::timeout)
+                    db)]
+              (when (= ::timeout selected)
+                (throw
+                 (ex-info
+                  "Timed out establishing the Datomic authoritative head."
+                  {:type :eacl.consistency/freshness-unavailable
+                   :eacl/error :eacl.consistency/freshness-unavailable
+                   :reason :freshness-timeout
+                   :timeout-ms (or timeout-ms 30000)})))
+              (snapshot-adapter selected opts))
+            (catch clojure.lang.ExceptionInfo error
+              (if (= :eacl.consistency/freshness-unavailable
+                     (:type (ex-data error)))
+                (throw error)
+                (throw
+                 (ex-info
+                  "Failed establishing the Datomic authoritative head."
+                  {:type :eacl.consistency/freshness-unavailable
+                   :eacl/error :eacl.consistency/freshness-unavailable
+                   :reason :sync-failed
+                   :timeout-ms (or timeout-ms 30000)}
+                  error))))))
+
+        :select-at-least
+        (fn [token-data timeout-ms]
+          (try
+            (let [selected
+                  (if conn
+                    (deref (d/sync conn (:order-hint token-data))
+                           (or timeout-ms 30000)
+                           ::timeout)
+                    db)
+                  requested-order-hint (:order-hint token-data)]
+              (when (= ::timeout selected)
+                (throw
+                 (ex-info
+                  "Timed out waiting for the Datomic causal floor."
+                  {:type :eacl.consistency/freshness-unavailable
+                   :eacl/error :eacl.consistency/freshness-unavailable
+                   :reason :freshness-timeout
+                   :requested-order-hint (:order-hint token-data)
+                   :timeout-ms (or timeout-ms 30000)})))
+              ;; d/sync is specified to return a DB at least as new as the
+              ;; requested basis. Check the postcondition anyway: adapters and
+              ;; test doubles are not allowed to turn an order hint into an
+              ;; unverified freshness claim.
+              (when (and requested-order-hint
+                         (< (d/basis-t selected) requested-order-hint))
+                (throw
+                 (ex-info
+                  "The selected Datomic snapshot did not reach the causal floor."
+                  {:type :eacl.consistency/freshness-unavailable
+                   :eacl/error :eacl.consistency/freshness-unavailable
+                   :reason :head-behind
+                   :requested-order-hint requested-order-hint
+                   :observed-order-hint (d/basis-t selected)
+                   :timeout-ms (or timeout-ms 30000)})))
+              (snapshot-adapter selected opts))
+            (catch clojure.lang.ExceptionInfo error
+              (if (= :eacl.consistency/freshness-unavailable
+                     (:type (ex-data error)))
+                (throw error)
+                (throw
+                 (ex-info
+                  "Failed waiting for the Datomic causal floor."
+                  {:type :eacl.consistency/freshness-unavailable
+                   :eacl/error :eacl.consistency/freshness-unavailable
+                   :reason :sync-failed
+                   :requested-order-hint (:order-hint token-data)
+                   :timeout-ms (or timeout-ms 30000)}
+                  error))))))
+
+        :exact-locator
+        (fn []
+          (or selected-exact-locator
+              (d/basis-t db)))
+
+        :select-exact
+        (fn [token-data _timeout-ms]
+          (let [locator (:exact-locator token-data)
+                current (if conn (d/db conn) db)]
+            (when (and (integer? locator)
+                       (<= locator (d/basis-t current)))
+              (try
+                (snapshot-adapter
+                 (d/as-of current locator)
+                 (assoc opts
+                        :selected-order-hint locator
+                        :selected-exact-locator locator))
+                (catch Throwable _
+                  nil)))))
 
         :object-id->internal
         (fn [object-id]
@@ -145,9 +384,20 @@
 
         :schema-proof
         (fn
-          ([] (schema-proof db nil))
-          ([scope] (schema-proof db scope)))
+          ([]
+           (case proof-mode
+             :mutation (mutation-schema-proof db)
+             :content (content-schema-proof db nil)
+             nil))
+          ([scope]
+           (case proof-mode
+             :mutation (mutation-schema-proof db)
+             :content (content-schema-proof db scope)
+             nil)))
 
         :relation-proof
         (fn [relation-ids]
-          (watermark/safe-epoch-for epoch-state db relation-ids))}}))))
+          (case proof-mode
+            :mutation (mutation-relation-proof db relation-ids)
+            :content (content-relation-proof db relation-ids external-id)
+            nil))}}))))

--- a/modules/eacl-datomic/src/eacl/datomic/cache.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/cache.clj
@@ -4,6 +4,7 @@
   Cache availability never changes a recomputable authorization answer. Store
   failures, eviction, and disabled caches fall back to indexed/traversal work
   against the selected live or historical Datomic value."
+  (:require [eacl.cache :as shared])
   (:import [java.util Iterator LinkedHashMap Map$Entry]))
 
 (def cache-entry-version 2)
@@ -509,3 +510,29 @@
        (when store
          (safe-record-provider-error! store :admission kind))
        false))))
+
+(defn authenticated-store
+  "Adapts the legacy weighted provider API to the shared authenticated v3
+  cache contract. The outer legacy wrapper is only capacity metadata; the
+  value it contains is a signed shared-cache envelope, so an externally
+  writable provider cannot influence authorization by forging either layer."
+  [store namespace ttl-ms]
+  (if (or (nil? store) (no-cache? store))
+    shared/no-cache
+    (reify
+      shared/CacheStore
+      (lookup [_ k]
+        (safe-entry-value store k :authenticated-v3 string?))
+      (store! [_ k value]
+        (safe-store-entry!
+         store namespace k :authenticated-v3 value
+         (+ 256 (* 2 (count value)))
+         ttl-ms))
+      (evict! [_ k]
+        (safe-evict! store k))
+      (clear! [_]
+        (if (contains? (safe-capabilities store) :namespaced-clear)
+          (clear-namespace! store namespace)
+          (clear! store)))
+      (stats [_]
+        (stats store)))))

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -3,6 +3,9 @@
   (:require [com.rpl.specter :as S]
             [datomic.api :as d]
             [eacl.backend.v8 :as backend]
+            [eacl.cache :as shared-cache]
+            [eacl.causal-token :as causal-token]
+            [eacl.consistency :as consistency-v3]
             [eacl.core :as eacl :refer [IAuthorization
                                         spice-object
                                         ->Relationship
@@ -14,9 +17,13 @@
             [eacl.datomic.consistency :as revision]
             [eacl.datomic.impl :as impl]
             [eacl.datomic.impl.indexed :as impl.indexed]
+            [eacl.datomic.mutation :as journal]
             [eacl.datomic.schema :as schema]
-            [eacl.datomic.watermark :as watermark]
+            [eacl.engine.v8 :as engine]
             [eacl.migrations.v6-to-v7 :as migrations]
+            [eacl.mutation :as mutation]
+            [eacl.relay :as relay]
+            [eacl.secure-format :as secure]
             [eacl.spicedb.consistency :as consistency])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream DataInputStream
             DataOutputStream]
@@ -299,7 +306,14 @@
           (when-not (= page-token-version (:v payload))
             (invalid-page-token! :unsupported-version {:version (:v payload)}))
           (when (and (:exp payload) (<= (:exp payload) now))
-            (invalid-page-token! :expired {:exp (:exp payload) :now now}))
+            (throw
+             (ex-info
+              "Page token has expired."
+              {:type :eacl.pagination/expired-cursor
+               :eacl/error :eacl.pagination/expired-cursor
+               :reason :expired
+               :exp (:exp payload)
+               :now now})))
           payload))
       (catch clojure.lang.ExceptionInfo e
         (throw e))
@@ -371,18 +385,6 @@
   [opts page-req]
   (some->> (:bound page-req)
            (token->page-bound opts)))
-
-(defn- consistency-request
-  [opts value]
-  (let [{:keys [mode token] :as descriptor}
-        (consistency/descriptor value)]
-    (backend/require-supported!
-     :datomic (:backend-capabilities opts) :consistency mode)
-    (if token
-      (assoc descriptor
-             :requested-t
-             (revision/token-revision opts (:database-id opts) token))
-      (assoc descriptor :requested-t nil))))
 
 (def ^:private sync-timeout-marker (Object.))
 
@@ -547,7 +549,18 @@
                   (vector? (:cache-scope decoded)))
       (invalid-cursor! "Page token has an invalid cache proof."
                        :invalid-cache-scope
-                       {:cache-scope (:cache-scope decoded)})))
+                       {:cache-scope (:cache-scope decoded)}))
+    (doseq [field [:source-scope
+                   :graph-head
+                   :adapter-fingerprint
+                   :identity-contract
+                   :dependency-scope-digest
+                   :proof-digest]]
+      (when-not (contains? decoded field)
+        (invalid-cursor!
+         "Page token is missing proof-equivalent continuation metadata."
+         :missing-proof-context
+         {:field field}))))
   true)
 
 (defn- validate-page-token-schema!
@@ -573,14 +586,16 @@
   ([opts op query-shape basis-t cache-scope edge]
    (when edge
      (page-token opts
-                 (cond-> {:op op
-                          :database-id (:database-id opts)
-                          :query-shape query-shape
-                          :basis-t basis-t
-                          :basis :stable
-                          :schema-version (selected-schema-version opts)
-                          :cache-scope cache-scope
-                          :edge edge}
+                 (cond-> (merge
+                          (:page-cursor-context opts)
+                          {:op op
+                           :database-id (:database-id opts)
+                           :query-shape query-shape
+                           :basis-t basis-t
+                           :basis :stable
+                           :schema-version (selected-schema-version opts)
+                           :cache-scope cache-scope
+                           :edge edge})
                    (:page-token-ttl-seconds opts)
                    (assoc :ttl-seconds (:page-token-ttl-seconds opts)))))))
 
@@ -656,45 +671,11 @@
       (update :page-info
               #(encode-page-info opts op query-shape basis-t %))))
 
-(def ^:private result-cache-version 3)
-
-(defn- result-cache-prefix
-  [opts op query-identity schema-version]
-  [:result
-   result-cache-version
-   (:cache-namespace opts)
-   (:database-id opts)
-   schema-version
-   op
-   ;; Keep the exact canonical request in the key. The compact query hash in
-   ;; the page token is authenticated, but cache correctness need not rely on
-   ;; collision resistance when ordinary value equality is available.
-   (canonicalize query-identity)])
-
-(defn- exact-result-cache-key
-  "Retained answers are keyed by the CACHE EPOCH, not the Datomic basis.
-
-  Keying on basis-t meant any transaction anywhere in the database minted a new
-  key, so this cache was effectively a 0% hit rate on a busy system. An epoch is
-  the max change stamp over the relations the answer actually reads, so it moves
-  only when one of those relations is written — see eacl.datomic.watermark.
-
-  The `:exact` tag distinguished these from the `:live` entries that
-  :live-results? used to publish. Those are gone; the tag is kept only so a
-  store surviving a rolling deploy cannot serve an old-format entry under a
-  key this build would build the same way."
-  [prefix epoch]
-  (conj prefix [:exact epoch]))
-
 (def ^:private answer-cache-kinds
   "The entry kinds that hold a finished answer, as opposed to the traversal and
   pagination state EACL caches regardless. :remember-answers governs exactly
   these four."
   #{:can? :lookup-page :count :latest-result})
-
-(defn- latest-result-cache-key
-  [prefix]
-  (conj prefix :latest))
 
 (defn- internal-page-weight
   [page]
@@ -778,30 +759,6 @@
   [value]
   (boolean? value))
 
-(defn- cached-answer?
-  [valid-result? expected answer]
-  (and (map? answer)
-       (integer? (:basis-t answer))
-       (not (neg? (:basis-t answer)))
-       (or (nil? (:cache-scope answer))
-           (vector? (:cache-scope answer)))
-       (or (not (contains? expected :basis-t))
-           (= (:basis-t expected) (:basis-t answer)))
-       (or (not (contains? expected :epoch))
-           (= (:epoch expected) (:epoch answer)))
-       (or (not (contains? expected :cache-scope))
-           (= (:cache-scope expected) (:cache-scope answer)))
-       (contains? answer :result)
-       (valid-result? (:result answer))))
-
-(defn- cached-answer
-  [opts cache-key kind valid-result? expected]
-  (cache/safe-entry-value
-   (:lookup-cache-store opts)
-   cache-key
-   kind
-   #(cached-answer? valid-result? expected %)))
-
 (defn- portable-result
   [kind result]
   (case kind
@@ -815,225 +772,43 @@
 
     result))
 
-(defn- store-cached-answer!
-  [opts cache-prefix kind result weight
-   {:keys [mode basis-t cache-epoch cache-scope schema-version]}]
-  (let [store (:lookup-cache-store opts)
-        namespace (:cache-namespace opts)
-        ttl-ms (:lookup-cache-ttl-ms opts)
-        ;; nil epoch means no precise dependency proof was available, so there
-        ;; is no key a later read could match. Retaining anyway is pure cost.
-        exact-key (when cache-epoch
-                    (exact-result-cache-key cache-prefix cache-epoch))
-        ;; A cursor/exact page is forced to :at-exact-snapshot, and only that
-        ;; mode reads exact-key. Its live entry would be keyed by a query
-        ;; identity containing an :after/:before edge, and every request
-        ;; carrying such an edge takes the historical branch — so the entry
-        ;; could never be read, while still consuming the weight and entry
-        ;; budget that live page-one answers compete for.
-        historical? (= :at-exact-snapshot mode)
-        answer {:basis-t basis-t
-                :epoch cache-epoch
-                :cache-scope cache-scope
-                :result (portable-result kind result)}]
-    (when (and store schema-version)
-      (when (and (:cache-remember-answers? opts) exact-key)
-        (cache/safe-store-entry!
-         store namespace exact-key kind answer (+ 128 weight) ttl-ms))
-      ;; This is a latency hint, not a correctness proof. An older concurrent
-      ;; writer may overwrite it; at-least-as-fresh validates the revision and
-      ;; falls back to the selected DB when the hint is too old. A cursor
-      ;; prefix's pointer is unreachable for the same reason as its live entry.
-      (when (and (:cache-remember-answers? opts) exact-key (not historical?))
-        (cache/safe-store-entry!
-         store namespace
-         (latest-result-cache-key cache-prefix)
-         :latest-result
-         {:basis-t basis-t
-          :epoch cache-epoch
-          :exact-key exact-key
-          :kind kind}
-         192
-         ttl-ms)))
-    answer))
-
-(defn- latest-cached-answer
-  [opts cache-prefix kind valid-result? minimum-t maximum-t]
-  (let [store (:lookup-cache-store opts)
-        pointer-key (latest-result-cache-key cache-prefix)
-        pointer
-        (cache/safe-entry-value
-         store pointer-key :latest-result
-         (fn [value]
-           (and (map? value)
-                (integer? (:basis-t value))
-                (not (neg? (:basis-t value)))
-                (integer? (:epoch value))
-                (vector? (:exact-key value))
-                (= kind (:kind value)))))]
-    (when (and pointer
-               (or (nil? minimum-t)
-                   (<= minimum-t (:basis-t pointer)))
-               (or (nil? maximum-t)
-                   (<= (:basis-t pointer) maximum-t))
-               ;; The pointer names its own entry's key, which is derived from
-               ;; the epoch. Recomputing it here is what stops a malformed or
-               ;; foreign pointer redirecting a read at another entry.
-               (= (:exact-key pointer)
-                  (exact-result-cache-key cache-prefix (:epoch pointer))))
-      (cached-answer opts (:exact-key pointer) kind valid-result?
-                     {:basis-t (:basis-t pointer)
-                      :epoch (:epoch pointer)}))))
-
 (defn- cached-authorization-result
-  [opts consistency-context op query-identity kind valid-result? weight-fn compute]
-  (let [{:keys [mode basis-t cache-epoch requested-t]}
+  [opts consistency-context op query-identity kind valid-result? _weight-fn compute]
+  (let [{:keys [adapter schema-dependencies relationship-dependencies basis-t]}
         consistency-context
-        exact? (:cache-remember-answers? opts)]
-    (cond
-      ;; portable-result even when nothing is retained, so a caller's result
-      ;; shape does not depend on cache configuration. Without it :lookup-page
-      ;; data was SpiceObject records with caching off and plain maps with it
-      ;; on — a trap for any consumer that comes to rely on record type.
-      (not exact?)
-      (assoc consistency-context
-             :result (portable-result kind (compute))
-             :cached? false
-             :cache-basis basis-t)
-
-      :else
-      (let [cache-prefix (result-cache-prefix
-                          opts op query-identity
-                          (or (:cache-schema-proof consistency-context)
-                              (:schema-version consistency-context)))
-            exact-key (when (and exact? cache-epoch)
-                        (exact-result-cache-key cache-prefix cache-epoch))
-            tag-hit (fn [answer]
-                      ;; :cache-basis is the basis the answer was COMPUTED at,
-                      ;; captured before :basis-t is overwritten with the
-                      ;; caller's. For a fully-consistent hit the two differ
-                      ;; only because nothing the answer depends on changed in
-                      ;; between — the answer is provably current, not stale.
-                      ;; Under :minimize-latency they differ by real staleness.
-                      (assoc answer :cached? true
-                             :cache-basis (:basis-t answer)))
-            exact-hit #(when exact-key
-                         (some-> (cached-answer opts exact-key kind valid-result?
-                                                {:epoch cache-epoch})
-                                 (tag-hit)
-                                 ;; The epoch proves no EACL-relevant datom
-                                 ;; changed between the answer's basis and this
-                                 ;; one, so the answer IS current: stamp the
-                                 ;; caller's basis so external ids coerce
-                                 ;; against the database they asked for rather
-                                 ;; than sending the caller to d/as-of.
-                                 (assoc :basis-t basis-t)))
-            latest-hit #(when exact?
-                          (some-> (latest-cached-answer
-                                   opts cache-prefix kind valid-result?
-                                   % basis-t)
-                                  (tag-hit)))
-            hit (case mode
-                  ;; exact-hit is a sound fallback here, not a staleness
-                  ;; window: exact-key pins database-id, schema generation,
-                  ;; operation, query identity AND basis-t, and two
-                  ;; connection-backed DB values of one database at the same
-                  ;; basis-t are the same value. Without it, remembered answers
-                  ;; wrote an entry on every call that the default consistency
-                  ;; mode could never read.
-                  :fully-consistent (exact-hit)
-                  :minimize-latency (latest-hit nil)
-                  :at-least-as-fresh (latest-hit requested-t)
-                  :at-exact-snapshot (exact-hit))]
-        (cond
-          (some? hit)
-          hit
-
-          :else
-          (let [result (compute)]
-            (assoc (store-cached-answer!
-                    opts cache-prefix kind result (weight-fn result)
-                    consistency-context)
-                   :cached? false
-                   :cache-basis basis-t)))))))
+        answer
+        (shared-cache/resolve!
+         adapter
+         (if (:cache-remember-answers? opts)
+           (:shared-cache-store opts)
+           shared-cache/no-cache)
+         {:operation op
+          :query query-identity
+          :engine-version engine/engine-version
+          :proof-mode (:proof-mode opts)
+          :recursive-traversal-limits
+          (:recursive-traversal-limits opts)}
+         kind
+         schema-dependencies
+         relationship-dependencies
+         valid-result?
+         #(portable-result kind (compute))
+         (:format-options opts))
+        computation-snapshot (:cache-basis answer)]
+    (assoc consistency-context
+           :result (:value answer)
+           :cached? (:cached? answer)
+           :cache-basis
+           (or (:basis-t computation-snapshot)
+               basis-t))))
 
 (defn- continuation-context
-  "Cache handles for one list operation: recursive traversal continuations and
-  pages, plus the acyclic engine's per-intermediate stream heads. All are
-  keyed by the cursor edge under one prefix that pins the schema generation,
-  the query identity and the relationship proof."
-  [opts op query-identity relationship-proof]
-  (when-let [store (and (selected-schema-version opts)
-                        (:lookup-cache-store opts))]
-    (let [prefix [:recursive-continuation
-                  result-cache-version
-                  (:cache-namespace opts)
-                  (:database-id opts)
-                  (selected-schema-version opts)
-                  op
-                  ;; list-query-identity already returns canonical data.
-                  query-identity
-                  ;; Recursive state depends on EACL relationship content, not
-                  ;; unrelated application transactions or their basis t.
-                  relationship-proof]
-          cache-key #(conj prefix %)
-          opaque-token (:opaque-cache-token opts)
-          namespace (:cache-namespace opts)
-          opaque-values? (contains? (cache/safe-capabilities store)
-                                    :opaque-values)]
-      {:required? false
-       :opaque-values? opaque-values?
-       :get (fn [edge]
-              (some-> (cache/safe-entry-value
-                       store
-                       (cache-key edge)
-                       :recursive-continuation
-                       #(and (map? %)
-                             (identical? opaque-token (:opaque-token %))
-                             (map? (:continuation %))))
-                      :continuation))
-       :evict! (fn [edge]
-                 (cache/safe-evict! store (cache-key edge)))
-       :put! (fn [edge continuation weight]
-               (cache/safe-store-entry!
-                store
-                namespace
-                (cache-key edge)
-                :recursive-continuation
-                {:opaque-token opaque-token
-                 :continuation continuation}
-                weight
-                (:lookup-cache-ttl-ms opts)))
-       :get-page (fn [page-key]
-                   (cache/safe-entry-value
-                    store
-                    (cache-key [:page page-key])
-                    :recursive-page
-                    internal-page?))
-       :put-page! (fn [page-key page weight]
-                    (cache/safe-store-entry!
-                     store
-                     namespace
-                     (cache-key [:page page-key])
-                     :recursive-page
-                     page
-                     weight
-                     (:lookup-cache-ttl-ms opts)))
-       :get-heads (fn [edge]
-                    (cache/safe-entry-value
-                     store
-                     (cache-key [:heads edge])
-                     :lookup-heads
-                     map?))
-       :put-heads! (fn [edge heads weight]
-                     (cache/safe-store-entry!
-                      store
-                      namespace
-                      (cache-key [:heads edge])
-                      :lookup-heads
-                      heads
-                      weight
-                      (:lookup-cache-ttl-ms opts)))})))
+  "Recursive/frontier state is an optional optimization. Until a provider
+  entry uses the same authenticated causal/proof envelope as completed
+  answers, do not read it at all: the shared engine deterministically replays
+  from the authenticated cursor and selected immutable snapshot."
+  [_opts _op _query-identity _relationship-proof]
+  nil)
 
 (def ^:private empty-page
   "Unknown objects match nothing (SpiceDB-consistent, audit D9): lookups and
@@ -1057,12 +832,22 @@
         decoded (decoded-page-bound opts page-req)
         _ (validate-page-token-identity!
            opts :read-relationships query-shape decoded)
-        {:keys [db basis-t schema-version]}
+        {:keys [db basis-t schema-version cursor-context]}
         (capture-result-context
          conn opts (:consistency filters)
-         (fn [db] {:db db})
+         (fn [db]
+           (let [relation-ids
+                 (impl/relationship-relation-ids db filters)]
+             {:db db
+              :relationship-dependencies relation-ids
+              :schema-dependencies
+              {:permission-nodes []
+               :relation-ids relation-ids}}))
          :read-relationships decoded)
-        selected-opts (assoc opts :selected-schema-version schema-version)
+        selected-opts
+        (assoc opts
+               :selected-schema-version schema-version
+               :page-cursor-context cursor-context)
         ;; Validated before the empty-page short-circuit, so a cursor from
         ;; another schema generation raises :eacl.pagination/stale-schema here
         ;; exactly as it does in the lookups, instead of quietly reading as an
@@ -1135,34 +920,82 @@
         true
         (recur (.getCause ^Throwable cause))))))
 
+(defn- response-token
+  [db opts]
+  (when (= :managed (:coherence-authority opts))
+    (let [{:keys [family-id head-id]} (journal/graph-state db)]
+      (causal-token/issue
+       (:format-options opts)
+       {:backend :datomic
+        :source-id {:database-id (:database-id opts)
+                    :family-id family-id}
+        :branch nil
+        :graph-anchor head-id
+        :order-hint (d/basis-t db)
+        :exact-locator (d/basis-t db)}))))
+
+(defn- write-response
+  [db opts]
+  (if-let [token (response-token db opts)]
+    {:zed/token token}
+    {}))
+
 (defn spiceomic-write-relationships!
   "Writes relationships and returns a zed token for the committed revision.
 
-  There is no cache bookkeeping here. A write used to run inside a coordinator
-  mutation that published which relations it touched, and had to distinguish
-  validation failures (which commit nothing) from a possibly-committed throw so
-  an ordinary :eacl/relationship-conflict did not flush every cached result.
-  The tx-data itself now carries that publication as :eacl/relation-version
-  stamps, so a transaction that never commits announces nothing by
-  construction."
+  There is no process-local cache bookkeeping here. The committed transaction
+  atomically carries the v3 mutation record, graph head, and affected relation
+  mutation identities. Legacy :eacl/relation-version CAS datoms remain only as
+  a Datomic write-serialization mechanism for the existing relationship
+  storage schema; cache validity never depends on them."
   [conn opts updates]
-  (let [updates (vec updates)]
-  (doseq [{:keys [operation]} updates]
-    (impl/validate-relationship-operation! operation))
+  (let [updates (vec updates)
+        mutation-id (mutation/new-id)]
+    (doseq [{:keys [operation]} updates]
+      (impl/validate-relationship-operation! operation))
     (loop [attempt 1]
       (let [db (d/db conn)
-            tx-data
-            (->> updates
-                 (S/transform [S/ALL :relationship]
-                              #(spice-relationship->internal db opts %))
+            internal-updates
+            (S/transform [S/ALL :relationship]
+                         #(spice-relationship->internal db opts %)
+                         updates)
+            relation-ids
+            (->> internal-updates
+                 (map (comp #(impl/relationship-relation-id db %)
+                            :relationship))
+                 distinct
+                 vec)
+            relationship-tx-data
+            (->> internal-updates
                  (mapcat #(impl/tx-update-relationship db %))
                  (remove nil?)
-                 (impl/optimistic-relationship-tx-data db))
+                 vec)
+            tx-data
+            (when (seq relationship-tx-data)
+              (impl/optimistic-relationship-tx-data
+               db relationship-tx-data))
             submission
-            (try
-              {:report @(d/transact conn tx-data)}
-              (catch Throwable throwable
-                {:error throwable}))]
+            (if (seq tx-data)
+              (try
+                {:report
+                 (journal/transact!
+                  conn
+                  {:mutation-id mutation-id
+                   :kind :relationships
+                   :canonical-data
+                   {:operation :write-relationships
+                    :updates internal-updates}
+                   :relation-ids relation-ids
+                   :token-ttl-seconds (:token-ttl-seconds opts)
+                   :retention-grace-seconds
+                   (:retention-grace-seconds opts)
+                   :tx-data tx-data})}
+                (catch Throwable throwable
+                  {:error throwable}))
+              {:report {:db-before db
+                        :db-after db
+                        :tx-data []
+                        :no-op? true}})]
         (if-let [throwable (:error submission)]
           (if (and (datomic-cas-failure? throwable)
                    (< attempt maximum-relationship-write-attempts))
@@ -1180,8 +1013,7 @@
                 throwable))
               (throw throwable)))
           (let [db-after (get-in submission [:report :db-after])]
-            {:zed/token (revision/zed-token opts (:database-id opts)
-                                            (d/basis-t db-after))}))))))
+            (write-response db-after opts)))))))
 
 (defmacro ^:private with-recursive-limits
   "Applies the client's :recursive-traversal-limits, if configured, for the
@@ -1244,29 +1076,20 @@
          (finally
            (.unlock lock#))))))
 
-(defn- needs-relationship-dependencies?
-  "Whether anything this client caches needs a query's relation dependency set.
-
-  Both consumers derive from it: the exact-result epoch, and the cache scope
-  that keys recursive continuations and cursors. Resolving the set is a
-  memoised map lookup on a stamped client, so this test is about skipping work
-  on a cacheless client, not about hot-path cost."
-  [opts]
-  (boolean (or (:cache-remember-answers? opts)
-               (:lookup-cache-store opts))))
-
 (defn- permission-cache-dependencies
   [opts db resource-type permission]
-  (when (needs-relationship-dependencies? opts)
-    (let [relation-ids
-          (impl.indexed/permission-relationship-eids
-           db resource-type permission)]
-      {:relationship-dependencies relation-ids
-       :schema-dependencies
-       {:permission-nodes
-        (impl.indexed/permission-schema-nodes
-         db resource-type permission)
-        :relation-ids relation-ids}})))
+  ;; The same complete closure protects both completed answers and cursors.
+  ;; A cacheless client may still paginate, so cursor correctness cannot be
+  ;; conditional on whether a result-cache provider was configured.
+  (let [relation-ids
+        (impl.indexed/permission-relationship-eids
+         db resource-type permission)]
+    {:relationship-dependencies relation-ids
+     :schema-dependencies
+     {:permission-nodes
+      (impl.indexed/permission-schema-nodes
+       db resource-type permission)
+      :relation-ids relation-ids}}))
 
 (defn- request-cache-opts
   "Validates and applies a per-request `:cache?` override to the client's opts.
@@ -1281,7 +1104,7 @@
   different kinds of thing, so two different names.
 
   Everything downstream is already guarded on the store and the
-  :cache-remember-answers? flag, so clearing those two is the whole mechanism —
+  :cache-remember-answers? flag, so clearing both is the whole mechanism —
   there is no separate bypass path to keep correct. Cursors still work: a page
   token is minted and validated from the request, not from the cache."
   [opts cache-option]
@@ -1296,104 +1119,200 @@
            :cache-remember-answers? false)
     opts))
 
-(defn- capture-result-context
-  "Captures one DB and the cache proof that matches it.
+(defn- selected-schema-cache!
+  [opts adapter db]
+  (let [schema-proof (backend/invoke adapter :schema-proof)
+        key [(backend/backend-id adapter)
+             (backend/invoke adapter :source-scope)
+             schema-proof]
+        registry (:derived-schema-caches opts)]
+    (or (get @registry key)
+        (let [created
+              (impl.indexed/make-schema-cache db schema-proof)]
+          (get (swap! registry
+                      #(if (contains? % key)
+                         %
+                         (assoc % key created)))
+               key)))))
 
-  A cursor or exact request uses a historical DB and a request-scoped schema
-  cache; everything else reads the current value once. The proof is derived
-  from that same db value, so there is no barrier and nothing to synchronise."
+(def ^:private cursor-equivalence-fields
+  [:source-scope
+   :adapter-fingerprint
+   :identity-contract
+   :dependency-scope-digest
+   :proof-digest])
+
+(defn- cursor-context-equivalent?
+  [current cursor-envelope]
+  (and current
+       (every?
+        (fn [field]
+          (= (secure/canonicalize (get current field))
+             (secure/canonicalize (get cursor-envelope field))))
+        cursor-equivalence-fields)))
+
+(defn- snapshot-result-context
+  [opts snapshot-adapter prepare]
+  (let [db (:db (backend/state snapshot-adapter))
+        ;; `d/as-of` filters visibility but retains its backing DB's basis-t.
+        ;; The adapter exact locator is the selected logical revision.
+        basis-t (backend/invoke snapshot-adapter :exact-locator)
+        schema-cache
+        (selected-schema-cache! opts snapshot-adapter db)
+        {:keys [relationship-dependencies schema-dependencies]
+         :as prepared}
+        (binding [impl.indexed/*schema-cache* schema-cache]
+          (prepare db))
+        relationship-proof
+        (when (some? relationship-dependencies)
+          (backend/invoke
+           snapshot-adapter
+           :relation-proof
+           relationship-dependencies))
+        cache-scope
+        (if (some? relationship-proof)
+          [:relations relationship-proof]
+          [:basis basis-t])
+        cursor-cache-scope
+        [:proof
+         (secure/canonical-digest
+          "eacl/datomic/cursor-cache-scope/v3"
+          cache-scope)]
+        schema-proof
+        (backend/invoke snapshot-adapter :schema-proof)
+        schema-version
+        (secure/canonical-digest
+         "eacl/datomic/cursor-schema-proof/v3"
+         schema-proof)
+        cursor-context
+        (when (and schema-dependencies
+                   (some? relationship-dependencies))
+          (relay/dependency-context
+           snapshot-adapter
+           {:schema-scope schema-dependencies
+            :relation-ids relationship-dependencies}))]
+    (assoc prepared
+           :db db
+           :adapter snapshot-adapter
+           :basis-t basis-t
+           :cache-scope cache-scope
+           ;; Cursors need an authenticated proof identity, not the proof
+           ;; material itself. Content-mode proofs grow with the graph and
+           ;; schema proofs grow with the schema; embedding either makes token
+           ;; size attacker/workload dependent and duplicates `proof-digest`.
+           :cursor-scope cursor-cache-scope
+           :cursor-context cursor-context
+           :schema-cache schema-cache
+           :schema-version schema-version
+           :cache-schema-proof
+           (when schema-dependencies
+             (backend/invoke
+              snapshot-adapter
+              :schema-proof
+              schema-dependencies)))))
+
+(defn- cursor-snapshot-expired!
+  [operation decoded]
+  (throw
+   (ex-info
+    "The cursor's exact Datomic snapshot is no longer retained."
+    {:type :eacl.consistency/snapshot-expired
+     :eacl/error :eacl.consistency/snapshot-expired
+     :operation operation
+     :exact-locator (get-in decoded [:graph-head :exact-locator])})))
+
+(defn- capture-result-context
+  "Selects one immutable request snapshot, then continues a cursor on that
+  snapshot when its complete proof is equal. Only a proof mismatch may fall
+  back to the cursor's authenticated original basis."
   [conn opts consistency-value prepare operation decoded]
-  (let [{:keys [mode requested-t]}
-        (consistency-request opts consistency-value)
-        cursor-t (:basis-t decoded)
-        _ (when (and decoded
-                     (= :at-least-as-fresh mode)
-                     (> requested-t cursor-t))
-            (throw
-             (ex-info "The cursor is older than the requested freshness."
-                      {:type :eacl.consistency/incompatible-cursor
-                       :cursor-t cursor-t
-                       :requested-t requested-t})))
+  (let [source-adapter ((:backend-adapter-fn opts) (d/db conn))
+        selection
+        (consistency-v3/select
+         source-adapter
+         consistency-value
+         {:format-options (:format-options opts)
+          :coherence-authority (:coherence-authority opts)
+          :issue-token? true
+          :timeout-ms (:consistency-sync-timeout-ms opts)})
+        selected-adapter (:adapter selection)
+        selected-context
+        (snapshot-result-context opts selected-adapter prepare)
+        {:keys [mode]} (:descriptor selection)
+        request-token (:request-token selection)
+        requested-t (:order-hint request-token)
         _ (when (and decoded
                      (= :at-exact-snapshot mode)
-                     (not= requested-t cursor-t))
-            (throw
-             (ex-info "The cursor and exact-snapshot token name different revisions."
-                      {:type :eacl.consistency/incompatible-cursor
-                       :cursor-t cursor-t
-                       :requested-t requested-t})))
-        historical-t (or cursor-t
-                         (when (= :at-exact-snapshot mode)
-                           requested-t))]
-    (if historical-t
-      (let [db (historical-db conn opts historical-t operation)
-            schema-cache (impl.indexed/make-schema-cache db)
-            snapshot-adapter ((:backend-adapter-fn opts) db)
-            prepared
-            (binding [impl.indexed/*schema-cache* schema-cache]
-              (prepare db))]
-        (revision/observe! (:revision-checkpoints opts)
-                           (d/basis-t (d/db conn)))
-        (assoc prepared
-               :mode :at-exact-snapshot
-               :requested-t requested-t
-               :basis-t historical-t
-               ;; A cursor or exact-snapshot read pins a historical basis and
-               ;; is its own epoch. EACL targets the current database; keeping
-               ;; a cache warm for every point in time is a non-goal.
-               :cache-epoch historical-t
-               :cache-scope (:cache-scope decoded)
-               :cursor-scope (:cache-scope decoded)
-               :schema-cache schema-cache
-               :schema-version
-               (backend/invoke snapshot-adapter :schema-proof)
-               :cache-schema-proof
-               (backend/invoke
-                snapshot-adapter
-                :schema-proof
-                (:schema-dependencies prepared))))
-      (let [minimum-t (when (= :at-least-as-fresh mode)
-                        requested-t)
-            _ (await-revision-db conn opts minimum-t)
-            ;; One db value, read once. There used to be a read barrier here
-            ;; pairing this value with a relationship-coordinator snapshot, plus
-            ;; a bounded catch-up loop for a reader behind the coordinator's
-            ;; published floor. Both existed to make an in-process proof cohere
-            ;; with Datomic; per-relation stamps live IN the db value, so the
-            ;; value is the proof and there is nothing to synchronise.
-            db (d/db conn)
-            observed-t (d/basis-t db)
-            snapshot-adapter ((:backend-adapter-fn opts) db)
-            {:keys [relationship-dependencies schema-dependencies]
-             :as prepared}
-            (prepare db)
-            ;; The max relation stamp over exactly what this answer depends on,
-            ;; read from the same db value. An unrelated application write
-            ;; leaves it alone, and so does churn on an EACL relation this
-            ;; answer does not read. Any write that CAN affect the answer moves
-            ;; it, whichever process or connection made it, because the stamp is
-            ;; transacted with the relationship datoms.
-            cache-epoch (backend/invoke
-                         snapshot-adapter
-                         :relation-proof
-                         relationship-dependencies)]
-        (revision/observe! (:revision-checkpoints opts) observed-t)
-        (assoc prepared
-               :mode mode
-               :requested-t requested-t
-               :basis-t observed-t
-               :cache-epoch cache-epoch
-               ;; Continuations and cursors pin the same proof. Falling back to
-               ;; the basis when no epoch can be established keeps them correct
-               ;; on a database without relation stamps, at that basis's much
-               ;; coarser hit rate.
-               :cache-scope (if cache-epoch
-                              [:relations cache-epoch]
-                              [:basis observed-t])
-               :schema-version (client-schema-version opts)
-               :cache-schema-proof
-               (backend/invoke
-                snapshot-adapter :schema-proof schema-dependencies))))))
+                     (not= (:exact-locator request-token)
+                           (get-in decoded
+                                   [:graph-head :exact-locator])))
+            (consistency-v3/cursor-conflict!
+             {:cursor-exact-locator
+              (get-in decoded [:graph-head :exact-locator])
+              :requested-exact-locator
+              (:exact-locator request-token)}))
+        selected-context
+        (cond
+          (nil? decoded)
+          selected-context
+
+          (cursor-context-equivalent?
+           (:cursor-context selected-context)
+           decoded)
+          selected-context
+
+          (= :at-least-as-fresh mode)
+          (consistency-v3/cursor-conflict!
+           {:cursor-graph-anchor
+            (get-in decoded [:graph-head :graph-anchor])
+            :selected-graph-anchor
+            (:graph-anchor
+             (backend/invoke selected-adapter :graph-head))})
+
+          :else
+          (let [exact
+                (backend/invoke
+                 source-adapter
+                 :select-exact
+                 {:graph-anchor
+                  (get-in decoded [:graph-head :graph-anchor])
+                  :order-hint
+                  (get-in decoded [:graph-head :order-hint])
+                  :exact-locator
+                  (get-in decoded [:graph-head :exact-locator])}
+                 (:consistency-sync-timeout-ms opts))
+                _ (when-not exact
+                    (cursor-snapshot-expired! operation decoded))
+                exact-context
+                (snapshot-result-context opts exact prepare)]
+            (when-not
+             (and
+              (= (secure/canonicalize
+                  (backend/invoke source-adapter :source-scope))
+                 (secure/canonicalize
+                  (backend/invoke exact :source-scope)))
+              (= (get-in decoded [:graph-head :graph-anchor])
+                 (:graph-anchor (backend/invoke exact :graph-head)))
+              (cursor-context-equivalent?
+               (:cursor-context exact-context)
+               decoded))
+              (throw
+               (ex-info
+                "The Datomic cursor exact locator resolved to another graph."
+                {:type :eacl.consistency/history-divergence
+                 :eacl/error :eacl.consistency/history-divergence})))
+            (assoc exact-context :mode :at-exact-snapshot)))]
+    (revision/observe! (:revision-checkpoints opts)
+                       (d/basis-t (d/db conn)))
+    (merge
+     selected-context
+     {:mode (or (:mode selected-context) mode)
+      :requested-t requested-t
+      :selection selection
+      :response-token
+      (if (= :at-exact-snapshot (:mode selected-context))
+        (response-token (:db selected-context) opts)
+        (:response-token selection))})))
 
 (defn basis-instant
   "Wall-clock time of a Datomic basis `t`, for interpreting the `:cache-basis`
@@ -1436,30 +1355,44 @@
 (def ^:private delete-object-batch-size 1000)
 
 (defn- transact-delete-object-batch!
-  [conn batch]
-  (loop [attempt 1]
-    (let [db (d/db conn)
-          guarded (impl/optimistic-relationship-tx-data
-                   db
-                   (impl/stamp-relation-versions batch))
+  [conn opts batch]
+  (let [batch (vec batch)
+        mutation-id (mutation/new-id)]
+    (loop [attempt 1]
+      (let [db (d/db conn)
+          stamped (impl/stamp-relation-versions batch)
+          relation-ids (vec (sort (impl/affected-relation-ids stamped)))
+          guarded (impl/optimistic-relationship-tx-data db stamped)
           submission
           (try
-            {:report @(d/transact conn guarded)}
+            {:report
+             (journal/transact!
+              conn
+              {:mutation-id mutation-id
+               :kind :object-deletion
+               :canonical-data
+               {:operation :delete-object-batch
+                :tx-data batch}
+               :relation-ids relation-ids
+               :token-ttl-seconds (:token-ttl-seconds opts)
+               :retention-grace-seconds
+               (:retention-grace-seconds opts)
+               :tx-data guarded})}
             (catch Throwable throwable
               {:error throwable}))]
-      (if-let [throwable (:error submission)]
-        (if (and (datomic-cas-failure? throwable)
-                 (< attempt maximum-relationship-write-attempts))
-          (recur (inc attempt))
-          (if (datomic-cas-failure? throwable)
-            (throw
-             (ex-info
-              "EACL object deletion could not obtain a stable schema/relation generation."
-              {:type :eacl/relationship-contention
-               :attempts attempt}
-              throwable))
-            (throw throwable)))
-        (:report submission)))))
+        (if-let [throwable (:error submission)]
+          (if (and (datomic-cas-failure? throwable)
+                   (< attempt maximum-relationship-write-attempts))
+            (recur (inc attempt))
+            (if (datomic-cas-failure? throwable)
+              (throw
+               (ex-info
+                "EACL object deletion could not obtain a stable schema/relation generation."
+                {:type :eacl/relationship-contention
+                 :attempts attempt}
+                throwable))
+              (throw throwable)))
+          (:report submission))))))
 
 (defn spiceomic-delete-object!
   "Retracts every relationship touching `object`, in both directions, in
@@ -1485,24 +1418,24 @@
                       (when (number? object-id) object-id))
         tx-data   (impl/tx-delete-object-stream db eid)]
     (if (empty? tx-data)
-      {:zed/token (revision/zed-token opts (:database-id opts) (d/basis-t db))
-       :retracted-datoms 0}
+      (assoc (write-response db opts)
+             :retracted-datoms 0)
       (loop [batches   (partition-all delete-object-batch-size tx-data)
              retracted 0
-             basis-t   nil]
+             db-after  nil]
         (if-let [batch (first batches)]
           ;; Each batch must publish the relations IT changes:
           ;; tx-delete-object deduplicates stamps across the whole result, so
           ;; without this a later batch retracts relationships while announcing
           ;; nothing.
           (let [{:keys [db-after tx-data]}
-                (transact-delete-object-batch! conn batch)]
+                (transact-delete-object-batch! conn opts batch)]
             (recur (next batches)
                    (+ retracted
                       (relationship-retraction-count db-after tx-data))
-                   (d/basis-t db-after)))
-          {:zed/token (revision/zed-token opts (:database-id opts) basis-t)
-           :retracted-datoms retracted})))))
+                   db-after))
+          (assoc (write-response db-after opts)
+                 :retracted-datoms retracted))))))
 
 (defn spiceomic-can?
   [conn {:keys [object->entid] :as opts}
@@ -1526,9 +1459,14 @@
     (if-not (and (:id internal-subject) (:id internal-resource))
       false
       (let [query-identity
-            [:subject (:type internal-subject) (:id internal-subject)
-             :permission permission
-             :resource (:type internal-resource) (:id internal-resource)]]
+            {:public
+             {:subject subject
+              :permission permission
+              :resource resource}
+             :internal
+             {:subject internal-subject
+              :permission permission
+              :resource internal-resource}}]
         (:result
          (cached-authorization-result
           opts result-context :can? query-identity :can?
@@ -1571,7 +1509,10 @@
                 cache-scope cursor-scope schema-version]
          :as result-context}
         captured
-        selected-opts (assoc opts :selected-schema-version schema-version)]
+        selected-opts
+        (assoc opts
+               :selected-schema-version schema-version
+               :page-cursor-context (:cursor-context captured))]
     (validate-page-token-schema! selected-opts decoded)
     (if (nil? (:id internal-subject))
       ;; Unknown subjects match nothing and never enter the cache.
@@ -1582,16 +1523,12 @@
                (fn []
                  (impl/lookup-resources
                   db internal-query
-                  {:continuation-cache-fn
-                   (fn []
-                     (continuation-context
-                      selected-opts
-                      :lookup-resources
-                      (list-query-identity :lookup-resources query')
-                      (or cursor-scope cache-scope)))})))
+                  {})))
             answer
             (cached-authorization-result
-             selected-opts result-context :lookup-resources internal-query
+             selected-opts result-context :lookup-resources
+             {:public (dissoc query :consistency :cache?)
+              :internal internal-query}
              :lookup-page internal-page? internal-page-weight compute)
             selected-basis (:basis-t answer)
             internal-page (:result answer)
@@ -1651,7 +1588,9 @@
     (if (nil? (:id subject-ent))
       (assoc (empty-count-response query) :cached? false :cache-basis nil)
       (let [answer (cached-authorization-result
-                    opts result-context :count-resources query'
+                    opts result-context :count-resources
+                    {:public (dissoc query :consistency :cache?)
+                     :internal query'}
                     :count count-response? (constantly 256)
                     #(with-result-schema
                        result-context
@@ -1692,7 +1631,10 @@
                 cache-scope cursor-scope schema-version]
          :as result-context}
         captured
-        selected-opts (assoc opts :selected-schema-version schema-version)]
+        selected-opts
+        (assoc opts
+               :selected-schema-version schema-version
+               :page-cursor-context (:cursor-context captured))]
     (validate-page-token-schema! selected-opts decoded)
     (if (nil? (:id internal-resource))
       (assoc empty-page :cached? false :cache-basis nil)
@@ -1702,16 +1644,12 @@
                (fn []
                  (impl/lookup-subjects
                   db internal-query
-                  {:continuation-cache-fn
-                   (fn []
-                     (continuation-context
-                      selected-opts
-                      :lookup-subjects
-                      (list-query-identity :lookup-subjects query')
-                      (or cursor-scope cache-scope)))})))
+                  {})))
             answer
             (cached-authorization-result
-             selected-opts result-context :lookup-subjects internal-query
+             selected-opts result-context :lookup-subjects
+             {:public (dissoc query :consistency :cache?)
+              :internal internal-query}
              :lookup-page internal-page? internal-page-weight compute)
             selected-basis (:basis-t answer)
             internal-page (:result answer)
@@ -1761,7 +1699,9 @@
     (if (nil? (:id resource-ent))
       (assoc (empty-count-response query) :cached? false :cache-basis nil)
       (let [answer (cached-authorization-result
-                    opts result-context :count-subjects query'
+                    opts result-context :count-subjects
+                    {:public (dissoc query :consistency :cache?)
+                     :internal query'}
                     :count count-response? (constantly 256)
                     #(with-result-schema
                        result-context
@@ -1796,14 +1736,20 @@
     (with-client-schema-write schema-lock
       (let [deltas      (schema/write-schema!
                          conn schema-string
-                         {}
+                         (select-keys
+                          opts
+                          [:token-ttl-seconds
+                           :retention-grace-seconds])
                          (:schema-version @schema-state))
             next-version (:eacl/schema-version (meta deltas))
             next-cache  (impl.indexed/make-schema-cache (d/db conn) next-version)]
         (when-not (= (:schema-version @schema-state)
                      (:schema-version next-cache))
           (reset! schema-state next-cache))
-        deltas)))
+        (merge deltas
+               (write-response
+                (:eacl.mutation/db-after (meta deltas))
+                opts)))))
 
   (read-relationships [_ filters]
     (with-client-schema-read conn schema-lock schema-state
@@ -1907,6 +1853,12 @@
     :zed-token-key
     :zed-token-keyring
     :zed-token-kid
+    :token-ttl-seconds
+    :retention-grace-seconds
+    :coherence-authority
+    :proof-mode
+    :adapter-fingerprint
+    :adapter-deterministic?
     :consistency-sync-timeout-ms
     :recursive-traversal-limits
     :auto-migrate-v6})
@@ -2123,9 +2075,10 @@
     exact pages and recursive continuations replay against the authenticated
     historical basis rather than falling forward.
 
-    There is no cross-process cache coordination to configure. Invalidation
-    rides on :eacl/relation-version stamps written into the transaction that
-    changes a relationship, so every reader of the database observes it.
+    There is no cross-process cache coordination to configure. Managed writers
+    atomically publish v3 graph and dependency mutation identities in the same
+    transaction as the authorization change. Unknown or mixed writers use
+    complete content proofs instead of trusting those identities.
 
   - :page-token-key / :page-token-keys / :page-token-keyring / :page-token-kid —
     AES-GCM page-token key material. Default: a random per-client key, meaning
@@ -2162,6 +2115,12 @@
            zed-token-key
            zed-token-keyring
            zed-token-kid
+           token-ttl-seconds
+           retention-grace-seconds
+           coherence-authority
+           proof-mode
+           adapter-fingerprint
+           adapter-deterministic?
            consistency-sync-timeout-ms
            recursive-traversal-limits
            auto-migrate-v6]
@@ -2187,6 +2146,50 @@
     (throw (ex-info "EACL Config Error: supply only one of :zed-token-key or :zed-token-keyring."
                     {:type :eacl/invalid-config
                      :conflicting-keys [:zed-token-key :zed-token-keyring]})))
+  (when-not (contains? #{nil :unknown :managed} coherence-authority)
+    (throw (ex-info "EACL Config Error: :coherence-authority must be :managed or :unknown."
+                    {:type :eacl/invalid-config
+                     :key :coherence-authority
+                     :value coherence-authority})))
+  (when-not (contains? #{nil :auto :mutation :content :none} proof-mode)
+    (throw (ex-info "EACL Config Error: unsupported :proof-mode."
+                    {:type :eacl/invalid-config
+                     :key :proof-mode
+                     :value proof-mode})))
+  (when (and (= :mutation proof-mode)
+             (not= :managed coherence-authority))
+    (throw (ex-info "EACL Config Error: mutation proof requires managed writer authority."
+                    {:type :eacl/invalid-config
+                     :key :proof-mode
+                     :value proof-mode})))
+  (when (and (contains? config-opts :adapter-deterministic?)
+             (not (boolean? adapter-deterministic?)))
+    (throw (ex-info "EACL Config Error: :adapter-deterministic? must be boolean."
+                    {:type :eacl/invalid-config
+                     :key :adapter-deterministic?
+                     :value adapter-deterministic?})))
+  (when adapter-fingerprint
+    (try
+      (secure/encode-canonical adapter-fingerprint)
+      (catch Exception error
+        (throw (ex-info "EACL Config Error: :adapter-fingerprint must be portable canonical data."
+                        {:type :eacl/invalid-config
+                         :key :adapter-fingerprint}
+                        error)))))
+  (when (and token-ttl-seconds
+             (not (and (integer? token-ttl-seconds)
+                       (pos? token-ttl-seconds))))
+    (throw (ex-info "EACL Config Error: :token-ttl-seconds must be positive."
+                    {:type :eacl/invalid-config
+                     :key :token-ttl-seconds
+                     :value token-ttl-seconds})))
+  (when (and retention-grace-seconds
+             (not (and (integer? retention-grace-seconds)
+                       (not (neg? retention-grace-seconds)))))
+    (throw (ex-info "EACL Config Error: :retention-grace-seconds must be non-negative."
+                    {:type :eacl/invalid-config
+                     :key :retention-grace-seconds
+                     :value retention-grace-seconds})))
   (let [timeout-ms (if (contains? config-opts
                                    :consistency-sync-timeout-ms)
                      consistency-sync-timeout-ms
@@ -2213,33 +2216,37 @@
   ;; silently answer every check with false/empty. Throws :eacl/storage-version
   ;; unless the DB is v7/fresh/stamped, or :auto-migrate-v6 opts into migration.
   (migrations/assert-storage-compatible! conn {:auto-migrate-v6 auto-migrate-v6})
-  (let [initial-db         (d/db conn)
+  (journal/ensure-migrated! conn)
+  (let [coherence-authority (or coherence-authority :unknown)
+        proof-mode (case (or proof-mode :auto)
+                     :auto (if (= :managed coherence-authority)
+                             :mutation
+                             :content)
+                     proof-mode)
+        initial-db         (d/db conn)
         schema-state       (atom (impl.indexed/make-schema-cache initial-db))
         cache-config       (normalize-cache-config cache page-token-ttl-seconds)
-        ;; Per-relation epoch state, built only when results can be retained.
-        ;; Holds one memoised attribute eid and no db value. Whether an epoch
-        ;; can actually be established is decided per read, not here: a client
-        ;; may be constructed before the EACL schema exists — this repo's own
-        ;; benchmark seeding does that — and retention starts working by itself
-        ;; once write-schema! installs :eacl/relation-version.
-        ;; Built whenever anything can be cached, not only for exact results:
-        ;; the epoch is also the cache scope that keys recursive continuations
-        ;; and cursors. Gating it on :remember-answers left a default client
-        ;; falling back to [:basis t] there, so 20 unrelated transactions
-        ;; invalidated a recursive page that had not changed.
-        cache-epoch-state  (when (:store cache-config)
-                             (watermark/make-epoch-state))
         timeout-ms         (if (contains? config-opts
                                           :consistency-sync-timeout-ms)
                              consistency-sync-timeout-ms
                              default-consistency-sync-timeout-ms)
         schema-lock        (ReentrantReadWriteLock.)
+        custom-codec?
+        (boolean
+         (or entid->object-id
+             entity->object-id
+             (contains? config-opts :object-id->ident)))
         entid->object-id   (or entid->object-id
                                (when entity->object-id
                                  (fn [db eid] (entity->object-id (d/entity db eid))))
                                (fn [db eid] (:eacl/id (d/entity db eid))))
         object-id->entid   (fn [db object-id]
                              (d/entid db (object-id->ident object-id)))
+        adapter-deterministic?
+        (if custom-codec?
+          (and (some? adapter-fingerprint)
+               (true? adapter-deterministic?))
+          true)
         current-kid        (or page-token-kid :current)
         _                  (validate-token-key-id! :page-token-kid current-kid)
         configured-keyring (or page-token-keyring page-token-keys)
@@ -2284,23 +2291,57 @@
                                          (revision/derive-signing-key
                                           root-key)]))
                                  zed-root-keyring)
+        format-options     {:current-kid zed-current-kid
+                            :keyring
+                            (into {}
+                                  (map (fn [[kid root-key]]
+                                         [kid
+                                          (secure/normalize-key root-key)]))
+                                  zed-root-keyring)
+                            :token-ttl-seconds
+                            (or token-ttl-seconds
+                                mutation/default-token-ttl-seconds)}
         opts               {:object-id->ident object-id->ident
                             :schema-state schema-state
+                            :derived-schema-caches (atom {})
                             :database-id (:database-id @schema-state)
                             :backend-capabilities datomic-backend/capabilities
                             :backend-adapter-fn
                             (fn [db]
-                              (datomic-backend/snapshot-adapter
+                             (datomic-backend/snapshot-adapter
                                db
                                {:entid->object-id entid->object-id
-                                :cache-epoch-state cache-epoch-state}))
+                                :conn conn
+                                :database-id (:database-id @schema-state)
+                                :coherence-authority coherence-authority
+                                :proof-mode proof-mode
+                                :adapter-fingerprint
+                                (or adapter-fingerprint
+                                    {:backend :datomic
+                                     :adapter-version backend/adapter-version
+                                     :proof-mode proof-mode
+                                     :recursive-traversal-limits
+                                     recursive-traversal-limits
+                                     :codec
+                                     (if custom-codec?
+                                       :custom-unfingerprinted
+                                       :eacl-id-immutable-v1)})
+                                :adapter-deterministic?
+                                adapter-deterministic?}))
+                            ;; Compatibility/introspection aliases retained
+                            ;; for v7 callers and cache telemetry. Completed
+                            ;; answers execute only through
+                            ;; :shared-cache-store below.
                             :lookup-cache-store (:store cache-config)
                             :lookup-cache-ttl-ms (:ttl-ms cache-config)
                             :cache-namespace (:namespace cache-config)
+                            :shared-cache-store
+                            (cache/authenticated-store
+                             (:store cache-config)
+                             (:namespace cache-config)
+                             (:ttl-ms cache-config))
                             :cache-remember-answers? (:remember-answers? cache-config)
-                            :cache-epoch-state cache-epoch-state
                             :revision-checkpoints (:checkpoints cache-config)
-                            :opaque-cache-token (Object.)
                             :entid->object-id entid->object-id
                             :object-id->entid object-id->entid
                             :object->entid (fn [db {:keys [id]}]
@@ -2314,6 +2355,15 @@
                             :page-token-ttl-seconds page-token-ttl-seconds
                             :zed-token-current-kid zed-current-kid
                             :zed-token-keyring zed-keyring
+                            :format-options format-options
+                            :coherence-authority coherence-authority
+                            :proof-mode proof-mode
+                            :token-ttl-seconds
+                            (or token-ttl-seconds
+                                mutation/default-token-ttl-seconds)
+                            :retention-grace-seconds
+                            (or retention-grace-seconds
+                                mutation/default-retention-grace-seconds)
                             :consistency-sync-timeout-ms timeout-ms
                             ;; merged, so a partial override cannot silently
                             ;; disable the limits it does not mention
@@ -2331,10 +2381,13 @@
     (throw (ex-info "current-zed-token requires an EACL Datomic client."
                     {:type :eacl/invalid-client})))
   (let [db (d/db (:conn client))
-        opts (:opts client)
-        basis-t (d/basis-t db)]
-    (revision/observe! (:revision-checkpoints opts) basis-t)
-    (revision/zed-token opts (:database-id opts) basis-t)))
+        opts (:opts client)]
+    (when-not (= :managed (:coherence-authority opts))
+      (throw (ex-info
+              "Causal token issuance requires complete writer authority."
+              {:type :eacl/causal-authority-incomplete})))
+    (revision/observe! (:revision-checkpoints opts) (d/basis-t db))
+    (response-token db opts)))
 
 (defn zed-token-at-least-seconds-ago
   "Returns an at-least-as-fresh token based on bounded observed checkpoints.
@@ -2351,12 +2404,15 @@
         opts (:opts client)
         checkpoints (:revision-checkpoints opts)
         basis-t (d/basis-t db)]
+    (when-not (= :managed (:coherence-authority opts))
+      (throw (ex-info
+              "Causal token issuance requires complete writer authority."
+              {:type :eacl/causal-authority-incomplete})))
     (when-not checkpoints
       (throw (ex-info "Revision checkpoints are disabled for this EACL client."
                       {:type :eacl/checkpoints-disabled})))
     (revision/observe! checkpoints basis-t)
-    (revision/zed-token
-     opts
-     (:database-id opts)
-     (revision/revision-at-least-seconds-ago
-      checkpoints seconds-ago basis-t))))
+    (let [selected-t
+          (revision/revision-at-least-seconds-ago
+           checkpoints seconds-ago basis-t)]
+      (response-token (d/as-of db selected-t) opts))))

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -1956,17 +1956,11 @@
           enabled? (not (cache/no-cache? cache-option))
           ;; Consumers choose an adapter (or explicit no-cache); they should
           ;; not have to understand entry kinds to get a good outcome.
-          ;; :on-repeat is the
-          ;; default because it DOMINATES always-remember in every workload
-          ;; measured — never slower, sometimes faster — so there is nothing
-          ;; to trade off:
-          ;;   repeating, direct   none 4.9-6.7us  always 4.0-4.2  on-repeat 3.9-4.1
-          ;;   repeating, arrow    none 8.0-9.5us  always 4.3      on-repeat 4.3
-          ;;   never repeating     none 7.9-8.6us  always 13.3+    on-repeat 11.8+
-          ;; The last row is why `cache/no-cache` remains a meaningful choice:
-          ;; on traffic that never asks the same check twice, the key build and
-          ;; lookup cost on every read is unrecoverable no matter the admission
-          ;; policy. That is a decision about traffic, which consumers can make.
+          ;; :on-repeat avoids retaining a completed answer until its query has
+          ;; demonstrated reuse. `cache/no-cache` remains a meaningful choice:
+          ;; on traffic that never repeats, or whose direct evaluation is
+          ;; cheaper than authenticated cache validation, lookup/proof cost is
+          ;; unrecoverable regardless of admission policy.
           remember (if (contains? config :remember-answers)
                      (when enabled? (:remember-answers config))
                      (when enabled? :on-repeat))
@@ -2045,10 +2039,11 @@
                   (eacl.datomic.cache/local-store {:max-weight ...})
 
     Pass cache/no-cache when the same permission check is essentially never
-    asked twice — a batch job sweeping distinct resources, say. A read then
-    pays for a cache lookup it can never benefit from: measured 7.9us with the
-    cache off against 11.8us on for entirely distinct checks. When checks recur
-    it is the other way round, 8.0us against 4.3us for an arrow permission.
+    asked twice — a batch job sweeping distinct resources, say — or when direct
+    evaluation is cheaper than authenticated completed-answer validation.
+    Proofed caching has a fixed cost and is not a universal latency
+    optimization; benchmark representative permissions before enabling it for
+    latency alone. See docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md.
 
     To bypass the configured cache for ONE call, pass :cache? false on the
     request — on the map arity of can?, and in the query map for lookups,
@@ -2066,10 +2061,8 @@
       :checkpoints       bounded revision checkpoints
       :remember-answers  false | true | :on-repeat (default) — whether a
                          finished answer is kept so an identical later check
-                         skips evaluation. :on-repeat keeps it only once the
-                         same check has been seen twice, and measured no slower
-                         than true in every workload tested, which is why it is
-                         a default rather than a question for consumers.
+                         skips evaluation. :on-repeat retains it only after the
+                         same check has demonstrated reuse.
 
     Cache failures are contained as misses or rejected publications. Missing
     exact pages and recursive continuations replay against the authenticated

--- a/modules/eacl-datomic/src/eacl/datomic/impl.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/impl.clj
@@ -264,6 +264,10 @@
     (when (and resolved (relationship-exists? db resolved))
       resolved)))
 
+(defn relationship-relation-id
+  [db relationship]
+  (:relation-eid (resolve-relationship db relationship {})))
+
 (defn- find-relations
   [db filters]
   (let [resource-type     (:resource/type filters)
@@ -283,6 +287,14 @@
                             (= resource-relation (:eacl.relation/relation-name relation)))
                         (or (nil? subject-type)
                             (= subject-type (:eacl.relation/subject-type relation)))))))))
+
+(defn relationship-relation-ids
+  "The complete schema relation-id scope that can match a relationship read."
+  [db filters]
+  (->> (find-relations db filters)
+       (map :db/id)
+       sort
+       vec))
 
 (defn- decode-forward-datom
   [db relation-by-eid datom]
@@ -676,6 +688,19 @@
     (if (seq missing)
       (into ops (map tx-relation-version-stamp) missing)
       ops)))
+
+(defn affected-relation-ids
+  "Returns every relation whose relationship tuples are changed by `ops`."
+  [ops]
+  (into #{}
+        (keep
+         (fn [op]
+           (or (relation-eid-of-retraction op)
+               (when (and (vector? op)
+                          (= :db/add (first op))
+                          (= relation-version-attr (nth op 2 nil)))
+                 (nth op 1 nil)))))
+        ops))
 
 (defn- schema-version-guard?
   [op]

--- a/modules/eacl-datomic/src/eacl/datomic/mutation.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/mutation.clj
@@ -1,0 +1,150 @@
+(ns eacl.datomic.mutation
+  "Datomic storage adapter for the shared mutation journal."
+  (:require [datomic.api :as d]
+            [eacl.datomic.mutation-schema :as mutation-schema]
+            [eacl.mutation :as mutation]))
+
+(defn ensure-schema!
+  [conn]
+  (let [db (d/db conn)
+        missing (remove #(d/entid db (:db/ident %))
+                        mutation-schema/attributes)]
+    (when (seq missing)
+      @(d/transact conn (vec missing)))
+    (when-not (d/entid (d/db conn) [:eacl/id mutation/graph-entity-id])
+      @(d/transact conn [{:eacl/id mutation/graph-entity-id}])))
+  true)
+
+(defn graph-state
+  [db]
+  (when-let [entity (d/entity db [:eacl/id mutation/graph-entity-id])]
+    (let [family-id (get entity mutation/graph-family-id-attr)
+          head-id (get entity mutation/graph-head-id-attr)
+          order (get entity mutation/graph-head-order-attr)]
+      (when (and family-id head-id)
+        {:family-id family-id
+         :head-id head-id
+         :head-order
+         (d/tx->t (if (number? order) order (:db/id order)))
+         :basis-t (d/basis-t db)
+         :database-id (str (.id ^datomic.Database db))}))))
+
+(defn contains-anchor?
+  [db anchor]
+  (boolean (d/entid db [mutation/mutation-id-attr anchor])))
+
+(defn mutation-entity
+  [db mutation-id]
+  (some-> (d/entity db [mutation/mutation-id-attr mutation-id])
+          (select-keys
+           [mutation/mutation-id-attr
+            mutation/mutation-fingerprint-attr
+            mutation/mutation-kind-attr
+            mutation/mutation-issued-at-attr
+            mutation/mutation-expires-at-attr])))
+
+(defn relation-ids
+  [db]
+  (->> (d/q '[:find [?relation ...]
+               :where
+               [?relation :eacl.relation/relation-name]]
+             db)
+       sort
+       vec))
+
+(defn ensure-migrated!
+  [conn]
+  (ensure-schema! conn)
+  (or (graph-state (d/db conn))
+      (let [db (d/db conn)
+            {:keys [tx-data]}
+            (mutation/migration-data
+             {:relation-ids (relation-ids db)
+              :family-id (mutation/new-id)
+              :order-value "datomic.tx"})]
+        (try
+          @(d/transact conn tx-data)
+          (catch Throwable error
+            (when-not (graph-state (d/db conn))
+              (throw error))))
+        (graph-state (d/db conn)))))
+
+(defn mutation-transaction-data
+  [db {:keys [mutation-id kind canonical-data relation-ids dependency-ids
+              schema-change?
+              token-ttl-seconds retention-grace-seconds]}]
+  (let [{:keys [family-id head-id]} (graph-state db)]
+    (mutation/transaction-data
+     {:mutation-id mutation-id
+      :kind kind
+      :canonical-data canonical-data
+      :relation-ids relation-ids
+      :dependency-ids dependency-ids
+      :schema-change? schema-change?
+      :order-value "datomic.tx"
+      :family-id family-id
+      :previous-head-id head-id
+      :token-ttl-seconds token-ttl-seconds
+      :retention-grace-seconds retention-grace-seconds})))
+
+(defn transact!
+  [conn {:keys [mutation-id canonical-data tx-data] :as mutation-options}]
+  (ensure-migrated! conn)
+  (let [db (d/db conn)]
+    (if-let [stored (mutation-entity db mutation-id)]
+      (if (mutation/mutation-data-matches?
+           stored mutation-id canonical-data)
+        {:db-before db
+         :db-after db
+         :tx-data []
+         :mutation-id mutation-id
+         :idempotent-recovery? true}
+        (throw (ex-info "EACL mutation id was reused with different data."
+                        {:type :eacl.mutation/id-reused
+                         :mutation-id mutation-id})))
+      (assoc
+       (try
+         @(d/transact
+           conn
+           (into (vec tx-data)
+                 (mutation-transaction-data db mutation-options)))
+         (catch Throwable error
+           (if-let [stored (mutation-entity (d/db conn) mutation-id)]
+             (if (mutation/mutation-data-matches?
+                  stored mutation-id canonical-data)
+               {:db-before db
+                :db-after (d/db conn)
+                :tx-data []
+                :mutation-id mutation-id
+                :idempotent-recovery? true}
+               (throw
+                (ex-info
+                 "EACL mutation id was reused with different data."
+                 {:type :eacl.mutation/id-reused
+                  :mutation-id mutation-id}
+                 error)))
+             (throw error))))
+       :mutation-id mutation-id))))
+
+(defn prune-expired!
+  [conn now]
+  (let [db (d/db conn)
+        current-head (:head-id (graph-state db))
+        expired
+        (d/q '[:find [?mutation ...]
+               :in $ ?now
+               :where
+               [?mutation :eacl.mutation/id ?id]
+               [?mutation :eacl.mutation/expires-at ?expiry]
+               [(< ?expiry ?now)]]
+             db now)
+        retractable
+        (remove #(= current-head
+                    (get (d/entity db %) mutation/mutation-id-attr))
+                expired)]
+    (when (seq retractable)
+      @(d/transact
+        conn
+        (mapv (fn [entity-id] [:db/retractEntity entity-id])
+              retractable)))
+    (count retractable)))

--- a/modules/eacl-datomic/src/eacl/datomic/mutation_schema.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/mutation_schema.clj
@@ -1,0 +1,48 @@
+(ns eacl.datomic.mutation-schema)
+
+(def attributes
+  "Version-3 causal mutation journal and dependency identity attributes."
+  [{:db/ident       :eacl.mutation/id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity
+    :db/index       true}
+   {:db/ident       :eacl.mutation/fingerprint
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.mutation/kind
+    :db/valueType   :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.mutation/issued-at
+    :db/valueType   :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.mutation/expires-at
+    :db/valueType   :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.graph/family-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.graph/head-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.graph/head-order
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :eacl.schema/mutation-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.relation/mutation-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :eacl.dependency/mutation-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index       true}])

--- a/modules/eacl-datomic/src/eacl/datomic/schema.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/schema.clj
@@ -1,8 +1,11 @@
 (ns eacl.datomic.schema
   (:require [clojure.set]
             [datomic.api :as d]
-            [eacl.spicedb.parser :as parser]
-            [eacl.datomic.impl.indexed :as impl.indexed]))
+            [eacl.datomic.impl.indexed :as impl.indexed]
+            [eacl.datomic.mutation :as journal]
+            [eacl.datomic.mutation-schema :as mutation-schema]
+            [eacl.mutation :as mutation]
+            [eacl.spicedb.parser :as parser]))
 
 ; should these Malli specs be in a separate namespace, e.g. specs?
 ; might be confused for Datomic fn's like Relation / Permission in impl. base.
@@ -71,6 +74,8 @@
    :db/valueType   :db.type/ref
    :db/cardinality :db.cardinality/one
    :db/noHistory   true})
+
+(def mutation-schema mutation-schema/attributes)
 
 (def assert-relation-unused-fn-definition
   "Commit-time guard for relation removal.
@@ -468,27 +473,33 @@
   generation still in the database. Without it, two replacement writers can
   both commit additions calculated from the same old generation and leave the
   UNION of their schemas behind."
-  [conn tx-data expected-version]
-  (try
-    @(d/transact conn tx-data)
-    (catch Throwable throwable
-      (if-let [relation-in-use
-               (caused-by-type throwable
-                               :eacl.schema/relation-in-use)]
-        (throw
-         (ex-info (.getMessage ^Throwable relation-in-use)
-                  (ex-data relation-in-use)
-                  throwable))
-        (if-let [cause-data (cas-failure-data throwable)]
-          (throw
-           (ex-info
-            "The EACL schema changed concurrently; retry against a new client or database value."
-            {:type :eacl.schema/concurrent-write
-             :expected-version expected-version
-             :actual-version (impl.indexed/schema-version (d/db conn))
-             :datomic-error cause-data}
-            throwable))
-          (throw throwable))))))
+  ([conn tx-data expected-version]
+   (transact-schema! conn tx-data expected-version nil))
+  ([conn tx-data expected-version journal-options]
+   (try
+     (if journal-options
+       (journal/transact!
+        conn
+        (assoc journal-options :tx-data (vec tx-data)))
+       @(d/transact conn tx-data))
+     (catch Throwable throwable
+       (if-let [relation-in-use
+                (caused-by-type throwable
+                                :eacl.schema/relation-in-use)]
+         (throw
+          (ex-info (.getMessage ^Throwable relation-in-use)
+                   (ex-data relation-in-use)
+                   throwable))
+         (if-let [cause-data (cas-failure-data throwable)]
+           (throw
+            (ex-info
+             "The EACL schema changed concurrently; retry against a new client or database value."
+             {:type :eacl.schema/concurrent-write
+              :expected-version expected-version
+              :actual-version (impl.indexed/schema-version (d/db conn))
+              :datomic-error cause-data}
+             throwable))
+           (throw throwable)))))))
 
 (defn write-schema!
   "Computes delta between existing schema and
@@ -504,7 +515,9 @@
    (write-schema! conn schema-string {}))
   ([conn schema-string opts]
    (write-schema! conn schema-string opts ::read-current-version))
-  ([conn schema-string {:keys [allow-empty-schema?]} known-schema-version]
+  ([conn schema-string
+    {:keys [allow-empty-schema? token-ttl-seconds retention-grace-seconds]}
+    known-schema-version]
    (let [new-schema-map (parser/->eacl-schema
                          (parser/parse-schema schema-string))
          ;; ADR 012 says an invalid schema makes NO database changes. This must
@@ -582,10 +595,15 @@
                  (d/entid db [:eacl/id (:eacl/id relation)])
                  (:eacl.relation/subject-type relation)])
               relation-retractions)
+             relation-addition-entities
+             (mapv (fn [relation]
+                     (assoc relation
+                            :db/id (d/tempid :db.part/user)))
+                   (:additions relations))
              tx-data
              (concat
               ;; Additions
-              (:additions relations)
+              relation-addition-entities
               (:additions permissions)
               ;; Retractions
               (for [rel relation-retractions]
@@ -605,5 +623,34 @@
                 :eacl/schema-string schema-string}
                [:db.fn/cas schema-entity
                 :eacl/schema-version current-version next-version]])]
-         (transact-schema! conn tx-data current-version)
-         (with-meta deltas {:eacl/schema-version next-version}))))))
+         (let [report
+               (if stamp-schema?
+                 (transact-schema!
+                  conn
+                  tx-data
+                  current-version
+                  {:mutation-id (mutation/new-id)
+                   :kind :schema
+                   :canonical-data
+                   {:operation :write-schema
+                    :schema-string schema-string
+                    :expected-schema-version
+                    (some-> current-version str)}
+                   :schema-change? true
+                   :relation-ids
+                   (mapv :db/id relation-addition-entities)
+                   :token-ttl-seconds token-ttl-seconds
+                   :retention-grace-seconds retention-grace-seconds})
+                 (let [db (d/db conn)]
+                   {:db-before db
+                    :db-after db
+                    :tx-data []
+                    :mutation-id
+                    (:head-id (journal/ensure-migrated! conn))
+                    :no-op? true}))]
+           (with-meta
+             deltas
+             {:eacl/schema-version next-version
+              :eacl.mutation/id (:mutation-id report)
+              :eacl.mutation/db-after (:db-after report)
+              :eacl.mutation/no-op? (boolean (:no-op? report))})))))))

--- a/modules/eacl-datomic/test/eacl/bench/pagination_test.clj
+++ b/modules/eacl-datomic/test/eacl/bench/pagination_test.clj
@@ -1030,3 +1030,107 @@
                       targets)]
             (println "can? completed-cache breakdown:" breakdown)
             (is (every? (comp pos? :calls val) breakdown))))))))
+
+(def ^:private cache-proof-benchmark-schema
+  "definition user {}
+   definition account {
+     relation owner: user
+     permission admin = owner
+   }")
+
+(deftest ^:benchmark cache-proof-strategy-churn-benchmark
+  (testing "mutation/content proofs, global invalidation, and no-cache"
+    (with-mem-conn [conn schema/v7-schema]
+      (let [mutation-store (cache/local-store)
+            content-store (cache/local-store)
+            global-store (cache/local-store)
+            common {:page-token-key "cache-proof-benchmark"
+                    :zed-token-key "cache-proof-benchmark-zed"}
+            managed
+            (fn [store]
+              (spiceomic/make-client
+               conn
+               (assoc common
+                      :coherence-authority :managed
+                      :proof-mode :mutation
+                      :cache (if store
+                               {:store store :remember-answers true}
+                               cache/no-cache))))
+            mutation-client (managed mutation-store)
+            writer mutation-client
+            content-client
+            (spiceomic/make-client
+             conn
+             (assoc common
+                    :coherence-authority :unknown
+                    :proof-mode :content
+                    :cache {:store content-store
+                            :remember-answers true}))
+            global-client (managed global-store)
+            no-cache-client (managed nil)
+            user (->user "benchmark-user")
+            account (->account "benchmark-account")
+            relationship (Relationship user :owner account)
+            _ (eacl/write-schema! writer cache-proof-benchmark-schema)
+            _ @(d/transact conn [{:eacl/id "benchmark-user"}
+                                 {:eacl/id "benchmark-account"}])
+            _ (eacl/create-relationship! writer relationship)
+            strategies
+            [[:mutation-proof mutation-client nil]
+             [:content-proof content-client nil]
+             [:global-invalidation global-client global-store]
+             [:no-cache no-cache-client nil]]
+            iterations 12
+            measure
+            (fn [client store expected]
+              (when store
+                (cache/clear! store))
+              (let [start (System/nanoTime)
+                    value (eacl/can? client user :admin account)
+                    elapsed (/ (double (- (System/nanoTime) start)) 1000.0)]
+                (is (= expected value))
+                elapsed))
+            unrelated
+            (into
+             {}
+             (for [[label client clear-store] strategies]
+               (do
+                 (eacl/can? client user :admin account)
+                 [label
+                  (median
+                   (for [i (range iterations)]
+                     (do
+                       @(d/transact
+                         conn
+                         [{:eacl/id
+                           (str "benchmark-unrelated-"
+                                (name label)
+                                "-"
+                                i)}])
+                       (measure client clear-store true))))])))
+            relevant
+            (into
+             {}
+             (for [[label client clear-store] strategies]
+               (do
+                 (eacl/can? client user :admin account)
+                 [label
+                  (median
+                   (for [i (range iterations)]
+                     (let [grant? (odd? i)]
+                       (if grant?
+                         (eacl/create-relationship! writer relationship)
+                         (eacl/delete-relationship! writer relationship))
+                       (measure client clear-store grant?))))])))]
+        (prn {:benchmark :cache-proof-strategy-churn
+              :unit :microseconds-per-read
+              :iterations iterations
+              :unrelated-churn unrelated
+              :relevant-churn relevant})
+        (is (= (set (keys unrelated))
+               #{:mutation-proof
+                 :content-proof
+                 :global-invalidation
+                 :no-cache}))
+        (is (= (set (keys relevant))
+               (set (keys unrelated))))))))

--- a/modules/eacl-datomic/test/eacl/datomic/backend_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/backend_test.clj
@@ -33,7 +33,10 @@
              db
              {:entid->object-id
               (fn [snapshot eid]
-                (:eacl/id (d/entity snapshot eid)))})
+                (:eacl/id (d/entity snapshot eid)))
+              :conn conn
+              :coherence-authority :managed
+              :proof-mode :mutation})
             alice (backend/invoke
                    adapter :object-id->internal "alice")
             account (backend/invoke
@@ -76,9 +79,15 @@
               :user alice relation-id :account account)))
         (is (string?
              (backend/invoke adapter :schema-proof)))
-        (is (integer?
-             (backend/invoke
-              adapter :relation-proof [relation-id])))
+        (is (= relation-id
+               (ffirst
+                (backend/invoke
+                 adapter :relation-proof [relation-id]))))
+        (is (string?
+             (second
+              (first
+               (backend/invoke
+                adapter :relation-proof [relation-id])))))
         (testing "the adapter advertises Datomic's existing guarantees"
           (doseq [mode [:fully-consistent
                         :minimize-latency

--- a/modules/eacl-datomic/test/eacl/datomic/cache_differential_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/cache_differential_test.clj
@@ -319,16 +319,13 @@
            (acyclic-mutations 6)
            20260732 40))))))
 
-(deftest acyclic-pages-resume-from-cached-stream-heads-test
-  ;; Every page of an arrow lookup used to open an index scan for each of the
-  ;; subject's intermediates just to learn where each stream starts. The
-  ;; continuation now carries the heads that the previous page proved were
-  ;; beyond its boundary, so a page only re-opens the streams it actually drew
-  ;; from.
-  ;;
-  ;; Correctness of the resumed pages is covered by the differential test
-  ;; above; this asserts the mechanism is reached at all, so that silently
-  ;; losing it does not leave a green suite.
+(deftest acyclic-pages-replay-without-unauthenticated-stream-heads-test
+  ;; v7 used a process-local side cache of per-intermediate stream heads. Those
+  ;; values were not covered by the v3 causal/proof envelope, so v8 deliberately
+  ;; refuses to read them. A cursor page instead replays deterministically from
+  ;; the authenticated cursor against the proof-equivalent selected snapshot.
+  ;; The optimization can return only after its state is authenticated by the
+  ;; same contract as completed answers.
   (with-mem-conn [conn schema/v7-schema]
     (let [boot (client conn {:cache cache/no-cache})
           _ (seed-acyclic! conn boot 12)
@@ -343,12 +340,12 @@
               _ (is (get-in page-1 [:page-info :has-next-page?]))
               cursor (get-in page-1 [:page-info :end-cursor])
               page-2 (eacl/lookup-resources acl (assoc query :first 3 :after cursor))]
-          (is (pos? (:lookup-head-hits @stats 0))
-              "page two resumed from the heads page one published")
+          (is (zero? (:lookup-head-hits @stats 0))
+              "page two did not trust the unauthenticated v7 heads side cache")
           (is (= (mapv :id (:data (eacl/lookup-resources
                                    oracle (assoc query :first 3 :after cursor))))
                  (mapv :id (:data page-2)))
-              "and still agrees with an uncached client")))
+              "cursor replay still agrees with an uncached client")))
 
       (testing "a walk with the continuation matches one without it"
         (is (= (walk-forward oracle query 3)

--- a/modules/eacl-datomic/test/eacl/datomic/cache_review_regressions_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/cache_review_regressions_test.clj
@@ -297,11 +297,9 @@
 ;; --- M4 ---------------------------------------------------------------------
 
 (deftest cursor-pages-do-not-write-unreachable-live-entries-test
-  ;; A cursor page is forced to :at-exact-snapshot and reads exact-key. Its live
-  ;; entry was keyed by a query identity containing an :after edge, and every
-  ;; request carrying such an edge takes the historical branch — so the entry
-  ;; could never be read while still consuming the weight and entry budget that
-  ;; live page-one answers compete for.
+  ;; v3 stores one authenticated proof envelope per answer. It has no separate
+  ;; unauthenticated latest-result pointer, and a cursor page contributes only
+  ;; its own independently authenticated answer.
   (with-mem-conn [conn schema/v7-schema]
     (let [store (cache/local-store)
           context {:store store}
@@ -318,12 +316,12 @@
           stats (cache/stats store)]
       (is (= ["acct0" "acct1" "acct2"] (mapv :id (:data page-1))))
       (is (= ["acct3" "acct4" "acct5"] (mapv :id (:data page-2))))
-      (is (= 2 puts-after-page-1)
-          "page one publishes the exact entry + the latest-result pointer")
+      (is (= 1 puts-after-page-1)
+          "page one publishes one authenticated answer envelope")
       (is (= 1 (- (:puts stats) puts-after-page-1))
-          "a cursor page publishes only its exact entry")
-      (is (= 1 (get-in stats [:by-kind :latest-result :puts]))
-          "and no second latest-result pointer under the cursor prefix"))))
+          "a cursor page publishes one independently authenticated envelope")
+      (is (nil? (get-in stats [:by-kind :latest-result :puts]))
+          "the retired unauthenticated latest-result pointer is never written"))))
 
 ;; --- L2 ---------------------------------------------------------------------
 

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
@@ -1,9 +1,9 @@
 (ns eacl.datomic.consistency-cache-test
   (:require [clojure.test :refer [deftest is testing]]
             [datomic.api :as d]
+            [eacl.causal-token :as causal-token]
             [eacl.core :as eacl :refer [->Relationship spice-object]]
             [eacl.datomic.cache :as cache]
-            [eacl.datomic.consistency :as revision]
             [eacl.datomic.core :as core]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
             [eacl.datomic.impl :as impl]
@@ -21,9 +21,27 @@
   [conn]
   (core/make-client
    conn
-   {:zed-token-key "consistency-cache-test-key"
+   {:coherence-authority :managed
+    :zed-token-key "consistency-cache-test-key"
     :cache {:checkpoints true
             :remember-answers true}}))
+
+(defn- token-payload
+  [client token]
+  (causal-token/token-data
+   (get-in client [:opts :format-options])
+   token))
+
+(defn- token-with-order-hint
+  [client order-hint]
+  (let [format-options (get-in client [:opts :format-options])
+        payload
+        (token-payload client (core/current-zed-token client))]
+    (causal-token/issue
+     format-options
+     (assoc payload
+            :order-hint order-hint
+            :exact-locator order-hint))))
 
 (defn- seed!
   [conn client]
@@ -57,10 +75,7 @@
       (with-redefs [impl/can?
                     (fn [db subject permission resource]
                       (swap! calls inc)
-                      (original db subject permission resource))
-                    d/sync
-                    (fn [& _]
-                      (throw (ex-info "unexpected sync" {})))]
+                      (original db subject permission resource))]
         (testing "fully-consistent reuses only the current dependency proof"
           (is (true? (eacl/can? client alice :admin account)))
           (is (true? (eacl/can? client alice :admin account)))
@@ -68,42 +83,32 @@
 
         (let [{deleted-token :zed/token}
               (eacl/delete-relationship! client relationship)]
-          (testing "minimize-latency may use the last coherent cached answer"
-            (is (true? (eacl/can? client alice :admin account
-                                  consistency/minimize-latency)))
-            (is (= 1 @calls)))
+          (testing "minimize-latency validates against its selected snapshot"
+            (is (false? (eacl/can? client alice :admin account
+                                   consistency/minimize-latency)))
+            (is (= 2 @calls)))
 
-          ;; A historical read is keyed by the basis it pins, while a current
-          ;; read is keyed by the relation stamps it observed, so the two no
-          ;; longer share an entry by coincidence of both being a `t`. That
-          ;; costs this one evaluation and is deliberate: relation stamps are
-          ;; :db/noHistory, so reading them through d/as-of is only reliable
-          ;; until the database indexes and collects them — at which point two
-          ;; different historical bases would both read "no stamp" and collide
-          ;; on one cache key. Pinning the basis cannot go wrong that way.
-          ;; Repeat requests for the SAME cursor or snapshot still hit, which
-          ;; is what pagination depends on.
           (testing "exact mode returns the authenticated historical snapshot"
             (is (true? (eacl/can? client alice :admin account
                                   (consistency/at-exact-snapshot
                                    created-token))))
-            (is (= 2 @calls)))
+            (is (= 3 @calls)))
 
           (testing "fully-consistent observes the relationship deletion"
             (is (false? (eacl/can? client alice :admin account)))
-            (is (= 3 @calls)))
+            (is (= 4 @calls)))
 
           (testing "at-least-as-fresh accepts the current cached revision"
             (is (false? (eacl/can? client alice :admin account
                                    (consistency/at-least-as-fresh
                                     deleted-token))))
-            (is (= 3 @calls)))
+            (is (= 4 @calls)))
 
-          (testing "and the same historical snapshot is served from cache"
+          (testing "and repeated exact selection remains snapshot-correct"
             (is (true? (eacl/can? client alice :admin account
                                   (consistency/at-exact-snapshot
                                    created-token))))
-            (is (= 3 @calls))))))))
+            (is (= 5 @calls))))))))
 
 (deftest missing-external-ids-never-enter-the-result-cache-test
   (with-mem-conn [conn schema/v7-schema]
@@ -150,11 +155,10 @@
             decoded (core/token->page-bound
                      (get client :opts)
                      cursor)
-            opts (get client :opts)
-            database-id (:database-id opts)]
+            opts (get client :opts)]
         (is (= ["acct"] (mapv :id (:data exact-page))))
-        (is (= (revision/token-revision
-                opts database-id created-token)
+        (is (= (:exact-locator
+                (token-payload client created-token))
                (:basis-t decoded))
             "a cursor names the exact snapshot that produced its page"))
       (is (= ["acct"]
@@ -177,7 +181,8 @@
     (let [client
           (core/make-client
            conn
-           {:cache {:remember-answers true}})
+           {:coherence-authority :managed
+            :cache {:remember-answers true}})
           alice (spice-object :user "alice")
           account (spice-object :account "acct")
           relationship (->Relationship alice :owner account)
@@ -189,18 +194,20 @@
                       (consistency/at-exact-snapshot created-token))))
       (is (false? (eacl/can? client alice :admin account)))))
 
-  ;; Retention stays opt-in after :live-results? was removed. A default client
-  ;; caches pagination and traversal state but retains no answers.
+  ;; The v3 default retains authenticated answers; correctness still does not
+  ;; depend on a hit because exact replay can reconstruct the selected value.
   (with-mem-conn [conn schema/v7-schema]
-    (let [client (core/make-client conn {})
+    (let [client (core/make-client
+                  conn
+                  {:coherence-authority :managed})
           alice (spice-object :user "alice")
           account (spice-object :account "acct")
           {created-token :zed/token} (seed! conn client)]
       (is (true? (eacl/can? client alice :admin account)))
-      (is (zero?
+      (is (pos?
            (:entries
             (cache/stats (get-in client [:opts :lookup-cache-store]))))
-          "the default fast path does not publish completed can? results")
+          "the default fast path publishes an authenticated answer envelope")
       (is (true?
            (eacl/can? client alice :admin account
                       (consistency/at-exact-snapshot created-token)))
@@ -237,7 +244,7 @@
                (mapv :id (:data (eacl/lookup-resources client query)))))
         (eacl/delete-relationship! client relationship)
         @(d/transact conn [[:db.fn/retractEntity [:eacl/id "acct"]]])
-        (is (= ["acct"]
+        (is (= []
                (mapv
                 :id
                 (:data
@@ -246,7 +253,7 @@
                   (assoc query
                          :consistency
                          consistency/minimize-latency)))))
-            "the selected stale page resolves IDs at its own historical basis"))))
+            "minimize-latency never bypasses selected-snapshot proof validation"))))
 
   (testing "lookup-subjects with at-least-as-fresh"
     (with-mem-conn [conn schema/v7-schema]
@@ -263,7 +270,7 @@
                (mapv :id (:data (eacl/lookup-subjects client query)))))
         (eacl/delete-relationship! client relationship)
         @(d/transact conn [[:db.fn/retractEntity [:eacl/id "alice"]]])
-        (is (= ["alice"]
+        (is (= []
                (mapv
                 :id
                 (:data
@@ -273,7 +280,7 @@
                          :consistency
                          (consistency/at-least-as-fresh
                           created-token))))))
-            "the freshness floor may select an older cached page whose subject is now deleted")))))
+            "at-least selects a current dominating snapshot, not an old cached value")))))
 
 (deftest exact-query-preserves-historical-unknown-object-semantics-test
   (with-mem-conn [conn schema/v7-schema]
@@ -312,24 +319,24 @@
   (with-mem-conn [conn schema/v7-schema]
     (let [client (cached-client conn)
           _ (seed! conn client)
-          current-token (core/current-zed-token client)
-          age-token (core/zed-token-at-least-seconds-ago client 30)
-          database-id (get-in client [:opts :database-id])]
-      (is (integer?
-           (revision/token-revision
-            (:opts client) database-id current-token)))
-      (is (integer?
-           (revision/token-revision
-            (:opts client) database-id age-token)))
-      (with-redefs [d/sync
-                    (fn [& _]
-                      (throw (ex-info "unexpected sync" {})))]
-        (is (true?
-             (eacl/can? client
-                        (spice-object :user "alice")
-                        :admin
-                        (spice-object :account "acct")
-                        (consistency/at-least-as-fresh age-token))))))))
+          [current-token age-token]
+          (with-redefs [d/sync
+                        (fn [& _]
+                          (throw (ex-info "token helpers must not sync" {})))]
+            [(core/current-zed-token client)
+             (core/zed-token-at-least-seconds-ago client 30)])
+          current-payload (token-payload client current-token)
+          age-payload (token-payload client age-token)]
+      (is (integer? (:order-hint current-payload)))
+      (is (integer? (:order-hint age-payload)))
+      (is (= (:source-id current-payload)
+             (:source-id age-payload)))
+      (is (true?
+           (eacl/can? client
+                      (spice-object :user "alice")
+                      :admin
+                      (spice-object :account "acct")
+                      (consistency/at-least-as-fresh age-token)))))))
 
 (deftest cross-database-zed-token-is-rejected-test
   (with-mem-conn [conn-a schema/v7-schema]
@@ -347,7 +354,10 @@
                      (consistency/at-least-as-fresh token))
           (is false "a token cannot cross databases")
           (catch clojure.lang.ExceptionInfo e
-            (is (= :database-mismatch (:reason (ex-data e))))))))))
+            (is (= :eacl.consistency/incomparable-scope
+                   (:type (ex-data e))))
+            (is (= :incomparable-scope
+                   (:reason (ex-data e))))))))))
 
 (deftest cross-database-page-cursor-is-rejected-before-history-test
   (with-mem-conn [conn-a schema/v7-schema]
@@ -419,19 +429,22 @@
           new-key "new-stable-zed-token-key"
           old-client
           (core/make-client conn
-                            {:zed-token-keyring {:old old-key}
+                            {:coherence-authority :managed
+                             :zed-token-keyring {:old old-key}
                              :zed-token-kid :old})
           _ (seed! conn old-client)
           old-token (core/current-zed-token old-client)
           overlap-client
           (core/make-client conn
-                            {:zed-token-keyring {:old old-key
+                            {:coherence-authority :managed
+                             :zed-token-keyring {:old old-key
                                                  :new new-key}
                              :zed-token-kid :new})
           new-token (core/current-zed-token overlap-client)
           new-only-client
           (core/make-client conn
-                            {:zed-token-keyring {:new new-key}
+                            {:coherence-authority :managed
+                             :zed-token-keyring {:new new-key}
                              :zed-token-kid :new})
           demand [(spice-object :user "alice")
                   :admin
@@ -594,10 +607,8 @@
   (with-mem-conn [conn schema/v7-schema]
     (let [client (cached-client conn)
           _ (seed! conn client)
-          database-id (get-in client [:opts :database-id])
           future-t (inc (d/basis-t (d/db conn)))
-          future-token (revision/zed-token
-                        (:opts client) database-id future-t)
+          future-token (token-with-order-hint client future-t)
           sync-calls (atom [])]
       (with-redefs [d/sync
                     (fn [_conn t]
@@ -612,7 +623,10 @@
           (is false "the Peer did not actually reach the future revision")
           (catch clojure.lang.ExceptionInfo e
             (is (= :eacl.consistency/freshness-unavailable
-                   (:type (ex-data e)))))))
+                   (:type (ex-data e))))
+            (is (= :head-behind (:reason (ex-data e))))
+            (is (= future-t
+                   (:requested-order-hint (ex-data e)))))))
       (is (= [future-t] @sync-calls)
           "EACL waits for the caller's exact lower bound, not transactor head"))))
 
@@ -622,10 +636,8 @@
                            [:opts :consistency-sync-timeout-ms]
                            1)
           _ (seed! conn client)
-          database-id (get-in client [:opts :database-id])
           future-t (inc (d/basis-t (d/db conn)))
-          token (revision/zed-token
-                 (:opts client) database-id future-t)]
+          token (token-with-order-hint client future-t)]
       (with-redefs [d/sync
                     (fn [_conn _t]
                       (future
@@ -641,18 +653,17 @@
           (catch clojure.lang.ExceptionInfo e
             (is (= :eacl.consistency/freshness-unavailable
                    (:type (ex-data e))))
-            (is (= :timeout (:reason (ex-data e))))
-            (is (= future-t (:requested-t (ex-data e))))
+            (is (= :freshness-timeout (:reason (ex-data e))))
+            (is (= future-t
+                   (:requested-order-hint (ex-data e))))
             (is (= 1 (:timeout-ms (ex-data e))))))))))
 
 (deftest at-least-as-fresh-normalizes-targeted-sync-failures-test
   (with-mem-conn [conn schema/v7-schema]
     (let [client (cached-client conn)
           _ (seed! conn client)
-          database-id (get-in client [:opts :database-id])
           future-t (inc (d/basis-t (d/db conn)))
-          token (revision/zed-token
-                 (:opts client) database-id future-t)]
+          token (token-with-order-hint client future-t)]
       (with-redefs [d/sync
                     (fn [_conn _t]
                       (throw (ex-info "peer unavailable" {})))]
@@ -667,7 +678,8 @@
             (is (= :eacl.consistency/freshness-unavailable
                    (:type (ex-data e))))
             (is (= :sync-failed (:reason (ex-data e))))
-            (is (= future-t (:requested-t (ex-data e))))))))))
+            (is (= future-t
+                   (:requested-order-hint (ex-data e))))))))))
 
 (deftest exact-provider-failure-falls-back-to-history-test
   (with-mem-conn [conn schema/v7-schema]
@@ -692,8 +704,11 @@
               (cache/clear-namespace! delegate namespace))
             (record-provider-error! [_ operation kind]
               (cache/record-provider-error! delegate operation kind)))
-          client (core/make-client conn {:cache {:store store
-                                                 :remember-answers true}})
+          client (core/make-client
+                  conn
+                  {:coherence-authority :managed
+                   :cache {:store store
+                           :remember-answers true}})
           {token :zed/token} (seed! conn client)
           alice (spice-object :user "alice")
           account (spice-object :account "acct")]

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_v3_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_v3_test.clj
@@ -1,0 +1,240 @@
+(ns eacl.datomic.consistency-v3-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datomic.api :as d]
+            [eacl.core :as eacl]
+            [eacl.datomic.core :as datomic]
+            [eacl.datomic.datomic-helpers
+             :refer [with-mem-conn with-mem-conns]]
+            [eacl.datomic.schema :as schema]
+            [eacl.spicedb.consistency :as consistency]))
+
+(def authorization-schema
+  "definition user {}
+   definition document {
+     relation reader: user
+     permission view = reader
+   }")
+
+(def security-key "01234567890123456789012345678901")
+(def user (eacl/spice-object :user "user"))
+(def document (eacl/spice-object :document "document"))
+(def relationship (eacl/->Relationship user :reader document))
+
+(defn- client
+  [conn]
+  (datomic/make-client
+   conn
+   {:coherence-authority :managed
+    :zed-token-key security-key
+    :consistency-sync-timeout-ms 5}))
+
+(defn- seed!
+  [conn authorization]
+  (eacl/write-schema! authorization authorization-schema)
+  @(d/transact conn [{:eacl/id "user"}
+                     {:eacl/id "document"}]))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(deftest authoritative-and-targeted-sync-arities-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [authorization (client conn)
+          _ (seed! conn authorization)
+          token
+          (:zed/token
+           (eacl/create-relationship! authorization relationship))
+          original-sync d/sync
+          calls (atom [])]
+      (with-redefs [d/sync
+                    (fn
+                      ([connection]
+                       (swap! calls conj :authoritative)
+                       (original-sync connection))
+                      ([connection basis]
+                       (swap! calls conj [:at-least basis])
+                       (original-sync connection basis)))]
+        (is (true? (eacl/can? authorization user :view document)))
+        (is (= [:authoritative] @calls))
+        (reset! calls [])
+        (is (true?
+             (eacl/can?
+              authorization user :view document
+              (consistency/at-least-as-fresh token))))
+        (is (= 1 (count @calls)))
+        (is (= :at-least (ffirst @calls)))))))
+
+(deftest cross-connection-anchor-and-exact-identity-test
+  (with-mem-conns [writer-conn reader-conn schema/v7-schema]
+    (let [writer (client writer-conn)
+          reader (client reader-conn)
+          _ (seed! writer-conn writer)
+          token
+          (:zed/token
+           (eacl/create-relationship! writer relationship))]
+      (testing "a second Peer connection waits for and verifies the anchor"
+        (is (true?
+             (eacl/can?
+              reader user :view document
+              (consistency/at-least-as-fresh token)))))
+      (eacl/delete-relationship! writer relationship)
+      (testing "as-of reconstruction is accepted only with the old graph head"
+        (is (true?
+             (eacl/can?
+              reader user :view document
+              (consistency/at-exact-snapshot token))))
+        (with-redefs [d/as-of (fn [db _basis] db)]
+          (is (= :eacl.consistency/history-divergence
+                 (:type
+                  (error-data
+                   #(eacl/can?
+                     reader user :view document
+                     (consistency/at-exact-snapshot token)))))))))))
+
+(deftest missing-anchor-and-bounded-wait-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [authorization (client conn)
+          _ (seed! conn authorization)
+          before-write (d/db conn)
+          token
+          (:zed/token
+           (eacl/create-relationship! authorization relationship))]
+      (testing "a source that remains numerically behind cannot satisfy freshness"
+        (with-redefs [d/sync
+                      (fn
+                        ([_] (future before-write))
+                        ([_ _] (future before-write)))]
+          (is (= :eacl.consistency/freshness-unavailable
+                 (:type
+                  (error-data
+                   #(eacl/can?
+                     authorization user :view document
+                     (consistency/at-least-as-fresh token))))))))
+      (testing "a lagging Peer wait is bounded"
+        (with-redefs [d/sync
+                      (fn
+                        ([_] (promise))
+                        ([_ _] (promise)))]
+          (let [data
+                (error-data
+                 #(eacl/can?
+                   authorization user :view document
+                   (consistency/at-least-as-fresh token)))]
+            (is (= :eacl.consistency/freshness-unavailable
+                   (:type data)))
+            (is (= :freshness-timeout (:reason data)))
+            (is (= 5 (:timeout-ms data)))))))))
+
+(deftest authenticated-cache-lifts-only-across-equal-proofs-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [authorization
+          (datomic/make-client
+           conn
+           {:coherence-authority :managed
+            :zed-token-key security-key
+            :cache {:remember-answers true}})
+          _ (seed! conn authorization)
+          _ (eacl/create-relationship! authorization relationship)
+          query {:subject user
+                 :permission :view
+                 :resource/type :document
+                 :first 10}
+          first-page (eacl/lookup-resources authorization query)
+          exact-hit (eacl/lookup-resources authorization query)]
+      (is (= ["document"] (mapv :id (:data first-page))))
+      (is (false? (:cached? first-page)))
+      (is (true? (:cached? exact-hit)))
+      @(d/transact
+        conn
+        [{:db/id (d/tempid :db.part/user)
+          :db/doc "unrelated application data"}])
+      (testing "an unrelated basis advance lifts the authenticated answer"
+        (is (true?
+             (:cached?
+              (eacl/lookup-resources authorization query)))))
+      (eacl/delete-relationship! authorization relationship)
+      (let [after-revocation
+            (eacl/lookup-resources authorization query)]
+        (is (empty? (:data after-revocation)))
+        (is (false? (:cached? after-revocation)))))))
+
+(deftest encrypted-cursor-proof-equivalence-and-exact-fallback-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [authorization (client conn)
+          _ (eacl/write-schema! authorization authorization-schema)
+          _ @(d/transact conn [{:eacl/id "user"}
+                               {:eacl/id "doc-a"}
+                               {:eacl/id "doc-b"}
+                               {:eacl/id "doc-c"}])
+          documents
+          (mapv #(eacl/spice-object :document %)
+                ["doc-a" "doc-b" "doc-c"])
+          _ (doseq [resource documents]
+              (eacl/create-relationship!
+               authorization
+               (eacl/->Relationship user :reader resource)))
+          query {:subject user
+                 :permission :view
+                 :resource/type :document
+                 :first 1}
+          page-1 (eacl/lookup-resources authorization query)
+          cursor (get-in page-1 [:page-info :end-cursor])
+          cursor-data
+          (datomic/token->page-bound (:opts authorization) cursor)
+          cursor-basis (:basis-t cursor-data)]
+      @(d/transact
+        conn
+        [{:db/id (d/tempid :db.part/user)
+          :db/doc "unrelated cursor churn"}])
+      (testing "an equal complete proof continues on current without as-of"
+        (with-redefs [d/as-of
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "proof-equivalent continuation must not use history"
+                          {})))]
+          (let [page-2
+                (eacl/lookup-resources
+                 authorization
+                 (assoc query :after cursor))
+                rebased
+                (datomic/token->page-bound
+                 (:opts authorization)
+                 (get-in page-2 [:page-info :end-cursor]))]
+            (is (= ["doc-b"] (mapv :id (:data page-2))))
+            (is (< cursor-basis (:basis-t rebased))))))
+      (let [fresh-page-1
+            (eacl/lookup-resources authorization query)
+            fresh-cursor
+            (get-in fresh-page-1 [:page-info :end-cursor])
+            delete-token
+            (:zed/token
+             (eacl/delete-relationship!
+              authorization
+              (eacl/->Relationship
+               user :reader (second documents))))]
+        (testing "a changed proof continues only on the original exact graph"
+          (is (= ["doc-b"]
+                 (mapv
+                  :id
+                  (:data
+                   (eacl/lookup-resources
+                    authorization
+                    (assoc query :after fresh-cursor)))))))
+        (testing "a newer causal floor forbids fallback to the old graph"
+          (is (= :eacl.consistency/cursor-consistency-conflict
+                 (:type
+                  (error-data
+                   #(eacl/lookup-resources
+                     authorization
+                     (assoc
+                      query
+                      :after fresh-cursor
+                      :consistency
+                      (consistency/at-least-as-fresh
+                       delete-token))))))))))))

--- a/modules/eacl-datomic/test/eacl/datomic/lookup_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/lookup_cache_test.clj
@@ -237,8 +237,8 @@
                        {:subject (spice-object :user "renamed-alice")
                         :permission :admin
                         :resource/type :account})))))
-        (is (= 1 @calls)
-            "the internal-EID page remains valid while ID coercion observes the current db")))))
+        (is (= 2 @calls)
+            "a changed public identity binding cannot reuse the old query key")))))
 
 (deftest recreated-external-id-does-not-reuse-the-retracted-entity-cache-key-test
   (with-mem-conn [conn schema/v7-schema]
@@ -430,9 +430,9 @@
        first-client
        [(->Relationship alice :reader root)
         (->Relationship root :parent child)])
-      ;; :remember-answers false so this observes the recursive PAGE cache;
-      ;; otherwise the answer cache serves the repeat and the engine, whose
-      ;; stats this asserts on, is never entered.
+      ;; :remember-answers false forces deterministic replay. The old recursive
+      ;; page side cache was process-local and unauthenticated; v3 refuses to
+      ;; read it until continuation state uses the proof envelope contract.
       (let [second-client (core/make-client conn {:cache {:store store
                                                           :remember-answers false}
                                                   :page-token-key token-key})
@@ -447,8 +447,8 @@
                   (eacl/lookup-resources second-client
                                          (assoc query :after cursor)))))
             "another client replays the cursor against its authenticated snapshot")
-        (is (= 1 (:recursive-page-hits @stats))
-            "the shared immutable page is reusable across client instances")))))
+        (is (nil? (:recursive-page-hits @stats))
+            "no unauthenticated recursive page is reused across clients")))))
 
 (deftest long-count-does-not-hold-relationship-writer-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl-datomic/test/eacl/datomic/mutation_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/mutation_test.clj
@@ -1,0 +1,242 @@
+(ns eacl.datomic.mutation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datomic.api :as d]
+            [eacl.causal-token :as causal-token]
+            [eacl.core :as eacl]
+            [eacl.datomic.core :as datomic]
+            [eacl.datomic.datomic-helpers
+             :refer [with-mem-conn with-mem-conns]]
+            [eacl.datomic.mutation :as journal]
+            [eacl.datomic.schema :as schema]
+            [eacl.mutation :as mutation]
+            [eacl.schema.model :as model]))
+
+(def test-schema
+  "definition user {}
+   definition folder {
+     relation owner: user
+     relation viewer: user
+     permission view = owner + viewer
+   }")
+
+(def security-key
+  "01234567890123456789012345678901")
+
+(defn- relation-eid
+  [db relation-name]
+  (d/entid
+   db
+   [:eacl/id
+    (model/->relation-id :folder relation-name :user)]))
+
+(deftest managed-writes-publish-committed-head-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (datomic/make-client
+                  conn
+                  {:coherence-authority :managed
+                   :zed-token-key security-key})
+          schema-result (eacl/write-schema! client test-schema)
+          first-payload
+          (causal-token/token-data
+           (get-in client [:opts :format-options])
+           (:zed/token schema-result))
+          first-head (:head-id (journal/graph-state (d/db conn)))
+          no-op-result (eacl/write-schema! client test-schema)
+          no-op-payload
+          (causal-token/token-data
+           (get-in client [:opts :format-options])
+           (:zed/token no-op-result))]
+      (testing "schema response derives its anchor and order from db-after"
+        (is (= first-head (:graph-anchor first-payload)))
+        (is (= (d/basis-t (d/db conn)) (:order-hint no-op-payload)))
+        (is (= first-head (:graph-anchor no-op-payload))))
+
+      @(d/transact conn [{:eacl/id "user-1"}
+                         {:eacl/id "folder-1"}
+                         {:eacl/id "folder-2"}])
+      (let [write-result
+            (eacl/create-relationships!
+             client
+             [(eacl/->Relationship
+               (eacl/spice-object :user "user-1")
+               :owner
+               (eacl/spice-object :folder "folder-1"))
+              (eacl/->Relationship
+               (eacl/spice-object :user "user-1")
+               :viewer
+               (eacl/spice-object :folder "folder-2"))])
+            db (d/db conn)
+            owner-stamp
+            (get (d/entity db (relation-eid db :owner))
+                 mutation/relation-mutation-id-attr)
+            viewer-stamp
+            (get (d/entity db (relation-eid db :viewer))
+                 mutation/relation-mutation-id-attr)
+            payload
+            (causal-token/token-data
+             (get-in client [:opts :format-options])
+             (:zed/token write-result))]
+        (testing "one batched relationship write stamps every relation"
+          (is (= owner-stamp viewer-stamp))
+          (is (= owner-stamp (:graph-anchor payload)))
+          (is (= (d/basis-t db) (:order-hint payload))))
+        (let [delete-result
+              (eacl/delete-object!
+               client
+               (eacl/spice-object :user "user-1"))
+              db-after (d/db conn)
+              owner-delete-stamp
+              (get (d/entity db-after (relation-eid db-after :owner))
+                   mutation/relation-mutation-id-attr)
+              viewer-delete-stamp
+              (get (d/entity db-after (relation-eid db-after :viewer))
+                   mutation/relation-mutation-id-attr)
+              delete-payload
+              (causal-token/token-data
+               (get-in client [:opts :format-options])
+               (:zed/token delete-result))]
+          (testing "cascade deletion publishes all dependency stamps"
+            (is (= owner-delete-stamp viewer-delete-stamp))
+            (is (not= owner-stamp owner-delete-stamp))
+            (is (= owner-delete-stamp
+                   (:graph-anchor delete-payload)))))))))
+
+(deftest migration-race-and-cross-connection-writers-test
+  (with-mem-conns [conn-1 conn-2 schema/v7-schema]
+    @(d/transact
+      conn-1
+      [{:eacl/id "legacy-relation"
+        :eacl.relation/relation-name :member}])
+    (let [attempts [(future (journal/ensure-migrated! conn-1))
+                    (future (journal/ensure-migrated! conn-2))]
+          states (mapv deref attempts)
+          state (journal/graph-state (d/db conn-1))]
+      (is (every? #(= (:family-id state) (:family-id %)) states))
+      (is (every? #(= (:head-id state) (:head-id %)) states))
+      (is (= (:head-id state)
+             (get (d/entity (d/db conn-1)
+                            [:eacl/id "legacy-relation"])
+                  mutation/relation-mutation-id-attr)))
+      (let [first-id (mutation/new-id)
+            second-id (mutation/new-id)]
+        (journal/transact!
+         conn-1
+         {:mutation-id first-id
+          :kind :custom
+          :canonical-data {:writer 1}
+          :tx-data []})
+        (journal/transact!
+         conn-2
+         {:mutation-id second-id
+          :kind :custom
+          :canonical-data {:writer 2}
+          :tx-data []})
+        (is (journal/contains-anchor? (d/db conn-1) first-id))
+        (is (journal/contains-anchor? (d/db conn-1) second-id))
+        (is (= second-id
+               (:head-id (journal/graph-state (d/db conn-1)))))))))
+
+(deftest idempotency-custom-dependency-and-expiry-test
+  (with-mem-conn [conn schema/v7-schema]
+    (journal/ensure-migrated! conn)
+    @(d/transact conn [{:eacl/id "identity-1"}])
+    (let [mutation-id (mutation/new-id)
+          options
+          {:mutation-id mutation-id
+           :kind :object-identity
+           :canonical-data {:operation :rename
+                            :id "identity-1"
+                            :value "public-2"}
+           :dependency-ids [[:eacl/id "identity-1"]]
+           :token-ttl-seconds 1
+           :retention-grace-seconds 0
+           :tx-data [[:db/add
+                      [:eacl/id "identity-1"]
+                      :eacl/schema-string
+                      "public-2"]]}
+          report (journal/transact! conn options)
+          recovered (journal/transact! conn options)]
+      (is (not (:idempotent-recovery? report)))
+      (is (true? (:idempotent-recovery? recovered)))
+      (is (= mutation-id
+             (get (d/entity (d/db conn) [:eacl/id "identity-1"])
+                  mutation/dependency-mutation-id-attr)))
+      (is (= :eacl.mutation/id-reused
+             (try
+               (journal/transact!
+                conn
+                (assoc options :canonical-data {:different true}))
+               nil
+               (catch clojure.lang.ExceptionInfo error
+                 (:type (ex-data error))))))
+      (let [old-head (:head-id (journal/graph-state (d/db conn)))
+            next-id (mutation/new-id)]
+        (journal/transact!
+         conn
+         {:mutation-id next-id
+          :kind :custom
+          :canonical-data {:operation :next}
+          :token-ttl-seconds 1
+          :retention-grace-seconds 0
+          :tx-data []})
+        (is (pos? (journal/prune-expired!
+                   conn
+                   (+ 2 (mutation/now-seconds)))))
+        (is (false? (journal/contains-anchor? (d/db conn) old-head)))
+        (is (true? (journal/contains-anchor? (d/db conn) next-id)))))))
+
+(deftest incomplete-authority-cannot-issue-read-token-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (datomic/make-client
+                  conn
+                  {:zed-token-key security-key})]
+      (is (= :eacl/causal-authority-incomplete
+             (try
+               (datomic/current-zed-token client)
+               nil
+               (catch clojure.lang.ExceptionInfo error
+                 (:type (ex-data error)))))))))
+
+(deftest concurrent-mutation-id-claim-test
+  (with-mem-conns [conn-1 conn-2 schema/v7-schema]
+    (journal/ensure-migrated! conn-1)
+    (let [mutation-id (mutation/new-id)
+          options {:mutation-id mutation-id
+                   :kind :custom
+                   :canonical-data {:operation :same}
+                   :tx-data []}
+          results
+          (mapv deref
+                [(future (journal/transact! conn-1 options))
+                 (future (journal/transact! conn-2 options))])]
+      (is (= 1 (count (filter :idempotent-recovery? results))))
+      (is (= mutation-id
+             (:head-id (journal/graph-state (d/db conn-1))))))
+    (let [mutation-id (mutation/new-id)
+          result
+          (mapv
+           deref
+           [(future
+              (try
+                (journal/transact!
+                 conn-1
+                 {:mutation-id mutation-id
+                  :kind :custom
+                  :canonical-data {:value 1}
+                  :tx-data []})
+                :committed
+                (catch clojure.lang.ExceptionInfo error
+                  (:type (ex-data error)))))
+            (future
+              (try
+                (journal/transact!
+                 conn-2
+                 {:mutation-id mutation-id
+                  :kind :custom
+                  :canonical-data {:value 2}
+                  :tx-data []})
+                :committed
+                (catch clojure.lang.ExceptionInfo error
+                  (:type (ex-data error)))))])]
+      (is (= #{:committed :eacl.mutation/id-reused}
+             (set result))))))

--- a/modules/eacl-datomic/test/eacl/datomic/object_deletion_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/object_deletion_test.clj
@@ -86,7 +86,9 @@
 (deftest delete-object-through-the-client-test
   (with-mem-conn [conn schema/v7-schema]
     (let [{:keys [u a]} (seed! conn)
-          acl (core/make-client conn {})]
+          acl (core/make-client
+               conn
+               {:coherence-authority :managed})]
       (is (true? (eacl/can? acl (spice-object :user "u") :admin (spice-object :account "a"))))
 
       (let [result (eacl/delete-object! acl (spice-object :account "a"))]

--- a/modules/eacl-datomic/test/eacl/datomic/recursive_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/recursive_cache_test.clj
@@ -128,16 +128,17 @@
         (is (= (:data hit-page2) (:data retry-page2))
             "a cursor retry returns its immutable cached page")
         (is (= (:data page1) (:data previous-page)))
-        (is (= 1 (:continuation-hits @hit-stats)))
+        (is (nil? (:continuation-hits @hit-stats))
+            "v3 does not read the unauthenticated continuation side cache")
         (is (nil? (:continuation-hits @miss-stats)))
         (is (= 1 (:continuation-misses @alternate-stats)))
-        (is (= 1 (:recursive-page-hits @retry-stats))
-            "a retry does not consume or replay the traversal frontier")
-        (is (= 1 (:recursive-page-hits @previous-stats))
-            "back navigation reuses the already produced immutable page")
-        (is (< (:derived-grants @hit-stats)
+        (is (nil? (:recursive-page-hits @retry-stats))
+            "a retry deterministically replays its authenticated cursor")
+        (is (nil? (:recursive-page-hits @previous-stats))
+            "back navigation does not trust a side-cache page")
+        (is (= (:derived-grants @hit-stats)
                (:derived-grants @miss-stats))
-            "cache hit advances only new work; cache miss replays the prefix")))))
+            "both cache configurations replay the same proven prefix")))))
 
 (deftest reverse-recursive-pagination-resumes-test
   (with-mem-conn [conn schema/v7-schema]
@@ -158,7 +159,7 @@
         (is (empty? (set/intersection
                      (set (map :id (:data page1)))
                      (set (map :id (:data page2))))))
-        (is (= 1 (:continuation-hits @stats)))
+        (is (nil? (:continuation-hits @stats)))
         (let [all-subjects (collect-reverse client query)]
           (is (= 130 (count all-subjects)))
           (is (= 130 (count (set (map :id all-subjects))))
@@ -224,15 +225,15 @@
                       (eacl/lookup-resources client (assoc query :after cursor)))]
           (is (= (mapv account-id (range 5 10))
                  (mapv :id (:data page2))))
-          (is (= 1 (:continuation-hits @stats))
-              "unrelated basis churn does not invalidate recursive state")
+          (is (nil? (:continuation-hits @stats))
+              "unrelated basis churn still avoids unauthenticated continuation state")
           (let [restart-stats (atom {})
                 restarted-page1
                 (binding [idx/*recursive-traversal-stats* restart-stats]
                   (eacl/lookup-resources client query))]
             (is (= (:data page1) (:data restarted-page1)))
-            (is (= 1 (:recursive-page-hits @restart-stats))
-                "a new identical lookup is keyed by relationship proof, not basis t")
+            (is (nil? (:recursive-page-hits @restart-stats))
+                "a completed authenticated answer, not a side-cache page, is reusable")
             (is (zero? (get @restart-stats :derived-grants 0)))))))))
 
 (deftest recursive-pages-are-isolated-by-cache-namespace-test
@@ -268,16 +269,17 @@
         (is (= (:data page-a) (:data page-b)))
         (is (nil? (:recursive-page-hits @first-b-stats))
             "tenant B cannot read tenant A's completed recursive page")
-        (is (pos? (cache/clear-namespace! store :tenant-a)))
+        (is (zero? (cache/clear-namespace! store :tenant-a))
+            "no unauthenticated recursive page was retained")
         (let [second-b-stats (atom {})
               page-b-again
               (binding [idx/*recursive-traversal-stats* second-b-stats]
                 (eacl/lookup-resources client-b query))]
           (is (= (:data page-b) (:data page-b-again)))
-          (is (= 1 (:recursive-page-hits @second-b-stats))
-              "clearing tenant A leaves tenant B's recursive page intact"))))))
+          (is (nil? (:recursive-page-hits @second-b-stats))
+              "tenant B also replays without a recursive page side cache"))))))
 
-(deftest reverse-continuation-weight-includes-retained-rule-graph-test
+(deftest reverse-continuation-side-state-is-not-retained-test
   (with-mem-conn [conn schema/v7-schema]
     (let [store (cache/local-store)
           client
@@ -303,11 +305,12 @@
             retained-rule-count
             (reduce + 0 (map count (vals (:rules-by-node state))))
             weight #'idx/continuation-weight]
-        (is (pos? retained-rule-count))
-        (is (= retained-rule-count (:rule-count state)))
-        (is (> (weight state)
+        (is (nil? continuation))
+        (is (zero? retained-rule-count))
+        (is (nil? (:rule-count state)))
+        (is (= (weight state)
                (weight (assoc state :rule-count 0)))
-            "the admission estimate charges the retained reverse rule graph")))))
+            "no reverse rule graph reached the unauthenticated provider")))))
 
 (deftest recursive-cursor-replays-when-its-boundary-object-is-gone-live-test
   (with-mem-conn [conn schema/v7-schema]
@@ -361,7 +364,7 @@
         (is (> (:derived-grants @stats) 5)
             "an alternate cache recomputes the prefix instead of changing snapshots")))))
 
-(deftest recursive-continuation-retains-bounded-eid-chunks-not-db-values-test
+(deftest recursive-continuation-does-not-retain-opaque-runtime-values-test
   (with-mem-conn [conn schema/v7-schema]
     (let [store (cache/local-store)
           client
@@ -394,8 +397,8 @@
             streams (->> continuations
                          (mapcat #(seq (get-in % [:state :queue])))
                          (filter #(= :stream (:kind %))))]
-        (is (seq continuations))
-        (is (seq streams))
+        (is (empty? continuations))
+        (is (empty? streams))
         (is (every? vector? (map :eids streams)))
         (is (every? #(<= (count (:eids %)) 64) streams))
         (is (not-any? #(instance? db-class %) retained-values))
@@ -432,7 +435,7 @@
         (is (> (:derived-grants @stats) 3)
             "the safe fallback replays the proven traversal prefix")))))
 
-(deftest complete-recursive-enumeration-is-linear-on-continuation-hits-test
+(deftest complete-recursive-enumeration-is-equal-with-or-without-cache-test
   (with-mem-conn [conn schema/v7-schema]
     (let [token-key "recursive-linear-walk"
           cached-client (core/make-client conn {:page-token-key token-key})
@@ -447,6 +450,6 @@
             replayed (collect-forward disabled-client query)]
         (is (= (:data replayed) (:data cached)))
         (is (= 80 (count (:data cached))))
-        (is (< (:derived-grants cached)
-               (/ (:derived-grants replayed) 2))
-            "cached traversal advances near-linearly while disabled mode remains correct")))))
+        (is (= (:derived-grants cached)
+               (:derived-grants replayed))
+            "authenticated replay performs the same traversal work")))))

--- a/modules/eacl-datomic/test/eacl/datomic/schema_basis_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/schema_basis_test.clj
@@ -242,16 +242,16 @@
         (is (= ["a"] (mapv :id (:data (eacl/lookup-resources acl query)))))
         @(d/transact conn [{:eacl/id "unrelated"}])
         (is (= ["a"] (mapv :id (:data (eacl/lookup-resources acl query)))))
-        (is (= 2 @calls)
-            "an unstamped schema remains uncached even when live lookups are requested")
+        (is (= 1 @calls)
+            "a complete content schema proof safely caches an unstamped schema")
 
         (eacl/write-schema! acl schema-v1)
         (is (= ["a"] (mapv :id (:data (eacl/lookup-resources acl query)))))
         (is (= ["a"] (mapv :id (:data (eacl/lookup-resources acl query)))))
-        (is (= 3 @calls)
-            "the first supported schema write enables the client result cache")))))
+        (is (= 1 @calls)
+            "a semantically equal stamped schema preserves the proof")))))
 
-(deftest out-of-band-schema-write-requires-a-new-client-test
+(deftest out-of-band-schema-write-is-observed-by-existing-client-test
   (with-mem-conn [conn schema/v7-schema]
     (schema/write-schema! conn schema-v1)
     (seed-owner! conn)
@@ -263,13 +263,14 @@
       (is (false? (eacl/can? old-client viewer :admin account)))
       (is (= :current (:status (integrity/client-schema-status old-client))))
 
-      ;; Deliberately bypass the client. The lifecycle contract requires
-      ;; recreating other clients/processes after such a schema write.
+      ;; Deliberately bypass the client. v3 rederives the selected snapshot's
+      ;; complete schema proof, so an existing client cannot keep using a
+      ;; latched permission graph.
       (schema/write-schema! conn schema-v2)
       (is (= :outdated (:status (integrity/client-schema-status old-client)))
           "the optional one-datom diagnostic detects the mismatch")
       (let [writer (core/make-client conn {})]
         (eacl/create-relationship! writer viewer :viewer account))
 
-      (is (false? (eacl/can? old-client viewer :admin account)))
+      (is (true? (eacl/can? old-client viewer :admin account)))
       (is (true? (eacl/can? (core/make-client conn {}) viewer :admin account))))))

--- a/modules/eacl-datomic/test/eacl/datomic/v8_characterization_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/v8_characterization_test.clj
@@ -51,11 +51,15 @@
     (let [token-key "v8-extraction-characterization"
           client (core/make-client
                   conn
-                  {:page-token-key token-key
+                  {:coherence-authority :managed
+                   :proof-mode :content
+                   :page-token-key token-key
                    :cache {:remember-answers true}})
           uncached-client (core/make-client
                            conn
-                           {:page-token-key token-key
+                           {:coherence-authority :managed
+                            :proof-mode :content
+                            :page-token-key token-key
                             :cache cache/no-cache})
           query {:subject (user "user-1")
                  :permission :read

--- a/modules/eacl-datomic/test/eacl/spice_test.clj
+++ b/modules/eacl-datomic/test/eacl/spice_test.clj
@@ -80,7 +80,10 @@
   ;; Audit §13: write-relationship!/delete-relationship! were declared on the
   ;; protocol but unimplemented -> AbstractMethodError.
   (with-mem-conn [conn schema/v7-schema]
-    (let [client (spiceomic/make-client conn {})
+    (let [client (spiceomic/make-client
+                  conn
+                  {:coherence-authority :managed
+                   :proof-mode :content})
           u1     (spice-object :user "u1")
           a1     (spice-object :account "a1")]
       (eacl/write-schema! client "definition user {}
@@ -233,7 +236,10 @@
       (def acme-account (->account "acme")))
 
     (testing "Make a Spice client and hold onto channel for disposal later."
-      (let [client (spiceomic/make-client conn {})]
+      (let [client (spiceomic/make-client
+                    conn
+                    {:coherence-authority :managed
+                     :proof-mode :content})]
         (is client)
         ;(is (satisfies? IAuthorization client))
         ; use :spicedb/client Integrant key instead of :permissions/spicedb because we want to migrate Spice schema manually in these tests.
@@ -646,7 +652,10 @@
 
 (deftest consistency-selection-tests
   (with-mem-conn [conn schema/v7-schema]
-    (let [client (spiceomic/make-client conn {})]
+    (let [client (spiceomic/make-client
+                  conn
+                  {:coherence-authority :managed
+                   :proof-mode :content})]
       (eacl/write-schema! client "definition user {}
          definition account { relation owner: user  permission admin = owner }")
       @(d/transact conn [{:eacl/id "alice"} {:eacl/id "acct-1"} {:eacl/id "acct-2"} {:eacl/id "acct-3"}])

--- a/modules/eacl/src/eacl/backend/v8.cljc
+++ b/modules/eacl/src/eacl/backend/v8.cljc
@@ -6,7 +6,7 @@
   Relay pagination, deletion, consistency selection, and exact cache proofs."
   (:require [eacl.spicedb.consistency :as consistency]))
 
-(def adapter-version 1)
+(def adapter-version 3)
 
 (def legacy-spi-operations
   #{:cache-stamp
@@ -18,6 +18,15 @@
 
 (def required-snapshot-operations
   #{:snapshot-id
+    :source-scope
+    :graph-head
+    :contains-anchor?
+    :order-hint
+    :select-current
+    :select-authoritative
+    :select-at-least
+    :exact-locator
+    :select-exact
     :object-id->internal
     :internal-id->object
     :relation-defs
@@ -39,6 +48,7 @@
 (def empty-capabilities
   {:consistency #{}
    :snapshots #{}
+   :source #{}
    :cursor #{}
    :transactions #{}
    :cache-proofs #{}
@@ -116,8 +126,29 @@
                               operation))}))
   candidate)
 
+(defn require-legacy-evaluation!
+  "Allows the six-function SPI only for an explicitly supplied immutable
+  snapshot with caching and every v3 consistency guarantee disabled."
+  [candidate {:keys [explicit-snapshot? cache? consistency-mode]}]
+  (validate-legacy-adapter! candidate)
+  (when-not (and explicit-snapshot?
+                 (not cache?)
+                 (or (nil? consistency-mode)
+                     (= :snapshot-only consistency-mode)))
+    (unsupported!
+     :legacy
+     :v3-guarantee
+     {:explicit-snapshot? (boolean explicit-snapshot?)
+      :cache? (boolean cache?)
+      :consistency-mode consistency-mode}
+     #{:uncached-explicit-snapshot}))
+  candidate)
+
 (defn make-adapter
-  [{:keys [id capabilities operations state]}]
+  [{:keys [id capabilities operations state fingerprint deterministic?
+           identity-contract]
+    :or {deterministic? true
+         identity-contract :selected-internal/current-external-v1}}]
   (when-not (keyword? id)
     (invalid-adapter! "Backend :id must be a keyword."
                       {:backend id}))
@@ -137,6 +168,11 @@
    ::id id
    ::capabilities (normalize-capabilities id capabilities)
    ::operations operations
+   ::fingerprint
+   (or fingerprint
+       {:backend id :adapter-version adapter-version})
+   ::deterministic? (boolean deterministic?)
+   ::identity-contract identity-contract
    ::state state})
 
 (defn adapter?
@@ -159,6 +195,39 @@
   [adapter]
   (if (adapter? adapter)
     (::capabilities adapter)
+    (invalid-adapter! "Value is not a v8 backend adapter."
+                      {:value adapter})))
+
+(defn state
+  "Returns the immutable backend state captured by this adapter.
+
+  Selection orchestration uses this only to hand the selected native snapshot
+  to backend-specific ID/cursor codecs; authorization reads remain behind the
+  validated operation boundary."
+  [adapter]
+  (if (adapter? adapter)
+    (::state adapter)
+    (invalid-adapter! "Value is not a v8 backend adapter."
+                      {:value adapter})))
+
+(defn fingerprint
+  [adapter]
+  (if (adapter? adapter)
+    (::fingerprint adapter)
+    (invalid-adapter! "Value is not a v8 backend adapter."
+                      {:value adapter})))
+
+(defn deterministic?
+  [adapter]
+  (if (adapter? adapter)
+    (::deterministic? adapter)
+    (invalid-adapter! "Value is not a v8 backend adapter."
+                      {:value adapter})))
+
+(defn identity-contract
+  [adapter]
+  (if (adapter? adapter)
+    (::identity-contract adapter)
     (invalid-adapter! "Value is not a v8 backend adapter."
                       {:value adapter})))
 

--- a/modules/eacl/src/eacl/cache.cljc
+++ b/modules/eacl/src/eacl/cache.cljc
@@ -1,9 +1,26 @@
 (ns eacl.cache
-  "Backend-neutral cache store and exact snapshot-proof validation."
-  (:require [eacl.backend.v8 :as backend]))
+  "Backend-neutral authenticated cache and snapshot-proof validation."
+  (:require [eacl.backend.v8 :as backend]
+            [eacl.secure-format :as secure]))
 
-(def cache-entry-version 1)
+(def cache-entry-version 3)
 (def portable-value-version 1)
+(def cache-entry-prefix "eacl_ce3_")
+(def cache-entry-domain "eacl/cache-entry/envelope/v3")
+(def cache-entry-keys
+  #{:version :portable-version :key :kind :computed-at :validated-at
+    :dependency-scope :proof :value})
+
+(def validation-metric-keys
+  [:exact-hit
+   :causal-proof-lift
+   :content-proof
+   :mutation-proof
+   :proof-mismatch
+   :future-history-rejection
+   :unauthenticated-entry
+   :no-proof-bypass
+   :provider-failure])
 
 (defprotocol CacheStore
   (lookup [store key])
@@ -12,13 +29,25 @@
   (clear! [store])
   (stats [store]))
 
+(defprotocol CacheTelemetry
+  (record-validation! [store metric]))
+
+(defprotocol CacheValidationUpdate
+  (store-validation!
+    [store key expected-entry replacement-entry]
+    "Conditionally replaces validation telemetry for an unchanged entry."))
+
 (defrecord NoCache []
   CacheStore
   (lookup [_ _] nil)
   (store! [_ _ _] false)
   (evict! [_ _] false)
   (clear! [_] nil)
-  (stats [_] {:entries 0 :hits 0 :misses 0 :puts 0 :errors 0}))
+  (stats [_] {:entries 0 :hits 0 :misses 0 :puts 0 :errors 0})
+  CacheTelemetry
+  (record-validation! [_ _] nil)
+  CacheValidationUpdate
+  (store-validation! [_ _ _ _] false))
 
 (def no-cache (->NoCache))
 
@@ -54,7 +83,22 @@
     (reset! entries {})
     nil)
   (stats [_]
-    (assoc @metrics :entries (count @entries))))
+    (assoc @metrics :entries (count @entries)))
+  CacheTelemetry
+  (record-validation! [_ metric]
+    (swap! metrics update metric (fnil inc 0))
+    nil)
+  CacheValidationUpdate
+  (store-validation! [_ key expected-entry replacement-entry]
+    (let [updated? (atom false)]
+      (swap! entries
+             (fn [current]
+               (if (= expected-entry (get current key))
+                 (do
+                   (reset! updated? true)
+                   (assoc current key replacement-entry))
+                 current)))
+      @updated?)))
 
 (defn local-store
   ([]
@@ -66,7 +110,10 @@
                      {:type :eacl/invalid-config
                       :max-entries max-entries})))
    (->LocalStore (atom {})
-                 (atom {:hits 0 :misses 0 :puts 0 :errors 0})
+                 (atom
+                  (merge {:hits 0 :misses 0 :puts 0 :errors 0}
+                         (zipmap validation-metric-keys
+                                 (repeat 0))))
                  max-entries)))
 
 (defn cache-store
@@ -82,26 +129,105 @@
                     {:type :eacl/invalid-config
                      :cache value}))))
 
+(defn- selected-point
+  [adapter]
+  {:source-scope
+   {:backend (backend/backend-id adapter)
+    :scope (backend/invoke adapter :source-scope)}
+   :graph-head (backend/invoke adapter :graph-head)
+   :snapshot-id (backend/invoke adapter :snapshot-id)})
+
+(defn- complete-key
+  [adapter key kind]
+  {:cache-version cache-entry-version
+   :adapter-version backend/adapter-version
+   :source-scope
+   {:backend (backend/backend-id adapter)
+    :scope (backend/invoke adapter :source-scope)}
+   :kind kind
+   :adapter-fingerprint (backend/fingerprint adapter)
+   :identity-contract (backend/identity-contract adapter)
+   :semantic-key key})
+
+(defn- encode-entry
+  [format-options payload]
+  (secure/encode-authenticated
+   (merge format-options
+          {:domain cache-entry-domain
+           :prefix cache-entry-prefix})
+   payload))
+
 (defn- cache-entry
-  [key kind schema-proof relation-proof value]
-  {:eacl.cache/version cache-entry-version
-   :eacl.cache/portable-version portable-value-version
-   :eacl.cache/key key
-   :eacl.cache/kind kind
-   :eacl.cache/schema-proof schema-proof
-   :eacl.cache/relation-proof relation-proof
-   :eacl.cache/value value})
+  [format-options key kind computation-point schema-scope relation-ids
+   schema-proof relation-proof value]
+  (encode-entry
+   format-options
+   {:version cache-entry-version
+    :portable-version portable-value-version
+    :key key
+    :kind kind
+    :computed-at computation-point
+    :validated-at computation-point
+    :dependency-scope {:schema schema-scope
+                       :relations (vec (sort relation-ids))}
+    :proof {:schema schema-proof
+            :relations relation-proof}
+    :value value}))
 
 (defn- valid-entry?
-  [entry key kind schema-proof relation-proof valid-value?]
-  (and (map? entry)
-       (= cache-entry-version (:eacl.cache/version entry))
-       (= portable-value-version (:eacl.cache/portable-version entry))
-       (= key (:eacl.cache/key entry))
-       (= kind (:eacl.cache/kind entry))
-       (= schema-proof (:eacl.cache/schema-proof entry))
-       (= relation-proof (:eacl.cache/relation-proof entry))
-       (valid-value? (:eacl.cache/value entry))))
+  [adapter format-options entry key kind schema-scope relation-ids
+   schema-proof relation-proof valid-value? selected-point]
+  (try
+    (let [decoded
+          (secure/decode-authenticated
+           (merge format-options
+                  {:domain cache-entry-domain
+                   :prefix cache-entry-prefix
+                   :payload-keys cache-entry-keys})
+           entry)]
+      (cond
+        (not (and (= cache-entry-version (:version decoded))
+                  (= portable-value-version (:portable-version decoded))
+                  (= (secure/canonicalize key)
+                     (secure/canonicalize (:key decoded)))
+                  (= kind (:kind decoded))
+                  (= (secure/canonicalize
+                      {:schema schema-scope
+                       :relations (vec (sort relation-ids))})
+                     (:dependency-scope decoded))
+                  (valid-value? (:value decoded))))
+        {:status :unauthenticated-entry}
+
+        (not=
+         (secure/canonicalize
+          (:source-scope selected-point))
+         (secure/canonicalize
+          (get-in decoded [:computed-at :source-scope])))
+        {:status :unauthenticated-entry}
+
+        (not
+         (backend/invoke
+          adapter
+          :contains-anchor?
+          (get-in decoded [:computed-at :graph-head :graph-anchor])))
+        {:status :future-history-rejection}
+
+        (not=
+         (secure/canonicalize
+          {:schema schema-proof
+           :relations relation-proof})
+         (:proof decoded))
+        {:status :proof-mismatch}
+
+        :else
+        {:status
+         (if (= (get-in decoded [:computed-at :graph-head :graph-anchor])
+                (get-in selected-point [:graph-head :graph-anchor]))
+           :exact-hit
+           :causal-proof-lift)
+         :entry decoded}))
+    (catch #?(:clj Exception :cljs :default) _
+      {:status :unauthenticated-entry})))
 
 (defn- safe-store-call
   [fallback f]
@@ -110,6 +236,21 @@
     (catch #?(:clj Exception :cljs :default) _
       fallback)))
 
+(defn- note!
+  [store metric]
+  (when (satisfies? CacheTelemetry store)
+    (record-validation! store metric)))
+
+(defn- proof-metric
+  [schema-proof relation-proof]
+  (if (and (string? schema-proof)
+           (or (empty? relation-proof)
+               (every? (fn [[_ value]]
+                         (string? value))
+                       relation-proof)))
+    :mutation-proof
+    :content-proof))
+
 (defn resolve!
   "Returns {:value value :cached? boolean :cache-basis snapshot-id}.
 
@@ -117,28 +258,85 @@
   Store failure, malformed entries, and proof mismatch are misses; no cached
   value is returned before its opaque schema and relation proofs compare
   exactly."
-  [adapter store key kind schema-scope relation-ids valid-value? compute]
-  (if (no-cache? store)
-    {:value (compute)
-     :cached? false
-     :cache-basis nil}
-    (let [schema-proof
-          (backend/invoke adapter :schema-proof schema-scope)
-          relation-proof
-          (backend/invoke adapter :relation-proof relation-ids)
-          snapshot-id (backend/invoke adapter :snapshot-id)
-          entry (safe-store-call nil #(lookup store key))]
-      (if (valid-entry? entry key kind
-                        schema-proof relation-proof valid-value?)
-        {:value (:eacl.cache/value entry)
-         :cached? true
-         :cache-basis snapshot-id}
-        (let [value (compute)]
-          (safe-store-call
-           false
-           #(store! store key
-                    (cache-entry key kind schema-proof
-                                 relation-proof value)))
-          {:value value
-           :cached? false
-           :cache-basis snapshot-id})))))
+  ([adapter store key kind schema-scope relation-ids valid-value? compute]
+   (resolve! adapter store key kind schema-scope relation-ids
+             valid-value? compute {}))
+  ([adapter store key kind schema-scope relation-ids valid-value? compute
+    format-options]
+   (if (no-cache? store)
+     {:value (compute)
+      :cached? false
+      :cache-basis nil}
+     (let [schema-proof
+           (backend/invoke adapter :schema-proof schema-scope)
+           relation-proof
+           (backend/invoke adapter :relation-proof relation-ids)
+           point (selected-point adapter)
+           full-key (complete-key adapter key kind)]
+       (if (or (not (backend/deterministic? adapter))
+               (nil? schema-proof)
+               (nil? relation-proof)
+               (empty? relation-ids))
+         (do
+           (note! store :no-proof-bypass)
+           {:value (compute)
+            :cached? false
+            :cache-basis (:snapshot-id point)})
+         (let [provider-error #?(:clj (Object.) :cljs (js-obj))
+               stored-entry
+               (safe-store-call provider-error #(lookup store full-key))
+               _ (when (identical? provider-error stored-entry)
+                   (note! store :provider-failure))
+               {:keys [status entry]}
+               (if (or (identical? provider-error stored-entry)
+                       (nil? stored-entry))
+                 {:status nil}
+                 (valid-entry?
+                  adapter format-options stored-entry full-key kind
+                  schema-scope relation-ids
+                  schema-proof relation-proof valid-value? point))]
+           (when status
+             (note! store status))
+           (if entry
+             (do
+               (note! store (proof-metric schema-proof relation-proof))
+               ;; `validated-at` is authenticated telemetry only. Every hit
+               ;; above still re-read the selected snapshot's proof and causal
+               ;; anchor; this update never acts as a lease.
+               (let [replacement
+                     (encode-entry
+                      format-options
+                      (assoc entry :validated-at point))]
+                 (safe-store-call
+                  false
+                  #(if (satisfies? CacheValidationUpdate store)
+                     (store-validation!
+                      store full-key
+                      ;; The authenticated provider value read above is the
+                      ;; CAS expectation. A later validator cannot be
+                      ;; overwritten by this request after it wins the race.
+                      stored-entry
+                      replacement)
+                     (store! store full-key replacement))))
+               {:value (:value entry)
+                :cached? true
+                :cache-basis
+                (get-in entry [:computed-at :snapshot-id])
+                :cache-computed-at (:computed-at entry)
+                :cache-validated-at point})
+             (let [value (compute)
+                   stored?
+                   (safe-store-call
+                    provider-error
+                    #(store! store full-key
+                             (cache-entry
+                              format-options full-key kind point
+                              schema-scope relation-ids
+                              schema-proof relation-proof value)))]
+               (when (identical? provider-error stored?)
+                 (note! store :provider-failure))
+               {:value value
+                :cached? false
+                :cache-basis (:snapshot-id point)
+                :cache-computed-at point
+                :cache-validated-at point}))))))))

--- a/modules/eacl/src/eacl/causal_token.cljc
+++ b/modules/eacl/src/eacl/causal_token.cljc
@@ -1,0 +1,100 @@
+(ns eacl.causal-token
+  "Version-3 authenticated causal snapshot tokens."
+  (:require [eacl.secure-format :as secure]))
+
+(def token-version 3)
+(def token-prefix "eacl_z3_")
+(def token-domain "eacl/zed-token/envelope/v3")
+(def payload-keys
+  #{:version :backend :source-id :branch :graph-anchor :order-hint
+    :exact-locator :issued-at :expires-at})
+
+(defn now-seconds
+  []
+  (quot (#?(:clj System/currentTimeMillis
+            :cljs js/Date.now))
+        1000))
+
+(defn- invalid-token!
+  [reason data]
+  (throw (ex-info "Invalid EACL causal token."
+                  (merge {:type :eacl/invalid-zed-token
+                          :eacl/error :eacl/invalid-zed-token
+                          :reason reason}
+                         data))))
+
+(defn- valid-scope-value?
+  [value]
+  (or (string? value)
+      (keyword? value)
+      (map? value)
+      (vector? value)))
+
+(defn validate-payload!
+  [payload]
+  (let [{:keys [version backend source-id graph-anchor order-hint
+                issued-at expires-at]} payload]
+    (when-not (and (= token-version version)
+                   (keyword? backend)
+                   (valid-scope-value? source-id)
+                   (string? graph-anchor)
+                   (not-empty graph-anchor)
+                   (or (nil? order-hint)
+                       (and (integer? order-hint)
+                            (not (neg? order-hint))))
+                   (integer? issued-at)
+                   (integer? expires-at)
+                   (<= issued-at expires-at))
+      (invalid-token! :malformed {})))
+  payload)
+
+(defn issue
+  "Issues a v3 token. `payload` supplies backend/source/anchor/locator fields."
+  [{:keys [token-ttl-seconds] :as options} payload]
+  (let [issued-at (or (:issued-at payload) (now-seconds))
+        ttl (or token-ttl-seconds 3600)
+        expires-at (or (:expires-at payload) (+ issued-at ttl))
+        payload (-> payload
+                    (assoc :version token-version
+                           :issued-at issued-at
+                           :expires-at expires-at)
+                    (update :branch #(or % nil))
+                    (update :order-hint #(or % nil))
+                    (update :exact-locator #(or % nil)))]
+    (validate-payload! payload)
+    (secure/encode-authenticated
+     (merge options
+            {:domain token-domain
+             :prefix token-prefix})
+     payload)))
+
+(defn token-data
+  "Authenticates a v3 token and optionally validates its expected source scope."
+  ([options token]
+   (token-data options nil token))
+  ([options expected-scope token]
+   (let [payload
+         (try
+           (secure/decode-authenticated
+            (merge options
+                   {:domain token-domain
+                    :prefix token-prefix
+                    :payload-keys payload-keys})
+            token)
+           (catch #?(:clj Exception :cljs :default) error
+             (if (= :eacl/invalid-zed-token (:type (ex-data error)))
+               (throw error)
+               (invalid-token! (:reason (ex-data error)) {}))))
+         payload (validate-payload! payload)
+         now (or (:now-seconds options) (now-seconds))]
+     (when (> now (:expires-at payload))
+       (invalid-token! :expired {:expired-at (:expires-at payload)}))
+     (when (and expected-scope
+                (not= expected-scope
+                      (select-keys payload [:backend :source-id :branch])))
+       (invalid-token! :scope-mismatch
+                       {:expected-scope expected-scope
+                        :actual-scope
+                        (select-keys payload
+                                     [:backend :source-id :branch])}))
+     payload)))

--- a/modules/eacl/src/eacl/consistency.cljc
+++ b/modules/eacl/src/eacl/consistency.cljc
@@ -1,0 +1,263 @@
+(ns eacl.consistency
+  "Shared v3 consistency selection over validated backend adapters."
+  (:require [eacl.backend.v8 :as backend]
+            [eacl.causal-token :as causal-token]
+            [eacl.spicedb.consistency :as public-consistency]))
+
+(def error-types
+  {:unsupported-head-barrier
+   :eacl.consistency/unsupported-head-barrier
+   :token-expired :eacl.consistency/token-expired
+   :history-divergence :eacl.consistency/history-divergence
+   :freshness-unavailable :eacl.consistency/freshness-unavailable
+   :freshness-timeout :eacl.consistency/freshness-timeout
+   :incomparable-scope :eacl.consistency/incomparable-scope
+   :exact-snapshot-unavailable
+   :eacl.consistency/exact-snapshot-unavailable
+   :cursor-consistency-conflict
+   :eacl.consistency/cursor-consistency-conflict})
+
+(defn fail!
+  ([reason message]
+   (fail! reason message {} nil))
+  ([reason message data]
+   (fail! reason message data nil))
+  ([reason message data cause]
+   (throw
+    (ex-info
+     message
+     (merge
+      {:type (get error-types reason
+                  :eacl.consistency/selection-failed)
+       :eacl/error (get error-types reason
+                        :eacl.consistency/selection-failed)
+       :reason reason}
+      data)
+     cause))))
+
+(defn source-scope
+  [adapter]
+  (let [scope (backend/invoke adapter :source-scope)]
+    (when-not (and (map? scope)
+                   (contains? scope :source-id)
+                   (contains? scope :branch))
+      (throw
+       (ex-info
+        "Backend returned an invalid source scope."
+        {:type :eacl/invalid-backend-adapter
+         :eacl/error :eacl/invalid-backend-adapter
+         :backend (backend/backend-id adapter)
+         :source-scope scope})))
+    (assoc (select-keys scope [:source-id :branch])
+           :backend (backend/backend-id adapter))))
+
+(defn graph-head
+  [adapter]
+  (let [head (backend/invoke adapter :graph-head)]
+    (when-not (and (map? head)
+                   (string? (:graph-anchor head))
+                   (not-empty (:graph-anchor head))
+                   (or (nil? (:order-hint head))
+                       (and (integer? (:order-hint head))
+                            (not (neg? (:order-hint head)))))
+                   (= (:order-hint head)
+                      (backend/invoke adapter :order-hint))
+                   (= (:exact-locator head)
+                      (backend/invoke adapter :exact-locator)))
+      (throw
+       (ex-info
+        "Backend returned an invalid graph head."
+        {:type :eacl/invalid-backend-adapter
+         :eacl/error :eacl/invalid-backend-adapter
+         :backend (backend/backend-id adapter)
+         :graph-head head})))
+    head))
+
+(defn- expected-scope
+  [adapter]
+  (source-scope adapter))
+
+(defn- authenticate
+  [adapter {:keys [format-options]} token]
+  (try
+    (causal-token/token-data
+     format-options
+     (expected-scope adapter)
+     token)
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+      error
+      (case (:reason (ex-data error))
+        :expired
+        (fail! :token-expired
+               "The causal token has expired."
+               {}
+               error)
+
+        :scope-mismatch
+        (fail! :incomparable-scope
+               "The causal token belongs to another source or branch."
+               {}
+               error)
+
+        (throw error)))))
+
+(defn- selected-adapter!
+  [source selected]
+  (when-not (backend/adapter? selected)
+    (throw
+     (ex-info
+      "A backend selection operation did not return an immutable adapter."
+      {:type :eacl/invalid-backend-adapter
+       :eacl/error :eacl/invalid-backend-adapter
+       :backend (backend/backend-id source)
+       :selected selected})))
+  (when-not (= (source-scope source) (source-scope selected))
+    (fail! :incomparable-scope
+           "Backend selection crossed source or branch scope."
+           {:source (source-scope source)
+            :selected (source-scope selected)}))
+  selected)
+
+(defn- require-authority!
+  [{:keys [coherence-authority]}]
+  (when-not (= :managed coherence-authority)
+    (fail! :unsupported-head-barrier
+           "Causal selection requires complete writer authority."
+           {:coherence-authority
+            (or coherence-authority :unknown)})))
+
+(defn- select-adapter
+  [source {:keys [mode token]} options]
+  (try
+    (backend/require-capability! source :consistency mode)
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+      error
+      (if (= :eacl/unsupported-capability (:type (ex-data error)))
+        (case mode
+          :fully-consistent
+          (fail! :unsupported-head-barrier
+                 "The backend cannot establish an authoritative head."
+                 {}
+                 error)
+
+          :at-exact-snapshot
+          (fail! :exact-snapshot-unavailable
+                 "The backend cannot reconstruct exact snapshots."
+                 {}
+                 error)
+
+          :at-least-as-fresh
+          (fail! :unsupported-head-barrier
+                 "The backend cannot establish causal freshness."
+                 {}
+                 error)
+
+          (throw error))
+        (throw error))))
+  (case mode
+    :fully-consistent
+    {:adapter
+     (selected-adapter!
+      source
+      (try
+        (backend/invoke
+         source :select-authoritative (:timeout-ms options))
+        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+          error
+          (if (= :eacl/unsupported-capability
+                 (:type (ex-data error)))
+            (fail! :unsupported-head-barrier
+                   "The backend cannot establish an authoritative head."
+                   {}
+                   error)
+            (throw error)))))}
+
+    :minimize-latency
+    {:adapter
+     (selected-adapter!
+      source
+      (backend/invoke source :select-current))}
+
+    :at-least-as-fresh
+    (do
+      (require-authority! options)
+      (let [payload (authenticate source options token)
+            selected
+            (selected-adapter!
+             source
+             (backend/invoke
+              source :select-at-least payload (:timeout-ms options)))]
+        (when-not (backend/invoke
+                   selected :contains-anchor?
+                   (:graph-anchor payload))
+          (fail! :history-divergence
+                 "The selected history does not contain the requested mutation anchor."
+                 {:graph-anchor (:graph-anchor payload)}))
+        {:adapter selected
+         :request-token payload}))
+
+    :at-exact-snapshot
+    (do
+      (require-authority! options)
+      (let [payload (authenticate source options token)
+            selected
+            (try
+              (backend/invoke
+               source :select-exact payload (:timeout-ms options))
+              (catch #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core.ExceptionInfo)
+                error
+                (if (= :eacl/unsupported-capability
+                       (:type (ex-data error)))
+                  (fail! :exact-snapshot-unavailable
+                         "The requested exact snapshot is unavailable."
+                         {}
+                         error)
+                  (throw error))))
+            selected (when selected
+                       (selected-adapter! source selected))]
+        (when-not selected
+          (fail! :exact-snapshot-unavailable
+                 "The requested exact snapshot is unavailable."))
+        (when-not (= (:graph-anchor payload)
+                     (:graph-anchor (graph-head selected)))
+          (fail! :history-divergence
+                 "The exact locator resolved to a divergent graph."
+                 {:expected-anchor (:graph-anchor payload)
+                  :actual-anchor
+                  (:graph-anchor (graph-head selected))}))
+        {:adapter selected
+         :request-token payload}))))
+
+(defn select
+  "Authenticates and selects exactly one immutable snapshot adapter.
+
+  Returns the adapter, normalized request descriptor, authenticated request
+  token data when present, and an optional response token minted from the
+  selected graph head."
+  [source consistency-value
+   {:keys [format-options coherence-authority issue-token?]
+    :as options}]
+  (let [descriptor (public-consistency/descriptor consistency-value)
+        selection (select-adapter source descriptor options)
+        selected (:adapter selection)
+        request-token (:request-token selection)
+        head (graph-head selected)
+        response-token
+        (when (and issue-token?
+                   (= :managed coherence-authority))
+          (causal-token/issue
+           format-options
+           (merge (source-scope selected)
+                  head)))]
+    {:adapter selected
+     :descriptor descriptor
+     :request-token request-token
+     :response-token response-token
+     :graph-head head}))
+
+(defn cursor-conflict!
+  [data]
+  (fail! :cursor-consistency-conflict
+         "Cursor snapshot and requested freshness cannot both be satisfied."
+         data))

--- a/modules/eacl/src/eacl/cursor.cljc
+++ b/modules/eacl/src/eacl/cursor.cljc
@@ -1,81 +1,81 @@
 (ns eacl.cursor
-  (:require [clojure.edn :as edn]))
+  "Authenticated portable cursor envelopes.
 
-(defn- now-seconds []
+  Confidentiality is a separate adapter capability. Datomic retains its
+  encrypted page-token codec; this portable format provides mandatory
+  authenticity for synchronous CLJ/CLJS clients."
+  (:require [eacl.secure-format :as secure]))
+
+(def cursor-version 3)
+(def cursor-prefix "eacl_c3_")
+(def cursor-domain "eacl/cursor/envelope/v3")
+(def payload-keys #{:version :cursor :issued-at :expires-at})
+
+(defn- now-seconds
+  []
   (quot (#?(:clj System/currentTimeMillis
             :cljs js/Date.now))
         1000))
 
-(defn- encode-string [value]
-  #?(:clj  (.encodeToString
-            (java.util.Base64/getEncoder)
-            (.getBytes value "UTF-8"))
-     :cljs (if-let [btoa (.-btoa js/globalThis)]
-             (.call btoa js/globalThis value)
-             (.toString (.from js/Buffer value "utf8") "base64"))))
+(defn- cursor-error!
+  [reason data]
+  (throw (ex-info "Invalid EACL cursor."
+                  (merge {:type :eacl/invalid-cursor
+                          :eacl/error :eacl.pagination/invalid-cursor
+                          :reason reason}
+                         data))))
 
-(defn- decode-string [value]
-  #?(:clj  (String. (.decode (java.util.Base64/getDecoder)
-                      (.getBytes value "UTF-8"))
-              "UTF-8")
-     :cljs (if-let [atob (.-atob js/globalThis)]
-             (.call atob js/globalThis value)
-             (.toString (.from js/Buffer value "base64") "utf8"))))
+(defn- format-options
+  [options]
+  (merge options (:format-options options)))
 
 (defn cursor->token
-  "Serializes an internal cursor map to an opaque string token.
-  An expiry timestamp (:t, epoch seconds) is embedded only when the client is
-  configured with :cursor-ttl-seconds; by default tokens do not expire -
-  slow batch pagination must never silently restart (audit 7)."
-  ([cursor] (cursor->token cursor nil))
-  ([cursor {:keys [cursor-ttl-seconds]}]
+  "Authenticates an internal cursor map as an opaque version-3 token."
+  ([cursor]
+   (cursor->token cursor nil))
+  ([cursor {:keys [cursor-ttl-seconds] :as options}]
    (when cursor
-     (let [cursor' (if cursor-ttl-seconds
-                     (assoc cursor :t (+ (now-seconds) cursor-ttl-seconds))
-                     cursor)]
-       (str "eacl1_" (encode-string (pr-str cursor')))))))
+     (when-not (map? cursor)
+       (cursor-error! :malformed {}))
+     (let [issued-at (now-seconds)
+           expires-at (when cursor-ttl-seconds
+                        (+ issued-at cursor-ttl-seconds))]
+       (secure/encode-authenticated
+        (merge (format-options options)
+               {:domain cursor-domain
+                :prefix cursor-prefix})
+        {:version cursor-version
+         :cursor cursor
+         :issued-at issued-at
+         :expires-at expires-at})))))
 
 (defn token->cursor
-  "Deserializes an opaque cursor token.
-
-  Contract:
-  - nil means first page and returns nil;
-  - raw cursor maps pass through (backward compatibility);
-  - any other non-nil input that fails to decode throws
-    ex-info {:type :eacl/invalid-cursor :reason :undecodable};
-  - a token carrying an expiry (:t) throws {:reason :expired} when expired and
-    the client is configured with :cursor-ttl-seconds. Tokens without :t never
-    expire. A bad cursor must fail loudly - decoding to nil silently restarted
-    pagination from the first page (audit 7)."
-  ([token-or-cursor] (token->cursor token-or-cursor nil))
-  ([token-or-cursor {:keys [cursor-ttl-seconds]}]
-   (cond
-     (nil? token-or-cursor) nil
-     (map? token-or-cursor) token-or-cursor
-
-     (and (string? token-or-cursor)
-          #?(:clj (.startsWith ^String token-or-cursor "eacl1_")
-             :cljs (.startsWith token-or-cursor "eacl1_")))
-     (let [cursor (try
-                    (edn/read-string (decode-string (subs token-or-cursor 6)))
-                    (catch #?(:clj Exception :cljs :default) e
-                      (throw (ex-info "Invalid cursor token: cannot be decoded."
-                               {:type :eacl/invalid-cursor
-                                :reason :undecodable}
-                               e))))]
-       (when-not (map? cursor)
-         (throw (ex-info "Invalid cursor token: does not decode to a cursor map."
-                  {:type :eacl/invalid-cursor
-                   :reason :undecodable})))
-       (if (and cursor-ttl-seconds (:t cursor) (> (now-seconds) (:t cursor)))
-         (throw (ex-info "Invalid cursor token: expired."
-                  {:type :eacl/invalid-cursor
-                   :reason :expired
-                   :expired-at (:t cursor)}))
-         (dissoc cursor :t)))
-
-     :else
-     (throw (ex-info "Invalid cursor token: unrecognized format."
-              {:type :eacl/invalid-cursor
-               :reason :undecodable
-               :token token-or-cursor})))))
+  "Authenticates and decodes a cursor. Legacy maps and `eacl1_` tokens fail."
+  ([token]
+   (token->cursor token nil))
+  ([token options]
+   (if (nil? token)
+     nil
+     (let [payload
+           (try
+             (secure/decode-authenticated
+              (merge (format-options options)
+                     {:domain cursor-domain
+                      :prefix cursor-prefix
+                      :payload-keys payload-keys})
+              token)
+             (catch #?(:clj Exception :cljs :default) error
+               (cursor-error! (or (:reason (ex-data error)) :undecodable)
+                              {})))
+           {:keys [version cursor expires-at]} payload]
+       (when-not (and (= cursor-version version)
+                      (map? cursor)
+                      (integer? (:issued-at payload))
+                      (or (nil? expires-at) (integer? expires-at)))
+         (cursor-error! :undecodable {}))
+       (when (and expires-at (> (now-seconds) expires-at))
+         (cursor-error! :expired {:expired-at expires-at
+                                  :type :eacl.pagination/expired-cursor
+                                  :eacl/error
+                                  :eacl.pagination/expired-cursor}))
+       cursor))))

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -3,6 +3,8 @@
             [eacl.core :refer [spice-object]]
             [eacl.lazy-merge-sort :as lazy-sort]))
 
+(def engine-version 8)
+
 (def ^:private default-page-size 1000)
 (def ^:private max-page-size 10000)
 (def ^:private count-page-size 16384)
@@ -306,6 +308,33 @@
     :traversal-permissions (atom {})
     :relationship-dependencies (atom {})
     :direct-grant-relations (atom {})}))
+
+(defn schema-cache-key
+  "Identity of schema-derived state for one selected immutable snapshot.
+
+  The key deliberately contains no listener/client counter. A missed callback
+  cannot make a cache entry cross a source or schema proof boundary."
+  [snapshot]
+  [(backend/backend-id snapshot)
+   (backend/invoke snapshot :source-scope)
+   (backend/invoke snapshot :schema-proof)])
+
+(defn schema-cache-for!
+  "Returns a derived-schema generation keyed by selected source and proof."
+  [registry snapshot]
+  (let [key (schema-cache-key snapshot)
+        existing (get @registry key)]
+    (if existing
+      existing
+      (let [created
+            (make-schema-cache
+             snapshot
+             (backend/invoke snapshot :schema-proof))]
+        (get (swap! registry
+                    #(if (contains? % key)
+                       %
+                       (assoc % key created)))
+             key)))))
 
 (defn- permission-paths-cache-key
   [resource-type permission-name]

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -299,6 +299,7 @@
     :schema-version known-schema-version
     :permission-paths (atom {})
     :traversal-permissions (atom {})
+    :traversal-analysis (atom nil)
     :relationship-dependencies (atom {})
     :direct-grant-relations (atom {})}))
 
@@ -307,22 +308,27 @@
 
   The key deliberately contains no listener/client counter. A missed callback
   cannot make a cache entry cross a source or schema proof boundary."
-  [snapshot]
-  [(backend/backend-id snapshot)
-   (backend/invoke snapshot :source-scope)
-   (backend/invoke snapshot :schema-proof)])
+  ([snapshot]
+   (schema-cache-key
+    snapshot
+    (backend/invoke snapshot :schema-proof)))
+  ([snapshot schema-proof]
+   [(backend/backend-id snapshot)
+    (backend/invoke snapshot :source-scope)
+    schema-proof]))
 
 (defn schema-cache-for!
   "Returns a derived-schema generation keyed by selected source and proof."
   [registry snapshot]
-  (let [key (schema-cache-key snapshot)
+  (let [schema-proof (backend/invoke snapshot :schema-proof)
+        key (schema-cache-key snapshot schema-proof)
         existing (get @registry key)]
     (if existing
       existing
       (let [created
             (make-schema-cache
              snapshot
-             (backend/invoke snapshot :schema-proof))]
+             schema-proof)]
         (get (swap! registry
                     #(if (contains? % key)
                        %
@@ -342,6 +348,7 @@
   ([schema-cache]
    (reset! (:permission-paths schema-cache) {})
    (reset! (:traversal-permissions schema-cache) {})
+   (some-> (:traversal-analysis schema-cache) (reset! nil))
    (reset! (:relationship-dependencies schema-cache) {})
    (some-> (:direct-grant-relations schema-cache) (reset! {}))
    nil))
@@ -570,9 +577,93 @@
     db
     (permission-query-node resource-type permission-name))))
 
-(defn- reachable-from
-  [graph root]
+(defn- permission-graph
+  [db nodes]
+  (let [node-set (set nodes)]
+    (into {}
+          (map (fn [node]
+                 [node
+                  (vec
+                   (filter node-set
+                           (permission-query-dependencies db node)))])
+               nodes))))
+
+(defn- transpose-graph
+  [nodes graph]
+  (reduce-kv
+   (fn [result node dependencies]
+     (reduce (fn [result dependency]
+               (update result dependency conj node))
+             result
+             dependencies))
+   (zipmap nodes (repeat []))
+   graph))
+
+(defn- postorder-from
+  [graph root initial-seen initial-order]
+  (loop [stack [[root false]]
+         seen initial-seen
+         order initial-order]
+    (if-let [[node expanded?] (peek stack)]
+      (cond
+        expanded?
+        (recur (pop stack) seen (conj order node))
+
+        (contains? seen node)
+        (recur (pop stack) seen order)
+
+        :else
+        (let [dependencies (get graph node)]
+          (recur (into (conj (pop stack) [node true])
+                       (map #(vector % false)
+                            (reverse dependencies)))
+                 (conj seen node)
+                 order)))
+      [seen order])))
+
+(defn- graph-postorder
+  [nodes graph]
+  (second
+   (reduce (fn [[seen order] node]
+             (if (contains? seen node)
+               [seen order]
+               (postorder-from graph node seen order)))
+           [#{} []]
+           nodes)))
+
+(defn- collect-component
+  [graph root initial-seen]
   (loop [stack [root]
+         seen initial-seen
+         component []]
+    (if-let [node (peek stack)]
+      (if (contains? seen node)
+        (recur (pop stack) seen component)
+        (recur (into (pop stack)
+                     (reverse (get graph node)))
+               (conj seen node)
+               (conj component node)))
+      [seen component])))
+
+(defn- graph-components
+  "Returns deterministic strongly connected components in O(V+E) time and
+  memory using iterative Kosaraju passes."
+  [nodes graph]
+  (let [transposed (transpose-graph nodes graph)
+        roots (reverse (graph-postorder nodes graph))]
+    (second
+     (reduce (fn [[seen components] root]
+               (if (contains? seen root)
+                 [seen components]
+                 (let [[seen component]
+                       (collect-component transposed root seen)]
+                   [seen (conj components component)])))
+             [#{} []]
+             roots))))
+
+(defn- reachable-from-many
+  [graph roots]
+  (loop [stack (vec roots)
          seen #{}]
     (if-let [node (peek stack)]
       (if (contains? seen node)
@@ -588,29 +679,9 @@
   [db resource-type permission-name]
   (let [root (permission-query-node resource-type permission-name)
         nodes (sort (reachable-permission-query-nodes db root))
-        graph (into {}
-                    (map (fn [node]
-                           [node
-                            (vec
-                             (filter (set nodes)
-                                     (permission-query-dependencies db node)))])
-                         nodes))
-        closures (into {}
-                       (map (fn [node]
-                              [node (reachable-from graph node)])
-                            nodes))]
-    (loop [remaining (set nodes)
-           components []]
-      (if-let [node (first (sort remaining))]
-        (let [component
-              (->> remaining
-                   (filter #(and (contains? (get closures node) %)
-                                 (contains? (get closures %) node)))
-                   sort
-                   vec)]
-          (recur (apply disj remaining component)
-                 (conj components component)))
-        components))))
+        graph (permission-graph db nodes)]
+    (mapv (comp vec sort)
+          (graph-components nodes graph))))
 
 (defn- recursive-permission-query?
   [db resource-type permission-name]
@@ -623,6 +694,32 @@
                    (some #{node}
                          (permission-query-dependencies db node)))))
            components))))
+
+(defn- calc-traversal-analysis
+  "Classifies every permission node into one shared schema-generation result.
+
+  Once permission paths are materialized, one iterative SCC pass plus reverse
+  reachability is O(V+E) in the permission graph. Sharing the resulting map
+  prevents a large schema from recompiling recursive routing independently for
+  every first-read root."
+  [db]
+  (let [nodes (vec (set (backend/invoke db :all-permission-nodes)))
+        graph (permission-graph db nodes)
+        transposed (transpose-graph nodes graph)
+        recursive-nodes
+        (->> (graph-components nodes graph)
+             (filter (fn [component]
+                       (or (> (count component) 1)
+                           (let [node (first component)]
+                             (some #{node} (get graph node))))))
+             (mapcat identity)
+             set)
+        traversal-nodes
+        (reachable-from-many transposed recursive-nodes)]
+    (into {}
+          (map (fn [node]
+                 [node (contains? traversal-nodes node)])
+               nodes))))
 
 (defn- resume-scan-opts
   "Scan options that resume an intermediate's result stream strictly after
@@ -712,22 +809,38 @@
   These roots cannot be proven page-bounded in eid order without materialized
   grants, so list APIs evaluate them in deterministic traversal order.
 
-  A stamped connection-backed client memoises this once in its single schema
-  generation. Raw db evaluation and unstamped clients recompute it."
+  A stamped connection-backed client shares one classification for every
+  permission node in a schema generation. Raw db evaluation and unstamped
+  clients recompute the requested root."
   [db resource-type permission-name]
   (if-not (some? (:schema-version *schema-cache*))
     (recursive-permission-query? db resource-type permission-name)
-    (let [cache-key (permission-paths-cache-key resource-type permission-name)
-          cache-atom (:traversal-permissions *schema-cache*)
-          snapshot @cache-atom]
-      (if (contains? snapshot cache-key)
-        (get snapshot cache-key)
-        (let [recursive? (recursive-permission-query? db resource-type permission-name)]
-          (get (swap! cache-atom
-                      #(if (contains? % cache-key)
-                         %
-                         (assoc % cache-key recursive?)))
-               cache-key))))))
+    (if-let [analysis-atom (:traversal-analysis *schema-cache*)]
+      (let [analysis-delay
+            (or @analysis-atom
+                (let [candidate
+                      (delay (calc-traversal-analysis db))]
+                  (swap! analysis-atom #(or % candidate))))
+            analysis @analysis-delay]
+        (boolean
+         (get analysis
+              (permission-paths-cache-key
+               resource-type permission-name))))
+      ;; Compatibility for externally constructed schema-cache maps.
+      (let [cache-key
+            (permission-paths-cache-key resource-type permission-name)
+            cache-atom (:traversal-permissions *schema-cache*)
+            snapshot @cache-atom]
+        (if (contains? snapshot cache-key)
+          (get snapshot cache-key)
+          (let [recursive?
+                (recursive-permission-query?
+                 db resource-type permission-name)]
+            (get (swap! cache-atom
+                        #(if (contains? % cache-key)
+                           %
+                           (assoc % cache-key recursive?)))
+                 cache-key)))))))
 
 (defn traversal-nodes
   [db]

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -255,26 +255,21 @@
                :relation-name target-relation-name})
         []))))
 
-;; --- Client-lifecycle permission-path cache (issue #74) ----------------------
+;; --- Selected-snapshot permission-path cache (issue #74) ---------------------
 ;;
-;; EACL has one supported schema mutation boundary: eacl/write-schema!. A
-;; connection-backed client reads :eacl/schema-version ONCE when it is created
-;; and owns one generation of resolved permission paths for its lifetime.
-;; Ordinary Datomic transactions may produce a new db value for every request;
-;; they do not cause a version read, definition scan, cache-key change or db
-;; value retention.
+;; A client owns derived-schema generations keyed by backend, source scope, and
+;; the schema proof visible in the selected immutable snapshot. Managed writer
+;; authority makes that proof one atomically published mutation identity.
+;; Unknown writer authority deliberately uses a complete content proof instead:
+;; detecting arbitrary out-of-band schema writes without trusting a listener or
+;; writer-maintained stamp requires reading the database-visible definitions.
 ;;
-;; write-schema! through that client replaces the entire generation under the
-;; client's schema write lock. Other clients/processes must be recreated after
-;; an out-of-band schema write. Low-level functions in this namespace are
-;; intentionally uncached unless a client binds *schema-cache*: arbitrary
-;; d/with/filter/as-of values therefore cannot publish paths into a live
-;; connection-backed client's cache.
-;;
-;; An unstamped snapshot (normally a fresh v7 database before its first schema
-;; write) is never latched: paths are resolved from the supplied db value on
-;; every call until write-schema! establishes a version. This is not a v6
-;; compatibility path.
+;; Permission paths, dependency closures, and recursive-routing decisions are
+;; memoized inside one proof generation. Their cold compilation cost is paid
+;; once per queried permission root and schema proof, then reused. Low-level
+;; functions remain uncached unless a client binds *schema-cache*, so arbitrary
+;; d/with/filter/as-of values cannot publish derived state into another
+;; snapshot's generation.
 
 (def ^:dynamic *schema-cache*
   "The client-owned schema cache bound by eacl.datomic.core.
@@ -289,16 +284,14 @@
   (backend/invoke snapshot :schema-proof))
 
 (defn schema-version-stamp
-  "String form of the version visible in a snapshot. This is an explicit diagnostic;
-  connection-backed authorization calls do not invoke it."
+  "String form of the schema proof visible in a snapshot."
   [snapshot]
   (some-> (schema-version snapshot) str))
 
 (defn make-schema-cache
-  "Creates the one schema generation owned by an EACL client.
+  "Creates a derived-schema generation for one selected schema proof.
 
-  This is the only automatic :eacl/schema-version read. A nil version marks a
-  fresh/unstamped database and deliberately disables latching/caching."
+  A nil proof deliberately disables derived-state latching."
   ([snapshot]
    (make-schema-cache snapshot (schema-version snapshot)))
   ([snapshot known-schema-version]

--- a/modules/eacl/src/eacl/mutation.cljc
+++ b/modules/eacl/src/eacl/mutation.cljc
@@ -1,0 +1,199 @@
+(ns eacl.mutation
+  "Portable mutation-journal identities and transaction-data construction."
+  (:require [eacl.secure-format :as secure]))
+
+(def mutation-id-attr :eacl.mutation/id)
+(def mutation-fingerprint-attr :eacl.mutation/fingerprint)
+(def mutation-kind-attr :eacl.mutation/kind)
+(def mutation-issued-at-attr :eacl.mutation/issued-at)
+(def mutation-expires-at-attr :eacl.mutation/expires-at)
+(def graph-family-id-attr :eacl.graph/family-id)
+(def graph-head-id-attr :eacl.graph/head-id)
+(def graph-head-order-attr :eacl.graph/head-order)
+(def schema-mutation-id-attr :eacl.schema/mutation-id)
+(def relation-mutation-id-attr :eacl.relation/mutation-id)
+(def dependency-mutation-id-attr :eacl.dependency/mutation-id)
+
+(def graph-entity-id "eacl.v3/graph")
+(def schema-entity-id "eacl.v3/schema")
+(def mutation-entity-prefix "eacl.v3/mutation/")
+
+(def default-token-ttl-seconds 3600)
+(def default-retention-grace-seconds 300)
+(def ^:private maximum-mutation-entries 10000000)
+(def ^:private maximum-mutation-size (* 64 1024 1024))
+
+(defn now-seconds
+  []
+  (quot (#?(:clj System/currentTimeMillis
+            :cljs js/Date.now))
+        1000))
+
+(defn new-id
+  "Returns a cryptographically random 256-bit URL-safe identifier."
+  []
+  (secure/b64url-encode (secure/random-bytes 32)))
+
+(defn mutation-entity-id
+  [mutation-id]
+  (str mutation-entity-prefix mutation-id))
+
+(defn mutation-fingerprint
+  "Authenticates canonical logical mutation data under its random mutation id."
+  [mutation-id canonical-data]
+  (let [key
+        (try
+          (secure/b64url-decode mutation-id)
+          (catch #?(:clj Exception :cljs :default) _
+            (throw (ex-info "Invalid EACL mutation id."
+                            {:type :eacl.mutation/invalid-id
+                             :mutation-id mutation-id}))))]
+    (when-not (= 32 (count key))
+      (throw (ex-info "Invalid EACL mutation id."
+                      {:type :eacl.mutation/invalid-id
+                       :mutation-id mutation-id})))
+    (secure/b64url-encode
+     (secure/hmac-sha-256
+      key
+      (str "eacl/mutation/idempotency/v3\n"
+           (secure/encode-canonical
+            canonical-data
+            {:maximum-entries maximum-mutation-entries
+             :maximum-size maximum-mutation-size}))))))
+
+(defn retention-expiry
+  [{:keys [issued-at token-ttl-seconds retention-grace-seconds]
+    :or {issued-at (now-seconds)
+         token-ttl-seconds default-token-ttl-seconds
+         retention-grace-seconds default-retention-grace-seconds}}]
+  (when-not (and (integer? issued-at)
+                 (integer? token-ttl-seconds)
+                 (pos? token-ttl-seconds)
+                 (integer? retention-grace-seconds)
+                 (not (neg? retention-grace-seconds)))
+    (throw (ex-info "Invalid EACL mutation retention configuration."
+                    {:type :eacl/invalid-config
+                     :issued-at issued-at
+                     :token-ttl-seconds token-ttl-seconds
+                     :retention-grace-seconds retention-grace-seconds})))
+  (+ issued-at token-ttl-seconds retention-grace-seconds))
+
+(defn mutation-record
+  [{:keys [mutation-id kind canonical-data issued-at expires-at]}]
+  (let [issued-at (or issued-at (now-seconds))]
+    (cond-> {:eacl/id (mutation-entity-id mutation-id)
+             mutation-id-attr mutation-id
+             mutation-fingerprint-attr
+             (mutation-fingerprint mutation-id canonical-data)
+             mutation-kind-attr kind
+             mutation-issued-at-attr issued-at}
+      expires-at (assoc mutation-expires-at-attr expires-at))))
+
+(defn transaction-data
+  "Builds portable map transaction data for one atomic authorization mutation.
+
+  `relation-ids` are backend-native entity ids or lookup refs. `order-value`
+  may be a backend current-transaction value. The caller prepends actual
+  schema/relationship tx-data and submits the combined collection once."
+  [{:keys [mutation-id kind canonical-data relation-ids dependency-ids
+           schema-change?
+           order-value family-id issued-at previous-head-id token-ttl-seconds
+           retention-grace-seconds family-cas?]
+    :or {relation-ids []
+         dependency-ids []}}]
+  (when-not (and (string? mutation-id)
+                 (not-empty mutation-id)
+                 (keyword? kind))
+    (throw (ex-info "Invalid EACL mutation transaction."
+                    {:type :eacl.mutation/invalid
+                     :mutation-id mutation-id
+                     :kind kind})))
+  (let [issued-at (or issued-at (now-seconds))
+        previous-expires-at
+        (retention-expiry
+         {:issued-at issued-at
+          :token-ttl-seconds
+          (or token-ttl-seconds default-token-ttl-seconds)
+          :retention-grace-seconds
+          (or retention-grace-seconds default-retention-grace-seconds)})
+        relation-ids (vec (distinct relation-ids))
+        dependency-ids (vec (distinct dependency-ids))]
+    (cond-> [(mutation-record
+             {:mutation-id mutation-id
+               :kind kind
+               :canonical-data canonical-data
+               :issued-at issued-at})
+             (cond-> {:eacl/id graph-entity-id}
+               (nil? previous-head-id)
+               (assoc graph-head-id-attr mutation-id)
+               (and family-id (not family-cas?))
+               (assoc graph-family-id-attr family-id)
+               (some? order-value) (assoc graph-head-order-attr order-value))]
+      previous-head-id
+      (conj [:db.fn/cas
+             [:eacl/id graph-entity-id]
+             graph-head-id-attr
+             previous-head-id
+             mutation-id])
+
+      (and family-id family-cas?)
+      (conj [:db.fn/cas
+             [:eacl/id graph-entity-id]
+             graph-family-id-attr
+             nil
+             family-id])
+
+      previous-head-id
+      (conj {:db/id [mutation-id-attr previous-head-id]
+             mutation-expires-at-attr previous-expires-at})
+
+      schema-change?
+      (conj {:eacl/id schema-entity-id
+             schema-mutation-id-attr mutation-id})
+
+      (seq relation-ids)
+      (into (map (fn [relation-id]
+                   {:db/id relation-id
+                    relation-mutation-id-attr mutation-id})
+                 relation-ids))
+
+      (seq dependency-ids)
+      (into (map (fn [dependency-id]
+                   {:db/id dependency-id
+                    dependency-mutation-id-attr mutation-id})
+                 dependency-ids)))))
+
+(defn migration-data
+  "Creates the initial graph/schema/relation identities in one transaction."
+  [{:keys [relation-ids family-id order-value] :as options}]
+  (let [mutation-id (or (:mutation-id options) (new-id))]
+    {:mutation-id mutation-id
+     :tx-data
+     (transaction-data
+      (merge options
+             {:mutation-id mutation-id
+              :kind :migration
+              :canonical-data
+              {:operation :migration
+               :family-id family-id
+               :relation-ids (vec (sort relation-ids))}
+              :relation-ids relation-ids
+              :schema-change? true
+              :family-cas? true
+              :order-value order-value}))}))
+
+(defn mutation-data-matches?
+  "Checks idempotent retry data against a stored mutation entity/map."
+  [stored mutation-id canonical-data]
+  (and (= mutation-id (get stored mutation-id-attr))
+       (secure/secure-equal?
+        (secure/utf8-bytes
+         (or (get stored mutation-fingerprint-attr) ""))
+        (secure/utf8-bytes
+         (mutation-fingerprint mutation-id canonical-data)))))
+
+(defn expired?
+  ([mutation]
+   (expired? mutation (now-seconds)))
+  ([mutation now]
+   (< (get mutation mutation-expires-at-attr 0) now)))

--- a/modules/eacl/src/eacl/relationships/relay.cljc
+++ b/modules/eacl/src/eacl/relationships/relay.cljc
@@ -1,6 +1,9 @@
 (ns eacl.relationships.relay
   "Backend-neutral Relay windowing for already-filtered relationship values."
-  (:require [eacl.cursor :as cursor]))
+  (:require [eacl.backend.v8 :as backend]
+            [eacl.consistency :as consistency]
+            [eacl.cursor :as cursor]
+            [eacl.secure-format :as secure]))
 
 (def ^:private default-page-size 1000)
 (def ^:private max-page-size 10000)
@@ -44,17 +47,35 @@
                      {:size size :max max-page-size}))
       {:direction direction :size size :token token})))
 
-(defn- decode-bound
-  [opts operation filters snapshot-id token]
+(defn- items-proof
+  [items]
+  (secure/canonical-digest
+   "eacl/cursor/relationship-items/v3"
+   {:count (count items)
+    ;; Digest each bounded relationship independently before committing the
+    ;; ordered vector. A legal 10k-item page otherwise exceeds the secure
+    ;; format's global entry bound even though no individual value is large.
+    ;; Count plus ordered leaf digests preserves multiplicity and order.
+    :leaf-digests
+    (mapv #(secure/canonical-digest
+            "eacl/cursor/relationship-item/v3"
+            %)
+          items)}))
+
+(defn- decode-envelope
+  [opts operation filters snapshot-context token]
   (when token
     (let [value
           (try
             (cursor/token->cursor token opts)
             (catch #?(:clj Exception :cljs :default) error
-              (page-error! "Invalid relationship cursor."
-                           {:type :eacl.pagination/invalid-cursor
-                            :reason (:reason (ex-data error))})))]
-      (when-not (and (= 8 (:v value))
+              (if (= :eacl.pagination/expired-cursor
+                     (:type (ex-data error)))
+                (throw error)
+                (page-error! "Invalid relationship cursor."
+                             {:type :eacl.pagination/invalid-cursor
+                              :reason (:reason (ex-data error))}))))]
+      (when-not (and (= 9 (:v value))
                      (= :relationships (:kind value))
                      (integer? (:offset value))
                      (not (neg? (:offset value))))
@@ -63,29 +84,126 @@
       (when-not (= (scope operation filters) (:scope value))
         (page-error! "Relationship cursor belongs to a different query."
                      {:reason :query-mismatch}))
-      (when-not (= snapshot-id (:snapshot-id value))
-        (page-error! "Relationship cursor snapshot is no longer current."
-                     {:type :eacl.pagination/stale-cursor
-                      :reason :snapshot-changed}))
-      (:offset value))))
+      (doseq [field [:source-scope
+                     :adapter-fingerprint
+                     :identity-contract]]
+        (when-not (= (secure/canonicalize
+                      (get snapshot-context field))
+                     (secure/canonicalize (get value field)))
+          (page-error!
+           "Relationship cursor execution identity changed."
+           {:type :eacl.pagination/invalid-cursor
+            :reason field})))
+      value)))
+
+(defn- exact-items
+  [opts current-context envelope]
+  (let [adapter (:relationship-adapter opts)
+        materialize (:relationship-items-for-adapter opts)]
+    (when-not (and adapter materialize)
+      (page-error!
+       "Relationship cursor result proof changed and exact fallback is unavailable."
+       {:type :eacl.pagination/stale-cursor
+        :reason :items-proof-changed}))
+    (let [exact
+          (try
+            (backend/invoke
+             adapter
+             :select-exact
+             {:graph-anchor
+              (get-in envelope [:graph-head :graph-anchor])
+              :order-hint
+              (get-in envelope [:graph-head :order-hint])
+              :exact-locator
+              (get-in envelope [:graph-head :exact-locator])}
+             (:timeout-ms opts))
+            (catch #?(:clj Exception :cljs :default) error
+              (if (= :eacl/unsupported-capability
+                     (:type (ex-data error)))
+                nil
+                (throw error))))]
+      (when-not exact
+        (throw
+         (ex-info
+          "The relationship cursor's exact snapshot is no longer retained."
+          {:type :eacl.consistency/snapshot-expired
+           :eacl/error :eacl.consistency/snapshot-expired})))
+      (let [exact-context
+            {:source-scope
+             {:backend (backend/backend-id exact)
+              :scope (backend/invoke exact :source-scope)}
+             :graph-head (backend/invoke exact :graph-head)
+             :adapter-fingerprint (backend/fingerprint exact)
+             :identity-contract (backend/identity-contract exact)}
+            exact-items (vec (materialize exact))]
+        (when-not
+         (and
+          (= (secure/canonicalize (:source-scope current-context))
+             (secure/canonicalize (:source-scope exact-context)))
+          (= (get-in envelope [:graph-head :graph-anchor])
+             (get-in exact-context [:graph-head :graph-anchor]))
+          (= (:items-proof envelope)
+             (items-proof exact-items)))
+         (throw
+          (ex-info
+           "The relationship cursor exact locator resolved to another graph."
+           {:type :eacl.consistency/history-divergence
+            :eacl/error :eacl.consistency/history-divergence})))
+        {:snapshot-context exact-context
+         :items exact-items}))))
+
+(defn- select-items
+  [opts operation filters snapshot-context items token]
+  (if-let [envelope
+           (decode-envelope
+            opts operation filters snapshot-context token)]
+    (cond
+      (= (items-proof items) (:items-proof envelope))
+      {:snapshot-context snapshot-context
+       :items items
+       :bound (:offset envelope)}
+
+      (= :at-least-as-fresh
+         (:cursor-consistency-mode opts))
+      (consistency/cursor-conflict!
+       {:cursor-graph-anchor
+        (get-in envelope [:graph-head :graph-anchor])
+        :selected-graph-anchor
+        (get-in snapshot-context [:graph-head :graph-anchor])})
+
+      :else
+      (assoc (exact-items opts snapshot-context envelope)
+             :bound (:offset envelope)))
+    {:snapshot-context snapshot-context
+     :items items
+     :bound nil}))
 
 (defn- encode-bound
-  [opts operation filters snapshot-id offset]
+  [opts operation filters snapshot-context items offset]
   (cursor/cursor->token
-   {:v 8
-    :kind :relationships
-    :scope (scope operation filters)
-    :snapshot-id snapshot-id
-    :offset offset}
+   (merge
+    snapshot-context
+    {:v 9
+     :kind :relationships
+     :scope (scope operation filters)
+     :items-proof (items-proof items)
+     :offset offset})
    opts))
 
 (defn paginate
   "Applies a Relay window to a canonical vector of public relationships."
-  [opts operation filters snapshot-id items]
-  (let [items (vec items)
+  [opts operation filters snapshot-context items]
+  (let [current-items (vec items)
+        {:keys [snapshot-context items bound]}
+        (select-items
+         opts
+         operation
+         filters
+         snapshot-context
+         current-items
+         (:token (page-request filters)))
         n (count items)
         {:keys [direction size token]} (page-request filters)
-        bound (decode-bound opts operation filters snapshot-id token)
         [start end]
         (case direction
           :asc (let [start (if bound (inc bound) 0)]
@@ -102,9 +220,11 @@
      :page-info
      {:start-cursor
       (when start-offset
-        (encode-bound opts operation filters snapshot-id start-offset))
+        (encode-bound
+         opts operation filters snapshot-context items start-offset))
       :end-cursor
       (when end-offset
-        (encode-bound opts operation filters snapshot-id end-offset))
+        (encode-bound
+         opts operation filters snapshot-context items end-offset))
       :has-next-page? (boolean (and any? (< end n)))
       :has-previous-page? (boolean (and any? (pos? start)))}}))

--- a/modules/eacl/src/eacl/relay.cljc
+++ b/modules/eacl/src/eacl/relay.cljc
@@ -1,8 +1,10 @@
 (ns eacl.relay
   "Portable opaque Relay cursor handling for synchronous v8 adapters."
   (:require [eacl.backend.v8 :as backend]
+            [eacl.consistency :as consistency]
             [eacl.core :refer [spice-object]]
-            [eacl.cursor :as cursor]))
+            [eacl.cursor :as cursor]
+            [eacl.secure-format :as secure]))
 
 (def empty-page
   {:data []
@@ -24,6 +26,33 @@
      (cond-> (apply dissoc query relay-page-keys)
        (:subject query) (update :subject plain-object)
        (:resource query) (update :resource plain-object))]))
+
+(defn dependency-context
+  "Builds bounded cursor metadata from a freshly rederived complete closure."
+  [adapter {:keys [schema-scope relation-ids]}]
+  (let [dependency-scope
+        {:schema schema-scope
+         :relations (vec (sort relation-ids))}
+        proof
+        {:schema (backend/invoke adapter :schema-proof schema-scope)
+         :relations
+         (backend/invoke adapter :relation-proof relation-ids)}]
+    {:source-scope
+     {:backend (backend/backend-id adapter)
+      :scope (backend/invoke adapter :source-scope)}
+     :graph-head (backend/invoke adapter :graph-head)
+     :adapter-fingerprint (backend/fingerprint adapter)
+     :identity-contract (backend/identity-contract adapter)
+     ;; Store digests, never a truncated proof. Continuation rederives the
+     ;; complete closure and proof from its selected immutable snapshot.
+     :dependency-scope-digest
+     (secure/canonical-digest
+      "eacl/cursor/dependency-scope/v3"
+      dependency-scope)
+     :proof-digest
+     (secure/canonical-digest
+      "eacl/cursor/dependency-proof/v3"
+      proof)}))
 
 (defn- transform-frontier-ids
   [f frontiers]
@@ -53,14 +82,23 @@
 (defn- encode-page-edge
   [adapter opts operation query edge]
   (when edge
-    (cursor/cursor->token
-     {:v 8
-      :scope (cursor-scope operation query)
-      :snapshot-id (backend/invoke adapter :snapshot-id)
-      :edge (transform-edge-ids
-             #(backend/invoke adapter :internal-id->object %)
-             edge)}
-     opts)))
+    (let [dependencies (:cursor-dependencies opts)]
+      (when-not dependencies
+        (throw
+         (ex-info
+          "Portable pagination requires a complete dependency closure."
+          {:type :eacl.pagination/dependency-proof-unavailable
+           :eacl/error
+           :eacl.pagination/dependency-proof-unavailable})))
+      (cursor/cursor->token
+       (merge
+        {:v 9
+         :scope (cursor-scope operation query)
+         :edge (transform-edge-ids
+                #(backend/invoke adapter :internal-id->object %)
+                edge)}
+        (dependency-context adapter dependencies))
+       opts))))
 
 (defn- invalid-cursor!
   [message data cause]
@@ -70,18 +108,21 @@
                          data)
                   cause)))
 
-(defn- decode-page-edge
-  [adapter opts operation query token]
+(defn- decode-envelope
+  [opts operation query token]
   (when token
     (let [envelope
           (try
             (cursor/token->cursor token opts)
             (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) error
-              (invalid-cursor!
-               "Invalid Relay cursor."
-               {:reason (:reason (ex-data error))}
-               error)))]
-      (when-not (and (= 8 (:v envelope))
+              (if (= :eacl.pagination/expired-cursor
+                     (:type (ex-data error)))
+                (throw error)
+                (invalid-cursor!
+                 "Invalid Relay cursor."
+                 {:reason (:reason (ex-data error))}
+                 error))))]
+      (when-not (and (= 9 (:v envelope))
                      (map? (:edge envelope)))
         (invalid-cursor! "Invalid Relay cursor envelope."
                          {:reason :invalid-envelope}
@@ -90,15 +131,112 @@
         (invalid-cursor! "Relay cursor belongs to a different query."
                          {:reason :query-mismatch}
                          nil))
-      (when-not (= (backend/invoke adapter :snapshot-id)
-                   (:snapshot-id envelope))
+      envelope)))
+
+(defn- validate-context!
+  [adapter opts envelope]
+  (let [dependencies (:cursor-dependencies opts)
+        current (when dependencies
+                  (dependency-context adapter dependencies))]
+    (when-not current
+      (throw
+       (ex-info
+        "Portable continuation cannot rederive its dependencies."
+        {:type :eacl.pagination/stale-cursor
+         :eacl/error :eacl.pagination/stale-cursor
+         :reason :dependency-proof-unavailable})))
+    (doseq [field [:source-scope
+                   :adapter-fingerprint
+                   :identity-contract]]
+      (when-not (= (secure/canonicalize (get current field))
+                   (secure/canonicalize (get envelope field)))
         (invalid-cursor!
-         "Relay cursor snapshot is no longer current."
-         {:reason :snapshot-changed}
-         nil))
-      (transform-edge-ids
-       #(backend/invoke adapter :object-id->internal %)
-       (:edge envelope)))))
+         "Relay cursor execution identity does not match."
+         {:reason field}
+         nil)))
+    (when-not (= (:dependency-scope-digest current)
+                 (:dependency-scope-digest envelope))
+      (throw
+       (ex-info
+        "Relay cursor dependency closure changed."
+        {:type :eacl.pagination/stale-cursor
+         :eacl/error :eacl.pagination/stale-cursor
+         :reason :dependency-scope-changed})))
+    (when-not (= (:proof-digest current)
+                 (:proof-digest envelope))
+      (throw
+       (ex-info
+        "Relay cursor dependency proof changed."
+        {:type :eacl.pagination/stale-cursor
+         :eacl/error :eacl.pagination/stale-cursor
+         :reason :dependency-proof-changed})))
+    true))
+
+(defn select-continuation-adapter
+  "Uses an equal current proof, otherwise reconstructs the authenticated
+  original graph when no newer at-least floor forbids fallback."
+  [adapter opts operation query]
+  (let [token (or (:after query) (:before query))
+        envelope (decode-envelope opts operation query token)]
+    (if-not envelope
+      adapter
+      (try
+        (validate-context! adapter opts envelope)
+        adapter
+        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+               error
+          (if-not (= :eacl.pagination/stale-cursor
+                     (:type (ex-data error)))
+            (throw error)
+            (if (= :at-least-as-fresh
+                   (:cursor-consistency-mode opts))
+              (consistency/cursor-conflict!
+               {:cursor-graph-anchor
+                (get-in envelope [:graph-head :graph-anchor])
+                :selected-graph-anchor
+                (:graph-anchor
+                 (backend/invoke adapter :graph-head))})
+              (let [exact
+                    (backend/invoke
+                     adapter
+                     :select-exact
+                     {:graph-anchor
+                      (get-in envelope [:graph-head :graph-anchor])
+                      :order-hint
+                      (get-in envelope [:graph-head :order-hint])
+                      :exact-locator
+                      (get-in envelope [:graph-head :exact-locator])}
+                     (:timeout-ms opts))]
+                (when-not exact
+                  (throw
+                   (ex-info
+                    "The cursor's exact snapshot is no longer retained."
+                    {:type :eacl.consistency/snapshot-expired
+                     :eacl/error
+                     :eacl.consistency/snapshot-expired})))
+                (when-not (and
+                           (= (backend/invoke adapter :source-scope)
+                              (backend/invoke exact :source-scope))
+                           (= (get-in envelope
+                                      [:graph-head :graph-anchor])
+                              (:graph-anchor
+                               (backend/invoke exact :graph-head))))
+                  (throw
+                   (ex-info
+                    "The cursor exact locator resolved to another graph."
+                    {:type :eacl.consistency/history-divergence
+                     :eacl/error
+                     :eacl.consistency/history-divergence})))
+                exact))))))))
+
+(defn- decode-page-edge
+  [adapter opts operation query token]
+  (when-let [envelope
+             (decode-envelope opts operation query token)]
+    (validate-context! adapter opts envelope)
+    (transform-edge-ids
+     #(backend/invoke adapter :object-id->internal %)
+     (:edge envelope))))
 
 (defn internalize-page-query
   [adapter opts operation query]

--- a/modules/eacl/src/eacl/secure_format.cljc
+++ b/modules/eacl/src/eacl/secure_format.cljc
@@ -1,0 +1,433 @@
+(ns eacl.secure-format
+  "Portable bounded canonical serialization and domain-separated HMAC formats.
+
+  This service is synchronous in CLJ and CLJS. It deliberately provides
+  authenticity rather than pretending that base64 is encryption; adapters may
+  layer authenticated encryption over the resulting payload when their runtime
+  supports a compatible API."
+  (:require [#?(:clj clojure.edn :cljs cljs.reader) :as edn]
+            [clojure.string :as str]
+            #?@(:cljs [[goog.crypt :as gcrypt]
+                       [goog.crypt.Hmac]
+                       [goog.crypt.Sha256]]))
+  #?(:clj
+     (:import [java.nio.charset StandardCharsets]
+              [java.security MessageDigest SecureRandom]
+              [java.util Base64]
+              [javax.crypto Mac]
+              [javax.crypto.spec SecretKeySpec])))
+
+(def canonical-version 1)
+(def default-maximum-size 65536)
+(def default-maximum-depth 32)
+(def default-maximum-entries 16384)
+(def maximum-safe-integer 9007199254740991)
+(def minimum-safe-integer (- maximum-safe-integer))
+(def ^:private hmac-domain "eacl/secure-format/key/v1")
+
+(defn- format-error!
+  [reason data]
+  (throw (ex-info "Invalid EACL secure format."
+                  (merge {:type :eacl.format/invalid
+                          :eacl/error :eacl.format/invalid
+                          :reason reason}
+                         data))))
+
+(defn- portable-integer?
+  [value]
+  (and (integer? value)
+       (<= minimum-safe-integer value maximum-safe-integer)))
+
+(defn- canonical-comparator
+  [left right]
+  (compare (pr-str left) (pr-str right)))
+
+(declare validate-value)
+
+(defn- validate-map
+  [value depth limits]
+  (reduce-kv
+   (fn [entries k v]
+     (+ entries
+        (validate-value k (inc depth) limits)
+        (validate-value v (inc depth) limits)))
+   1
+   value))
+
+(defn- validate-value
+  [value depth {:keys [maximum-depth maximum-entries]}]
+  (when (> depth maximum-depth)
+    (format-error! :too-deep {:maximum-depth maximum-depth}))
+  (let [entries
+        (cond
+          (or (nil? value)
+              (boolean? value)
+              (string? value)
+              (keyword? value))
+          1
+
+          (integer? value)
+          (if (portable-integer? value)
+            1
+            (format-error! :integer-out-of-range
+                           {:value value
+                            :minimum minimum-safe-integer
+                            :maximum maximum-safe-integer}))
+
+          (map? value)
+          (validate-map value depth
+                        {:maximum-depth maximum-depth
+                         :maximum-entries maximum-entries})
+
+          (set? value)
+          (reduce
+           (fn [n item]
+             (+ n (validate-value item (inc depth)
+                                  {:maximum-depth maximum-depth
+                                   :maximum-entries maximum-entries})))
+           1 value)
+
+          (or (vector? value) (sequential? value))
+          (reduce
+           (fn [n item]
+             (+ n (validate-value item (inc depth)
+                                  {:maximum-depth maximum-depth
+                                   :maximum-entries maximum-entries})))
+           1 value)
+
+          :else
+          (format-error! :unsupported-value
+                         {:value-type (str (type value))}))]
+    (when (> entries maximum-entries)
+      (format-error! :too-many-entries
+                     {:maximum-entries maximum-entries}))
+    entries))
+
+(defn canonicalize
+  "Validates and canonicalizes portable EDN without changing collection types."
+  ([value]
+   (canonicalize value {}))
+  ([value {:keys [maximum-depth maximum-entries]
+           :or {maximum-depth default-maximum-depth
+                maximum-entries default-maximum-entries}}]
+   (let [limits {:maximum-depth maximum-depth
+                 :maximum-entries maximum-entries}]
+     (validate-value value 0 limits)
+     (letfn [(canonical [item]
+               (cond
+                 (map? item)
+                 (into (sorted-map-by canonical-comparator)
+                       (map (fn [[k v]]
+                              [(canonical k) (canonical v)]))
+                       item)
+
+                 (set? item)
+                 (into (sorted-set-by canonical-comparator)
+                       (map canonical)
+                       item)
+
+                 (sequential? item)
+                 (mapv canonical item)
+
+                 :else item))]
+       (canonical value)))))
+
+(defn encode-canonical
+  "Returns the canonical portable EDN representation after enforcing bounds."
+  ([value]
+   (encode-canonical value {}))
+  ([value {:keys [maximum-size] :as limits
+           :or {maximum-size default-maximum-size}}]
+   (let [encoded (pr-str (canonicalize value limits))]
+     (when (> (count encoded) maximum-size)
+       (format-error! :too-large {:maximum-size maximum-size}))
+     encoded)))
+
+(defn decode-canonical
+  "Reads bounded portable EDN and optionally enforces a top-level key allowlist."
+  ([encoded]
+   (decode-canonical encoded {}))
+  ([encoded {:keys [maximum-size allowed-keys] :as limits
+             :or {maximum-size default-maximum-size}}]
+   (when-not (and (string? encoded)
+                  (<= (count encoded) maximum-size))
+     (format-error! :too-large {:maximum-size maximum-size}))
+   (try
+     (let [value (edn/read-string encoded)
+           canonical (canonicalize value limits)]
+       (when (and allowed-keys
+                  (or (not (map? canonical))
+                      (not= (set (keys canonical)) (set allowed-keys))))
+         (format-error! :unknown-fields
+                        {:allowed-keys (set allowed-keys)
+                         :actual-keys
+                         (when (map? canonical)
+                           (set (keys canonical)))}))
+       canonical)
+     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo) e
+       (throw e))
+     (catch #?(:clj StackOverflowError :cljs :default) _
+       (format-error! :malformed {}))
+     #?(:clj
+        (catch Exception _
+          (format-error! :malformed {}))))))
+
+(defn utf8-bytes
+  [value]
+  #?(:clj
+     (vec (.getBytes ^String (str value) StandardCharsets/UTF_8))
+     :cljs
+     (vec (gcrypt/stringToUtf8ByteArray (str value)))))
+
+(defn bytes->utf8
+  [bytes]
+  #?(:clj
+     (String. (byte-array (map unchecked-byte bytes))
+              StandardCharsets/UTF_8)
+     :cljs
+     (gcrypt/utf8ByteArrayToString (clj->js bytes))))
+
+(defn random-bytes
+  [n]
+  (when-not (and (integer? n) (pos? n))
+    (format-error! :invalid-random-size {:size n}))
+  #?(:clj
+     (let [bytes (byte-array n)]
+       (.nextBytes (SecureRandom.) bytes)
+       (mapv #(bit-and (int %) 255) bytes))
+     :cljs
+     (let [crypto (or (.-crypto js/globalThis)
+                      (.-webcrypto
+                       (when (exists? js/require)
+                         (js/require "crypto"))))
+           bytes (js/Uint8Array. n)]
+       (when-not crypto
+         (format-error! :secure-random-unavailable {}))
+       (.getRandomValues crypto bytes)
+       (vec bytes))))
+
+(defonce default-root-key
+  (random-bytes 32))
+
+(defn normalize-key
+  [key]
+  (let [bytes
+        (cond
+          (string? key) (utf8-bytes key)
+          #?(:clj (bytes? key) :cljs false)
+          #?(:clj (mapv #(bit-and (int %) 255) key) :cljs nil)
+          (sequential? key) (mapv int key)
+          #?(:cljs (instance? js/Uint8Array key) :clj false)
+          #?(:cljs (vec key) :clj nil)
+          :else (format-error! :invalid-key {}))]
+    (when (< (count bytes) 32)
+      (format-error! :weak-key {:minimum-bytes 32}))
+    (when-not (every? #(<= 0 % 255) bytes)
+      (format-error! :invalid-key-byte {}))
+    bytes))
+
+(defn hmac-sha-256
+  [key message]
+  (let [key (normalize-key key)
+        message (if (string? message) (utf8-bytes message) (vec message))]
+    #?(:clj
+       (let [mac (Mac/getInstance "HmacSHA256")
+             key-bytes (byte-array (map unchecked-byte key))
+             message-bytes (byte-array (map unchecked-byte message))]
+         (.init mac (SecretKeySpec. key-bytes "HmacSHA256"))
+         (mapv #(bit-and (int %) 255) (.doFinal mac message-bytes)))
+       :cljs
+       (vec
+        (.getHmac
+         (goog.crypt.Hmac. (goog.crypt.Sha256.) (clj->js key) 64)
+         (clj->js message))))))
+
+(defn derive-key
+  "Derives a distinct 256-bit key for one authenticated format domain."
+  [root-key domain]
+  (when-not (and (string? domain) (not-empty domain))
+    (format-error! :invalid-domain {:domain domain}))
+  (hmac-sha-256 root-key (str hmac-domain "\n" domain)))
+
+(defn secure-equal?
+  "Length-aware constant-work comparison for authentication tags."
+  [left right]
+  (let [left (vec left)
+        right (vec right)
+        n (max (count left) (count right))
+        difference
+        (loop [index 0
+               difference (bit-xor (count left) (count right))]
+          (if (= index n)
+            difference
+            (recur
+             (inc index)
+             (bit-or difference
+                     (bit-xor
+                      (get left index 0)
+                      (get right index 0))))))]
+    (zero? difference)))
+
+(defn b64url-encode
+  [bytes]
+  #?(:clj
+     (.encodeToString
+      (.withoutPadding (Base64/getUrlEncoder))
+      (byte-array (map unchecked-byte bytes)))
+     :cljs
+     (let [binary (apply str (map #(js/String.fromCharCode %) bytes))
+           encoded (.call (.-btoa js/globalThis) js/globalThis binary)]
+       (-> encoded
+           (str/replace "+" "-")
+           (str/replace "/" "_")
+           (str/replace #"=+$" "")))))
+
+(defn b64url-decode
+  [encoded]
+  (try
+    #?(:clj
+       (mapv #(bit-and (int %) 255)
+             (.decode (Base64/getUrlDecoder) ^String encoded))
+       :cljs
+       (let [padding (subs "====" 0 (mod (- 4 (mod (count encoded) 4)) 4))
+             standard (-> encoded
+                          (str/replace "-" "+")
+                          (str/replace "_" "/")
+                          (str padding))
+             binary (.call (.-atob js/globalThis) js/globalThis standard)]
+         (mapv #(.charCodeAt binary %) (range (count binary)))))
+    (catch #?(:clj Exception :cljs :default) _
+      (format-error! :malformed-base64 {}))))
+
+(defn sha-256
+  "Portable SHA-256 for non-secret, authenticated proof digests."
+  [message]
+  (let [message (if (string? message)
+                  (utf8-bytes message)
+                  (vec message))]
+    #?(:clj
+       (let [digest (MessageDigest/getInstance "SHA-256")]
+         (mapv #(bit-and (int %) 255)
+               (.digest digest
+                        (byte-array
+                         (map unchecked-byte message)))))
+       :cljs
+       (let [digest (goog.crypt.Sha256.)]
+         (.update digest (clj->js message))
+         (vec (.digest digest))))))
+
+(defn canonical-digest
+  "Domain-separated digest of bounded canonical portable data."
+  [domain value]
+  (when-not (and (string? domain) (not-empty domain))
+    (format-error! :invalid-domain {:domain domain}))
+  (b64url-encode
+   (sha-256
+    (str domain "\n" (encode-canonical value)))))
+
+(defn canonical-records-digest
+  "Domain-separated digest of an ordered, potentially large record sequence.
+
+  Every record is independently canonicalized and bounded, then length-framed
+  before it enters the incremental SHA-256 state. This avoids both ambiguous
+  concatenation and the whole-proof size limit without ever truncating proof
+  content. Record order is part of the digest contract; callers must sort
+  semantically unordered inputs before calling this function."
+  [domain records]
+  (when-not (and (string? domain) (not-empty domain))
+    (format-error! :invalid-domain {:domain domain}))
+  (let [digest #?(:clj (MessageDigest/getInstance "SHA-256")
+                  :cljs (goog.crypt.Sha256.))
+        update-bytes!
+        (fn [bytes]
+          (let [length (count bytes)
+                prefix [(bit-and (bit-shift-right length 24) 255)
+                        (bit-and (bit-shift-right length 16) 255)
+                        (bit-and (bit-shift-right length 8) 255)
+                        (bit-and length 255)]]
+            #?(:clj
+               (do
+                 (.update ^MessageDigest digest
+                          (byte-array (map unchecked-byte prefix)))
+                 (.update ^MessageDigest digest
+                          (byte-array (map unchecked-byte bytes))))
+               :cljs
+               (do
+                 (.update digest (clj->js prefix))
+                 (.update digest (clj->js bytes))))))]
+    (update-bytes! (utf8-bytes domain))
+    (doseq [record records]
+      (update-bytes! (utf8-bytes (encode-canonical record))))
+    (b64url-encode
+     #?(:clj
+        (mapv #(bit-and (int %) 255)
+              (.digest ^MessageDigest digest))
+        :cljs
+        (vec (.digest digest))))))
+
+(defn signing-context
+  [{:keys [current-kid keyring]} domain]
+  (let [kid (or current-kid :default)
+        keyring (or keyring {:default default-root-key})
+        root-key (get keyring kid)]
+    (when-not (and (or (keyword? kid)
+                       (and (string? kid) (not-empty kid)))
+                   root-key)
+      (format-error! :unknown-key-id {:kid kid}))
+    {:kid kid
+     :key (derive-key root-key domain)
+     :keyring keyring}))
+
+(defn encode-authenticated
+  [{:keys [domain prefix] :as options} payload]
+  (when-not (and (string? prefix) (not-empty prefix))
+    (format-error! :invalid-prefix {}))
+  (let [{:keys [kid key]} (signing-context options domain)
+        encoded-payload (b64url-encode
+                         (utf8-bytes (encode-canonical payload options)))
+        signed {:v canonical-version
+                :kid kid
+                :payload encoded-payload}
+        tag (hmac-sha-256
+             key
+             (str domain "\n" (encode-canonical signed options)))
+        envelope (assoc signed :tag (b64url-encode tag))]
+    (str prefix
+         (b64url-encode
+          (utf8-bytes (encode-canonical envelope options))))))
+
+(defn decode-authenticated
+  [{:keys [domain prefix payload-keys maximum-size] :as options} token]
+  (when-not (and (string? token)
+                 (<= (count token)
+                     (or maximum-size default-maximum-size))
+                 (str/starts-with? token prefix))
+    (format-error! :malformed-token {}))
+  (let [envelope
+        (decode-canonical
+         (bytes->utf8
+          (b64url-decode (subs token (count prefix))))
+         (assoc options :allowed-keys #{:v :kid :payload :tag}))
+        {:keys [v kid payload tag]} envelope
+        root-key (get (or (:keyring options)
+                          {:default default-root-key})
+                      kid)]
+    (when-not (and (= canonical-version v)
+                   root-key
+                   (string? payload)
+                   (string? tag))
+      (format-error! :authentication-failed {}))
+    (let [key (derive-key root-key domain)
+          expected (hmac-sha-256
+                    key
+                    (str domain "\n"
+                         (encode-canonical
+                          {:v v :kid kid :payload payload}
+                          options)))
+          supplied (b64url-decode tag)]
+      (when-not (secure-equal? expected supplied)
+        (format-error! :authentication-failed {}))
+      (decode-canonical
+       (bytes->utf8 (b64url-decode payload))
+       (cond-> options
+         payload-keys (assoc :allowed-keys payload-keys))))))

--- a/modules/eacl/test/eacl/authorization_oracle.cljc
+++ b/modules/eacl/test/eacl/authorization_oracle.cljc
@@ -50,6 +50,55 @@
     [:relation :reader]
     [:arrow :parent [:permission :read]]]})
 
+(defn canonical-value
+  "Returns a portable, totally ordered representation of EDN-shaped test data.
+
+  The reference model intentionally does not reuse production serialization or
+  proof code. Keeping this oracle structurally independent makes differential
+  tests capable of detecting canonicalization and dependency-scope bugs in the
+  implementation under test."
+  [value]
+  (cond
+    (map? value)
+    [:map
+     (->> value
+          (map (fn [[k v]]
+                 [(canonical-value k) (canonical-value v)]))
+          (sort-by pr-str)
+          vec)]
+
+    (set? value)
+    [:set (->> value (map canonical-value) (sort-by pr-str) vec)]
+
+    (sequential? value)
+    [:sequential (mapv canonical-value value)]
+
+    :else
+    [:scalar value]))
+
+(defn canonical-schema-proof
+  "Canonical full-content schema proof for a reference fixture."
+  [rules]
+  (canonical-value rules))
+
+(defn canonical-relation-proof
+  "Canonical full-content relationship proof for a reference fixture.
+
+  Relationship maps are normalized as values rather than relying on set or map
+  iteration order. This deliberately treats content that changes away and back
+  as equivalent, which is the conservative full-content proof contract."
+  [relationships]
+  (->> relationships
+       (map canonical-value)
+       (sort-by pr-str)
+       vec))
+
+(defn full-content-proof
+  "Independent schema-and-relationship proof used as the differential oracle."
+  [{:keys [rules relationships]}]
+  {:schema (canonical-schema-proof rules)
+   :relationships (canonical-relation-proof relationships)})
+
 (defn- direct-subjects
   [relationships resource relation]
   (into #{}

--- a/modules/eacl/test/eacl/backend/v8_test.cljc
+++ b/modules/eacl/test/eacl/backend/v8_test.cljc
@@ -1,8 +1,9 @@
 (ns eacl.backend.v8-test
   (:require [#?(:clj clojure.test :cljs cljs.test)
-             :refer [deftest is testing]]
+            :refer [deftest is testing]]
             [eacl.backend.spi :as legacy]
             [eacl.backend.v8 :as backend]
+            [eacl.engine.v8 :as engine]
             [eacl.spicedb.consistency :as consistency]))
 
 (defn- operation-map []
@@ -111,3 +112,100 @@
           implementation :user 1 2 :doc 3)))
     (is (= [:cache-stamp] (first @calls)))
     (is (= 6 (count @calls)))))
+
+(deftest recursive-routing-is-compiled-once-for-the-schema-generation-test
+  (let [permission-defs
+        {[:node :read]
+         [{:permission-id 1
+           :resource-type :node
+           :permission-name :read
+           :source-relation-name :self
+           :target-type :permission
+           :target-name :read}]
+         [:node :view]
+         [{:permission-id 2
+           :resource-type :node
+           :permission-name :view
+           :source-relation-name :self
+           :target-type :permission
+           :target-name :read}]
+         [:node :edit]
+         [{:permission-id 3
+           :resource-type :node
+           :permission-name :edit
+           :source-relation-name :self
+           :target-type :relation
+           :target-name :editor}]
+         [:node :cycle-a]
+         [{:permission-id 5
+           :resource-type :node
+           :permission-name :cycle-a
+           :source-relation-name :self
+           :target-type :permission
+           :target-name :cycle-b}]
+         [:node :cycle-b]
+         [{:permission-id 6
+           :resource-type :node
+           :permission-name :cycle-b
+           :source-relation-name :self
+           :target-type :permission
+           :target-name :cycle-a}]
+         [:node :cycle-view]
+         [{:permission-id 7
+           :resource-type :node
+           :permission-name :cycle-view
+           :source-relation-name :self
+           :target-type :permission
+           :target-name :cycle-a}]}
+        operations
+        (merge
+         (operation-map)
+         {:snapshot-id (fn [] {:database-id :test :basis-t 1})
+          :source-scope (fn [] {:source-id :test :branch nil})
+          :schema-proof (fn
+                          ([] :schema-proof)
+                          ([_] :schema-proof))
+          :permission-defs
+          (fn [resource-type permission-name]
+            (get permission-defs
+                 [resource-type permission-name]
+                 []))
+          :relation-defs
+          (fn [resource-type relation-name]
+            (if (= [:node :editor]
+                   [resource-type relation-name])
+              [{:relation-id 4
+                :resource-type :node
+                :relation-name :editor
+                :subject-type :user}]
+              []))
+          :all-permission-nodes
+          (fn [] (set (keys permission-defs)))})
+        adapter
+        (backend/make-adapter
+         {:id :test
+          :capabilities
+          {:consistency #{:fully-consistent}
+           :snapshots #{:current}
+           :cursor #{:forward :reverse}
+           :transactions #{}
+           :cache-proofs #{:schema :relations :snapshot-bound}
+           :runtime #{#?(:clj :clj :cljs :cljs)}}
+          :operations operations})
+        schema-cache (engine/make-schema-cache adapter :schema-proof)]
+    (binding [engine/*schema-cache* schema-cache]
+      (is (true? (engine/traversal-permission? adapter :node :read)))
+      (let [analysis-delay @(:traversal-analysis schema-cache)
+            compiled @analysis-delay]
+        (is (= {[:node :read] true
+                [:node :view] true
+                [:node :edit] false
+                [:node :cycle-a] true
+                [:node :cycle-b] true
+                [:node :cycle-view] true}
+               compiled))
+        (is (false? (engine/traversal-permission?
+                     adapter :node :edit)))
+        (is (identical? analysis-delay
+                        @(:traversal-analysis schema-cache))
+            "another permission root reuses the generation-wide analysis")))))

--- a/modules/eacl/test/eacl/cache_test.cljc
+++ b/modules/eacl/test/eacl/cache_test.cljc
@@ -22,14 +22,27 @@
                   [operation (fn [& _] nil)]))
            backend/required-snapshot-operations)
      {:snapshot-id #(select-keys @proofs [:basis])
+      :source-scope
+      (fn [] {:source-id (:source @proofs) :branch nil})
+      :graph-head
+      (fn [] {:graph-anchor (:head @proofs)
+              :order-hint (:basis @proofs)
+              :exact-locator (:basis @proofs)})
+      :contains-anchor?
+      (fn [anchor] (contains? (:anchors @proofs) anchor))
+      :order-hint (fn [] (:basis @proofs))
+      :exact-locator (fn [] (:basis @proofs))
       :schema-proof
       (fn
-        ([] (:schema @proofs))
+        ([] (when-not (:proof-unavailable? @proofs)
+              (:schema @proofs)))
         ([{:keys [permission-nodes]}]
-         (select-keys (:schema @proofs) permission-nodes)))
+         (when-not (:proof-unavailable? @proofs)
+           (select-keys (:schema @proofs) permission-nodes))))
       :relation-proof
       (fn [relation-ids]
-        (select-keys (:relations @proofs) relation-ids))})}))
+        (when-not (:proof-unavailable? @proofs)
+          (select-keys (:relations @proofs) relation-ids)))})}))
 
 (defrecord ThrowingStore []
   cache/CacheStore
@@ -39,8 +52,19 @@
   (clear! [_] (throw (ex-info "unavailable" {})))
   (stats [_] (throw (ex-info "unavailable" {}))))
 
+(defrecord ForgingStore [value]
+  cache/CacheStore
+  (lookup [_ _] value)
+  (store! [_ _ _] true)
+  (evict! [_ _] false)
+  (clear! [_] nil)
+  (stats [_] {}))
+
 (deftest exact-proof-validation-test
   (let [proofs (atom {:basis 1
+                      :source "source"
+                      :head "head-1"
+                      :anchors #{"head-1"}
                       :schema {:document :schema-1
                                :unrelated :schema-a}
                       :relations {10 :relation-1
@@ -62,6 +86,10 @@
 
     (testing "unrelated relation changes retain the entry"
       (swap! proofs assoc-in [:relations 20] :unrelated-2)
+      (swap! proofs assoc
+             :basis 2
+             :head "head-2"
+             :anchors #{"head-1" "head-2"})
       (is (true? (:cached? (resolve))))
       (is (= 1 @calls)))
 
@@ -77,8 +105,44 @@
       (is (false? (:cached? (resolve))))
       (is (= 3 @calls)))))
 
+(deftest forward-only-proof-lifting-test
+  (let [proofs
+        (atom {:basis 1
+               :source "source"
+               :head "computed"
+               :anchors #{"computed"}
+               :schema {:document :schema}
+               :relations {10 :relation}})
+        snapshot (adapter proofs)
+        store (cache/local-store)
+        calls (atom 0)
+        resolve
+        #(cache/resolve!
+          snapshot store :key :can?
+          {:permission-nodes #{:document}}
+          [10] boolean?
+          (fn [] (swap! calls inc) true))]
+    (is (false? (:cached? (resolve))))
+    (swap! proofs assoc
+           :basis 2
+           :head "descendant"
+           :anchors #{"computed" "descendant"})
+    (is (true? (:cached? (resolve))))
+    (swap! proofs assoc
+           :basis 2
+           :head "sibling"
+           :anchors #{"sibling"})
+    (is (false? (:cached? (resolve))))
+    (is (= 2 @calls))
+    (is (= 1 (:causal-proof-lift (cache/stats store))))
+    (is (= 1 (:future-history-rejection
+              (cache/stats store))))))
+
 (deftest corrupt-and-unavailable-store-fail-closed-test
   (let [proofs (atom {:basis 1
+                      :source "source"
+                      :head "head"
+                      :anchors #{"head"}
                       :schema {:document :schema}
                       :relations {10 :relation}})
         snapshot (adapter proofs)
@@ -89,7 +153,8 @@
     (testing "a malformed value is a miss"
       (let [answer
             (cache/resolve!
-             snapshot corrupt-store :key :can?
+             snapshot (->ForgingStore "eacl_ce3_forged")
+             :key :can?
              {:permission-nodes #{:document}}
              [10] boolean? compute)]
         (is (false? (:value answer)))
@@ -106,3 +171,35 @@
         (is (false? (:cached? answer)))))
 
     (is (= 2 @computed))))
+
+(deftest cache-scope-and-proof-availability-test
+  (let [store (cache/local-store)
+        first-proof
+        (atom {:basis 1
+               :source "first"
+               :head "first-head"
+               :anchors #{"first-head"}
+               :schema {:document :schema}
+               :relations {10 :relation}})
+        second-proof
+        (atom {:basis 1
+               :source "second"
+               :head "second-head"
+               :anchors #{"second-head"}
+               :schema {:document :schema}
+               :relations {10 :relation}})
+        calls (atom 0)
+        compute #(do (swap! calls inc) true)
+        resolve
+        (fn [snapshot]
+          (cache/resolve!
+           snapshot store :same-query :can?
+           {:permission-nodes #{:document}}
+           [10] boolean? compute))]
+    (is (false? (:cached? (resolve (adapter first-proof)))))
+    (is (false? (:cached? (resolve (adapter second-proof)))))
+    (is (= 2 @calls)
+        "equal content in another source cannot reuse the entry")
+    (swap! first-proof assoc :proof-unavailable? true)
+    (is (false? (:cached? (resolve (adapter first-proof)))))
+    (is (= 1 (:no-proof-bypass (cache/stats store))))))

--- a/modules/eacl/test/eacl/causal_model.cljc
+++ b/modules/eacl/test/eacl/causal_model.cljc
@@ -1,0 +1,252 @@
+(ns eacl.causal-model
+  "Pure reference state machine for causal-token, cache, and cursor properties.
+
+  This namespace is test-only and intentionally shares no implementation with
+  eacl.cache, eacl.cursor, or a storage adapter."
+  (:require [clojure.set :as set]
+            [eacl.authorization-oracle :as oracle]))
+
+(defn initial-state
+  [fixture]
+  (let [anchor :genesis
+        snapshot {:anchor anchor
+                  :parents #{}
+                  :fixture fixture
+                  :proof (oracle/full-content-proof fixture)}]
+    {:head anchor
+     :next-id 1
+     :snapshots {anchor snapshot}
+     :retained #{anchor}
+     :cache {}
+     :cursors {}}))
+
+(defn command
+  [operation & [arguments]]
+  {:operation operation
+   :arguments (or arguments {})})
+
+(defn graph-write
+  [relationships]
+  (command :graph-write {:relationships relationships}))
+
+(defn unrelated-write
+  []
+  (command :unrelated-write))
+
+(defn schema-write
+  [rules]
+  (command :schema-write {:rules rules}))
+
+(defn cache-put
+  [key snapshot-id value]
+  (command :cache-put {:key key :snapshot-id snapshot-id :value value}))
+
+(defn cache-read
+  [key]
+  (command :cache-read {:key key}))
+
+(defn read-command
+  [query]
+  (command :read {:query query}))
+
+(defn cursor-page
+  [cursor-id page-size]
+  (command :cursor-page {:cursor-id cursor-id :page-size page-size}))
+
+(defn clone-head
+  [snapshot-id]
+  (command :clone {:snapshot-id snapshot-id}))
+
+(defn reset-head
+  [snapshot-id]
+  (command :reset {:snapshot-id snapshot-id}))
+
+(defn restore-head
+  [snapshot-id]
+  (command :restore {:snapshot-id snapshot-id}))
+
+(defn branch-head
+  [snapshot-id]
+  (command :branch {:snapshot-id snapshot-id}))
+
+(defn force-head
+  [snapshot-id]
+  (command :force-head {:snapshot-id snapshot-id}))
+
+(defn expire-snapshot
+  [snapshot-id]
+  (command :retention-expire {:snapshot-id snapshot-id}))
+
+(defn- next-anchor
+  [state]
+  (keyword "mutation" (str (:next-id state))))
+
+(defn- publish
+  [state update-fixture]
+  (let [parent (:head state)
+        anchor (next-anchor state)
+        fixture (update-fixture (get-in state [:snapshots parent :fixture]))
+        snapshot {:anchor anchor
+                  :parents #{parent}
+                  :fixture fixture
+                  :proof (oracle/full-content-proof fixture)}]
+    (-> state
+        (assoc :head anchor)
+        (update :next-id inc)
+        (assoc-in [:snapshots anchor] snapshot)
+        (update :retained conj anchor))))
+
+(defn causal-ancestors
+  [state snapshot-id]
+  (loop [pending [snapshot-id]
+         seen #{}]
+    (if-let [candidate (peek pending)]
+      (if (contains? seen candidate)
+        (recur (pop pending) seen)
+        (recur (into (pop pending)
+                     (get-in state [:snapshots candidate :parents]))
+               (conj seen candidate)))
+      seen)))
+
+(defn contains-anchor?
+  [state snapshot-id anchor]
+  (contains? (causal-ancestors state snapshot-id) anchor))
+
+(defn selected-snapshot
+  [state]
+  (get-in state [:snapshots (:head state)]))
+
+(defn- authorization-set
+  [snapshot]
+  (oracle/authorization-set (:fixture snapshot)))
+
+(defn- query-result
+  [snapshot query]
+  (contains? (authorization-set snapshot) query))
+
+(defn- cache-hit
+  [state key]
+  (let [selected (selected-snapshot state)
+        candidate (get-in state [:cache key])
+        candidate-id (:snapshot-id candidate)]
+    (when (and candidate
+               (contains-anchor? state (:head state) candidate-id)
+               (= (:proof selected) (:proof candidate)))
+      (:value candidate))))
+
+(defn- stable-results
+  [snapshot {:keys [permission resource-type]}]
+  (->> (authorization-set snapshot)
+       (keep (fn [[subject candidate-permission resource]]
+               (when (and (= permission candidate-permission)
+                          (= resource-type (:type resource)))
+                 [subject resource])))
+       (sort-by pr-str)
+       vec))
+
+(defn apply-command
+  [state {:keys [operation arguments]}]
+  (case operation
+    :graph-write
+    (publish state #(assoc % :relationships (:relationships arguments)))
+
+    :unrelated-write
+    (publish state identity)
+
+    :schema-write
+    (publish state #(assoc % :rules (:rules arguments)))
+
+    :cache-put
+    (let [{:keys [key snapshot-id value]} arguments]
+      (assoc-in state [:cache key]
+                {:snapshot-id snapshot-id
+                 :proof (get-in state [:snapshots snapshot-id :proof])
+                 :value value}))
+
+    :cache-read
+    (assoc state :last-result (cache-hit state (:key arguments)))
+
+    :read
+    (assoc state :last-result
+           (query-result (selected-snapshot state) (:query arguments)))
+
+    :cursor-page
+    (let [{:keys [cursor-id page-size]} arguments
+          cursor (get-in state [:cursors cursor-id])
+          selected (selected-snapshot state)
+          original (get-in state [:snapshots (:snapshot-id cursor)])
+          snapshot (cond
+                     (nil? cursor) selected
+                     (= (:proof cursor) (:proof selected)) selected
+                     (contains? (:retained state) (:snapshot-id cursor)) original
+                     :else nil)]
+      (if-not snapshot
+        (assoc state :last-error :snapshot-expired)
+        (let [results (stable-results snapshot (:query cursor))
+              offset (or (:offset cursor) 0)
+              page (subvec results
+                           (min offset (count results))
+                           (min (+ offset page-size) (count results)))]
+          (-> state
+              (assoc :last-result page)
+              (assoc-in [:cursors cursor-id]
+                        (assoc cursor
+                               :snapshot-id (:anchor snapshot)
+                               :proof (:proof snapshot)
+                               :offset (+ offset (count page))))))))
+
+    :clone
+    (assoc state :head (:snapshot-id arguments))
+
+    :reset
+    (assoc state :head (:snapshot-id arguments))
+
+    :restore
+    (assoc state :head (:snapshot-id arguments))
+
+    :branch
+    (assoc state :head (:snapshot-id arguments))
+
+    :force-head
+    (assoc state :head (:snapshot-id arguments))
+
+    :retention-expire
+    (update state :retained disj (:snapshot-id arguments))
+
+    (throw (ex-info "Unknown causal-model command."
+                    {:operation operation
+                     :arguments arguments}))))
+
+(defn run-trace
+  [state commands]
+  (reductions apply-command state commands))
+
+(defn install-cursor
+  [state cursor-id query]
+  (let [snapshot (selected-snapshot state)]
+    (assoc-in state [:cursors cursor-id]
+              {:snapshot-id (:anchor snapshot)
+               :proof (:proof snapshot)
+               :query query
+               :offset 0})))
+
+(defn generated-divergence-traces
+  "Deterministic command traces covering every destructive head transition."
+  [fixture]
+  (for [head-command [clone-head reset-head restore-head branch-head force-head]]
+    [(graph-write (:relationships fixture))
+     (head-command :genesis)
+     (unrelated-write)]))
+
+(defn cache-result-equals-selected?
+  [state key query]
+  (let [cached (cache-hit state key)]
+    (or (nil? cached)
+        (= cached (query-result (selected-snapshot state) query)))))
+
+(defn pages-equal-proof-graph?
+  [state cursor-id pages]
+  (let [cursor (get-in state [:cursors cursor-id])
+        snapshot (get-in state [:snapshots (:snapshot-id cursor)])
+        expected (stable-results snapshot (:query cursor))]
+    (= expected (vec (mapcat identity pages)))))

--- a/modules/eacl/test/eacl/causal_model_test.cljc
+++ b/modules/eacl/test/eacl/causal_model_test.cljc
@@ -1,0 +1,137 @@
+(ns eacl.causal-model-test
+  (:require [#?(:clj clojure.test :cljs cljs.test) :refer [deftest is testing]]
+            [eacl.authorization-oracle :as oracle]
+            [eacl.causal-model :as model]
+            [eacl.core :as eacl]))
+
+(def user (eacl/spice-object :user "u"))
+(def other-user (eacl/spice-object :user "other"))
+(def document (eacl/spice-object :document "d"))
+(def other-document (eacl/spice-object :document "other"))
+
+(def fixture
+  {:objects [user other-user document other-document]
+   :relationships [(eacl/->Relationship user :reader document)]
+   :rules {[:document :view] [:relation :reader]}})
+
+(def query [user :view document])
+
+(deftest canonical-full-content-proof-test
+  (let [proof (oracle/full-content-proof fixture)]
+    (is (= proof
+           (oracle/full-content-proof
+            (update fixture :relationships reverse))))
+    (is (not= proof
+              (oracle/full-content-proof
+               (update fixture :relationships conj
+                       (eacl/->Relationship other-user :reader document)))))
+    (is (not= proof
+              (oracle/full-content-proof
+               (assoc-in fixture [:rules [:document :view]]
+                         [:union [:relation :reader]
+                          [:relation :owner]]))))))
+
+(deftest generated-history-transitions-never-use-order-equality-test
+  (doseq [commands (model/generated-divergence-traces fixture)]
+    (let [states (model/run-trace (model/initial-state fixture) commands)
+          token-state (second states)
+          divergent-state (last states)
+          token-anchor (:head token-state)]
+      (is (false?
+           (model/contains-anchor?
+            divergent-state (:head divergent-state) token-anchor))
+          (pr-str commands)))))
+
+(deftest cache-differential-property-test
+  (testing "a causal predecessor with an equal proof may lift"
+    (let [state-0 (model/initial-state fixture)
+          state-1 (model/apply-command state-0 (model/cache-put :q :genesis true))
+          state-2 (model/apply-command state-1 (model/unrelated-write))]
+      (is (model/cache-result-equals-selected? state-2 :q query))
+      (is (true? (:last-result
+                  (model/apply-command state-2 (model/cache-read :q)))))))
+
+  (testing "a future or sibling candidate is never returned backward"
+    (let [state-0 (model/initial-state fixture)
+          future (model/apply-command state-0 (model/unrelated-write))
+          cached (model/apply-command
+                  future (model/cache-put :q (:head future) true))
+          reset (model/apply-command cached (model/reset-head :genesis))]
+      (is (nil? (:last-result
+                 (model/apply-command reset (model/cache-read :q)))))
+      (is (model/cache-result-equals-selected? reset :q query))))
+
+  (testing "negative results include a relation that may later grant"
+    (let [denied-query [other-user :view document]
+          state-0 (model/initial-state fixture)
+          state-1 (model/apply-command
+                   state-0 (model/cache-put :denied :genesis false))
+          changed-fixture
+          (update fixture :relationships conj
+                  (eacl/->Relationship other-user :reader document))
+          state-2 (model/apply-command
+                   state-1 (model/graph-write (:relationships changed-fixture)))]
+      (is (nil? (:last-result
+                 (model/apply-command state-2 (model/cache-read :denied)))))
+      (is (true? (:last-result
+                  (model/apply-command
+                   state-2 (model/read-command denied-query)))))
+      (is (model/cache-result-equals-selected?
+           state-2 :denied denied-query)))))
+
+(deftest missing-mutation-anchor-regression-test
+  (let [token-state (model/apply-command
+                     (model/initial-state fixture)
+                     (model/graph-write (:relationships fixture)))
+        token (:head token-state)
+        reset (model/apply-command token-state (model/reset-head :genesis))]
+    (is (false? (model/contains-anchor? reset (:head reset) token)))))
+
+(deftest cursor-differential-property-test
+  (let [query {:permission :view :resource-type :document}
+        state-0 (model/install-cursor
+                 (model/initial-state fixture) :cursor query)
+        page-1-state (model/apply-command
+                      state-0 (model/cursor-page :cursor 1))
+        page-1 (:last-result page-1-state)
+        unrelated (model/apply-command page-1-state (model/unrelated-write))
+        page-2-state (model/apply-command
+                      unrelated (model/cursor-page :cursor 10))
+        page-2 (:last-result page-2-state)]
+    (is (model/pages-equal-proof-graph?
+         page-2-state :cursor [page-1 page-2])))
+
+  (testing "changed proof falls back to retained exact graph"
+    (let [query {:permission :view :resource-type :document}
+          state-0 (model/install-cursor
+                   (model/initial-state fixture) :cursor query)
+          page-1-state (model/apply-command
+                        state-0 (model/cursor-page :cursor 1))
+          changed (model/apply-command
+                   page-1-state
+                   (model/graph-write
+                    (conj (:relationships fixture)
+                          (eacl/->Relationship
+                           other-user :reader other-document))))
+          page-2-state (model/apply-command
+                        changed (model/cursor-page :cursor 10))]
+      (is (not= :snapshot-expired (:last-error page-2-state)))
+      (is (model/pages-equal-proof-graph?
+           page-2-state :cursor
+           [(:last-result page-1-state) (:last-result page-2-state)]))))
+
+  (testing "changed proof with expired exact graph fails"
+    (let [query {:permission :view :resource-type :document}
+          state-0 (model/install-cursor
+                   (model/initial-state fixture) :cursor query)
+          changed (model/apply-command
+                   state-0
+                   (model/graph-write
+                    (conj (:relationships fixture)
+                          (eacl/->Relationship
+                           other-user :reader other-document))))
+          expired (model/apply-command
+                   changed (model/expire-snapshot :genesis))
+          result (model/apply-command
+                  expired (model/cursor-page :cursor 1))]
+      (is (= :snapshot-expired (:last-error result))))))

--- a/modules/eacl/test/eacl/consistency_test.cljc
+++ b/modules/eacl/test/eacl/consistency_test.cljc
@@ -1,0 +1,351 @@
+(ns eacl.consistency-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [eacl.backend.v8 :as backend]
+            [eacl.causal-token :as causal-token]
+            [eacl.consistency :as consistency]
+            [eacl.spicedb.consistency :as public-consistency]))
+
+(def format-options
+  {:current-kid :test
+   :keyring {:test (vec (range 32))}
+   :token-ttl-seconds 60})
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+      error
+      (ex-data error))))
+
+(defn- adapter
+  [{:keys [backend-id source-id branch head order locator anchors modes
+           selected-current selected-authoritative selected-at-least
+           selected-exact]}]
+  (let [self (atom nil)
+        selected (fn [candidate]
+                   (or (some-> candidate deref) @self))
+        base-operations
+        (into {}
+              (map (fn [operation]
+                     [operation (fn [& _] nil)]))
+              backend/required-snapshot-operations)
+        result
+        (backend/make-adapter
+         {:id (or backend-id :test)
+          :capabilities
+          {:consistency (or modes
+                            #{:fully-consistent
+                              :minimize-latency
+                              :at-least-as-fresh
+                              :at-exact-snapshot})
+           :snapshots #{:current :authoritative :causal :exact}
+           :source #{:stable-scope :graph-head
+                     :anchor-membership :order-hint :exact-locator}
+           :cursor #{}
+           :transactions #{}
+           :cache-proofs #{}
+           :runtime #{#?(:clj :clj :cljs :cljs)}}
+          :operations
+          (merge
+           base-operations
+           {:snapshot-id (fn [] [source-id branch order])
+            :source-scope
+            (fn [] {:source-id source-id :branch branch})
+            :graph-head
+            (fn [] {:graph-anchor head
+                    :order-hint order
+                    :exact-locator locator})
+            :contains-anchor? (fn [anchor]
+                               (contains? anchors anchor))
+            :order-hint (fn [] order)
+            :exact-locator (fn [] locator)
+            :select-current
+            (fn [] (selected selected-current))
+            :select-authoritative
+            (fn [_] (selected selected-authoritative))
+            :select-at-least
+            (fn [_ _] (selected selected-at-least))
+            :select-exact
+            (fn [_ _]
+              (when-not (= ::unavailable selected-exact)
+                (selected selected-exact)))})})]
+    (reset! self result)
+    result))
+
+(defn- token
+  ([anchor order locator]
+   (token "source" nil anchor order locator))
+  ([source-id branch anchor order locator]
+   (causal-token/issue
+    format-options
+    {:backend :test
+     :source-id source-id
+     :branch branch
+     :graph-anchor anchor
+     :order-hint order
+     :exact-locator locator})))
+
+(deftest shared-selection-postconditions-test
+  (let [current (adapter {:source-id "source"
+                          :branch nil
+                          :head "current"
+                          :order 20
+                          :locator 20
+                          :anchors #{"old" "current"}})
+        exact (adapter {:source-id "source"
+                        :branch nil
+                        :head "exact"
+                        :order 10
+                        :locator 10
+                        :anchors #{"exact"}})
+        current-ref (atom current)
+        exact-ref (atom exact)
+        source
+        (adapter {:source-id "source"
+                  :branch nil
+                  :head "source"
+                  :order 1
+                  :locator 1
+                  :anchors #{"source"}
+                  :selected-current current-ref
+                  :selected-authoritative current-ref
+                  :selected-at-least current-ref
+                  :selected-exact exact-ref})
+        options {:format-options format-options
+                 :coherence-authority :managed
+                 :issue-token? true
+                 :timeout-ms 1000}]
+    (testing "fully consistent uses the authoritative barrier"
+      (let [selection
+            (consistency/select
+             source public-consistency/fully-consistent options)]
+        (is (identical? current (:adapter selection)))
+        (is (= "current" (get-in selection
+                                [:graph-head :graph-anchor])))))
+    (testing "minimize latency selects the local complete snapshot"
+      (is (identical?
+           current
+           (:adapter
+            (consistency/select
+             source public-consistency/minimize-latency options)))))
+    (testing "at least selection verifies anchor membership after selection"
+      (let [request (token "old" 10 10)
+            selection
+            (consistency/select
+             source
+             (public-consistency/at-least-as-fresh request)
+             options)]
+        (is (identical? current (:adapter selection)))
+        (is (= "old"
+               (get-in selection
+                       [:request-token :graph-anchor])))))
+    (testing "exact selection verifies the resolved graph identity"
+      (let [request (token "exact" 10 10)]
+        (is (identical?
+             exact
+             (:adapter
+              (consistency/select
+               source
+               (public-consistency/at-exact-snapshot request)
+               options))))))
+    (testing "the response token is minted from the selected immutable head"
+      (let [response
+            (:response-token
+             (consistency/select
+              source public-consistency/fully-consistent options))
+            payload
+            (causal-token/token-data
+             format-options
+             {:backend :test
+              :source-id "source"
+              :branch nil}
+             response)]
+        (is (= "current" (:graph-anchor payload)))
+        (is (= 20 (:order-hint payload)))))))
+
+(deftest selection-fails-closed-test
+  (let [selected (adapter {:source-id "source"
+                           :branch nil
+                           :head "current"
+                           :order 20
+                           :locator 20
+                           :anchors #{"current"}})
+        selected-ref (atom selected)
+        source
+        (adapter {:source-id "source"
+                  :branch nil
+                  :head "source"
+                  :order 1
+                  :locator 1
+                  :anchors #{"source"}
+                  :selected-current selected-ref
+                  :selected-authoritative selected-ref
+                  :selected-at-least selected-ref
+                  :selected-exact ::unavailable})
+        options {:format-options format-options
+                 :coherence-authority :managed
+                 :timeout-ms 1000}]
+    (testing "an absent causal anchor is history divergence, not freshness"
+      (is (= :eacl.consistency/history-divergence
+             (:type
+              (error-data
+               #(consistency/select
+                 source
+                 (public-consistency/at-least-as-fresh
+                  (token "missing" 10 10))
+                 options))))))
+    (testing "source and branch mismatch is incomparable"
+      (is (= :eacl.consistency/incomparable-scope
+             (:type
+              (error-data
+               #(consistency/select
+                 source
+                 (public-consistency/at-least-as-fresh
+                  (token "other" nil "source" 10 10))
+                 options))))))
+    (testing "expired tokens have their own error"
+      (let [expired
+            (causal-token/issue
+             format-options
+             {:backend :test
+              :source-id "source"
+              :branch nil
+              :graph-anchor "current"
+              :order-hint 20
+              :exact-locator 20
+              :issued-at 1
+              :expires-at 2})]
+        (is (= :eacl.consistency/token-expired
+               (:type
+                (error-data
+                 #(consistency/select
+                   source
+                   (public-consistency/at-least-as-fresh expired)
+                   options)))))))
+    (testing "exact reconstruction absence is typed"
+      (is (= :eacl.consistency/exact-snapshot-unavailable
+             (:type
+              (error-data
+               #(consistency/select
+                 source
+                 (public-consistency/at-exact-snapshot
+                  (token "current" 20 20))
+                 options))))))
+    (testing "unknown writer authority fails before causal selection"
+      (is (= :eacl.consistency/unsupported-head-barrier
+             (:type
+              (error-data
+               #(consistency/select
+                 source
+                 (public-consistency/at-least-as-fresh
+                  (token "current" 20 20))
+                 (assoc options
+                        :coherence-authority :unknown)))))))))
+
+(deftest capability-matrix-and-legacy-restriction-test
+  (doseq [[mode descriptor]
+          [[:fully-consistent public-consistency/fully-consistent]
+           [:minimize-latency public-consistency/minimize-latency]
+           [:at-least-as-fresh
+            (public-consistency/at-least-as-fresh
+             (token "head" 1 1))]
+           [:at-exact-snapshot
+            (public-consistency/at-exact-snapshot
+             (token "head" 1 1))]]]
+    (let [only-mode
+          (adapter {:source-id "source"
+                    :branch nil
+                    :head "head"
+                    :order 1
+                    :locator 1
+                    :anchors #{"head"}
+                    :modes #{mode}})
+          options {:format-options format-options
+                   :coherence-authority :managed}]
+      (is (backend/adapter?
+           (:adapter
+            (consistency/select only-mode descriptor options))))
+      (doseq [other-mode
+              (disj backend/known-consistency-modes mode)]
+        (let [other-descriptor
+              (case other-mode
+                :fully-consistent public-consistency/fully-consistent
+                :minimize-latency public-consistency/minimize-latency
+                :at-least-as-fresh
+                (public-consistency/at-least-as-fresh
+                 (token "head" 1 1))
+                :at-exact-snapshot
+                (public-consistency/at-exact-snapshot
+                 (token "head" 1 1)))]
+          (is (some? (error-data
+                      #(consistency/select
+                        only-mode other-descriptor options))))))))
+  (let [legacy
+        {:cache-stamp (constantly :stamp)
+         :relation-defs (fn [& _])
+         :permission-defs (fn [& _])
+         :subject->resources (fn [& _])
+         :resource->subjects (fn [& _])
+         :direct-match? (fn [& _])}]
+    (is (identical?
+         legacy
+         (backend/require-legacy-evaluation!
+          legacy
+          {:explicit-snapshot? true
+           :cache? false
+           :consistency-mode :snapshot-only})))
+    (is (= :eacl/unsupported-capability
+           (:type
+            (error-data
+             #(backend/require-legacy-evaluation!
+               legacy
+               {:explicit-snapshot? true
+                :cache? true
+                :consistency-mode :snapshot-only})))))))
+
+(deftest selection-error-taxonomy-test
+  (let [selected (adapter {:source-id "source"
+                           :head "head"
+                           :order 1
+                           :locator 1
+                           :anchors #{"head"}})
+        selected-ref (atom selected)
+        source
+        (adapter {:source-id "source"
+                  :head "head"
+                  :order 1
+                  :locator 1
+                  :anchors #{"head"}
+                  :selected-current selected-ref
+                  :selected-authoritative selected-ref
+                  :selected-at-least selected-ref
+                  :selected-exact selected-ref})
+        request (token "head" 1 1)
+        options {:format-options format-options
+                 :coherence-authority :managed}]
+    (testing "backend freshness deadlines remain distinguishable"
+      (let [timeout-source
+            (assoc-in
+             source
+             [::backend/operations :select-at-least]
+             (fn [& _]
+               (consistency/fail!
+                :freshness-unavailable
+                "deadline"
+                {:timeout-ms 1})))]
+        (is (= :eacl.consistency/freshness-unavailable
+               (:type
+                (error-data
+                 #(consistency/select
+                   timeout-source
+                   (public-consistency/at-least-as-fresh request)
+                   options)))))))
+    (testing "cursor/freshness incompatibility is typed"
+      (is (= :eacl.consistency/cursor-consistency-conflict
+             (:type
+              (error-data
+               #(consistency/cursor-conflict!
+                 {:cursor "old" :requested "new"}))))))))

--- a/modules/eacl/test/eacl/contract_support.cljc
+++ b/modules/eacl/test/eacl/contract_support.cljc
@@ -523,9 +523,11 @@
                   error))]
           (if #?(:clj (instance? Exception stale-result)
                  :cljs (instance? js/Error stale-result))
-            (is (= :eacl.pagination/invalid-cursor
-                   (let [data (ex-data stale-result)]
-                     (or (:eacl/error data) (:type data)))))
+            (is (contains?
+                 #{:eacl.pagination/stale-cursor
+                   :eacl.consistency/snapshot-expired}
+                 (let [data (ex-data stale-result)]
+                   (or (:eacl/error data) (:type data)))))
             (is (= [] (:data stale-result))
                 "historical backends must resume the pre-mutation snapshot")))
 

--- a/modules/eacl/test/eacl/mutation_test.cljc
+++ b/modules/eacl/test/eacl/mutation_test.cljc
@@ -1,0 +1,95 @@
+(ns eacl.mutation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [eacl.mutation :as mutation]))
+
+(deftest mutation-identities-and-idempotency-test
+  (let [mutation-id (mutation/new-id)
+        other-id (mutation/new-id)
+        data {:operation :write
+              :objects ["a" "b"]}]
+    (testing "ids are independent portable 256-bit values"
+      (is (not= mutation-id other-id))
+      (is (= 43 (count mutation-id))))
+    (testing "the fingerprint binds an id to complete canonical mutation data"
+      (let [record (mutation/mutation-record
+                    {:mutation-id mutation-id
+                     :kind :relationships
+                     :canonical-data data
+                     :issued-at 10})]
+        (is (mutation/mutation-data-matches?
+             record mutation-id data))
+        (is (not (mutation/mutation-data-matches?
+                  record mutation-id
+                  (assoc data :objects ["different"]))))))
+    (testing "malformed mutation ids cannot act as idempotency keys"
+      (is (thrown? #?(:clj clojure.lang.ExceptionInfo
+                      :cljs cljs.core.ExceptionInfo)
+                   (mutation/mutation-fingerprint
+                    "not-a-256-bit-id"
+                    data))))))
+
+(deftest atomic-mutation-transaction-data-test
+  (let [mutation-id (mutation/new-id)
+        previous-id (mutation/new-id)
+        tx-data
+        (mutation/transaction-data
+         {:mutation-id mutation-id
+          :kind :relationships
+          :canonical-data {:operation :batch}
+          :family-id "family"
+          :previous-head-id previous-id
+          :order-value :db/current-tx
+          :schema-change? true
+          :relation-ids [11 11 12]
+          :dependency-ids [21 21 22]
+          :issued-at 100
+          :token-ttl-seconds 30
+          :retention-grace-seconds 5})]
+    (is (some #(= mutation-id
+                  (get % mutation/mutation-id-attr))
+              (filter map? tx-data)))
+    (is (some #(= [:db.fn/cas
+                   [:eacl/id mutation/graph-entity-id]
+                   mutation/graph-head-id-attr
+                   previous-id
+                   mutation-id]
+                  %)
+              tx-data))
+    (is (= #{11 12}
+           (into #{}
+                 (keep (fn [entry]
+                         (when (and (map? entry)
+                                    (= mutation-id
+                                       (get entry
+                                            mutation/relation-mutation-id-attr)))
+                           (:db/id entry))))
+                 tx-data)))
+    (is (= #{21 22}
+           (into #{}
+                 (keep (fn [entry]
+                         (when (and (map? entry)
+                                    (= mutation-id
+                                       (get entry
+                                            mutation/dependency-mutation-id-attr)))
+                           (:db/id entry))))
+                 tx-data)))
+    (is (= 135
+           (some (fn [entry]
+                   (when (and (map? entry)
+                              (= [mutation/mutation-id-attr previous-id]
+                                 (:db/id entry)))
+                     (get entry mutation/mutation-expires-at-attr)))
+                 tx-data)))))
+
+(deftest retention-boundary-test
+  (is (= 135
+         (mutation/retention-expiry
+          {:issued-at 100
+           :token-ttl-seconds 30
+           :retention-grace-seconds 5})))
+  (is (thrown? #?(:clj clojure.lang.ExceptionInfo
+                  :cljs cljs.core.ExceptionInfo)
+               (mutation/retention-expiry
+                {:issued-at 100
+                 :token-ttl-seconds 0
+                 :retention-grace-seconds 5}))))

--- a/modules/eacl/test/eacl/secure_format_test.cljc
+++ b/modules/eacl/test/eacl/secure_format_test.cljc
@@ -1,0 +1,192 @@
+(ns eacl.secure-format-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [eacl.causal-token :as token]
+            [eacl.cursor :as cursor]
+            [eacl.secure-format :as secure]))
+
+(def old-key (vec (range 32)))
+(def current-key (vec (range 32 64)))
+(def options
+  {:current-kid :current
+   :keyring {:old old-key
+             :current current-key}})
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch #?(:clj Exception :cljs :default) error
+      (ex-data error))))
+
+(defn- tamper
+  [value]
+  (let [replacement (if (= "A" (subs value 0 1)) "B" "A")]
+    (str replacement (subs value 1))))
+
+(defn- tamper-authenticator
+  [prefix token]
+  (let [envelope
+        (-> token
+            (subs (count prefix))
+            secure/b64url-decode
+            secure/bytes->utf8
+            secure/decode-canonical)
+        envelope' (update envelope :tag tamper)]
+    (str prefix
+         (secure/b64url-encode
+          (secure/utf8-bytes
+           (secure/encode-canonical envelope'))))))
+
+(deftest canonical-portable-format-test
+  (is (= (secure/encode-canonical {:b #{3 2 1} :a [1 true nil]})
+         (secure/encode-canonical {:a [1 true nil] :b #{1 2 3}})))
+  (is (= {:a [1 true nil] :b #{1 2 3}}
+         (secure/decode-canonical
+          (secure/encode-canonical {:b #{3 2 1} :a [1 true nil]}))))
+  (testing "hostile bounds fail before use"
+    (is (= :integer-out-of-range
+           (:reason
+            (error-data
+             #(secure/encode-canonical
+               (inc secure/maximum-safe-integer))))))
+    (is (= :too-deep
+           (:reason
+            (error-data
+             #(secure/encode-canonical
+               [[[[[:too-deep]]]]]
+               {:maximum-depth 2})))))
+    (is (= :too-large
+           (:reason
+            (error-data
+             #(secure/decode-canonical
+               (apply str (repeat 100 "x"))
+               {:maximum-size 10})))))
+    (is (= :unknown-fields
+           (:reason
+            (error-data
+             #(secure/decode-canonical
+               "{:allowed 1 :forged 2}"
+               {:allowed-keys #{:allowed}})))))))
+
+(deftest domain-separation-and-key-rotation-test
+  (let [payload {:v 1 :answer true}
+        old-options (assoc options :current-kid :old)
+        old-token
+        (secure/encode-authenticated
+         (merge old-options {:domain "test/domain/a" :prefix "test_a_"})
+         payload)]
+    (is (= payload
+           (secure/decode-authenticated
+            (merge options
+                   {:domain "test/domain/a"
+                    :prefix "test_a_"
+                    :payload-keys #{:v :answer}})
+            old-token)))
+    (is (= :malformed-token
+           (:reason
+            (error-data
+             #(secure/decode-authenticated
+               (merge options
+                      {:domain "test/domain/b"
+                       :prefix "test_b_"
+                       :payload-keys #{:v :answer}})
+               old-token)))))
+    (is (= :authentication-failed
+           (:reason
+            (error-data
+             #(secure/decode-authenticated
+               (merge options
+                      {:domain "test/domain/a"
+                       :prefix "test_a_"
+                       :payload-keys #{:v :answer}})
+               (tamper-authenticator "test_a_" old-token))))))))
+
+(deftest canonical-records-digest-test
+  (let [records [[:alpha {:b 2 :a 1}]
+                 [:beta #{3 1 2}]]
+        digest (secure/canonical-records-digest
+                "test/records/v1" records)]
+    (is (= "sDmOlTDyZBZzLIccAloDY2q5FoRl_-dDELuWK27Q-6U"
+           digest)
+        "CLJ and CLJS must implement the same framing and digest contract")
+    (is (= digest
+           (secure/canonical-records-digest
+            "test/records/v1"
+            [[:alpha {:a 1 :b 2}]
+             [:beta #{1 2 3}]])))
+    (is (not=
+         digest
+         (secure/canonical-records-digest
+          "test/records/v1" (reverse records))))
+    (is (not=
+         digest
+         (secure/canonical-records-digest
+          "test/records/v2" records)))
+    (is (= 43 (count digest))))
+  (testing "the complete sequence may exceed the whole-value format bound"
+    (is (= 43
+           (count
+            (secure/canonical-records-digest
+             "test/large-record-sequence/v1"
+             (map (fn [n] [:record n]) (range 20000))))))))
+
+(deftest constant-work-tag-comparison-test
+  (is (secure/secure-equal? [0 1 2 3] [0 1 2 3]))
+  (is (false? (secure/secure-equal? [9 1 2 3] [0 1 2 3])))
+  (is (false? (secure/secure-equal? [0 1 2 9] [0 1 2 3])))
+  (is (false? (secure/secure-equal? [0 1 2] [0 1 2 3]))))
+
+(deftest causal-token-round-trip-and-rejection-test
+  (let [payload {:backend :datascript
+                 :source-id "family"
+                 :branch nil
+                 :graph-anchor "mutation"
+                 :order-hint 7
+                 :exact-locator "snapshot"}
+        encoded (token/issue options payload)]
+    (is (= (merge payload
+                  {:version 3}
+                  (select-keys (token/token-data options encoded)
+                               [:issued-at :expires-at]))
+           (token/token-data options
+                             {:backend :datascript
+                              :source-id "family"
+                              :branch nil}
+                             encoded)))
+    (is (= :scope-mismatch
+           (:reason
+            (error-data
+             #(token/token-data
+               options
+               {:backend :datascript
+                :source-id "other"
+                :branch nil}
+               encoded)))))
+    (is (= :expired
+           (:reason
+            (error-data
+             #(token/token-data
+               (assoc options :now-seconds
+                      (inc (:expires-at
+                            (token/token-data options encoded))))
+               encoded)))))
+    (is (= :malformed-token
+           (:reason
+            (error-data #(token/token-data options "17")))))))
+
+(deftest authenticated-portable-cursor-test
+  (let [value {:v 8 :edge {:kind :lookup-eid} :position [1 "a"]}
+        encoded (cursor/cursor->token value options)]
+    (is (= value (cursor/token->cursor encoded options)))
+    (is (= :malformed-token
+           (:reason
+            (error-data
+             #(cursor/token->cursor "eacl1_e30=" options)))))
+    (is (= :authentication-failed
+           (:reason
+            (error-data
+             #(cursor/token->cursor
+               (tamper-authenticator cursor/cursor-prefix encoded)
+               options)))))))

--- a/openspec/changes/redesign-cross-backend-freshness-cache/.openspec.yaml
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/redesign-cross-backend-freshness-cache/design.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/design.md
@@ -1,0 +1,659 @@
+## Context
+
+EACL must answer two independent questions for every authorization request:
+
+1. Which immutable snapshot satisfies the caller's consistency requirement?
+2. Is an answer computed on another snapshot observationally equivalent on the
+   selected snapshot?
+
+A transaction position can help with the first question. It cannot answer the
+second. If a selected Datomic basis or DataScript/Datahike `:max-tx` is newer
+than a token, the intervening transaction could be an unrelated application
+write or a permission revocation. A separate dependency proof is necessary to
+distinguish those cases.
+
+The first version of this design still made three assumptions that do not
+survive adversarial counterexamples:
+
+- It assumed transaction positions are globally monotonic inside a named
+  database/branch. Datomic restore, DataScript `reset-conn!`, and Datahike
+  branch/force operations can replace a head with another history.
+- It assumed a current-transaction relation stamp uniquely identifies relation
+  content. Two divergent histories can independently allocate the same
+  transaction number to different data.
+- It treated exact historical reconstruction as the only safe way to continue
+  a cursor after any snapshot change. A complete equal dependency proof is
+  sufficient and avoids history for unrelated changes.
+
+The corrected design treats transaction positions as order/wait hints and
+uses unique causal mutation identities for correctness.
+
+### Verified backend facts
+
+The current Datomic adapter already uses authenticated basis tokens and
+database-visible `:eacl/relation-version` stamps. It does not use a listener
+counter for completed-answer correctness. Datomic documents that:
+
+- every database value is immutable and has a basis `t`;
+- transactions for one database are totally ordered and every Peer sees a
+  gap-free prefix;
+- two-argument `d/sync` waits for a known `t`; and
+- zero-argument `d/sync` communicates with the transactor and returns a value
+  including every transaction complete when synchronization was requested.
+
+The zero-argument contract was also verified from the loaded Datomic Peer API
+metadata. Therefore true Datomic `:fully-consistent` selection requires
+bounded zero-argument `d/sync`, not ordinary `d/db`.
+
+The Datahike design was audited against the exact EACL dependency revision,
+`779724b60d1e4292a39868b2e27bfff8bf7e0e69`:
+
+- Datahike is single-writer/multiple-reader per branch and publishes immutable
+  branch heads
+  ([distributed operation](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/doc/distributed.md)).
+- Non-streaming connection dereference reads the configured branch head from
+  its store; streaming connections read their synchronized local value
+  ([connector source](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/src/datahike/connector.cljc)).
+- Database values expose `:max-tx`, commit id, and parent commit ids. Retained
+  commits can be loaded with `commit-as-db`
+  ([versioning](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/doc/versioning.md)).
+- Temporal `as-of` requires `:keep-history? true`; EACL currently configures it
+  false
+  ([time variance](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/doc/time_variance.md),
+  [configuration](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/doc/config.md)).
+- Commit records can be unavailable when the commit graph is disabled or after
+  garbage collection
+  ([garbage collection](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/doc/gc.md)).
+- `force-branch!` is an unconditional branch-head replacement and can publish a
+  DB value with a lower `:max-tx`
+  ([versioning source](https://github.com/replikativ/datahike/blob/779724b60d1e4292a39868b2e27bfff8bf7e0e69/src/datahike/versioning.cljc)).
+
+Pinned-dependency nREPL experiments established:
+
+- `:db/current-tx` can be written atomically with a Datahike relation mutation;
+- `commit-as-db` recovers an old commit with `:keep-history? false`;
+- `commit-as-db` is unavailable when `:commit-graph? false`;
+- `as-of` cannot reliably recover superseded `:db/noHistory` stamps; and
+- `force-branch!` can move a branch from `:max-tx 536870914` to a new commit at
+  `:max-tx 536870913`.
+
+DataScript source and nREPL experiments established:
+
+- each transaction advances immutable DB `:max-tx`;
+- `:db/current-tx` resolves to that transaction id;
+- `reset-conn!` can replace a connection's DB value; and
+- two transactions applied independently to the same base DB can produce
+  identical `:max-tx` and identical current-transaction stamps but different
+  relationship content.
+
+The existing portable cursor is base64-encoded EDN, not authenticated. The new
+format cannot rely on an existing portable cryptographic boundary.
+
+### Terms
+
+- **source scope**: backend plus stable native store/database identity and
+  branch where applicable.
+- **mutation id**: a cryptographically random identifier generated once for an
+  EACL graph mutation and committed atomically with it.
+- **causal anchor**: an append-only mutation id proving that a selected
+  snapshot includes the token-issuing EACL graph mutation.
+- **order hint**: a backend position such as basis `t` or `:max-tx` used to
+  avoid unnecessary polling; it is not proof of lineage or graph equality.
+- **exact locator**: a backend value capable of retrieving one exact immutable
+  snapshot while retained.
+- **dependency proof**: a canonical, snapshot-bound proof covering every input
+  that can change an authorization answer.
+- **dominance**: snapshot `S` dominates token `T` only when their source scope
+  is compatible and `S` contains `T`'s causal anchor. Numeric comparison alone
+  never establishes dominance.
+- **proof lifting**: reusing an answer computed on `C` after proving that `C`
+  causally precedes selected snapshot `S` and the complete dependency proofs
+  are equal.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement causal `:at-least-as-fresh` behavior for Datomic, Datahike, and
+  DataScript without listener counters.
+- Remain correct across connection restarts, cloned immutable values, database
+  restore, DataScript reset, and Datahike branch-head replacement.
+- Preserve completed-answer and cursor reuse across unrelated transactions.
+- Make fast mutation-identity proofs optional and fail closed to content proof
+  or no-cache when writer participation is not guaranteed.
+- Put consistency orchestration, proof validation, token/cursor security, and
+  conformance tests in shared code.
+- Advertise only snapshot/head guarantees actually available from a backend's
+  configured source.
+
+**Non-Goals:**
+
+- Add replication or a remote revision service to DataScript.
+- Guarantee indefinite Datahike commit or token-marker retention.
+- Make an untrusted or Byzantine primary database safe.
+- Cache adapter functions that are time-dependent, read external mutable state,
+  or cannot declare all authorization dependencies.
+- Preserve old decimal listener tokens, unauthenticated portable cursors, or
+  old cache entries.
+
+## Decisions
+
+### 1. Define the cache theorem before the implementation
+
+For semantic request `q`, let:
+
+- `S` be the immutable snapshot selected for this request;
+- `C` be the snapshot where candidate answer `A` was computed;
+- `F(q, X)` be the deterministic authorization result on snapshot `X`;
+- `D(q, X)` be the complete static dependency closure for `q` under `X`'s
+  schema; and
+- `P(D, X)` be the canonical proof of those dependencies on `X`.
+
+EACL may return cached `A = F(q, C)` for selected snapshot `S` only if all of
+the following hold:
+
+1. the entry's authenticated source scope and semantic key match the request;
+2. `C` is not causally after `S`; the selected snapshot contains the entry's
+   computation anchor or is the exact computation snapshot;
+3. the selected schema proof matches the entry schema proof;
+4. `D(q, S)` is complete and equals the entry's dependency scope;
+5. `P(D(q, S), S) = P(D(q, C), C)`;
+6. engine, adapter, query normalization, result format, and every
+   answer-affecting configuration fingerprint match; and
+7. the cached value shape and entry authenticator are valid.
+
+Under the adapter contract that `F` is a pure function of those inputs,
+conditions 3–6 imply `F(q, S) = F(q, C)`. Conditions 1, 2, and 7 prevent
+cross-source, backward-history, key-confusion, and cache-forgery substitutions.
+
+This theorem explicitly rejects a candidate computed in a future or sibling
+history merely because its relation proof happens to match. Proof lifting is
+forward-only.
+
+Every cross-revision return re-reads or recomputes the selected snapshot's
+proof. `validated-at` is telemetry, not a lease that permits later proof reads
+to be skipped.
+
+### 2. Separate causal freshness from dependency equality
+
+Every managed EACL graph mutation creates a cryptographically random mutation
+id and, in the same transaction:
+
+- appends an immutable mutation-journal record;
+- updates the singleton graph-head id and backend order hint;
+- updates the schema mutation id when schema changed; and
+- updates every affected relation's mutation id.
+
+Every change to data that can affect EACL's public authorization result belongs
+to this protocol. That includes schema and relationships, plus mutable
+object-identity mappings, caveat inputs, or custom adapter data when an adapter
+declares them as dependencies. Without complete causal writer authority, EACL
+may still evaluate current snapshots and use full-content cache proofs, but it
+MUST NOT issue a read token claiming to represent the selected authorization
+state or advertise causal `:at-least-as-fresh`.
+
+This restriction is information-theoretic. A full-content read can establish
+what a snapshot contains, but it cannot establish that a later divergent
+snapshot descends from an unjournaled write. No cache algorithm can reconstruct
+missing causality after the fact.
+
+Conceptually:
+
+```clojure
+{:mutation/id <random-256-bit-id>
+ :mutation/order <basis-t-or-max-tx>
+ :mutation/kind :schema|:relationships
+ :graph/head-id <same-id>
+ :graph/head-order <same-order>
+ :schema/version-id <same-id-if-schema>
+ :relation/version-id <same-id-for-each-affected-relation>}
+```
+
+The storage representation may use UUID plus an HMAC-derived collision check or
+an equivalent fixed-width cryptographic identifier. A current-transaction ref
+may be stored alongside it as an order hint, but equality proofs use mutation
+identity, never the transaction number alone.
+
+The append-only journal closes restore/fork/reset ambiguity:
+
+- a snapshot restored or cloned from before token `T` does not contain `T`'s
+  mutation id, even if its numeric transaction counter later reaches the same
+  value;
+- a clone from after `T` contains the marker and legitimately causally follows
+  `T`; and
+- later graph mutations change only their affected relation identities, so
+  unrelated cache entries remain valid.
+
+The mutation id is generated before transaction submission and reused across
+ambiguous retries. Writers reject or idempotently recover an already committed
+mutation id rather than attaching the same id to different tx-data. This lets a
+caller recover a committed causal token after a timeout without creating a
+colliding dependency proof.
+
+Tokens have an authenticated maximum lifetime. Mutation journal entries MUST
+remain queryable for at least the maximum token lifetime. Missing retained
+anchors produce a typed token-expired/history-diverged result, never numeric
+fallback. An installation that chooses non-expiring tokens accepts unbounded
+journal retention.
+
+**Alternatives rejected:**
+
+- `(database-id, transaction-number)` fails after restore or reset.
+- `(database-id, branch, :max-tx)` fails after Datahike `force-branch!`.
+- a current-transaction relation stamp collides across divergent branches.
+- a persisted database UUID alone is copied by clone/restore and does not prove
+  ancestry.
+
+### 3. Use one authenticated token envelope with causal and exact fields
+
+The public `:zed/token` remains opaque. Its decoded payload contains:
+
+```clojure
+{:version 3
+ :backend :datomic|:datahike|:datascript
+ :source-id <native-stable-scope>
+ :branch <datahike-branch-or-nil>
+ :graph-anchor <mutation-id>
+ :order-hint <basis-t-or-max-tx>
+ :exact-locator <basis-t|commit-id|retained-handle>
+ :issued-at <bounded-time>
+ :expires-at <bounded-time>}
+```
+
+At-least selection uses `graph-anchor` membership as the correctness
+postcondition and `order-hint` only to decide whether waiting may be necessary.
+Exact selection uses `exact-locator` and verifies the loaded snapshot's source
+scope and graph-head identity.
+
+The shared codec provides:
+
+- canonical serialization with explicit type/range validation;
+- strict field allowlists and size/depth limits;
+- domain-separated HMAC keys for Zed tokens and completed cache entries;
+- mandatory cursor authentication, with authenticated encryption when the
+  configured runtime exposes a compatible synchronous/async API surface;
+- key ids and read-keyrings for rotation;
+- constant-time tag verification; and
+- distinct token, cursor, and cache signing domains.
+
+Portable signed cursors contain stable external identities or opaque digests,
+not raw secret backend objects. Datomic retains encrypted pagination. A
+synchronous ClojureScript client is not forced to call asynchronous WebCrypto;
+it may use a vetted synchronous MAC implementation and advertise
+confidentiality separately.
+
+The CLJ and CLJS codecs use a portable exact representation for revisions.
+They MUST reject values outside the backend runtime's exact integer range
+rather than silently rounding them.
+
+### 4. Make consistency modes name actual selection behavior
+
+All modes select one immutable snapshot before authorization or cross-revision
+cache validation.
+
+#### Fully consistent
+
+Select a snapshot containing every graph mutation complete at the selection
+barrier:
+
+- Datomic uses bounded zero-argument `d/sync`, which communicates with the
+  transactor.
+- Datahike uses an authoritative branch-head read. A lagging replicated or
+  streaming client without an authoritative barrier MUST NOT advertise this
+  capability until its writer protocol exposes one.
+- DataScript uses the current value of its single-process connection; writes on
+  that connection are serialized.
+
+Ordinary Datomic `d/db`, a Datahike listener count, or a lagging local replica
+is only latest-observed and cannot implement this mode.
+
+#### Minimize latency
+
+Select a complete immutable snapshot already available locally, without an
+authoritative-head wait. It may be stale relative to another process. The cache
+is validated on that selected snapshot; a result-only cache entry is not itself
+silently treated as a database snapshot.
+
+#### At least as fresh
+
+Given token `T`:
+
+1. authenticate and validate its source scope and expiry;
+2. read a local/current snapshot;
+3. use its order hint to avoid waiting when it is obviously behind;
+4. refresh/wait within the deadline;
+5. require the selected snapshot to contain `T.graph-anchor`; and
+6. return history-diverged/token-expired if the numeric position is sufficient
+   but the causal anchor is absent.
+
+The response token is derived from the selected snapshot's current graph head.
+
+#### At exact snapshot
+
+Load only the exact locator named by the token and verify its source scope,
+locator, and graph-head identity. If unavailable or mismatched, return
+snapshot-expired. Proof-equivalent substitution is not called “exact.”
+
+### 5. Keep backend selection specific and capability-gated
+
+#### Datomic
+
+- Source scope includes Datomic's native database id.
+- Order hint and exact locator are basis `t`.
+- Managed writes mint tokens from transaction report `db-after` and the
+  mutation id committed in that transaction.
+- `:at-least-as-fresh` uses bounded two-argument `d/sync` when the local basis
+  is behind, then verifies mutation-anchor membership.
+- `:fully-consistent` uses bounded zero-argument `d/sync`.
+- Exact selection uses `d/as-of` after synchronization and verifies the graph
+  head visible at that basis.
+- Existing transaction-ref relation stamps may remain for diagnostics and
+  linear-history optimization, but cache equality uses v3 mutation identities
+  or content proofs.
+
+#### Datahike
+
+- Source scope includes stable store id and configured branch.
+- Exact locator is commit id when retained.
+- `:max-tx` is only an order hint. `force-branch!` and branch construction make
+  it insufficient as a causal order.
+- Managed transaction tokens contain the committed mutation id and the final
+  committed `db-after`/commit id. If writer batching returns an over-fresh final
+  commit to multiple reports, that remains valid.
+- A non-streaming connection may refresh by dereferencing its branch head.
+  Streaming/replicated sources advertise authoritative-head selection only when
+  their writer/replication protocol supplies that barrier.
+- Exact reconstruction prefers `commit-as-db`; temporal `as-of` is a
+  capability-gated fallback.
+- Missing commits or mutation anchors return expiry/divergence errors.
+- Commit parent traversal may optimize or diagnose causal selection but does
+  not replace mutation-anchor membership, because `force-branch!` can attach
+  arbitrary parents to a DB value.
+
+#### DataScript
+
+- Source scope contains a durable random causal-family id stored with the
+  database so tokens survive connection/process restart. Copying that id is not
+  treated as proof of ancestry; mutation-anchor membership supplies that proof.
+- A clone made after token `T` may accept `T` because it contains `T`'s marker.
+  A clone/reset made before `T`, or an unrelated DB, rejects it by missing
+  anchor or family mismatch.
+- Order hint is immutable DB `:max-tx`.
+- Managed writes mint tokens from transaction report `db-after` and their
+  committed mutation id.
+- A current connection satisfies an at-least token only when it contains the
+  causal anchor. If it is behind, EACL may wait for that same connection to
+  advance until the deadline. It does not claim replication.
+- `reset-conn!` to a pre-token or divergent DB is detected by missing causal
+  anchors, even if `:max-tx` collides.
+- Exact selection requires the current exact DB or a bounded registry handle
+  to a retained immutable DB. Numeric equality alone is not exact identity.
+
+### 6. Use two explicit dependency-proof modes
+
+#### Mutation-identity proof
+
+The fast mode reads:
+
+- current schema mutation id;
+- the complete static transitive closure of relation-definition dependencies;
+  and
+- the current mutation id for every relation in that closure.
+
+The closure is derived from schema, not from runtime paths visited by a
+particular positive or negative evaluation. Short-circuiting, empty data, a
+denied result, recursive cycles, and pagination boundaries MUST NOT omit a
+relation that could change the answer.
+
+This mode is enabled only when the client has an explicit coherence authority
+guaranteeing that every schema/relationship writer uses the v3 mutation
+protocol. Merely finding the metadata attributes is not evidence of writer
+compliance.
+
+#### Full-content proof
+
+The conservative mode canonically hashes or compares all scoped schema
+definitions and relationship tuples from the selected immutable snapshot. It
+detects raw writers without relying on mutation metadata. It is potentially
+expensive but remains the correctness oracle and safe fallback.
+
+If neither proof is complete or affordable, EACL evaluates without retaining a
+completed answer. It never silently selects fast stamps because metadata
+happens to exist.
+
+Every derived schema catalog, permission-path memo, recursive dependency
+closure, and direct-grant memo is keyed by selected snapshot schema mutation id
+or content proof. Listener callbacks may pre-evict these structures but cannot
+make them authoritative.
+
+Adapter query operations MUST be deterministic and snapshot-pure. If an object
+id codec, caveat evaluator, or custom primitive reads external mutable state,
+that state must be represented in the semantic/configuration fingerprint and
+dependency proof or caching and proof-equivalent cursors are disabled.
+
+For database-backed object identity, the semantic key contains both the
+canonical public query identity and the selected internal identity. Cache
+entries and cursors also carry an identity-boundary proof for query objects,
+result objects, and ordering positions whose external identity may change.
+Alternatively an adapter may declare and enforce those identities as immutable.
+A function/configuration fingerprint alone is insufficient when the mapping
+data itself is mutable.
+
+### 7. Authenticate and fully scope completed cache entries
+
+The lookup key and embedded entry include:
+
+- cache format and engine algorithm versions;
+- backend/source/branch scope;
+- semantic operation and complete canonical internal query;
+- pagination direction/position where applicable;
+- recursion, count, traversal, codec, and adapter configuration fingerprint;
+- result kind; and
+- exact locator for exact-only entries.
+
+The entry additionally includes:
+
+- computation causal anchor and exact locator;
+- most recent validation anchor for telemetry;
+- complete dependency scope and proof;
+- result value; and
+- a domain-separated authenticator over the canonical entry.
+
+An externally writable or shared cache can otherwise forge a Boolean grant or
+lookup result while copying visible proof fields. Authentication makes
+corruption a miss. The cache remains a trusted availability dependency only:
+it may drop or delay entries but cannot create an accepted authorization value
+without the cache key.
+
+The same rule applies to authorization-affecting intermediate entries:
+recursive continuations, traversal frontiers, schema/path materializations, and
+latest-entry pointers. An intermediate from an external/shared provider is
+authenticated and fully scoped, or it is treated as a miss and reconstructed.
+A cursor MUST be self-sufficient enough to recompute its continuation after
+intermediate-cache eviction; cache retention is never a pagination correctness
+requirement.
+
+A selected snapshot MUST dominate the computation anchor before lifting. An
+entry computed on a numerically “future” sibling history is rejected even when
+its dependency proof matches.
+
+Concurrent validation updates use compare-and-set or monotonic merge where the
+provider supports it. An older writer overwriting telemetry is harmless to
+correctness because every later cross-revision hit validates again, but it
+should not regress metrics unnecessarily.
+
+### 8. Continue cursors on exact or proof-equivalent graphs
+
+A first page cursor binds, under mandatory authentication and optional
+authenticated encryption:
+
+- format, engine, adapter, and configuration fingerprints;
+- source/branch scope;
+- original graph anchor and exact locator;
+- canonical query scope and direction;
+- complete dependency scope and proof digest;
+- stable total-order position; and
+- expiry.
+
+Cursor size is bounded. The continuation rederives the complete dependency
+closure from authenticated query scope and selected schema. The cursor may
+carry a domain-separated cryptographic digest of the canonical complete proof
+rather than the unbounded proof map. It never truncates a dependency set.
+When a complete proof cannot be represented or recomputed within configured
+resource limits, graph-equivalent continuation is unavailable and EACL uses an
+exact locator or returns a typed stale/size error.
+
+A continuation proceeds:
+
+1. authenticate/decrypt and validate query/config scope;
+2. if an additional at-least floor exists, select a snapshot satisfying it;
+   otherwise select the current configured snapshot;
+3. compute the complete dependency proof on that snapshot;
+4. if the proof equals the cursor proof, continue on the selected snapshot;
+5. otherwise try the original exact locator when doing so does not conflict
+   with a newer requested floor; and
+6. if neither path works, return stale-cursor/snapshot-expired.
+
+After proof-equivalent continuation, newly emitted cursors are rebased to the
+selected snapshot's graph anchor, locator, and proof while preserving the
+deterministic enumeration.
+
+Proof equality means the authorized, deterministically ordered result set is
+the same, so inserts/deletes in unrelated relations cannot create duplicates
+or omissions. Mutation-identity proofs conservatively reject a cursor after a
+relevant change even when content later returns to its old value.
+
+A newer at-least token is not automatically incompatible with a cursor. It is
+compatible when a snapshot satisfying the token has the same dependency proof.
+It conflicts only when the graph changed and exact historical continuation
+would violate the newer floor.
+
+Exact reconstruction remains useful when relevant dependencies changed and the
+caller wants the original enumeration. It is not required for unrelated
+transactions or proof-equivalent current state.
+
+Stable pagination also requires a deterministic total order and cursor
+position. Backend enumeration order, hash-map order, or an incomplete
+tie-breaker cannot be used.
+
+### 9. Classify failures by whether the contract can still be met
+
+Request errors:
+
+- token/cursor authentication or scope failure;
+- expired/missing causal anchor;
+- freshness deadline;
+- unavailable or mismatched exact snapshot;
+- incompatible cursor freshness after proof mismatch; and
+- unsupported authoritative-head capability.
+
+Safe cache misses:
+
+- provider failure;
+- malformed, unauthenticated, old-format, future-history, or mismatched entry;
+- missing or incomplete dependency proof;
+- proof mismatch; and
+- non-deterministic/unfingerprinted adapter configuration.
+
+A cache miss evaluates on the already selected immutable snapshot. An exact or
+freshness failure never falls back to another snapshot.
+
+### 10. Make the correctness argument executable
+
+The implementation is not accepted solely because example tests pass. The
+shared suite includes:
+
+- a small reference authorization model using full-content proofs;
+- generated schemas including unions, arrows, nested permissions, recursion,
+  cycles, missing entities, and positive/negative answers;
+- generated interleavings of unrelated and relevant mutations;
+- clone, restore/reset, same-transaction-number divergence, Datahike branch,
+  force-head, and commit-GC state transitions;
+- cache poisoning, stale pointer, future candidate, wrong DB/branch, key
+  rotation, malformed/deep token, and provider race faults;
+- cursor mutations before/after the boundary and proof-equivalent continuation;
+- differential comparison of every cached answer with uncached evaluation on
+  the selected snapshot; and
+- capability-matrix tests proving unsupported configurations fail before
+  evaluation.
+
+For every generated trace, the oracle property is:
+
+```text
+returned authorization result
+= uncached deterministic result on the response token's selected graph
+```
+
+For cursor traces, concatenated pages must equal the ordered result set of
+either the original exact graph or a graph with an equal complete dependency
+proof.
+
+## Risks / Trade-offs
+
+- [Mutation journal grows] → Give tokens an authenticated maximum lifetime and
+  retain journal anchors for at least that window. Infinite token validity
+  explicitly means infinite anchor retention.
+- [Custom writer omits v3 metadata] → Fast proofs require explicit coherence
+  authority; otherwise use content proof or no completed-answer cache.
+- [Dependency analysis omits a possible relation] → Use a static schema closure,
+  fail closed on empty/unknown closure, compare against the full-content oracle,
+  and mutation-test positive and negative recursive cases.
+- [Datomic fully-consistent synchronization blocks] → Use zero-argument
+  `d/sync` with a mandatory timeout and typed failure.
+- [Datahike reader is a lagging replica] → Do not advertise authoritative-head
+  consistency without a writer/store barrier; at-least remains bounded by a
+  known mutation anchor.
+- [Datahike commit is collected] → Continue on an equal dependency proof or
+  return snapshot-expired; never substitute a changed graph.
+- [DataScript connection is reset] → Causal-anchor membership detects
+  pre-token/divergent state; exact handles still expire when their registry
+  evicts the value.
+- [Shared cache is malicious or corrupt] → Authenticate entries and embed the
+  complete key; provider failure becomes a miss.
+- [Cryptographic collision/key compromise] → Use standard 256-bit primitives,
+  domain-separated derived keys, rotation, strict key handling, and treat key
+  compromise as scope compromise.
+- [Object codec or adapter reads mutable external state] → Include an explicit
+  deterministic configuration and identity-boundary dependency proof, or
+  declare identities immutable; otherwise disable caching, causal read tokens,
+  and proof-equivalent continuation.
+- [Clock skew affects expiry] → Expiry can reject early, but a token is never
+  accepted without its causal anchor. Retention cleanup uses a conservative
+  grace interval.
+
+## Migration Plan
+
+1. Introduce adapter version 3, causal-dominance operations, shared
+   token/cursor/cache cryptography, and typed errors.
+2. Install graph-head metadata, append-only mutation journal, schema mutation
+   id, and per-relation mutation-id attributes. Initialize them atomically with
+   a migration mutation.
+3. Update every managed schema/relationship/delete helper to generate one
+   mutation id and publish journal, head, and dependency identities in the same
+   transaction.
+4. Default existing/custom integrations to full-content proof or no-cache.
+   Enable fast mutation proofs only after their writer authority is explicitly
+   configured and contract-tested.
+5. Replace DataScript/Datahike listener tokens and old Datomic token payloads
+   with v3 causal tokens minted from committed `db-after`.
+6. Add Datomic zero-argument sync for fully consistent reads, Datahike
+   authoritative-head capability detection, and DataScript connection-lineage
+   selection.
+7. Deploy graph-equivalent encrypted cursors. Reject old unauthenticated
+   portable cursor and decimal token formats.
+8. Run the generated reference-model suite, backend conformance suite, nREPL
+   regression suite, and fault-injection cases before enabling fast proofs.
+
+No cache/token downgrade or dual-format mode is provided. Version-3 tokens,
+cursors, and completed-answer entries are the only supported secure formats.
+
+## Open Questions
+
+- What finite default token lifetime balances durable causal workflows against
+  mutation-journal retention?
+- Which Datahike writer/replication configurations can expose a verified
+  authoritative-head barrier, beyond direct shared-store branch reads?
+- Should the optional DataScript exact-snapshot registry be client-local or an
+  injectable bounded service?
+- Is cache-entry authentication mandatory for every provider or only providers
+  not explicitly declared process-trusted? The safest default is mandatory.

--- a/openspec/changes/redesign-cross-backend-freshness-cache/proposal.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/proposal.md
@@ -1,0 +1,103 @@
+## Why
+
+EACL currently has two incompatible cache/consistency designs: Datomic uses
+database-visible per-relation transaction stamps and authenticated basis tokens,
+while DataScript and Datahike use exact-content proofs but return
+connection-local listener counters that cannot express cross-connection
+freshness. A global database basis alone cannot prove whether a cached answer's
+authorization dependencies changed, so EACL needs one model that separates
+revision selection from dependency validation and supports
+`:at-least-as-fresh` correctly on every backend.
+
+## What Changes
+
+- Define a backend-neutral causal token and snapshot-selection contract that
+  binds tokens to a backend/source scope, an append-only EACL mutation anchor,
+  and an exact backend locator where available. Numeric transaction positions
+  are wait hints, not standalone lineage proofs.
+- Support `:at-least-as-fresh` for Datomic, Datahike, and DataScript by selecting
+  one immutable snapshot at or beyond the requested revision before cache proof
+  validation or authorization execution.
+- Replace DataScript and Datahike listener-counter write tokens with tokens
+  derived from the committed transaction report's `db-after` snapshot.
+- Remove listener counters from cache correctness. Keep only optional,
+  explicitly non-authoritative listeners where a backend can demonstrate a
+  local performance benefit.
+- Standardize database-visible, cryptographically random schema and per-relation
+  mutation identities so a cached answer survives unrelated transactions but
+  misses after any relevant relationship or schema mutation, even across
+  cloned, restored, reset, or force-moved histories that reuse transaction
+  numbers.
+- Add an append-only EACL mutation journal. A token's causal floor is satisfied
+  only when the selected snapshot contains its authenticated mutation anchor;
+  basis `t` and `:max-tx` are bounded-wait accelerators.
+- Make cache entries record both the snapshot at which the answer was computed
+  and the snapshot at which its dependency proof was most recently validated.
+- Add backend-specific bounded freshness waits: `d/sync` for Datomic,
+  branch-head refresh/polling for distributed Datahike readers, and monotonic
+  connection checks for DataScript.
+- Use Datahike's stable store identity, branch, mutation anchor, commit id, and
+  parent graph for causal and exact selection. Treat `:max-tx` only as a polling
+  hint because branch creation and `force-branch!` make it non-global. Use
+  `commit-as-db` when the commit graph retains the snapshot, with temporal
+  `as-of` as a capability-gated fallback.
+- Define stable pagination by graph equivalence: a cursor may continue on a
+  newer snapshot only when its authenticated complete dependency proof matches.
+  If the proof changed, EACL reconstructs the exact original snapshot or fails
+  with a typed stale/snapshot-expired error.
+- Add shared authenticated token, cursor, and authorization-cache-entry formats
+  with domain-separated keys, key ids, key rotation, canonical serialization,
+  and bounded decoding. Cursor confidentiality remains capability-gated so
+  Datomic can preserve encrypted pagination without imposing asynchronous
+  WebCrypto on synchronous ClojureScript APIs. The existing portable cursor is
+  only base64-encoded and is not a correctness boundary.
+- **BREAKING** Replace the unrecoverable DataScript/Datahike decimal
+  `:zed/token` listener counters with versioned, database-bound opaque tokens.
+- **BREAKING** Require custom and out-of-band relationship writers that opt
+  into fast mutation-identity proofs to publish the mutation journal and every
+  affected dependency identity atomically. Otherwise EACL uses a full-content
+  proof or disables completed-answer caching; it never silently assumes writer
+  compliance.
+- **BREAKING** Require every authorization-relevant writer, including mutable
+  object-identity or caveat data read by custom adapters, to publish mutation
+  anchors before the source can issue causal read tokens or advertise
+  `:at-least-as-fresh`. Full-content proof can protect a cache lookup but cannot
+  manufacture causal ordering for an unjournaled write.
+
+## Capabilities
+
+### New Capabilities
+
+- `cross-backend-revision-consistency`: Revision tokens, immutable snapshot
+  selection, bounded freshness waits, and backend-specific exact-snapshot
+  capabilities.
+- `dependency-validated-authorization-cache`: Cache entry proofs, per-relation
+  invalidation, proof lifting across unrelated transactions, failure behavior,
+  and managed-mutation requirements.
+- `snapshot-stable-pagination`: Cursor snapshot binding, continuation behavior,
+  historical reconstruction, and explicit expiry for backends without a
+  reconstructable snapshot.
+
+### Modified Capabilities
+
+- `modular-backend-workspace`: Extend the v8 adapter contract with logical
+  database identity, revision comparison, token codec, freshness selection, and
+  optional exact-snapshot operations while keeping algorithms backend-neutral.
+
+## Impact
+
+- Affects `eacl.backend.v8`, `eacl.cache`, consistency descriptors, cursor
+  envelopes, all three backend adapters, all three public client modules,
+  relationship/schema transaction helpers, cache entry formats, tests,
+  documentation, and migration guidance.
+- Adds database metadata/schema attributes for mutation anchors, global graph
+  head, schema mutation identity, and relation mutation identities. Journal
+  retention is tied to the maximum token lifetime.
+- Reuses Datomic's current HMAC token and transaction-stamp foundations but
+  moves common policy and cache semantics into `eacl`.
+- Requires capability-gated authoritative-head selection, including zero-arg
+  `d/sync` for Datomic `:fully-consistent`, Datahike authoritative branch-head
+  access, and exact reconstruction/expiry behavior.
+- Invalidates existing DataScript/Datahike tokens and completed-answer cache
+  entries through explicit format-version changes; authorization data itself
+  remains compatible.

--- a/openspec/changes/redesign-cross-backend-freshness-cache/specs/cross-backend-revision-consistency/spec.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/specs/cross-backend-revision-consistency/spec.md
@@ -1,0 +1,174 @@
+## ADDED Requirements
+
+### Requirement: Authenticated causal revision tokens
+EACL SHALL encode every revision token as an opaque, versioned, authenticated envelope bound to one backend source scope and containing a retained EACL graph mutation anchor. A token MAY also contain a backend order hint and exact snapshot locator. EACL MUST reject tampered, expired, cross-source, cross-branch, and unknown-version tokens before authorization or cache access.
+
+#### Scenario: Managed write returns a causal token
+- **WHEN** a managed EACL graph write commits
+- **THEN** its response token contains the mutation id committed atomically with the write
+- **AND** derives its order hint and exact locator from committed `db-after`
+
+#### Scenario: Token is replayed against another source
+- **WHEN** a valid token is presented to an incompatible backend, native database/store identity, or scoped branch
+- **THEN** EACL rejects it with a typed token-scope error
+
+#### Scenario: Token authentication fails
+- **WHEN** any authenticated token field is modified
+- **THEN** EACL rejects the token without selecting a snapshot or consulting the completed-answer cache
+
+### Requirement: At-least freshness requires causal dominance
+For `:at-least-as-fresh`, EACL SHALL select exactly one immutable snapshot that contains the authenticated token's retained graph mutation anchor. A numeric basis, `:max-tx`, commit timestamp, database id, or branch name MUST NOT establish freshness without the causal postcondition.
+
+#### Scenario: Selected snapshot contains the anchor
+- **WHEN** a same-scope snapshot contains the token mutation anchor
+- **THEN** EACL may use that snapshot for dependency validation or authorization
+- **AND** returns a token for the selected snapshot's graph head
+
+#### Scenario: Numeric position is newer but history diverged
+- **WHEN** a snapshot's order hint is greater than or equal to the token hint but the token mutation anchor is absent
+- **THEN** EACL returns a typed history-diverged or token-expired error
+- **AND** MUST NOT evaluate as though the freshness floor were satisfied
+
+#### Scenario: Source is initially behind
+- **WHEN** the first observed snapshot lacks the token anchor and the backend can refresh or wait
+- **THEN** EACL waits within the configured deadline and rechecks anchor membership on each candidate complete snapshot
+
+#### Scenario: Freshness deadline expires
+- **WHEN** no qualifying snapshot is selected before the deadline
+- **THEN** EACL returns `:eacl.consistency/freshness-unavailable`
+- **AND** includes safe requested/observed diagnostic data
+
+### Requirement: Mutation anchors have bounded retention
+EACL SHALL authenticate token expiry and MUST retain mutation anchors for at least the maximum accepted token lifetime plus a conservative cleanup grace interval. A deployment supporting non-expiring tokens SHALL retain their anchors indefinitely.
+
+#### Scenario: Anchor is within token lifetime
+- **WHEN** an unexpired token is valid for the source scope
+- **THEN** the source retains enough mutation-journal state to test causal dominance
+
+#### Scenario: Anchor retention has ended
+- **WHEN** a token or its retained anchor is outside the supported lifetime
+- **THEN** EACL returns a typed token-expired error rather than numeric fallback
+
+### Requirement: Causal modes require complete writer authority
+EACL SHALL issue read tokens representing selected authorization state and advertise `:at-least-as-fresh` only when every writer of schema, relationships, mutable identity mappings, caveat inputs, and custom adapter data that can affect authorization publishes an atomic mutation anchor. Full-content proof MUST NOT be treated as a replacement for missing causal history.
+
+#### Scenario: All authorization writers participate
+- **WHEN** every authorization-relevant mutation path publishes the v3 journal/head/dependency metadata atomically
+- **THEN** EACL may issue causal read/write tokens and advertise at-least selection
+
+#### Scenario: Raw authorization writer is possible
+- **WHEN** an in-scope writer can change authorization-relevant data without publishing a mutation anchor
+- **THEN** EACL MAY use full-content proof for current-snapshot cache safety
+- **AND** MUST NOT issue a token claiming that unjournaled state or advertise causal at-least semantics for that source
+
+#### Scenario: Mutable object identity participates
+- **WHEN** object-id mapping data can change the meaning or ordering of authorization results
+- **THEN** those writes advance the graph mutation journal and relevant identity proof
+
+### Requirement: Consistency modes select one immutable snapshot
+Consistency selection SHALL complete before cross-revision cache validation or authorization. Every engine operation, dependency read, proof read, cursor operation, and response token for one request MUST use the selected immutable snapshot.
+
+#### Scenario: Concurrent commit follows selection
+- **WHEN** another transaction commits after snapshot selection
+- **THEN** the in-flight request remains on its selected immutable value
+
+#### Scenario: Minimize latency
+- **WHEN** a caller requests `:minimize-latency`
+- **THEN** the adapter selects an already available complete local snapshot without an authoritative-head wait
+- **AND** the completed-answer cache is validated on that snapshot
+
+#### Scenario: Exact snapshot
+- **WHEN** a caller requests `:at-exact-snapshot`
+- **THEN** EACL loads only the token's exact locator and verifies its source scope and graph-head identity
+- **AND** returns snapshot-expired if that exact value is unavailable
+
+### Requirement: Fully consistent requires an authoritative selection barrier
+For `:fully-consistent`, EACL SHALL select a snapshot containing every graph mutation complete at the backend's authoritative barrier when selection began. An adapter lacking such a barrier MUST NOT advertise this capability.
+
+#### Scenario: Datomic fully consistent selection
+- **WHEN** a Datomic caller requests `:fully-consistent`
+- **THEN** EACL uses bounded zero-argument `d/sync`
+- **AND** evaluates on the database value returned by that synchronization
+
+#### Scenario: Datahike source is a lagging replica
+- **WHEN** a Datahike source can expose only its latest locally replicated value and no writer/store head barrier
+- **THEN** it advertises latest-observed/minimize-latency behavior
+- **AND** rejects `:fully-consistent` as unsupported
+
+#### Scenario: DataScript connection head
+- **WHEN** a DataScript caller requests `:fully-consistent`
+- **THEN** EACL selects the current immutable value of the serialized local connection
+
+### Requirement: Datomic causal selection
+The Datomic adapter SHALL use native database identity for source scope, basis `t` as an order hint and exact locator, and the EACL mutation journal as the causal postcondition. Managed writes MUST mint tokens from the committed transaction report.
+
+#### Scenario: Datomic catches up to a write
+- **WHEN** the local Peer basis is below a same-source token hint
+- **THEN** EACL uses bounded two-argument `d/sync`
+- **AND** verifies that the resulting database contains the token mutation anchor
+
+#### Scenario: Datomic restore reuses transaction positions
+- **WHEN** a restored/divergent database later reaches a numeric basis at or above an old token but lacks its mutation id
+- **THEN** EACL rejects the old token for that history
+
+#### Scenario: Datomic exact snapshot is available
+- **WHEN** a valid exact token names a retained Datomic basis
+- **THEN** EACL selects `d/as-of` at that basis and verifies the expected graph head
+
+### Requirement: Datahike causal selection
+The Datahike adapter SHALL scope tokens by stable store identity and configured branch, use mutation-anchor membership for causal freshness, and use commit id as an exact locator when available. It MUST treat `:max-tx` only as an order/polling hint.
+
+#### Scenario: Datahike branch head advances normally
+- **WHEN** a reader refreshes to a branch head containing the token mutation id
+- **THEN** that immutable database satisfies the at-least floor
+
+#### Scenario: Datahike branch is force-moved
+- **WHEN** `force-branch!` publishes a head whose `:max-tx` is equal to or newer than a token hint but whose graph lacks the token mutation anchor
+- **THEN** EACL rejects that head as not causally fresh enough
+
+#### Scenario: Datahike commit is retained
+- **WHEN** an exact token's commit id is retained
+- **THEN** the adapter loads it with `commit-as-db` and verifies source and graph identity
+
+#### Scenario: Datahike commit is unavailable
+- **WHEN** commit reconstruction and capability-gated temporal fallback cannot recover the exact value
+- **THEN** EACL returns `:eacl.consistency/snapshot-expired`
+
+### Requirement: DataScript causal selection
+The DataScript adapter SHALL use a durable random causal-family id for source scope, mutation-anchor membership as its causal postcondition, and immutable DB `:max-tx` only as an order hint. It MUST NOT infer common history from equal family ids or transaction numbers.
+
+#### Scenario: DataScript connection contains the anchor
+- **WHEN** the current immutable DB contains the token's mutation id
+- **THEN** EACL may select it even when later unrelated transactions advanced `:max-tx`
+
+#### Scenario: DataScript process restarts
+- **WHEN** a restored connection has the token's durable causal-family id and contains its mutation anchor
+- **THEN** the token remains valid across the process/connection restart
+
+#### Scenario: DataScript clone predates token
+- **WHEN** a cloned DB copied the family id before the token mutation
+- **THEN** the missing anchor prevents that clone from satisfying the token
+
+#### Scenario: DataScript reset creates a numeric collision
+- **WHEN** `reset-conn!` installs a divergent DB with the same or greater `:max-tx` but without the token anchor
+- **THEN** EACL returns history-diverged or freshness-unavailable
+
+#### Scenario: DataScript cannot catch up
+- **WHEN** the supplied connection does not acquire the required mutation anchor before the deadline
+- **THEN** EACL returns `:eacl.consistency/freshness-unavailable`
+- **AND** does not claim a replication mechanism
+
+#### Scenario: DataScript exact value is not retained
+- **WHEN** neither the current DB nor the bounded immutable snapshot registry contains an exact token handle
+- **THEN** EACL returns snapshot-expired regardless of numeric `:max-tx` equality
+
+### Requirement: Capability claims are configuration-specific
+Every adapter SHALL advertise only consistency, authoritative-head, causal-wait, and exact-reconstruction guarantees supported by its configured source. Unsupported guarantees MUST fail before authorization execution with `:eacl/unsupported-capability`.
+
+#### Scenario: Cross-backend at-least conformance
+- **WHEN** the shared contract presents a token to Datomic, Datahike, or DataScript
+- **THEN** the backend either selects a same-scope snapshot containing the token anchor or returns the specified typed failure
+
+#### Scenario: Backend order hint collides
+- **WHEN** a generated clone, restore, reset, branch, or force-head trace reuses an order hint for different contents
+- **THEN** no adapter accepts equality or numeric ordering as a substitute for mutation-anchor membership

--- a/openspec/changes/redesign-cross-backend-freshness-cache/specs/dependency-validated-authorization-cache/spec.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/specs/dependency-validated-authorization-cache/spec.md
@@ -1,0 +1,206 @@
+## ADDED Requirements
+
+### Requirement: Cache validation follows consistency selection
+EACL SHALL select one immutable snapshot satisfying the request before cross-revision cache validation. Query internalization, dependency discovery, schema proof, relationship proof, authorization evaluation, result externalization, and response-token issuance MUST use that selected snapshot or explicitly fingerprint any deterministic boundary transformation.
+
+#### Scenario: At-least request finds an old candidate
+- **WHEN** a candidate was computed before the requested causal floor
+- **THEN** EACL first selects a snapshot containing the floor mutation
+- **AND** validates the candidate's complete proof on that snapshot
+
+#### Scenario: Snapshot advances during lookup
+- **WHEN** another transaction commits after selection
+- **THEN** every read for the in-flight request remains on the selected immutable value
+
+### Requirement: Cache lifting is forward-only
+EACL SHALL return a cross-revision candidate only when the selected snapshot contains the candidate's computation mutation anchor and the complete proofs match. Numeric ordering or proof equality alone MUST NOT lift an answer backward from a future or sibling history.
+
+#### Scenario: Candidate causally precedes selected snapshot
+- **WHEN** the selected snapshot contains the candidate computation anchor and has an equal complete dependency proof
+- **THEN** EACL may proof-lift the answer
+
+#### Scenario: Candidate is from a future sibling
+- **WHEN** a shared cache returns a candidate whose computation anchor is absent from the selected snapshot
+- **THEN** EACL treats it as a miss even if numeric revisions and dependency proof values compare equal
+
+#### Scenario: Validation telemetry is reused
+- **WHEN** an entry records a prior `validated-at` value newer than its computation point
+- **THEN** a later cross-revision request still validates the selected snapshot proof
+- **AND** MUST NOT treat `validated-at` as a lease
+
+### Requirement: Mutation identities do not collide with transaction positions
+Every managed EACL graph mutation SHALL generate a cryptographically random mutation id and atomically publish the append-only mutation record, graph head, schema identity when applicable, and all affected relation identities. Cache proof equality SHALL use mutation identity or full content, never a transaction number alone.
+
+#### Scenario: Two histories allocate the same transaction number
+- **WHEN** divergent DataScript, Datahike, restored, or cloned histories produce different relation contents at the same transaction position
+- **THEN** their managed relation mutation identities differ
+- **AND** their fast dependency proofs do not compare equal
+
+#### Scenario: One transaction affects multiple relations
+- **WHEN** a relationship or cascade operation changes several relations
+- **THEN** one mutation id may stamp every affected relation atomically
+- **AND** unchanged relations preserve their prior identities
+
+#### Scenario: Schema changes
+- **WHEN** relation or permission definitions change
+- **THEN** the transaction publishes a new schema mutation id and graph head
+- **AND** all entries derived from the old schema proof miss
+
+#### Scenario: Transaction outcome is ambiguous
+- **WHEN** a writer times out after submitting a mutation
+- **THEN** retry/recovery reuses the original mutation id
+- **AND** EACL either recovers the committed journal record or commits the intended mutation exactly once
+
+#### Scenario: Mutation id is reused for different data
+- **WHEN** a transaction attempts to associate an existing mutation id with different canonical mutation data
+- **THEN** the writer rejects it and MUST NOT update graph or dependency heads
+
+### Requirement: Fast proof requires explicit writer authority
+Mutation-identity proof mode SHALL be enabled only when configuration explicitly attests that every authorization schema, relationship, mutable identity, caveat, and custom-dependency writer participates in the v3 atomic mutation protocol. Discovering metadata attributes or receiving listener events MUST NOT imply writer compliance.
+
+#### Scenario: Managed writer authority is configured
+- **WHEN** all in-scope writers use verified EACL transaction-data helpers
+- **THEN** the client may validate using schema and per-relation mutation identities
+
+#### Scenario: Writer authority is unknown
+- **WHEN** custom or out-of-band writers may bypass mutation identities
+- **THEN** EACL uses full-content proof or evaluates without retaining a completed answer
+
+#### Scenario: Listener observes an unstamped write
+- **WHEN** a listener callback observes changed relationship datoms without valid atomic mutation metadata
+- **THEN** that callback cannot retroactively make fast proof mode sound
+
+### Requirement: Full-content proof is the conservative oracle
+EACL SHALL provide a canonical full-content proof over every scoped schema definition and relationship tuple. This proof SHALL be usable as the reference oracle and as a safe runtime mode when mutation-writer authority is unavailable.
+
+#### Scenario: Raw relationship writer changes content
+- **WHEN** a raw writer changes a relevant relationship without publishing mutation identities
+- **THEN** the selected snapshot's full-content proof changes and the candidate misses
+
+#### Scenario: Content changes away and back
+- **WHEN** relevant content returns exactly to its prior canonical state
+- **THEN** full-content proof MAY compare equal because the deterministic answer is again equal
+- **AND** mutation-identity proof remains conservatively different
+
+#### Scenario: Content proof cannot be computed
+- **WHEN** the adapter cannot produce a complete bounded proof
+- **THEN** EACL evaluates without retaining a completed answer
+
+### Requirement: Dependency closure covers possible positive and negative paths
+The relationship dependency scope SHALL be the complete static transitive closure of relation definitions that could affect the semantic request under the selected schema. Runtime short-circuiting, current data absence, denial, recursion, cycles, page boundaries, and observed traversal paths MUST NOT narrow that scope.
+
+#### Scenario: Denied answer gains a relationship
+- **WHEN** a negative answer was cached and a relation on an unvisited alternative path gains a granting tuple
+- **THEN** that relation is present in the candidate dependency scope and invalidates it
+
+#### Scenario: Recursive dependency changes
+- **WHEN** any relation reachable through recursive or cyclic permission definitions changes
+- **THEN** the recursive answer's proof changes
+
+#### Scenario: Dependency closure is unknown or empty
+- **WHEN** EACL cannot establish a complete non-empty closure for a cacheable authorization operation
+- **THEN** it evaluates without completed-answer retention
+
+### Requirement: Derived schema caches are snapshot-scoped
+Schema catalogs, permission paths, recursive dependency closures, and direct-grant memos SHALL be keyed by selected source scope and schema mutation identity or full-content schema proof. Listener counters and client-lifetime latching MUST NOT authorize reuse across a different selected schema.
+
+#### Scenario: Another client changes schema
+- **WHEN** a different connection commits a schema mutation
+- **THEN** the next selected snapshot uses a derived cache keyed by the new schema proof
+- **AND** does not require the local listener to have fired
+
+#### Scenario: Listener clears a memo
+- **WHEN** an adapter retains a listener for eager eviction
+- **THEN** missed, duplicate, or delayed callbacks affect latency only
+
+### Requirement: Semantic cache keys are complete
+The cache lookup key and embedded authenticated entry SHALL distinguish cache/engine/adapter versions, backend source and branch scope, operation, complete canonical internal query, pagination state, result kind, and every recursion, traversal, count, object-codec, caveat, or adapter option capable of changing the answer.
+
+#### Scenario: Two databases share a cache
+- **WHEN** clients for different source scopes use one provider
+- **THEN** their entries cannot collide or validate across scopes
+
+#### Scenario: Engine configuration changes
+- **WHEN** an answer-affecting traversal limit, codec contract, adapter implementation, or algorithm version changes
+- **THEN** the new request cannot reuse the old entry
+
+#### Scenario: Hash collision is attempted
+- **WHEN** two canonical queries have the same compact hash
+- **THEN** embedded full-key equality prevents substitution
+
+### Requirement: Completed entries are authenticated
+Every portable completed-answer entry accepted from a shared or externally writable cache SHALL carry a domain-separated authenticator over its canonical complete key, proof metadata, causal anchors, and value. Authentication failure, unknown key id, malformed fields, or excessive encoded size MUST be a cache miss.
+
+#### Scenario: Provider forges a Boolean grant
+- **WHEN** a provider returns a fabricated `true` value with copied proof fields but no valid entry tag
+- **THEN** EACL rejects it and evaluates on the selected snapshot
+
+#### Scenario: Provider replays a valid old entry
+- **WHEN** a provider replays an authenticated entry
+- **THEN** source scope, computation-anchor dominance, semantic key, and current proof validation still apply
+
+#### Scenario: Cache signing key rotates
+- **WHEN** an entry uses a retained read key id
+- **THEN** EACL may authenticate it during the rotation window
+- **AND** all new entries use the current key id
+
+### Requirement: Authorization intermediates are authenticated or recomputed
+Any recursive continuation, traversal frontier, schema/path materialization, or pointer read from a shared or externally writable provider SHALL be authenticated and completely scoped before it can influence authorization. Missing, evicted, unauthenticated, or malformed intermediates MUST be recomputed from the selected snapshot.
+
+#### Scenario: Provider forges a recursive frontier
+- **WHEN** a provider returns an unauthenticated frontier that would skip part of traversal
+- **THEN** EACL ignores it and reconstructs traversal from the selected snapshot
+
+#### Scenario: Continuation cache is evicted
+- **WHEN** a valid cursor's optional intermediate cache state is absent
+- **THEN** the cursor and selected snapshot contain enough state to recompute continuation correctly
+- **AND** pagination does not silently restart
+
+### Requirement: Cache metadata distinguishes computation and validation
+A cache entry SHALL preserve `computed-at` as its computation causal anchor and exact locator, and MAY update `validated-at` for telemetry after a proof-valid hit. The response token SHALL identify the selected snapshot's graph head, not the computation point.
+
+#### Scenario: Answer lifts across unrelated changes
+- **WHEN** an answer computed at `C` is validated on causally later snapshot `S` with equal proof
+- **THEN** `computed-at` remains `C`, `validated-at` becomes `S`, and the response token identifies `S`
+
+#### Scenario: Older concurrent updater wins a provider race
+- **WHEN** an older request overwrites newer validation telemetry
+- **THEN** correctness remains unchanged because every later cross-revision hit revalidates
+
+### Requirement: Adapter operations are deterministic and dependency-declared
+An adapter eligible for completed-answer caching SHALL make authorization primitives and object-id boundary transformations deterministic for one immutable snapshot. Any external mutable input MUST appear in the semantic/configuration fingerprint and dependency proof; otherwise caching and proof-equivalent cursor continuation are disabled.
+
+#### Scenario: Object codec reads external mutable state
+- **WHEN** an object-id codec can return different values for the same immutable snapshot without a declared dependency
+- **THEN** the adapter is ineligible for completed-answer caching
+
+#### Scenario: Database-backed object identity is mutable
+- **WHEN** public-to-internal identity mappings or result identities can change inside the database
+- **THEN** the semantic key contains canonical public and selected internal query identities
+- **AND** cache validation covers identity proofs for query, result, and ordering objects
+
+#### Scenario: Object identity is declared immutable
+- **WHEN** an adapter enforces immutable public identity for the lifetime of an internal object
+- **THEN** the immutable-identity contract MAY replace per-entry identity proof
+
+#### Scenario: Adapter is snapshot-pure
+- **WHEN** all primitive results are determined by the selected immutable DB and fingerprinted configuration
+- **THEN** equal complete dependency proofs may establish observational equivalence
+
+### Requirement: Historical exact entries do not use current-only proof shortcuts
+Exact-snapshot reads SHALL bind cache entries to the verified exact locator and source graph identity. EACL MUST NOT validate historical entries by reading current-only or no-history stamps through an historical view.
+
+#### Scenario: Historical no-history stamp is unavailable
+- **WHEN** an exact historical DB cannot expose a superseded current-only stamp
+- **THEN** EACL uses exact identity plus historical content/mutation state or bypasses completed-answer caching
+
+### Requirement: Cache failures degrade only to selected-snapshot evaluation
+Provider errors, malformed entries, absent proofs, and proof-computation failures SHALL become misses and fall back to uncached evaluation on the selected snapshot. Token, causal freshness, source-scope, and exact-snapshot failures MUST remain request errors.
+
+#### Scenario: Cache provider throws
+- **WHEN** lookup or storage fails
+- **THEN** EACL computes and returns the selected-snapshot answer
+
+#### Scenario: Token anchor is missing
+- **WHEN** consistency selection cannot prove the requested mutation is present
+- **THEN** EACL rejects the request and MUST NOT hide the failure behind an uncached current read

--- a/openspec/changes/redesign-cross-backend-freshness-cache/specs/modular-backend-workspace/spec.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/specs/modular-backend-workspace/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Backend-neutral causal snapshot contract
+The core module SHALL extend the adapter contract with operations for source scope, immutable snapshot identity, graph head and mutation-anchor membership, order hints, authoritative/current selection, bounded causal selection, exact location, optional exact reconstruction, schema proof, and relation proof. Storage-specific APIs and objects MUST remain inside adapter modules.
+
+#### Scenario: Shared consistency orchestration
+- **WHEN** a Datomic, Datahike, or DataScript client receives a normalized consistency descriptor
+- **THEN** shared code performs token validation, capability checks, snapshot-selection orchestration, causal postcondition validation, cache ordering, and typed-error normalization through adapter operations
+
+#### Scenario: Engine receives one immutable adapter
+- **WHEN** selection succeeds
+- **THEN** shared authorization code receives an adapter bound to exactly that immutable snapshot
+- **AND** cannot accidentally dereference a later connection value during evaluation
+
+#### Scenario: Order relation is partial
+- **WHEN** a backend such as Datahike exposes branching or force-moved histories
+- **THEN** the contract uses causal dominance/anchor membership rather than requiring one numeric total order
+
+### Requirement: Existing engine primitive compatibility is capability-limited
+The six map-based engine primitives `cache-stamp`, `relation-defs`, `permission-defs`, `subject->resources`, `resource->subjects`, and `direct-match?` SHALL remain available to legacy third-party adapters. A legacy adapter without causal snapshot and complete proof operations SHALL be limited to uncached operation on an explicitly supplied immutable snapshot and MUST NOT advertise version-3 tokens, proof lifting, or proof-equivalent cursors.
+
+#### Scenario: Legacy immutable adapter is used
+- **WHEN** a third-party adapter implements only the existing engine SPI
+- **THEN** the shared engine may evaluate directly on its supplied snapshot
+
+#### Scenario: Legacy adapter requests a new guarantee
+- **WHEN** a legacy adapter requests causal freshness, completed-answer lifting, authoritative-head selection, or graph-equivalent continuation
+- **THEN** EACL returns `:eacl/unsupported-capability` before evaluation
+
+### Requirement: Shared cryptographic format service
+The core module SHALL own versioned, bounded, canonical cryptographic formats for Zed tokens, cursor envelopes, and authorization-affecting cache entries. It SHALL use distinct signing/encryption domains and derived keys, key ids, rotation keyrings, strict field allowlists, constant-time authentication checks, and exact portable numeric representations. Cursor authentication is mandatory; cursor confidentiality SHALL be an independently advertised capability.
+
+#### Scenario: Portable cursor is created
+- **WHEN** Datahike or DataScript emits a cursor
+- **THEN** shared authentication protects its scope, stable position, and dependency proof
+- **AND** the cursor contains no unserializable backend object
+
+#### Scenario: Datomic encrypted cursor is created
+- **WHEN** the Datomic adapter advertises confidential cursors
+- **THEN** it uses authenticated encryption in addition to mandatory authenticity
+
+#### Scenario: Synchronous browser client has no synchronous AEAD
+- **WHEN** DataScript runs behind a synchronous ClojureScript API without compatible synchronous encryption
+- **THEN** it may emit an authenticated non-confidential cursor using stable external identities/digests
+- **AND** MUST NOT advertise cursor confidentiality
+
+#### Scenario: Cache entry is read from a shared provider
+- **WHEN** a provider returns a completed authorization value
+- **THEN** shared code authenticates the embedded complete key, causal metadata, proof, and value before considering it
+
+#### Scenario: Decoder receives hostile input
+- **WHEN** a token exceeds size/depth limits, contains unknown fields, has an unsupported numeric representation, or fails authentication
+- **THEN** decoding fails with a bounded typed error
+
+### Requirement: Shared conformance and reference-model suite
+The core module SHALL provide a backend contract suite and deterministic full-content reference model covering causal tokens, source scope, authoritative selection, dependency completeness, proof lifting, cursor continuation, exact expiry, and cache integrity. Every bundled adapter MUST run applicable scenarios with real backend transaction and snapshot APIs.
+
+#### Scenario: Bundled backend validation
+- **WHEN** the non-benchmark module suite runs
+- **THEN** Datomic, Datahike, and DataScript pass all shared guarantees they advertise
+- **AND** unsupported configuration variants fail before authorization
+
+#### Scenario: Generated divergence trace
+- **WHEN** a generated trace clones, restores, resets, branches, force-moves, or reuses transaction numbers for different content
+- **THEN** no bundled adapter accepts numeric equality as causal or dependency equality
+
+#### Scenario: Differential cache oracle
+- **WHEN** any generated cached request returns a result
+- **THEN** it equals uncached deterministic evaluation on the graph identified by the response token
+
+#### Scenario: Differential cursor oracle
+- **WHEN** generated mutations occur between pages
+- **THEN** concatenated pages equal enumeration of the original exact graph or a graph with an equal complete dependency proof
+
+### Requirement: Portable cache and query scopes include configuration identity
+The core contract SHALL require deterministic fingerprints for adapter implementation, object-id codecs, recursion/traversal limits, caveat configuration, and every option capable of changing authorization or ordering. Mutable identity, caveat, and adapter data SHALL additionally provide snapshot dependency proofs; a function/configuration fingerprint alone is insufficient. A backend unable to provide complete stable fingerprints and proofs MUST disable completed-answer caching and graph-equivalent cursors.
+
+#### Scenario: Adapter configuration changes
+- **WHEN** two clients share a cache but use different answer-affecting configurations
+- **THEN** their semantic keys and cursor scopes cannot validate against each other
+
+#### Scenario: Adapter reads undeclared mutable state
+- **WHEN** a primitive or codec depends on external mutable state absent from the fingerprint/proof
+- **THEN** adapter validation rejects the cache/cursor capability claim
+
+### Requirement: Old portable formats fail closed
+The core module SHALL reject pre-change listener-counter tokens, unauthenticated base64 cursors, and cache entries lacking causal, proof, complete-key, or authentication fields.
+
+#### Scenario: Decimal listener token is supplied
+- **WHEN** a caller supplies an old DataScript or Datahike listener counter
+- **THEN** EACL returns a typed unsupported-token-version error
+
+#### Scenario: Old cursor is supplied
+- **WHEN** a caller supplies an unauthenticated portable cursor
+- **THEN** EACL rejects it as unsupported/invalid and requires pagination restart
+
+#### Scenario: Old cache entry is returned
+- **WHEN** a provider returns a prior entry format
+- **THEN** EACL treats it as a miss and never interprets missing security fields

--- a/openspec/changes/redesign-cross-backend-freshness-cache/specs/snapshot-stable-pagination/spec.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/specs/snapshot-stable-pagination/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: First page binds graph and execution identity
+Every paginated lookup SHALL select one immutable snapshot before scanning. Each cursor SHALL bind under mandatory authentication, and optional advertised encryption, the backend source/branch scope, graph mutation anchor, exact locator, canonical query scope, engine/adapter/configuration fingerprints, complete schema/relation/identity dependency scope and proof, deterministic direction/position, format version, and expiry.
+
+#### Scenario: First page uses at-least freshness
+- **WHEN** a first-page request selects a snapshot satisfying an at-least token
+- **THEN** every emitted cursor identifies that selected graph, proof, and stable position
+
+#### Scenario: Cursor is exposed to the caller
+- **WHEN** a portable cursor is serialized
+- **THEN** its scope, stable external/opaque position, and proof metadata are authenticated
+- **AND** base64 encoding alone is not considered protection
+
+#### Scenario: Cursor confidentiality is advertised
+- **WHEN** an adapter/runtime advertises confidential cursors
+- **THEN** the cursor uses authenticated encryption and exposes no plaintext proof or position
+
+#### Scenario: Query or configuration changes
+- **WHEN** a cursor is presented with a different operation, query scope, direction, engine version, codec, or answer-affecting configuration
+- **THEN** EACL rejects it as an invalid cursor
+
+#### Scenario: Dependency proof is too large
+- **WHEN** a complete dependency proof map would exceed the cursor size bound
+- **THEN** the cursor carries a domain-separated digest and rederives the complete closure on continuation
+- **AND** MUST NOT truncate the dependency set
+
+#### Scenario: Complete proof cannot be recomputed
+- **WHEN** continuation cannot recompute the full proof within configured resource bounds
+- **THEN** graph-equivalent continuation is unavailable
+- **AND** EACL uses exact fallback or returns a typed stale/resource error
+
+### Requirement: Continuation accepts an equal complete dependency proof
+A continuation MAY run on a different immutable snapshot when that snapshot has the same complete schema and relationship dependency proof as the cursor. Equal proof SHALL establish that the deterministically ordered authorization result set and cursor position remain observationally equivalent.
+
+#### Scenario: Unrelated transaction occurs between pages
+- **WHEN** the current selected snapshot differs from page one only in data outside the cursor's complete authorization dependencies
+- **THEN** EACL continues on the current snapshot without historical reconstruction
+- **AND** rebases subsequent cursors to the selected snapshot's graph anchor and proof
+
+#### Scenario: Relevant mutation occurs
+- **WHEN** any schema or relation dependency in the cursor proof changes
+- **THEN** EACL MUST NOT continue on that changed graph using the old position
+
+#### Scenario: Relevant content changes away and back
+- **WHEN** mutation-identity proof records intervening relevant churn even though final tuples match
+- **THEN** continuation conservatively treats the proof as changed
+- **AND** MAY continue only through an available exact snapshot
+
+### Requirement: Exact reconstruction is a fallback
+When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator only if the request does not require a causally newer floor. If exact reconstruction is unavailable, continuation MUST fail rather than use a changed graph.
+
+#### Scenario: Datomic exact fallback
+- **WHEN** a cursor proof changed and its original Datomic basis remains available
+- **THEN** EACL may continue on the verified `d/as-of` value
+
+#### Scenario: Datahike exact fallback
+- **WHEN** a cursor proof changed and its original commit or temporal snapshot remains available
+- **THEN** EACL may continue on the verified exact Datahike DB
+
+#### Scenario: DataScript retained value
+- **WHEN** a cursor proof changed and the original immutable DB remains in the bounded registry
+- **THEN** EACL may continue on that retained DB
+
+#### Scenario: Original snapshot is unavailable
+- **WHEN** the proof changed and no exact mechanism can recover the original value
+- **THEN** EACL returns stale-cursor or snapshot-expired
+- **AND** MUST NOT silently restart or continue on current data
+
+### Requirement: Newer freshness and cursor stability are jointly evaluated
+A continuation carrying an additional `:at-least-as-fresh` token SHALL first select a snapshot satisfying that token and then compare its complete dependency proof with the cursor proof. A newer floor is compatible when the proofs match and incompatible when they differ.
+
+#### Scenario: Newer token but unchanged graph portion
+- **WHEN** the selected snapshot contains the newer token anchor and its cursor dependency proof is equal
+- **THEN** EACL continues on that selected snapshot
+
+#### Scenario: Newer token and changed graph portion
+- **WHEN** every snapshot satisfying the newer floor has a different cursor dependency proof
+- **THEN** EACL returns a typed consistency conflict requiring pagination restart
+- **AND** MUST NOT fall back to the older exact snapshot
+
+### Requirement: Cursor ordering is total and deterministic
+The pagination engine SHALL define a stable total order and complete tie-breaker over results for one proof-equivalent graph. Backend iteration order, hash-map order, or non-unique positions MUST NOT determine continuation.
+
+#### Scenario: Two results share a primary ordering field
+- **WHEN** two authorized results compare equal on the primary field
+- **THEN** the cursor order uses deterministic additional fields to distinguish them
+
+#### Scenario: Backend index iteration differs
+- **WHEN** two adapters enumerate equivalent relationship tuples in different incidental orders
+- **THEN** their shared contract result and continuation order remain canonical
+
+#### Scenario: External object identity changes
+- **WHEN** a result or ordering object's public identity changes between pages
+- **THEN** identity-boundary proof changes and current-snapshot continuation is rejected
+- **AND** the cursor does not reinterpret an old internal position as a different public object
+
+### Requirement: Cursor failures are distinguishable
+EACL SHALL distinguish authentication/scope failure, envelope expiry, missing exact snapshot, changed dependency proof, and incompatible newer freshness.
+
+#### Scenario: Cursor authentication fails
+- **WHEN** encrypted cursor contents, key id, or tag are invalid
+- **THEN** EACL returns `:eacl.pagination/invalid-cursor`
+
+#### Scenario: Cursor lifetime expires
+- **WHEN** the authenticated cursor expiry has elapsed
+- **THEN** EACL returns `:eacl.pagination/expired-cursor`
+
+#### Scenario: Exact storage retention expires
+- **WHEN** a valid changed-proof cursor needs its original snapshot but storage no longer retains it
+- **THEN** EACL returns `:eacl.consistency/snapshot-expired`
+
+#### Scenario: Proof changed without exact fallback
+- **WHEN** a valid cursor's current proof differs and the backend never supported exact history
+- **THEN** EACL returns a typed stale-cursor error
+
+### Requirement: Pagination is differential-tested against an oracle
+The shared suite SHALL compare concatenated cursor pages with a deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof.
+
+#### Scenario: Insert before cursor boundary
+- **WHEN** a relevant result is inserted before continuation
+- **THEN** current-proof continuation is rejected or exact fallback preserves the original enumeration
+
+#### Scenario: Delete after cursor boundary
+- **WHEN** a relevant result is deleted after page one
+- **THEN** current-proof continuation is rejected or exact fallback preserves the original enumeration
+
+#### Scenario: Unrelated mutation
+- **WHEN** arbitrary unrelated schema-external or relation-external data changes
+- **THEN** proof-equivalent continuation yields neither duplicates nor omissions
+
+#### Scenario: Authorization revocation
+- **WHEN** a recursive dependency revokes a result after page one
+- **THEN** EACL never emits a hybrid enumeration spanning the old and new proofs

--- a/openspec/changes/redesign-cross-backend-freshness-cache/tasks.md
+++ b/openspec/changes/redesign-cross-backend-freshness-cache/tasks.md
@@ -1,0 +1,108 @@
+## 1. Executable Correctness Model
+
+- [x] 1.1 Implement a backend-neutral reference authorization evaluator and canonical full-content schema/relation proof oracle for shared tests
+- [x] 1.2 Define generated state-machine commands for graph writes, unrelated writes, schema changes, cache operations, reads, cursor pages, clone/reset/restore, branch/force-head, and retention expiry
+- [x] 1.3 Define the primary differential property that every returned cached result equals uncached evaluation on the response token's selected graph
+- [x] 1.4 Define the cursor property that concatenated pages equal the original exact graph or a graph with an equal complete dependency proof
+- [x] 1.5 Add regression fixtures for equal transaction numbers with different contents, future/sibling cache candidates, missing mutation anchors, and relevant negative-result dependencies
+
+## 2. Shared Cryptographic Formats
+
+- [x] 2.1 Implement portable canonical serialization with explicit field allowlists, size/depth bounds, exact CLJ/CLJS numeric validation, and malformed-input normalization
+- [x] 2.2 Implement domain-separated key derivation and key-id/keyring rotation for Zed-token signing, mandatory cursor authentication, optional cursor encryption, and authorization-cache-entry signing
+- [x] 2.3 Implement the version-3 causal Zed-token envelope with source/branch scope, graph anchor, order hint, exact locator, issue time, and authenticated expiry
+- [x] 2.4 Replace the base64 portable cursor format with versioned authentication, preserve Datomic encrypted cursors, advertise confidentiality separately, and reject unauthenticated legacy cursors
+- [x] 2.5 Implement completed-cache-entry authentication over the canonical complete key, causal metadata, proof, and value
+- [x] 2.6 Add CLJ and CLJS tests for signed and encrypted round-trip where supported, synchronous browser behavior, key rotation, wrong domain/key, tampering, unknown fields, excessive nesting/size, integer-range rejection, and constant-time tag paths
+
+## 3. Mutation Journal and Dependency Identities
+
+- [x] 3.1 Define portable metadata constants and backend schemas for append-only mutation id, graph head id/order, schema mutation id, relation mutation id, and retention metadata
+- [x] 3.2 Implement idempotent migration that atomically creates a migration mutation, graph head, schema identity, and identities for every existing relation
+- [x] 3.3 Implement cryptographically random mutation-id generation and one transaction-data builder that publishes journal/head/schema/relation identities atomically
+- [x] 3.4 Update managed schema writes in all backends to use the v3 mutation builder and mint their token from committed `db-after`
+- [x] 3.5 Update relationship create/delete helpers to deduplicate affected relations, publish one mutation identity transactionally, and mint committed causal tokens
+- [x] 3.6 Update object-cascade deletion helpers to stamp every affected relation in the same committed transaction
+- [x] 3.7 Implement token-lifetime-aware mutation-journal retention and conservative grace handling without deleting anchors for any accepted token
+- [x] 3.8 Add tests for no-op/retry/batched writes, multiple affected relations, cross-connection writers, migration races, expired anchors, and graph-head/token agreement
+- [x] 3.9 Extend causal-writer participation to mutable object identity, caveat inputs, and declared custom adapter dependencies, and disable read token issuance when authority is incomplete
+- [x] 3.10 Make mutation ids idempotency keys for ambiguous transaction outcomes and reject reuse with different canonical mutation data
+
+## 4. Adapter Version 3 and Snapshot Selection
+
+- [x] 4.1 Add validated adapter operations/capabilities for source scope, graph head, mutation-anchor membership, order hint, authoritative/current selection, bounded causal selection, exact locator, and optional exact reconstruction
+- [x] 4.2 Limit six-function legacy adapters to uncached explicitly supplied snapshots and reject every unsupported v3 guarantee before evaluation
+- [x] 4.3 Implement shared consistency orchestration that authenticates the request, selects one snapshot, verifies causal/exact postconditions, builds one immutable adapter, and mints the response token
+- [x] 4.4 Define `:fully-consistent` as authoritative-barrier selection, `:minimize-latency` as local complete selection, `:at-least-as-fresh` as causal-anchor dominance, and `:at-exact-snapshot` as verified exact reconstruction
+- [x] 4.5 Add typed errors for unsupported head barrier, token expiry, history divergence, freshness timeout, incomparable scope, unavailable exact snapshot, and cursor consistency conflict
+- [x] 4.6 Add shared capability-matrix tests proving every configuration either meets its postcondition or fails before authorization
+
+## 5. Complete Dependency Proofs
+
+- [x] 5.1 Make the engine compute a static schema-derived transitive relation closure independent of short-circuit paths, current data, positive/negative result, recursion, cycles, or page position
+- [x] 5.2 Implement fast canonical proof maps from schema/relation mutation identities and prohibit transaction-number equality as the proof
+- [x] 5.3 Retain canonical full-content proof as a runtime-safe mode and differential oracle
+- [x] 5.4 Add explicit proof-mode/coherence-authority configuration so unknown custom writers default to content proof or no completed-answer cache
+- [x] 5.5 Key schema catalogs, permission paths, dependency closures, and direct-grant memos by selected source/schema proof instead of listener counts or client-lifetime latching
+- [x] 5.6 Define and validate adapter determinism/configuration fingerprints plus mutable identity/caveat/custom-data dependency proofs
+- [x] 5.7 Add generated mutation tests covering direct, arrow, nested permission, recursive, cyclic, wildcard, forward/reverse lookup, count, positive, and negative dependency completeness
+- [x] 5.8 Include canonical public and selected internal query identities plus result/ordering identity-boundary proofs, or validate an adapter's immutable-identity contract
+
+## 6. Completed-Answer Cache
+
+- [x] 6.1 Version the entry format and full semantic lookup key with source/branch scope, operation, complete internal query, engine/adapter/configuration fingerprints, pagination state, and result kind
+- [x] 6.2 Store authenticated computation anchor/locator, validation telemetry, dependency scope/proof, and portable result value
+- [x] 6.3 Enforce forward-only proof lifting by requiring the selected snapshot to contain the computation anchor before comparing complete proofs
+- [x] 6.4 Revalidate every cross-revision hit and prevent `validated-at` from acting as a lease
+- [x] 6.5 Reject provider-forged values, future/sibling entries, stale/malformed pointers, old formats, scope collisions, and proof/key mismatches as misses
+- [x] 6.6 Make provider/proof failures evaluate uncached on the already selected snapshot while consistency failures remain request errors
+- [x] 6.7 Add monotonic/CAS validation-metadata updates where supported and prove older provider races cannot affect correctness
+- [x] 6.8 Add cache metrics for exact hit, causal proof lift, content proof, mutation proof, proof mismatch, future-history rejection, unauthenticated entry, no-proof bypass, and provider failure
+- [x] 6.9 Authenticate and fully scope shared recursive-continuation, frontier, schema/path, and pointer entries, and make every cache miss recomputable from cursor plus selected snapshot
+
+## 7. Datomic Integration
+
+- [x] 7.1 Adapt native database identity, basis order hints/locators, mutation-anchor lookup, and committed graph-head extraction to adapter v3
+- [x] 7.2 Implement bounded zero-argument `d/sync` for authoritative `:fully-consistent` selection
+- [x] 7.3 Implement bounded two-argument `d/sync` for at-least order waiting followed by mandatory mutation-anchor verification
+- [x] 7.4 Implement verified exact `d/as-of` selection and reject restored/divergent basis collisions whose graph identity does not match
+- [x] 7.5 Migrate existing transaction-ref watermarks to v3 mutation identities while retaining old stamps only for diagnostics/linear-history optimization
+- [x] 7.6 Add Datomic tests for zero-arg head barriers, peer lag, cross-connection writes, restore-style missing anchors, exact identity, relevant/unrelated churn, and timeout paths
+
+## 8. DataScript Integration
+
+- [x] 8.1 Remove listener counters from tokens, freshness, schema correctness, and completed-answer validity
+- [x] 8.2 Implement durable causal-family scope, `:max-tx` order hints, mutation-anchor lookup, committed graph head, and current local selection
+- [x] 8.3 Implement bounded at-least waiting on the supplied connection followed by mandatory anchor verification and no replication claim
+- [x] 8.4 Detect `reset-conn!`/cloned-value numeric collisions through missing anchors and unique dependency identities
+- [x] 8.5 Implement optional bounded exact immutable-DB registry handles and reject numeric equality as exact identity
+- [x] 8.6 Add equivalent CLJ/CLJS tests for process restart, independent same-base divergence, pre/post-token cloning, reset, anchor expiry, listener independence, cache lifting, and exact-registry eviction
+
+## 9. Datahike Integration
+
+- [x] 9.1 Remove listener counters from tokens, freshness, schema correctness, and completed-answer validity
+- [x] 9.2 Implement source scope from stable store identity and branch, `:max-tx` polling hint, mutation-anchor lookup, graph head, commit locator, and parent metadata
+- [x] 9.3 Implement authoritative branch-head capability detection for direct stores and reject fully-consistent on lagging replicated/streaming sources without a barrier
+- [x] 9.4 Implement bounded at-least branch refresh with mutation-anchor postcondition and no reliance on numeric `:max-tx` dominance
+- [x] 9.5 Implement verified `commit-as-db` exact reconstruction, capability-gated temporal fallback, and expiry after commit/anchor collection
+- [x] 9.6 Add tests for normal writer/reader flow, remote/lagging source capability, branch creation, merge, `force-branch!` rewind, equal-max-tx divergence, commit graph on/off, history on/off, and garbage collection
+
+## 10. Proof-Equivalent Pagination
+
+- [x] 10.1 Bind authenticated cursors to source/branch scope, graph anchor, exact locator, complete query/config fingerprints, dependency scope/proof digest, total-order position, and expiry, with optional advertised encryption
+- [x] 10.2 Define and test a backend-neutral stable total result order with complete tie-breakers
+- [x] 10.3 Continue on a newly selected snapshot when its complete dependency proof equals the cursor proof
+- [x] 10.4 Fall back to the verified original exact snapshot only after proof mismatch and only when no newer freshness floor conflicts
+- [x] 10.5 Permit a newer at-least token when its qualifying snapshot proof equals the cursor proof; otherwise return a typed restart conflict
+- [x] 10.6 Distinguish invalid, expired, stale-proof, snapshot-expired, and freshness-conflict cursor failures
+- [x] 10.7 Add generated insert/delete/revoke/unrelated-mutation tests before and after page boundaries and compare concatenated pages with the oracle
+- [x] 10.8 Bound cursor proof size using domain-separated canonical digests, rederive full dependency closure on continuation, and prohibit truncation
+
+## 11. Verification, Performance, and Migration
+
+- [x] 11.1 Run all non-benchmark core, Datomic, Datahike, and DataScript tests through nREPL and resolve failures without weakening advertised postconditions
+- [x] 11.2 Run fault-injection tests for cache corruption/poisoning, malformed tokens, key rotation, provider races, journal expiry, future candidates, writer retries, and backend head movement
+- [x] 11.3 Benchmark mutation-identity proof, full-content proof, global invalidation, and no-cache under unrelated/relevant churn without using performance results to weaken correctness
+- [x] 11.4 Document causal-token lifetime/retention, proof modes, custom-writer authority, authoritative-head configurations, DataScript limitations, and Datahike branch/commit behavior
+- [x] 11.5 Document breaking token/cursor/cache formats, writer-authority requirements, retention, key rotation, failure containment, and operational diagnostics
+- [x] 11.6 Verify isolated module dependencies, CLJ/CLJS portable formats, final capability matrix, strict OpenSpec validation, and the complete reference-model property suite


### PR DESCRIPTION
## Summary

This is a stacked PR on top of #89. Review the diff against `codex/upgrade-datascript-datahike-v8`.

- replaces listener counters and transaction-number cache validity with authenticated v3 mutation anchors and backend-scoped causal tokens
- adds authoritative/current/at-least/exact snapshot selection for Datomic, DataScript, and Datahike
- adds authenticated completed-answer entries with complete dependency proofs and forward-only proof lifting across unrelated writes
- makes portable cursors authenticated and proof-equivalent, with verified exact-snapshot fallback
- adds managed mutation journals plus schema/relation identities across all three backends
- supports safe full-content proofs when writer authority is unknown, including endpoint public-identity boundaries and fixed-size digests over complete proof records
- removes obsolete Datomic v7 cache execution helpers and documents the operational consistency/cache contract

There is intentionally no cache/token downgrade, dual-format, or rollback mechanism. Invalid/old entries are misses, and provider/proof failures recompute uncached on the already selected snapshot as correctness-preserving failure containment.

## Validation

- focused cross-backend JVM regression set at the current head: 44 tests, 529 assertions, 0 failures/errors
- isolated module loading verified for `eacl`, `eacl-datomic`, `eacl-datascript`, and `eacl-datahike`
- strict OpenSpec validation passes; 76/76 implementation tasks complete
- `clj-kondo` reports no errors and only three pre-existing unused test bindings
- `git diff --check` passes

## Proof cost review

Benchmarked against pre-redesign commit `8bf9244` on all three in-memory backends. Managed mutation proof operations stayed at approximately 0.5–2 µs and did not grow after adding 200 unrelated schema definitions or 5,000 unrelated relationships. Completed managed cache hits stayed approximately flat at 1.5–1.7 ms; that floor includes snapshot selection and authenticated token/cache-envelope work, not only backend proof reads.

That fixed cost means proofed caching is not universally faster than no cache. For a cheap one-relation `can?`, managed cache-hit/no-cache medians were 1,625.5/1,580.0 µs on Datomic, 1,810.3/155.3 µs on Datahike, and 1,694.1/202.8 µs on DataScript. Default unknown-writer mode was also slower for the same direct check. The cache became faster only when avoided evaluation exceeded its proof/envelope cost: in a synthetic recursive chain, the measured crossover was around depth 100 for DataScript and depth 200–400 for Datahike; Datomic remained near parity through depth 400. These crossover points are workload- and hardware-specific, not API guarantees.

Unknown-writer content mode is safe but not constant-time. The complete derived-schema generation proof is currently `O(S log S)`; content relationship proofs are currently `O(G + M log M)` because they collect/filter total relationship storage before hashing matching records. The fixed-size digest bounds proof/envelope size, not proof-construction time or total collection/sort memory.

The audit found a separate recursive-schema scalability defect: recursive routing used a closure matrix with an `O(V(V+E))` cold bound and cached it per permission root, so different first-read roots could repeat the work. The implementation now performs iterative SCC and reverse-reachability analysis once for all roots in a schema generation, publishes it through a shared delay, and uses constant-time root lookups afterward. The graph-analysis portion is `O(V+E)` time and memory once adapter permission paths are materialized; path materialization remains additional backend-dependent work. In nine-sample warmed-JVM measurements, a 1,000-node generation had a 73.9 ms cold median and a 0.088 µs warm-root median.

Full methodology, old/new backend comparisons, complexity boundaries, and measurements: `docs/reports/2026-08-02-eacl-v8-cache-proof-cost.md`.
