### PR TITLE
Align Datahike relationship storage with Datomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,12 @@ API (it scans both relationship indexes):
   @(d/transact conn tx-data))
 ```
 
+Datahike uses the same two endpoint tuple datoms and therefore has the same
+deletion contract. Its offline detector is
+`eacl.datahike.integrity/dangling-relationship-report`; repair a reported
+endpoint through `eacl/delete-object!` with its raw eid so the v3 mutation
+journal and cache dependencies are advanced atomically.
+
 ## Schema Syntax
 
 EACL uses the SpiceDB schema DSL. Use `eacl/write-schema!` to define your schema:
@@ -1032,7 +1038,11 @@ Now you can transact relationships. The usual way is `eacl/create-relationships!
   follows that protocol. Mixed or hand-written writers must use the default
   `:unknown` authority, where `:proof-mode :auto` selects complete content
   proofs and detects database-visible changes without listener coordination.
-- *Deleting entities:* `:db.fn/retractEntity` does not remove an entity's relationships. Consumers should delete relationships first; `delete-object!` is a convenience helper, and `eacl.datomic.integrity` provides explicit detection/repair — see [Deleting a permissioned entity](#deleting-a-permissioned-entity).
+- *Deleting entities:* Datomic and Datahike entity retraction does not remove
+  peer relationship tuples. Consumers should delete relationships first;
+  `delete-object!` is a convenience helper, and the backend integrity
+  namespaces provide explicit detection — see
+  [Deleting a permissioned entity](#deleting-a-permissioned-entity).
 - *Recursive cursors benefit from their continuation:* a permission that transitively depends on itself
   (`permission read = reader + parent->read`) is evaluated in traversal order. Sequential cache
   hits resume the traversal and avoid `O(N²/page-size)` enumeration. An evicted, expired, rejected,

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -3,9 +3,11 @@
 The major version increments because v8.0 adds the database-visible v3 mutation
 journal and authenticated causal tokens/cache entries/cursors, and moves the
 DataScript/Datahike ports to the v8 Relay list/count contract. The relationship
-storage model is unchanged (`:eacl/storage-version` stays at 7). Client
-construction performs an idempotent additive migration that creates the graph
-family/head, schema mutation identity, and identities for existing relations.
+storage version stays at 7: Datomic keeps its v7 layout, Datahike now uses that
+same two-tuple physical layout, and DataScript keeps its backend-specific
+entity/composite representation. Client construction performs an idempotent
+additive migration that creates the graph family/head, schema mutation
+identity, and identities for existing relations.
 
 ## Modular artifacts
 
@@ -16,7 +18,9 @@ EACL v8.0 is a workspace with independently consumable modules:
 - `modules/eacl-datomic` contains the complete v8 Datomic implementation.
 - `modules/eacl-datascript` contains the CLJ/CLJS DataScript adapter.
 - `modules/eacl-datahike` contains the CLJ Datahike adapter and supports both
-  keyword and numeric attribute-reference representations.
+  keyword and numeric attribute-reference representations. Its relationship
+  storage now matches Datomic's two cardinality-many heterogeneous endpoint
+  tuples; DataScript retains its entity/composite-index storage adapter.
 
 Existing Datomic namespace imports do not change. Consumers replace the root
 Git dependency with `:deps/root "modules/eacl-datomic"`; this packaging change
@@ -139,8 +143,8 @@ number equality.
   writers must either use the v3 mutation builder or keep
   `:coherence-authority :unknown`.
 - Consumers should call `delete-relationships!` before retracting an entity.
-  `eacl.datomic.integrity/dangling-relationship-report` detects reverse ghost tuples left by an
-  incorrect deletion sequence.
+  The Datomic and Datahike integrity reports detect ghost tuple halves left by
+  an incorrect deletion sequence.
 - Relationship update operations are validated before endpoint resolution. `delete-object!`
   reports actual committed relationship-datom retractions across all batches.
 

--- a/modules/eacl-datahike/PORTING.md
+++ b/modules/eacl-datahike/PORTING.md
@@ -98,7 +98,9 @@ are tested; three consequences are load-bearing.
    resolves the attribute representation where Datahike's `index-range`
    requires it.
 
-MEASURED, both modes: `(:attribute-refs? (:config db))` is the reliable flag.
+MEASURED, both modes: `(:attribute-refs? (dbi/-config db))` is the reliable
+flag. Concrete DB records also expose `:config` directly; temporal/filter
+wrappers do not, and instead delegate `IDB/-config` to their origin database.
 
 ## Composite schema-tuple seek bounds
 

--- a/modules/eacl-datahike/PORTING.md
+++ b/modules/eacl-datahike/PORTING.md
@@ -1,8 +1,10 @@
 # The Datahike backend
 
-A port of `modules/eacl-datascript`. DataScript was the right template rather
-than Datomic, because DataScript and Datahike diverge from Datomic in the *same*
-place — see "Tuple seek bounds" below.
+The first Datahike port was derived from `modules/eacl-datascript`. The v8
+relationship layer now deliberately follows `modules/eacl-datomic`: Datahike
+supports heterogeneous tuples, so it does not need DataScript's relationship
+entity plus derived composite indexes. DataScript keeps that backend-specific
+layout until it gains heterogeneous tuples.
 
 Status: `eacl.datahike.contract-test` runs the shared v8 public API,
 recursive, cache, and independent-oracle contracts **twice**, once per
@@ -14,20 +16,49 @@ asynchronous and the backend SPI is synchronous.
 
 ## Layout
 
-Five namespaces. `eacl.datahike.db` holds the
-adapter primitives — `entid`, attribute representation, and the three index
-accessors — so that everything above it reads like the DataScript source and
-every datahike divergence lives in one file:
+Six namespaces. `eacl.datahike.db` holds entity-id, attribute-representation,
+and index-access primitives so Datahike API spelling and temporal-seek behavior
+stay below the EACL relationship model:
 
 | | |
 |---|---|
-| `db.clj` | adapter primitives (no eacl concepts) |
+| `db.clj` | adapter primitives (no EACL concepts) |
 | `schema.clj` | attribute declarations, `create-conn`, `write-schema!` |
-| `impl.clj` | the legacy SPI compatibility implementation and relationship scans |
+| `impl.clj` | Datomic-layout relationship transactions, scans, and cleanup |
+| `integrity.clj` | explicit offline dangling-half diagnostics |
 | `backend.clj` | the validated v8 snapshot adapter and cache proofs |
 | `core.clj` | `IAuthorization`, v8 Relay/cache integration, and `make-client` |
 
-## What differs from the DataScript source
+## Physical relationship layout
+
+One relationship is exactly two heterogeneous tuple datoms, identical to the
+Datomic Pro adapter:
+
+```clojure
+[subject-eid forward-attr
+ [subject-type relation-eid resource-type resource-eid]]
+
+[resource-eid reverse-attr
+ [resource-type relation-eid subject-type subject-eid]]
+```
+
+Authorization traversal reads the endpoint-local EAVT segment. Global
+relationship listing and relation-in-use checks read AVET tuple ranges. Writes
+add or retract both halves in one Datahike transaction. `:touch` treats a
+half-pair as absent and reasserts both datoms; `:delete` retracts both
+unconditionally.
+
+The layout costs two relationship datoms rather than a relationship entity,
+five component datoms, and five derived tuple datoms. It also has Datomic's
+integrity tradeoff: `:db/retractEntity` does not follow refs inside tuple
+values. Consumers must call EACL relationship deletion first. The explicit
+`eacl.datahike.integrity` report detects surviving peer halves offline.
+
+The old Datahike entity/composite layout existed only on the unreleased v8
+branch. Databases created from that branch must be recreated; the adapter does
+not dual-read or migrate the obsolete physical model.
+
+## What differs from DataScript
 
 | | DataScript | Datahike |
 |---|---|---|
@@ -52,26 +83,24 @@ numeric ref under `:attribute-refs? true` (Datomic's representation). This is a
 creation-time, one-way choice per database. Both modes are supported and both
 are tested; three consequences are load-bearing.
 
-1. A composite tuple attribute under `:attribute-refs?` needs datahike
-   **>= 0.8.1759** (replikativ/datahike#921). Before that fix the tuples were
-   silently never derived and never validated. The adapter's ordered
-   relationship access depends on those tuples, so every permission check
-   denied.
+1. A composite tuple attribute under `:attribute-refs?` needs Datahike
+   **>= 0.8.1759** (replikativ/datahike#921). EACL still uses derived composite
+   tuples for relation and permission definitions. Relationship tuples are
+   explicit heterogeneous values and are not derived.
 
 2. `index-range`'s `:attrid` is the one accessor that does **not** accept the
    attribute keyword in both modes: under `:attribute-refs?` it demands the
    numeric ref and raises. `db/avet-range` resolves it via `db/attr-repr`.
    (`datoms` and `seek-datoms` take the keyword in either mode.)
 
-3. Anything comparing a datom's `:a` against a set of keywords matches nothing
-   under `:attribute-refs?`. In this module that is `core/schema-transaction?`,
-   the tx listener that evicts cached permission paths. Left unresolved it
-   fails **OPEN** — `can?` keeps answering from pre-change permission paths and
-   grants what the schema has just revoked. `db/attr-ident` resolves it.
+3. Anything comparing a datom's `:a` directly against a keyword matches
+   nothing under `:attribute-refs?`. The adapter avoids raw comparisons and
+   resolves the attribute representation where Datahike's `index-range`
+   requires it.
 
 MEASURED, both modes: `(:attribute-refs? (:config db))` is the reliable flag.
 
-## Tuple seek bounds — the one non-obvious ordering fact
+## Composite schema-tuple seek bounds
 
 MEASURED on datahike 0.8.1759, in BOTH modes:
 
@@ -81,28 +110,25 @@ seek [:room :owner nil]    → [:room :owner :party]  ; correct
 seek [:room :owner :party] → [:room :owner :party]  ; correct
 ```
 
-A PARTIAL tuple is not a valid seek bound — identical to DataScript, whose
-adapter comments "DataScript sorts vectors by LENGTH FIRST". Datomic is the
-outlier, and `modules/eacl-datomic` relies on Datomic's behaviour.
+A partial composite tuple is therefore not a reliable seek bound. Datahike
+0.8.1759 also fails to apply an `AsOfDB` wrapper's temporal context to
+`seek-datoms`. `db/seek-tuple-prefix` consequently restricts `datoms` to the
+exact AVET attribute and filters its bounded schema-definition segment by
+prefix. Relation-definition cardinality is bounded by schema size.
 
-So `db/seek-tuple-prefix` pads to full tuple arity with `nil` (`nil` sorts
-lowest) and then takes the matching prefix. Padding is both correct AND
-O(log n) — do not replace it with a scan of the whole attribute segment.
-
-`seek-datoms` also runs off the end of the attribute into the next one, so the
-`take-while` guards on `:a` as well as on the value.
+This issue does not force a DataScript-style relationship model. The hot
+relationship paths use explicit heterogeneous values through endpoint-local
+EAVT scans or full-length AVET range bounds.
 
 ## A coverage trap worth knowing about
 
 The shared contract goes through `make-client`, whose v8 adapter serves
-relation definitions from a prebuilt schema catalog — a full index scan. So
-**the contract suite does not exercise every legacy tuple seek**. The seek is
-also reached by the bare-db v7 compatibility path and by the
-relation-retraction guard, which is why `backend-test` tests it directly.
+relation definitions from a prebuilt schema catalog. So **the contract suite
+does not exercise every schema tuple-prefix path**. The bare-db compatibility
+path does, and `backend-test` covers it directly.
 
-Both mechanisms above were verified non-vacuously by breaking them:
-removing the padding fails 12 assertions in both modes; comparing `:a` raw
-fails exactly 1, only under `:attribute-refs?`.
+The schema-prefix and relationship-storage regressions run in both attribute
+representations so a keyword-only implementation cannot pass silently.
 
 ## Adapter surfaces
 
@@ -117,7 +143,8 @@ this module.
 The public v8 client uses `eacl.datahike.backend/snapshot-adapter`. Its
 validated operation map adds snapshot identity, object ID conversion,
 permission-node discovery, cursor frontier identity, and scoped schema/relation
-proofs. Capabilities explicitly limit Datahike to current
-`:fully-consistent` snapshots and synchronous CLJ cursors. Authorization graph
-compilation, SCC/fixed-point traversal, Relay behavior, and cache validation
-stay in `modules/eacl`.
+proofs. Direct-writer stores support authoritative current selection; retained
+commit graphs or temporal history support exact reconstruction; managed stores
+support causal at-least selection. Authorization graph compilation,
+SCC/fixed-point traversal, Relay behavior, and cache validation stay in
+`modules/eacl`.

--- a/modules/eacl-datahike/PORTING.md
+++ b/modules/eacl-datahike/PORTING.md
@@ -111,14 +111,23 @@ seek [:room :owner :party] → [:room :owner :party]  ; correct
 ```
 
 A partial composite tuple is therefore not a reliable seek bound. Datahike
-0.8.1759 also fails to apply an `AsOfDB` wrapper's temporal context to
-`seek-datoms`. `db/seek-tuple-prefix` consequently restricts `datoms` to the
-exact AVET attribute and filters its bounded schema-definition segment by
-prefix. Relation-definition cardinality is bounded by schema size.
+0.8.1759 does carry an `AsOfDB` wrapper's temporal context into
+`seek-datoms`, but its full-tuple temporal seek can position after a
+historically visible tuple that was retracted later. This was reproduced with
+an exact `(entity, attribute)` `datoms` read returning the old relationship
+while the equivalent lower-bound seek started in a later index segment.
 
-This issue does not force a DataScript-style relationship model. The hot
-relationship paths use explicit heterogeneous values through endpoint-local
-EAVT scans or full-length AVET range bounds.
+Concrete and retained-commit DB values consequently use padded prefix seeks.
+Temporal/filter wrappers use exact attribute- or endpoint-bounded `datoms`
+followed by prefix filtering. Those wrapper reads remain bounded by schema size
+for definitions and by one endpoint for relationships. Attribute guards on the
+seek path resolve the configured representation through Datahike's database
+protocol, which also works when attributes are numeric refs.
+
+The hot relationship paths use explicit heterogeneous values through
+endpoint-local EAVT seeks or full-length AVET range bounds. Every prefix seek
+checks the appropriate entity/attribute index boundary because Datahike seeks
+continue into the next segment when no value matches the requested prefix.
 
 ## A coverage trap worth knowing about
 

--- a/modules/eacl-datahike/README.md
+++ b/modules/eacl-datahike/README.md
@@ -9,12 +9,33 @@ errors through the same backend-neutral engine used by Datomic and DataScript.
 
 Responsibilities:
 
-- Datahike schema installation and relationship transactions
+- Datahike schema installation and Datomic-compatible relationship transactions
 - current immutable-snapshot selection and object/reference conversion
 - ordered adjacency in both keyword and numeric `:attribute-refs?` modes
 - proof-equivalent authenticated Relay cursors with exact fallback
 - database-visible mutation identities plus schema/relation proofs
 - `delete-object!` relationship cleanup
+
+Relationships use the same physical layout as EACL's Datomic Pro adapter. One
+logical relationship is two cardinality-many heterogeneous tuple datoms:
+
+```clojure
+[subject-eid :eacl.v7.relationship/subject-type+relation+resource-type+resource
+ [subject-type relation-eid resource-type resource-eid]]
+
+[resource-eid :eacl.v7.relationship/resource-type+relation+subject-type+subject
+ [resource-type relation-eid subject-type subject-eid]]
+```
+
+This avoids a relationship entity and five derived composite indexes. As with
+Datomic, retracting an endpoint directly can leave its peer tuple behind.
+Consumers must remove relationships through EACL before retracting a
+permissioned entity. `eacl.datahike.integrity/dangling-relationship-report`
+provides an explicit offline audit for violations of that contract.
+
+This replaces the unreleased v8 Datahike relationship-entity layout. Recreate
+pre-release Datahike databases rather than carrying both physical models; no
+rollback or dual-read migration is included.
 
 Datahike supports local `:minimize-latency`, managed causal at-least selection,
 and exact reconstruction from retained commits or temporal history. It

--- a/modules/eacl-datahike/deps.edn
+++ b/modules/eacl-datahike/deps.edn
@@ -3,8 +3,8 @@
         cloudafrica/eacl {:local/root "../eacl"}
         com.rpl/specter {:mvn/version "1.1.4"}
         ;; 0.8.1759 is the first release carrying replikativ/datahike#921. Below it
-        ;; EVERY relation and permission tuple silently fails to derive under
-        ;; :attribute-refs? — and the tuples ARE the v7 engine, so every check denies.
+        ;; relation and permission composite tuples silently fail to derive under
+        ;; :attribute-refs?, making the authorization schema invisible.
         org.replikativ/datahike {:mvn/version "0.8.1759"}}
  :aliases {:build {:extra-paths ["."]
                    :ns-default build

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -153,26 +153,33 @@
 
 (defn- content-relation-proof
   [db relation-ids external-id]
-  (let [wanted (set relation-ids)]
+  (let [wanted (set relation-ids)
+        forward
+        (when (seq wanted)
+          (for [{subject :e value :v}
+                (ddb/avet-datoms
+                 db schema/forward-relationship-attr)
+                :let [[subject-type relation-id
+                       resource-type resource] value]
+                :when (contains? wanted relation-id)]
+            [:forward relation-id
+             subject-type subject (external-id db subject)
+             resource-type resource (external-id db resource)]))
+        reverse
+        (when (seq wanted)
+          (for [{resource :e value :v}
+                (ddb/avet-datoms
+                 db schema/reverse-relationship-attr)
+                :let [[resource-type relation-id
+                       subject-type subject] value]
+                :when (contains? wanted relation-id)]
+            [:reverse relation-id
+             subject-type subject (external-id db subject)
+             resource-type resource (external-id db resource)]))]
     {:content-digest
      (secure/canonical-records-digest
       "eacl/datahike/relationship-content-proof/v3"
-      (->> (d/q '[:find ?relation ?subject-type ?subject
-                  ?resource-type ?resource
-                  :where
-                  [?relationship :eacl.relationship/relation ?relation]
-                  [?relationship :eacl.relationship/subject-type ?subject-type]
-                  [?relationship :eacl.relationship/subject ?subject]
-                  [?relationship :eacl.relationship/resource-type ?resource-type]
-                  [?relationship :eacl.relationship/resource ?resource]]
-                db)
-           (filter #(contains? wanted (nth % 0)))
-           sort
-           (map (fn [[relation subject-type subject
-                      resource-type resource]]
-                  [:relationship relation
-                   subject-type subject (external-id db subject)
-                   resource-type resource (external-id db resource)]))))}))
+      (sort (concat forward reverse)))}))
 
 (defn- mutation-schema-proof
   [db]
@@ -342,11 +349,9 @@
 
        :direct-match?
        (fn [subject-type subject-id relation-id resource-type resource-id]
-         (boolean
-          (ddb/entid
-           db
-           [schema/relationship-full-key-attr
-            [subject-type subject-id relation-id resource-type resource-id]])))
+         (impl/direct-match?
+          db subject-type subject-id relation-id
+          resource-type resource-id))
 
        :all-permission-nodes
        (fn []

--- a/modules/eacl-datahike/src/eacl/datahike/core.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/core.clj
@@ -281,7 +281,10 @@
 
 (defn datahike-write-relationships!
   [conn opts updates]
-  (let [db (d/db conn)
+  (let [updates (vec updates)
+        _ (doseq [{:keys [operation]} updates]
+            (impl/validate-relationship-operation! operation))
+        db (d/db conn)
         internal-updates
         (S/transform [S/ALL :relationship]
                      #(spice-relationship->internal db opts %)
@@ -316,44 +319,58 @@
         (journal/ensure-migrated! conn)
         (write-response (d/db conn) opts)))))
 
+(def ^:private relationship-attrs
+  #{schema/forward-relationship-attr
+    schema/reverse-relationship-attr})
+
+(defn- relationship-retraction-count
+  [db tx-data]
+  (let [attr-reprs
+        (into #{} (map #(ddb/attr-repr db %)) relationship-attrs)]
+    (count
+     (filter
+      (fn [{:keys [a added]}]
+        (and (false? added)
+             (contains? attr-reprs a)))
+      tx-data))))
+
 (defn datahike-delete-object!
-  "Removes every relationship that references `object`, without retracting the
-  object entity itself."
+  "Removes both halves of every relationship touching `object`, without
+   retracting the object entity itself."
   [conn {:keys [object->entid] :as opts} object]
-  (let [db (d/db conn)]
-    (when-let [object-eid (object->entid db object)]
-      (let [relationship-eids
-            (d/q '[:find [?relationship ...]
-                   :in $ ?object
-                   :where
-                   (or [?relationship :eacl.relationship/subject ?object]
-                       [?relationship :eacl.relationship/resource ?object])]
-                 db object-eid)
-            relation-ids
-            (d/q '[:find [?relation ...]
-                   :in $ [?relationship ...]
-                   :where
-                   [?relationship :eacl.relationship/relation ?relation]]
-                 db relationship-eids)]
-        (when (seq relationship-eids)
-          (journal/transact!
-           conn
-           {:mutation-id (mutation/new-id)
-            :kind :object-deletion
-            :canonical-data
-            {:operation :delete-object
-             :object object
-             :relationship-eids (vec (sort relationship-eids))}
-            :relation-ids relation-ids
-            :token-ttl-seconds (:token-ttl-seconds opts)
-            :retention-grace-seconds
-            (:retention-grace-seconds opts)
-            :tx-data
-            (mapv (fn [relationship-eid]
-                    [:db/retractEntity relationship-eid])
-                  relationship-eids)})))))
-  (journal/ensure-migrated! conn)
-  (write-response (d/db conn) opts))
+  (let [db (d/db conn)
+        object-eid
+        (or (try
+              (object->entid db object)
+              (catch Exception _
+                nil))
+            (when (number? (:id object))
+              (:id object)))
+        tx-data (impl/tx-delete-object db object-eid)]
+    (if (seq tx-data)
+      (let [report
+            (journal/transact!
+             conn
+             {:mutation-id (mutation/new-id)
+              :kind :object-deletion
+              :canonical-data
+              {:operation :delete-object
+               :object object
+               :tx-data tx-data}
+              :relation-ids (impl/affected-relation-ids tx-data)
+              :token-ttl-seconds (:token-ttl-seconds opts)
+              :retention-grace-seconds
+              (:retention-grace-seconds opts)
+              :tx-data tx-data})]
+        (assoc (write-response (:db-after report) opts)
+               :retracted-datoms
+               (relationship-retraction-count
+                (:db-after report)
+                (:tx-data report))))
+      (do
+        (journal/ensure-migrated! conn)
+        (assoc (write-response (d/db conn) opts)
+               :retracted-datoms 0)))))
 
 (defn- relationship-seq
   [relationships]

--- a/modules/eacl-datahike/src/eacl/datahike/db.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/db.clj
@@ -25,14 +25,6 @@
                           {:type :eacl/invalid-entity-id
                            :value eid-or-ref}))))
 
-(defn attr-ident
-  "A datom's `:a` as an ident. Datahike reports `:a` as the attribute keyword by
-   default and as a numeric ref under `:attribute-refs? true` (Datomic's
-   representation), so code that compares `:a` against a keyword set matches
-   nothing in the second mode without this."
-  [db a]
-  (if (number? a) (:db/ident (d/entity db a)) a))
-
 (defn attribute-refs?
   "Whether this db represents attributes as numeric refs (Datomic's
    representation) rather than as keywords. A creation-time choice, so it is
@@ -74,6 +66,46 @@
   "Datoms of `attr`, optionally restricted to an exact value."
   ([db attr] (d/datoms db {:index :avet :components [attr]}))
   ([db attr v] (d/datoms db {:index :avet :components [attr v]})))
+
+(defn eavt-datoms
+  "Datoms on `entity` for `attr`, optionally restricted to an exact value.
+   Datahike resolves the attribute keyword in both attribute representations."
+  ([db entity attr]
+   (d/datoms db {:index :eavt :components [entity attr]}))
+  ([db entity attr v]
+   (d/datoms db {:index :eavt :components [entity attr v]})))
+
+(defn eavt-tuple-prefix
+  "Datoms on `entity` whose `arity`-tuple value starts with `prefix`.
+
+   Current and retained-commit DB values use a full-length seek bound, so the
+   scan starts at the requested tuple segment. Datahike 0.8.1759's `AsOfDB`
+   does not apply its temporal context to `seek-datoms`; temporal wrappers
+   therefore use exact EAVT datoms plus a bounded endpoint-local filter."
+  ([db entity attr arity prefix]
+   (eavt-tuple-prefix db entity attr arity prefix nil))
+  ([db entity attr arity prefix lower-tail]
+   (let [prefix (vec prefix)
+         prefix-size (count prefix)
+         missing (- arity prefix-size)
+         lower-bound
+         (if (some? lower-tail)
+           (into prefix
+                 (cons lower-tail (repeat (dec missing) nil)))
+           (into prefix (repeat missing nil)))
+         matches-prefix?
+         (fn [{:keys [v]}]
+           (and (vector? v)
+                (= arity (count v))
+                (= prefix (subvec v 0 prefix-size))))]
+     (if (:config db)
+       (->> (d/seek-datoms
+             db
+             {:index :eavt
+              :components [entity attr lower-bound]})
+            (take-while matches-prefix?))
+       (filter matches-prefix?
+               (eavt-datoms db entity attr))))))
 
 (defn avet-range
   "Datoms of `attr` whose value falls in [`start`, `end`]. Datahike's

--- a/modules/eacl-datahike/src/eacl/datahike/db.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/db.clj
@@ -5,7 +5,8 @@
 
    This namespace is JVM-only, as is the rest of the module: datahike's
    ClojureScript API is asynchronous, and the backend SPI is synchronous."
-  (:require [datahike.api :as d]))
+  (:require [datahike.api :as d]
+            [datahike.db.interface :as dbi]))
 
 (defn entid
   "`entid` as DataScript and Datomic define it: a number passes through
@@ -28,9 +29,11 @@
 (defn attribute-refs?
   "Whether this db represents attributes as numeric refs (Datomic's
    representation) rather than as keywords. A creation-time choice, so it is
-   constant for the life of the database."
+   constant for the life of the database. Use Datahike's database protocol
+   rather than record-field lookup so temporal wrappers delegate to their
+   origin database."
   [db]
-  (boolean (:attribute-refs? (:config db))))
+  (boolean (:attribute-refs? (dbi/-config db))))
 
 (defn attr-repr
   "`attr` in the representation this db uses for it: the keyword itself, or its
@@ -41,26 +44,49 @@
     (entid db attr)
     attr))
 
+(defn- direct-db?
+  "Whether `db` is a concrete Datahike DB rather than a temporal/filter wrapper.
+   Concrete and retained-commit DB records carry their config as a field.
+   Wrappers delegate `IDB/-config` but deliberately do not expose that field."
+  [db]
+  (some? (:config db)))
+
 (defn seek-tuple-prefix
   "Datoms of composite-tuple attribute `attr` (of `arity` components) whose
    value begins with `prefix`.
 
-   Restrict the scan to the exact AVET attribute first, then filter its tuple
-   values. Datahike 0.8.1759's `AsOfDB` delegates `seek-datoms` without applying
-   the temporal wrapper's seek context: a padded composite lower bound can skip
-   the wanted historical tuple and start in the following attribute. Exact
-   `datoms` does apply that context. Relation-definition cardinality is bounded
-   by the authorization schema, so this preserves correctness on temporal
-   snapshots without widening the scan to the database."
+   Datahike orders vectors by length before contents, so pad the seek key to the
+   tuple's full arity. The attribute guard is load-bearing: `seek-datoms`
+   continues into the next attribute when the requested prefix has no match.
+
+   Datahike carries an `AsOfDB` temporal context into `seek-datoms`, but
+   0.8.1759 can position a full-tuple temporal seek after a historically visible
+   tuple that was retracted later. Wrapper values therefore use exact AVET
+   datoms plus a schema-bounded prefix filter."
   [db attr arity prefix]
   (let [prefix (vec prefix)
         n      (count prefix)]
-    (->> (d/datoms db {:index :avet :components [attr]})
-         (filter (fn [{:keys [v]}]
-                   (and (vector? v)
-                        (= arity (count v))
-                        (<= n arity)
-                        (= prefix (subvec v 0 n))))))))
+    (if (> n arity)
+      []
+      (let [matches-prefix?
+            (fn [{:keys [v]}]
+              (and (vector? v)
+                   (= arity (count v))
+                   (= prefix (subvec v 0 n))))]
+        (if (direct-db? db)
+          (let [padded (into prefix (repeat (- arity n) nil))
+                a-repr (attr-repr db attr)]
+            (->> (d/seek-datoms
+                  db
+                  {:index :avet
+                   :components [attr padded]})
+                 (take-while
+                  (fn [{:keys [a] :as datom}]
+                    (and (= a-repr a)
+                         (matches-prefix? datom))))))
+          (filter matches-prefix?
+                  (d/datoms db {:index :avet
+                                :components [attr]})))))))
 
 (defn avet-datoms
   "Datoms of `attr`, optionally restricted to an exact value."
@@ -78,34 +104,43 @@
 (defn eavt-tuple-prefix
   "Datoms on `entity` whose `arity`-tuple value starts with `prefix`.
 
-   Current and retained-commit DB values use a full-length seek bound, so the
-   scan starts at the requested tuple segment. Datahike 0.8.1759's `AsOfDB`
-   does not apply its temporal context to `seek-datoms`; temporal wrappers
-   therefore use exact EAVT datoms plus a bounded endpoint-local filter."
+   A full-length lower bound positions the scan at the requested tuple segment.
+   The entity and attribute guards prevent a missing prefix from running into a
+   different relationship attribute on the same endpoint. Current and
+   retained-commit values use that seek. Temporal/filter wrappers use exact EAVT
+   datoms plus an endpoint-local prefix filter because Datahike 0.8.1759 can
+   skip a historically visible tuple after a later retraction."
   ([db entity attr arity prefix]
    (eavt-tuple-prefix db entity attr arity prefix nil))
   ([db entity attr arity prefix lower-tail]
    (let [prefix (vec prefix)
          prefix-size (count prefix)
-         missing (- arity prefix-size)
-         lower-bound
-         (if (some? lower-tail)
-           (into prefix
-                 (cons lower-tail (repeat (dec missing) nil)))
-           (into prefix (repeat missing nil)))
-         matches-prefix?
-         (fn [{:keys [v]}]
-           (and (vector? v)
-                (= arity (count v))
-                (= prefix (subvec v 0 prefix-size))))]
-     (if (:config db)
-       (->> (d/seek-datoms
-             db
-             {:index :eavt
-              :components [entity attr lower-bound]})
-            (take-while matches-prefix?))
-       (filter matches-prefix?
-               (eavt-datoms db entity attr))))))
+         missing (- arity prefix-size)]
+     (if (neg? missing)
+       []
+       (let [lower-bound
+             (if (and (some? lower-tail) (pos? missing))
+               (into prefix
+                     (cons lower-tail (repeat (dec missing) nil)))
+               (into prefix (repeat missing nil)))
+             matches-prefix?
+             (fn [{:keys [v]}]
+               (and (vector? v)
+                    (= arity (count v))
+                    (= prefix (subvec v 0 prefix-size))))]
+         (if (direct-db? db)
+           (let [a-repr (attr-repr db attr)]
+             (->> (d/seek-datoms
+                   db
+                   {:index :eavt
+                    :components [entity attr lower-bound]})
+                  (take-while
+                   (fn [{:keys [e a] :as datom}]
+                     (and (= entity e)
+                          (= a-repr a)
+                          (matches-prefix? datom))))))
+           (filter matches-prefix?
+                   (eavt-datoms db entity attr))))))))
 
 (defn avet-range
   "Datoms of `attr` whose value falls in [`start`, `end`]. Datahike's

--- a/modules/eacl-datahike/src/eacl/datahike/impl.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/impl.clj
@@ -69,33 +69,29 @@
            :subject-type (nth v 2)})
         (ddb/avet-datoms db schema/relation-key-attr)))
 
-(defn- exclusive-start-id
-  [cursor-id]
-  (if cursor-id
-    (inc cursor-id)
-    0))
-
-(defn- bounded-relationship-target-ids
-  [db attr prefix cursor-id]
-  (->> (ddb/avet-range db
-                       attr
-                       (conj prefix (exclusive-start-id cursor-id))
-                       (conj prefix max-entid))
-       (map (fn [{:keys [v]}] (peek v)))))
+(defn- relationship-datoms-on-entity
+  [db entity attr prefix lower-id]
+  (ddb/eavt-tuple-prefix db entity attr 4 prefix lower-id))
 
 (defn subject->resources
   [db subject-type subject-id relation-id resource-type cursor-resource-id]
-  (bounded-relationship-target-ids db
-                                   schema/forward-relationship-attr
-                                   [subject-type subject-id relation-id resource-type]
-                                   cursor-resource-id))
+  (->> (relationship-datoms-on-entity
+        db subject-id schema/forward-relationship-attr
+        [subject-type relation-id resource-type]
+        cursor-resource-id)
+       (map (comp #(nth % 3) :v))
+       (drop-while #(and cursor-resource-id
+                         (<= % cursor-resource-id)))))
 
 (defn resource->subjects
   [db resource-type resource-id relation-id subject-type cursor-subject-id]
-  (bounded-relationship-target-ids db
-                                   schema/reverse-relationship-attr
-                                   [resource-type resource-id relation-id subject-type]
-                                   cursor-subject-id))
+  (->> (relationship-datoms-on-entity
+        db resource-id schema/reverse-relationship-attr
+        [resource-type relation-id subject-type]
+        cursor-subject-id)
+       (map (comp #(nth % 3) :v))
+       (drop-while #(and cursor-subject-id
+                         (<= % cursor-subject-id)))))
 
 (defn build-schema-catalog
   [db]
@@ -121,8 +117,12 @@
            (ddb/avet-datoms db schema/permission-key-attr))})
 
 (defn- relationship-tuple
-  [{:keys [subject-type subject-id relation-id resource-type resource-id]}]
-  [subject-type subject-id relation-id resource-type resource-id])
+  [{:keys [subject-type relation-id resource-type resource-id]}]
+  [subject-type relation-id resource-type resource-id])
+
+(defn- reverse-relationship-tuple
+  [{:keys [resource-type relation-id subject-type subject-id]}]
+  [resource-type relation-id subject-type subject-id])
 
 (defn- internal-id
   [db value]
@@ -180,49 +180,109 @@
                    (catch clojure.lang.ExceptionInfo e
                      (when-not (= :eacl/unknown-object (:type (ex-data e)))
                        (throw e))))
-        existing (when resolved
-                   (ddb/entid db [schema/relationship-full-key-attr
-                                  (relationship-tuple resolved)]))]
-    (when existing
+        existing? (and resolved
+                       (seq
+                        (ddb/eavt-datoms
+                         db
+                         (:subject-id resolved)
+                         schema/forward-relationship-attr
+                         (relationship-tuple resolved)))
+                       (seq
+                        (ddb/eavt-datoms
+                         db
+                         (:resource-id resolved)
+                         schema/reverse-relationship-attr
+                         (reverse-relationship-tuple resolved))))]
+    (when existing?
       resolved)))
 
 (defn relationship-relation-id
   [db relationship]
   (:relation-id (resolve-relationship db relationship)))
 
-(defn- relationship-entity
+(defn- add-relationship-txes
   [resolved]
-  {:eacl.relationship/subject-type  (:subject-type resolved)
-   :eacl.relationship/subject       (:subject-id resolved)
-   :eacl.relationship/relation      (:relation-id resolved)
-   :eacl.relationship/resource-type (:resource-type resolved)
-   :eacl.relationship/resource      (:resource-id resolved)})
+  [[:db/add
+    (:subject-id resolved)
+    schema/forward-relationship-attr
+    (relationship-tuple resolved)]
+   [:db/add
+    (:resource-id resolved)
+    schema/reverse-relationship-attr
+    (reverse-relationship-tuple resolved)]])
+
+(defn- retract-relationship-txes
+  [resolved]
+  [[:db/retract
+    (:subject-id resolved)
+    schema/forward-relationship-attr
+    (relationship-tuple resolved)]
+   [:db/retract
+    (:resource-id resolved)
+    schema/reverse-relationship-attr
+    (reverse-relationship-tuple resolved)]])
+
+(defn direct-match?
+  [db subject-type subject-id relation-id resource-type resource-id]
+  (boolean
+   (seq
+    (ddb/eavt-datoms
+     db subject-id schema/forward-relationship-attr
+     [subject-type relation-id resource-type resource-id]))))
+
+(defn- reverse-match?
+  [db resource-type resource-id relation-id subject-type subject-id]
+  (boolean
+   (seq
+    (ddb/eavt-datoms
+     db resource-id schema/reverse-relationship-attr
+     [resource-type relation-id subject-type subject-id]))))
+
+(defn- relationship-exists?
+  [db {:keys [subject-type subject-id relation-id
+              resource-type resource-id]}]
+  (and (direct-match? db subject-type subject-id relation-id
+                      resource-type resource-id)
+       (reverse-match? db resource-type resource-id relation-id
+                       subject-type subject-id)))
+
+(def ^:private supported-relationship-operations
+  #{:create :touch :delete})
+
+(defn validate-relationship-operation!
+  [operation]
+  (when-not (contains? supported-relationship-operations operation)
+    (throw
+     (ex-info
+      (str (pr-str operation)
+           " relationship update is not supported. Use :create, :touch or :delete.")
+      {:type :eacl/unsupported-operation
+       :operation operation})))
+  true)
 
 (defn tx-update-relationship
   [db {:keys [operation relationship]}]
+  (validate-relationship-operation! operation)
   (let [resolved (resolve-relationship db relationship)
-        tuple    (relationship-tuple resolved)
-        existing (ddb/entid db [schema/relationship-full-key-attr tuple])]
+        exists?  (relationship-exists? db resolved)]
     (case operation
       :touch
-      (when-not existing
-        [(relationship-entity resolved)])
+      (when-not exists?
+        (add-relationship-txes resolved))
 
       :create
-      (if existing
-        (throw (ex-info ":create relationship conflicts with existing tuple relationship"
-                        {:relationship relationship}))
-        [(relationship-entity resolved)])
+      (if exists?
+        (throw
+         (ex-info
+          ":create conflicts with an existing relationship. Use :touch for idempotent writes."
+          {:type :eacl/relationship-conflict
+           :relationship relationship}))
+        (add-relationship-txes resolved))
 
       :delete
-      (when existing
-        [[:db/retractEntity existing]])
-
-      :unspecified
-      [(relationship-entity resolved)]
-
-      (throw (ex-info "Unknown relationship operation"
-                      {:operation operation})))))
+      ;; Datahike ignores retraction of an absent datom. Retracting both halves
+      ;; unconditionally makes a half-written relationship repairable.
+      (retract-relationship-txes resolved))))
 
 (defn read-relationships
   [db filters]
@@ -250,12 +310,13 @@
                             rows))
               (exact-match-row [spec cursor]
                 (let [row (when (and (:subject-id spec) (:resource-id spec))
-                            (when (ddb/entid db [schema/relationship-full-key-attr
-                                                 [(:subject-type spec)
-                                                  (:subject-id spec)
-                                                  (:relation-id spec)
-                                                  (:resource-type spec)
-                                                  (:resource-id spec)]])
+                            (when (direct-match?
+                                   db
+                                   (:subject-type spec)
+                                   (:subject-id spec)
+                                   (:relation-id spec)
+                                   (:resource-type spec)
+                                   (:resource-id spec))
                               (relationship-row spec (:subject-id spec) (:resource-id spec))))]
                   (if row
                     (drop-until-after-cursor spec cursor [row])
@@ -263,70 +324,60 @@
               (scan-forward-anchored [spec cursor]
                 (if (:resource-id spec)
                   (exact-match-row spec cursor)
-                  (->> (ddb/avet-range db
-                                       schema/forward-relationship-attr
-                                       [(:subject-type spec)
-                                        (:subject-id spec)
-                                        (:relation-id spec)
-                                        (:resource-type spec)
-                                        (or (:resource cursor) 0)]
-                                       [(:subject-type spec)
-                                        (:subject-id spec)
-                                        (:relation-id spec)
-                                        (:resource-type spec)
-                                        max-entid])
+                  (->> (relationship-datoms-on-entity
+                        db
+                        (:subject-id spec)
+                        schema/forward-relationship-attr
+                        [(:subject-type spec)
+                         (:relation-id spec)
+                         (:resource-type spec)]
+                        (:resource cursor))
                        (map (fn [{:keys [v]}]
-                              (relationship-row spec (nth v 1) (nth v 4))))
+                              (relationship-row
+                               spec (:subject-id spec) (nth v 3))))
                        (drop-until-after-cursor spec cursor))))
               (scan-reverse-anchored [spec cursor]
                 (if (:subject-id spec)
                   (exact-match-row spec cursor)
-                  (->> (ddb/avet-range db
-                                       schema/reverse-relationship-attr
-                                       [(:resource-type spec)
-                                        (:resource-id spec)
-                                        (:relation-id spec)
-                                        (:subject-type spec)
-                                        (or (:subject cursor) 0)]
-                                       [(:resource-type spec)
-                                        (:resource-id spec)
-                                        (:relation-id spec)
-                                        (:subject-type spec)
-                                        max-entid])
+                  (->> (relationship-datoms-on-entity
+                        db
+                        (:resource-id spec)
+                        schema/reverse-relationship-attr
+                        [(:resource-type spec)
+                         (:relation-id spec)
+                         (:subject-type spec)]
+                        (:subject cursor))
                        (map (fn [{:keys [v]}]
-                              (relationship-row spec (nth v 4) (nth v 1))))
+                              (relationship-row
+                               spec (nth v 3) (:resource-id spec))))
                        (drop-until-after-cursor spec cursor))))
               (scan-forward-partial [spec cursor]
                 (->> (ddb/avet-range db
-                                     schema/forward-partial-relationship-attr
+                                     schema/forward-relationship-attr
                                      [(:subject-type spec)
                                       (:relation-id spec)
                                       (:resource-type spec)
-                                      (or (:resource cursor) 0)
-                                      0]
+                                      (or (:resource cursor) 0)]
                                      [(:subject-type spec)
                                       (:relation-id spec)
                                       (:resource-type spec)
-                                      max-entid
                                       max-entid])
-                     (map (fn [{:keys [v]}]
-                            (relationship-row spec (nth v 4) (nth v 3))))
+                     (map (fn [{:keys [e v]}]
+                            (relationship-row spec e (nth v 3))))
                      (drop-until-after-cursor spec cursor)))
               (scan-reverse-partial [spec cursor]
                 (->> (ddb/avet-range db
-                                     schema/reverse-partial-relationship-attr
+                                     schema/reverse-relationship-attr
                                      [(:resource-type spec)
                                       (:relation-id spec)
                                       (:subject-type spec)
-                                      (or (:subject cursor) 0)
-                                      0]
+                                      (or (:subject cursor) 0)]
                                      [(:resource-type spec)
                                       (:relation-id spec)
                                       (:subject-type spec)
-                                      max-entid
                                       max-entid])
-                     (map (fn [{:keys [v]}]
-                            (relationship-row spec (nth v 3) (nth v 4))))
+                     (map (fn [{:keys [e v]}]
+                            (relationship-row spec (nth v 3) e)))
                      (drop-until-after-cursor spec cursor)))
               (scan-spec [spec cursor]
                 (case (:scan-kind spec)
@@ -338,6 +389,134 @@
          (relationship-engine/plan-scans (all-relation-defs db) filters')
          filters'
          scan-spec)))))
+
+;; A relationship is split across its endpoints. A bare retractEntity removes
+;; only the half stored on that entity because Datahike does not follow refs
+;; embedded in heterogeneous tuple values. The supported deletion path removes
+;; both halves before the caller retracts the object entity.
+
+(defn- relation-triples
+  [db]
+  (mapv (fn [{:keys [e v]}]
+          [(nth v 0) e (nth v 2)])
+        (ddb/avet-datoms db schema/relation-key-attr)))
+
+(defn- relationship-pair-retractions
+  [subject-type subject-id relation-id resource-type resource-id]
+  [[:db/retract
+    subject-id
+    schema/forward-relationship-attr
+    [subject-type relation-id resource-type resource-id]]
+   [:db/retract
+    resource-id
+    schema/reverse-relationship-attr
+    [resource-type relation-id subject-type subject-id]]])
+
+(defn tx-delete-object
+  "Returns transaction data removing both halves of every relationship touching
+   `object-id`. The object entity itself is left intact.
+
+   Peer-index probes also find surviving halves after a caller has already
+   retracted the object entity and passes its raw numeric eid."
+  [db object-id]
+  (if-let [object-eid (internal-id db object-id)]
+    (let [triples (relation-triples db)]
+      (->>
+       (concat
+        (mapcat
+         (fn [{:keys [v]}]
+           (let [[subject-type relation-id
+                  resource-type resource-id] v]
+             (relationship-pair-retractions
+              subject-type object-eid relation-id resource-type resource-id)))
+         (ddb/eavt-datoms
+          db object-eid schema/forward-relationship-attr))
+
+        (mapcat
+         (fn [{:keys [v]}]
+           (let [[resource-type relation-id
+                  subject-type subject-id] v]
+             (relationship-pair-retractions
+              subject-type subject-id relation-id resource-type object-eid)))
+         (ddb/eavt-datoms
+          db object-eid schema/reverse-relationship-attr))
+
+        (mapcat
+         (fn [[resource-type relation-id subject-type]]
+           (mapcat
+            (fn [{resource-id :e}]
+              (relationship-pair-retractions
+               subject-type object-eid relation-id resource-type resource-id))
+            (ddb/avet-datoms
+             db schema/reverse-relationship-attr
+             [resource-type relation-id subject-type object-eid])))
+         triples)
+
+        (mapcat
+         (fn [[resource-type relation-id subject-type]]
+           (mapcat
+            (fn [{subject-id :e}]
+              (relationship-pair-retractions
+               subject-type subject-id relation-id resource-type object-eid))
+            (ddb/avet-datoms
+             db schema/forward-relationship-attr
+             [subject-type relation-id resource-type object-eid])))
+         triples))
+       distinct
+       vec))
+    []))
+
+(defn affected-relation-ids
+  "Every relation named by relationship tuple retraction ops."
+  [tx-data]
+  (->> tx-data
+       (keep
+        (fn [op]
+          (when (and (vector? op)
+                     (= :db/retract (first op))
+                     (contains?
+                      #{schema/forward-relationship-attr
+                        schema/reverse-relationship-attr}
+                      (nth op 2 nil)))
+            (nth (nth op 3) 1))))
+       distinct
+       sort
+       vec))
+
+(defn orphaned-relationship-halves
+  "Lazy offline scan of relationship halves whose matching peer half is absent."
+  [db]
+  (concat
+   (for [{subject-id :e v :v}
+         (ddb/avet-datoms db schema/forward-relationship-attr)
+         :let [[subject-type relation-id resource-type resource-id] v]
+         :when
+         (empty?
+          (ddb/eavt-datoms
+           db resource-id schema/reverse-relationship-attr
+           [resource-type relation-id subject-type subject-id]))]
+     {:half :forward
+      :e subject-id
+      :attr schema/forward-relationship-attr
+      :v (vec v)
+      :subject-eid subject-id
+      :resource-eid resource-id
+      :relation-eid relation-id})
+   (for [{resource-id :e v :v}
+         (ddb/avet-datoms db schema/reverse-relationship-attr)
+         :let [[resource-type relation-id subject-type subject-id] v]
+         :when
+         (empty?
+          (ddb/eavt-datoms
+           db subject-id schema/forward-relationship-attr
+           [subject-type relation-id resource-type resource-id]))]
+     {:half :reverse
+      :e resource-id
+      :attr schema/reverse-relationship-attr
+      :v (vec v)
+      :subject-eid subject-id
+      :resource-eid resource-id
+      :relation-eid relation-id})))
 
 (defn- normalize-backend-options
   [cache-stamp-or-opts]
@@ -403,9 +582,8 @@
       :resource->subjects (fn [resource-type resource-id relation-id subject-type cursor-subject-id]
                             (resource->subjects db resource-type resource-id relation-id subject-type cursor-subject-id))
       :direct-match? (fn [subject-type subject-id relation-id resource-type resource-id]
-                       (boolean
-                        (ddb/entid db [schema/relationship-full-key-attr
-                                       [subject-type subject-id relation-id resource-type resource-id]])))})))
+                       (direct-match? db subject-type subject-id relation-id
+                                      resource-type resource-id))})))
 
 (defn- backend*
   [db-or-backend]

--- a/modules/eacl-datahike/src/eacl/datahike/integrity.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/integrity.clj
@@ -13,8 +13,10 @@
 (defn dangling-relationship-report
   "Returns total and per-half dangling counts plus a bounded sample.
 
-   `:sample-size` defaults to 20. This is an offline
-   O(number-of-relationship-datoms) operation."
+   `:sample-size` defaults to 20. This is an offline operation that scans every
+   relationship half and performs one exact peer-half index probe per half.
+   With a logarithmic persistent index lookup, its expected cost is
+   O(H log D) for H relationship halves in a database of D datoms."
   ([db]
    (dangling-relationship-report db {}))
   ([db {:keys [sample-size] :or {sample-size 20}}]

--- a/modules/eacl-datahike/src/eacl/datahike/integrity.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/integrity.clj
@@ -1,0 +1,45 @@
+(ns eacl.datahike.integrity
+  "Explicit, offline relationship-integrity diagnostics.
+
+   Nothing here runs on an authorization hot path. A full report scans both
+   relationship tuple attributes and probes the peer half of every datom."
+  (:require [eacl.datahike.impl :as impl]))
+
+(defn dangling-relationship-halves
+  "Returns a lazy sequence of relationship halves whose peer half is absent."
+  [db]
+  (impl/orphaned-relationship-halves db))
+
+(defn dangling-relationship-report
+  "Returns total and per-half dangling counts plus a bounded sample.
+
+   `:sample-size` defaults to 20. This is an offline
+   O(number-of-relationship-datoms) operation."
+  ([db]
+   (dangling-relationship-report db {}))
+  ([db {:keys [sample-size] :or {sample-size 20}}]
+   (when-not (and (integer? sample-size)
+                  (not (neg? sample-size)))
+     (throw
+      (ex-info
+       ":sample-size must be a non-negative integer."
+       {:type :eacl.integrity/invalid-options
+        :sample-size sample-size})))
+   (let [{:keys [count by-half sample]}
+         (reduce
+          (fn [{:keys [count] :as report} half]
+            (cond-> (-> report
+                        (assoc :count (unchecked-inc count))
+                        (update-in
+                         [:by-half (:half half)]
+                         (fnil unchecked-inc 0)))
+              (< count sample-size)
+              (update :sample conj half)))
+          {:count 0
+           :by-half {:forward 0 :reverse 0}
+           :sample []}
+          (dangling-relationship-halves db))]
+     {:valid? (zero? count)
+      :dangling-count count
+      :by-half by-half
+      :sample sample})))

--- a/modules/eacl-datahike/src/eacl/datahike/mutation.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/mutation.clj
@@ -49,6 +49,32 @@
        op))
    tx-data))
 
+(def ^:private migration-visibility-timeout-ms 30000)
+(def ^:private migration-visibility-poll-ms 2)
+
+(defn- cas-conflict?
+  [error]
+  (loop [cause error]
+    (cond
+      (nil? cause) false
+      (= :transact/cas (:error (ex-data cause))) true
+      :else (recur (.getCause ^Throwable cause)))))
+
+(defn- await-graph-state
+  [conn]
+  ;; Datahike validates queued transactions before it commits the batch. A
+  ;; losing migration therefore receives its CAS error just before the winning
+  ;; migration's committed db becomes visible through the shared connection.
+  (let [deadline
+        (+ (System/nanoTime)
+           (* 1000000 migration-visibility-timeout-ms))]
+    (loop []
+      (or
+       (graph-state (d/db conn))
+       (when (< (System/nanoTime) deadline)
+         (Thread/sleep migration-visibility-poll-ms)
+         (recur))))))
+
 (defn ensure-migrated!
   [conn]
   (or (graph-state (d/db conn))
@@ -60,11 +86,16 @@
               :family-id (mutation/new-id)
               :order-value :db/current-tx})]
         (try
-          (d/transact conn (native-tx-data db tx-data))
+          (or
+           (some-> (d/transact conn (native-tx-data db tx-data))
+                   :db-after
+                   graph-state)
+           (graph-state (d/db conn)))
           (catch Throwable error
-            (when-not (graph-state (d/db conn))
-              (throw error))))
-        (graph-state (d/db conn)))))
+            (if (cas-conflict? error)
+              (or (await-graph-state conn)
+                  (throw error))
+              (throw error)))))))
 
 (defn mutation-transaction-data
   [db {:keys [mutation-id kind canonical-data relation-ids dependency-ids

--- a/modules/eacl-datahike/src/eacl/datahike/schema.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/schema.clj
@@ -7,19 +7,10 @@
             [eacl.spicedb.parser :as parser]))
 
 (def forward-relationship-attr
-  :eacl.v7.relationship/subject-type+subject+relation+resource-type+resource)
+  :eacl.v7.relationship/subject-type+relation+resource-type+resource)
 
 (def reverse-relationship-attr
-  :eacl.v7.relationship/resource-type+resource+relation+subject-type+subject)
-
-(def forward-partial-relationship-attr
-  :eacl.v7.relationship/subject-type+relation+resource-type+resource+subject)
-
-(def reverse-partial-relationship-attr
-  :eacl.v7.relationship/resource-type+relation+subject-type+subject+resource)
-
-(def relationship-full-key-attr
-  :eacl.relationship/full-key)
+  :eacl.v7.relationship/resource-type+relation+subject-type+subject)
 
 (def relation-key-attr
   :eacl.relation/resource-type+relation-name+subject-type)
@@ -29,24 +20,11 @@
 
 (def max-entid Long/MAX_VALUE)
 
-(def schema-change-attrs
-  #{:eacl.relation/resource-type
-    :eacl.relation/relation-name
-    :eacl.relation/subject-type
-    :eacl.relation/resource-type+relation-name+subject-type
-    :eacl.permission/resource-type
-    :eacl.permission/permission-name
-    :eacl.permission/source-relation-name
-    :eacl.permission/target-type
-    :eacl.permission/target-name
-    :eacl.permission/resource-type+permission-name
-    :eacl.permission/full-key
-    :eacl/schema-string})
-
 (def ^:private component-schema
-  "The attributes composite tuples are derived FROM. Datahike's `:write`
-   flexibility needs a declared `:db/valueType` and `:db/cardinality` on every
-   attribute, which DataScript's schema map leaves implicit."
+  "The attributes schema-definition composite tuples are derived FROM.
+   Datahike's `:write` flexibility needs a declared `:db/valueType` and
+   `:db/cardinality` on every attribute, which DataScript's schema map leaves
+   implicit."
   [{:db/ident       :eacl/id
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one
@@ -132,32 +110,13 @@
    {:db/ident       :eacl.dependency/mutation-id
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one
-    :db/index       true}
-
-   {:db/ident       :eacl.relationship/subject
-    :db/valueType   :db.type/ref
-    :db/cardinality :db.cardinality/one}
-   {:db/ident       :eacl.relationship/relation
-    :db/valueType   :db.type/ref
-    :db/cardinality :db.cardinality/one}
-   {:db/ident       :eacl.relationship/resource
-    :db/valueType   :db.type/ref
-    :db/cardinality :db.cardinality/one}
-   {:db/ident       :eacl.relationship/subject-type
-    :db/valueType   :db.type/keyword
-    :db/cardinality :db.cardinality/one
-    :db/index       true}
-   {:db/ident       :eacl.relationship/resource-type
-    :db/valueType   :db.type/keyword
-    :db/cardinality :db.cardinality/one
     :db/index       true}])
 
 (def ^:private tuple-schema
-  "The composite tuples. These ARE the v7 engine: every relationship traversal
-   is a bounded range over one of the four orderings below, so each must be
-   indexed. Deriving them requires datahike >= 0.8.1759 (replikativ/datahike#921)
-   under `:attribute-refs?`; before that fix they were silently never derived,
-   and every permission check denied."
+  "Schema-definition composite tuples plus Datomic-compatible heterogeneous
+   relationship tuples. A relationship is stored as exactly two datoms: its
+   forward tuple on the subject entity and reverse tuple on the resource
+   entity."
   [{:db/ident       :eacl.relation/resource-type+relation-name+subject-type
     :db/valueType   :db.type/tuple
     :db/tupleAttrs  [:eacl.relation/resource-type
@@ -182,50 +141,22 @@
     :db/cardinality :db.cardinality/one
     :db/unique      :db.unique/identity}
 
-   {:db/ident       :eacl.relationship/full-key
-    :db/valueType   :db.type/tuple
-    :db/tupleAttrs  [:eacl.relationship/subject-type
-                     :eacl.relationship/subject
-                     :eacl.relationship/relation
-                     :eacl.relationship/resource-type
-                     :eacl.relationship/resource]
-    :db/cardinality :db.cardinality/one
-    :db/unique      :db.unique/identity}
    {:db/ident       forward-relationship-attr
     :db/valueType   :db.type/tuple
-    :db/tupleAttrs  [:eacl.relationship/subject-type
-                     :eacl.relationship/subject
-                     :eacl.relationship/relation
-                     :eacl.relationship/resource-type
-                     :eacl.relationship/resource]
-    :db/cardinality :db.cardinality/one
+    :db/tupleTypes  [:db.type/keyword
+                     :db.type/ref
+                     :db.type/keyword
+                     :db.type/ref]
+    :db/cardinality :db.cardinality/many
     :db/index       true}
+
    {:db/ident       reverse-relationship-attr
     :db/valueType   :db.type/tuple
-    :db/tupleAttrs  [:eacl.relationship/resource-type
-                     :eacl.relationship/resource
-                     :eacl.relationship/relation
-                     :eacl.relationship/subject-type
-                     :eacl.relationship/subject]
-    :db/cardinality :db.cardinality/one
-    :db/index       true}
-   {:db/ident       forward-partial-relationship-attr
-    :db/valueType   :db.type/tuple
-    :db/tupleAttrs  [:eacl.relationship/subject-type
-                     :eacl.relationship/relation
-                     :eacl.relationship/resource-type
-                     :eacl.relationship/resource
-                     :eacl.relationship/subject]
-    :db/cardinality :db.cardinality/one
-    :db/index       true}
-   {:db/ident       reverse-partial-relationship-attr
-    :db/valueType   :db.type/tuple
-    :db/tupleAttrs  [:eacl.relationship/resource-type
-                     :eacl.relationship/relation
-                     :eacl.relationship/subject-type
-                     :eacl.relationship/subject
-                     :eacl.relationship/resource]
-    :db/cardinality :db.cardinality/one
+    :db/tupleTypes  [:db.type/keyword
+                     :db.type/ref
+                     :db.type/keyword
+                     :db.type/ref]
+    :db/cardinality :db.cardinality/many
     :db/index       true}])
 
 (def datahike-schema
@@ -304,17 +235,18 @@
 (def compare-schema model/compare-schema)
 
 (defn count-relationships-using-relation
-  "Counts relationships that reference the given relation, exactly.
-  Scans the forward-partial index whose leading components are
-  [subject-type relation]; a range over the forward index with varying middle
-  components would span other relations of the same subject-type and overcount."
+  "Counts forward relationship tuples that reference the given relation."
   [db {:eacl.relation/keys [resource-type relation-name subject-type]}]
   (let [relation-id  (model/->relation-id resource-type relation-name subject-type)
         relation-eid (ddb/entid db [:eacl/id relation-id])]
     (if-not relation-eid
       0
-      (count (ddb/seek-tuple-prefix db forward-partial-relationship-attr 5
-                                    [subject-type relation-eid])))))
+      (count
+       (ddb/avet-range
+        db
+        forward-relationship-attr
+        [subject-type relation-eid resource-type 0]
+        [subject-type relation-eid resource-type max-entid])))))
 
 (defn write-schema!
   "Parses, validates, diffs and transacts a SpiceDB schema string.

--- a/modules/eacl-datahike/test/eacl/datahike/backend_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/backend_test.clj
@@ -2,18 +2,12 @@
   "Datahike-specific tests for the paths the shared contract does not reach.
 
    `assert-seeded-contracts!` goes through `make-client`, which serves relation
-   definitions from a prebuilt schema catalog — a full index scan. So the
-   contract suite never exercises the tuple SEEK, which is where datahike's
-   length-first vector ordering bites, nor cache invalidation on a schema
-   change, which is where the numeric attribute representation bites.
+   definitions from a prebuilt schema catalog. So the contract suite never
+   exercises the schema tuple-prefix path or the relation-in-use range directly.
 
-   They fail in OPPOSITE directions, and neither is visible without a test that
-   names it: a mispositioned seek finds no relation definition and DENIES, while
-   a listener that fails to recognise a schema change keeps answering from
-   pre-change permission paths and so GRANTS what the schema has just revoked.
-
-   Every test runs in both attribute representations. The stale-cache failure
-   appears ONLY under :attribute-refs?, where a datom's :a is a number."
+   Every test runs in both attribute representations. Datahike reports `:a` as
+   a keyword by default and as a numeric ref under `:attribute-refs?`, and an
+   adapter that assumes only one representation can silently deny access."
   (:require [clojure.test :refer [deftest is testing]]
             [datahike.api :as d]
             [eacl.contract-support :as contract]
@@ -72,7 +66,7 @@
         (is (false? (impl/can? db (user "user-2") :reboot (server "server-1"))))))))
 
 (deftest a-relation-in-use-cannot-be-dropped-from-the-schema
-  ;; The guard counts via the forward-partial seek, so an under-counting seek
+  ;; The guard counts the Datomic-layout forward tuple range. Under-counting
   ;; would let a schema write orphan live relationships.
   (doseq [[label config] modes]
     (testing label
@@ -114,11 +108,9 @@
                }")))))))
 
 (deftest a-schema-change-invalidates-cached-permission-paths
-  ;; Permission paths are cached per conn and evicted by a tx listener that
-  ;; recognises EACL's schema attributes in the tx-data. Under
-  ;; :attribute-refs? a datom's :a is a NUMBER, so a listener comparing :a
-  ;; against a keyword set recognises nothing, and can? keeps answering from the
-  ;; pre-change paths — granting access the new schema does not.
+  ;; A schema write replaces the adapter's derived-schema generation. The
+  ;; authorization result must not reuse permission paths compiled from the
+  ;; previous generation in either attribute representation.
   (doseq [[label config] modes]
     (testing label
       (let [[_ client] (seeded-conn config)

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -184,11 +184,46 @@
         schema-proof (backend/invoke before-adapter :schema-proof)
         before-proof
         (backend/invoke before-adapter :relation-proof [relation-id])
-        user-eid (ddb/entid (d/db conn) [:eacl/id "user"])]
+        user-eid (ddb/entid (d/db conn) [:eacl/id "user"])
+        document-eid
+        (ddb/entid (d/db conn) [:eacl/id "document"])]
     (is (= #{:content-digest} (set (keys schema-proof))))
     (is (= 43 (count (:content-digest schema-proof))))
     (is (= #{:content-digest} (set (keys before-proof))))
     (is (= 43 (count (:content-digest before-proof))))
+    (let [reverse
+          (first
+           (ddb/eavt-datoms
+            (d/db conn)
+            document-eid
+            :eacl.v7.relationship/resource-type+relation+subject-type+subject))]
+      (d/transact
+       conn
+       [[:db/retract
+         document-eid
+         :eacl.v7.relationship/resource-type+relation+subject-type+subject
+         (vec (:v reverse))]])
+      (let [half-proof
+            (backend/invoke
+             (datahike-backend/snapshot-adapter
+              (d/db conn) (:opts authorization))
+             :relation-proof
+             [relation-id])]
+        (is (not= before-proof half-proof)
+            "a missing physical half invalidates a content-proof cache hit"))
+      (eacl/write-relationship!
+       authorization
+       {:operation :touch
+        :subject user
+        :relation :reader
+        :resource document})
+      (is (= before-proof
+             (backend/invoke
+              (datahike-backend/snapshot-adapter
+               (d/db conn) (:opts authorization))
+              :relation-proof
+              [relation-id]))
+          "repairing the pair restores the same content proof"))
     (d/transact conn [[:db/retract user-eid :eacl/id "user"]
                       [:db/add user-eid :eacl/id "renamed-user"]])
     (let [after-adapter

--- a/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
@@ -6,11 +6,10 @@
 
    The suite runs TWICE, once per attribute representation. Datahike reports a
    datom's `:a` as the attribute keyword by default and as a numeric ref under
-   `:attribute-refs? true` (Datomic's representation), and the second mode is
-   the one that fails silently rather than loudly: composite tuples need
-   replikativ/datahike#921 to be derived at all, and any code comparing `:a`
-   against a keyword simply stops matching. Both are permission DENIALS, so a
-   single-mode suite would go green while every check answered false."
+   `:attribute-refs? true` (Datomic's representation). Composite relation and
+   permission tuples need replikativ/datahike#921 to derive in the latter mode,
+   and code comparing `:a` directly against a keyword stops matching. Both
+   failures deny permissions, so both representations remain mandatory."
   (:require [clojure.test :refer [deftest testing]]
             [datahike.api :as d]
             [eacl.cache :as cache]

--- a/modules/eacl-datahike/test/eacl/datahike/storage_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/storage_test.clj
@@ -4,6 +4,7 @@
             [eacl.core :as eacl]
             [eacl.datahike.core :as datahike]
             [eacl.datahike.db :as ddb]
+            [eacl.datahike.impl :as impl]
             [eacl.datahike.integrity :as integrity]
             [eacl.datahike.schema :as schema]
             [eacl.schema.model :as model]))
@@ -13,6 +14,11 @@
    definition account {
      relation owner: user
      permission admin = owner
+   }")
+
+(def ^:private self-relationship-schema
+  "definition node {
+     relation peer: node
    }")
 
 (def ^:private modes
@@ -111,6 +117,58 @@
                        db-after
                        account-2-eid
                        schema/reverse-relationship-attr))))))
+          (finally
+            (d/release conn)))))))
+
+(deftest relationship-prefix-seeks-stay-within-the-requested-attribute-test
+  (doseq [[label attribute-refs?] modes]
+    (testing label
+      (let [conn
+            (datahike/create-conn
+             nil
+             {:attribute-refs? attribute-refs?
+              :commit-graph? false
+              :keep-history? true})
+            client (datahike/make-client conn {})
+            node-a (eacl/spice-object :node "node-a")
+            node-b (eacl/spice-object :node "node-b")
+            relationship (eacl/->Relationship node-b :peer node-a)]
+        (try
+          (eacl/write-schema! client self-relationship-schema)
+          (d/transact conn [{:eacl/id "node-a"}
+                            {:eacl/id "node-b"}])
+          (eacl/create-relationship! client relationship)
+          (let [snapshot (d/db conn)
+                snapshot-tx (:max-tx snapshot)
+                node-a-eid (ddb/entid snapshot [:eacl/id "node-a"])
+                node-b-eid (ddb/entid snapshot [:eacl/id "node-b"])
+                relation-eid
+                (ddb/entid
+                 snapshot
+                 [:eacl/id
+                  (model/->relation-id :node :peer :node)])
+                assert-snapshot!
+                (fn [db]
+                  (is (= [node-a-eid]
+                         (vec
+                          (impl/subject->resources
+                           db :node node-b-eid relation-eid :node nil))))
+                  (is (empty?
+                       (impl/subject->resources
+                        db :node node-a-eid relation-eid :node nil))
+                      "an incoming edge must not be returned as outgoing")
+                  (is (= [node-b-eid]
+                         (vec
+                          (impl/resource->subjects
+                           db :node node-a-eid relation-eid :node nil))))
+                  (is (empty?
+                       (impl/resource->subjects
+                        db :node node-b-eid relation-eid :node nil))
+                      "an outgoing edge must not be returned as incoming"))]
+            (assert-snapshot! snapshot)
+            (eacl/delete-relationship! client relationship)
+            (assert-snapshot!
+             (d/as-of (d/db conn) snapshot-tx)))
           (finally
             (d/release conn)))))))
 

--- a/modules/eacl-datahike/test/eacl/datahike/storage_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/storage_test.clj
@@ -1,0 +1,210 @@
+(ns eacl.datahike.storage-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [eacl.core :as eacl]
+            [eacl.datahike.core :as datahike]
+            [eacl.datahike.db :as ddb]
+            [eacl.datahike.integrity :as integrity]
+            [eacl.datahike.schema :as schema]
+            [eacl.schema.model :as model]))
+
+(def ^:private relationship-schema
+  "definition user {}
+   definition account {
+     relation owner: user
+     permission admin = owner
+   }")
+
+(def ^:private modes
+  {"attributes as keywords" false
+   "attributes as numeric refs" true})
+
+(defn- seeded
+  [attribute-refs?]
+  (let [conn (datahike/create-conn
+              nil
+              {:attribute-refs? attribute-refs?})
+        client (datahike/make-client conn {})
+        user (eacl/spice-object :user "user")
+        account (eacl/spice-object :account "account")
+        relationship (eacl/->Relationship user :owner account)]
+    (eacl/write-schema! client relationship-schema)
+    (d/transact conn [{:eacl/id "user"}
+                      {:eacl/id "account"}])
+    (eacl/create-relationship! client relationship)
+    {:conn conn
+     :client client
+     :user user
+     :account account
+     :relationship relationship}))
+
+(defn- relationship-state
+  [db]
+  (let [user-eid (ddb/entid db [:eacl/id "user"])
+        account-eid (ddb/entid db [:eacl/id "account"])
+        relation-eid
+        (ddb/entid
+         db
+         [:eacl/id
+          (model/->relation-id :account :owner :user)])]
+    {:user-eid user-eid
+     :account-eid account-eid
+     :relation-eid relation-eid
+     :forward
+     (vec
+      (ddb/eavt-datoms
+       db user-eid schema/forward-relationship-attr))
+     :reverse
+     (vec
+      (ddb/eavt-datoms
+       db account-eid schema/reverse-relationship-attr))}))
+
+(deftest relationships-use-two-datomic-compatible-tuple-datoms-test
+  (doseq [[label attribute-refs?] modes]
+    (testing label
+      (let [{:keys [conn client user]} (seeded attribute-refs?)]
+        (try
+          (let [db (d/db conn)
+                {:keys [user-eid account-eid relation-eid
+                        forward reverse]}
+                (relationship-state db)]
+            (is (= [[user-eid
+                     [[:user relation-eid :account account-eid]]]]
+                   [[(:e (first forward))
+                     (mapv :v forward)]]))
+            (is (= [[account-eid
+                     [[:account relation-eid :user user-eid]]]]
+                   [[(:e (first reverse))
+                     (mapv :v reverse)]]))
+            (is (= 2 (+ (count forward) (count reverse)))
+                "one relationship costs exactly two relationship datoms")
+            (is (nil? (ddb/entid db :eacl.relationship/full-key)))
+            (is (nil?
+                 (ddb/entid
+                  db
+                  :eacl.v7.relationship/subject-type+subject+relation+resource-type+resource)))
+            (is (nil?
+                 (ddb/entid
+                  db
+                  :eacl.v7.relationship/resource-type+resource+relation+subject-type+subject)))
+
+            (d/transact conn [{:eacl/id "account-2"}])
+            (eacl/create-relationship!
+             client
+             (eacl/->Relationship
+              user
+              :owner
+              (eacl/spice-object :account "account-2")))
+            (let [db-after (d/db conn)
+                  account-2-eid
+                  (ddb/entid db-after [:eacl/id "account-2"])]
+              (is (= 2
+                     (count
+                      (ddb/eavt-datoms
+                       db-after
+                       user-eid
+                       schema/forward-relationship-attr)))
+                  "cardinality-many retains both resources on the subject")
+              (is (= 1
+                     (count
+                      (ddb/eavt-datoms
+                       db-after
+                       account-2-eid
+                       schema/reverse-relationship-attr))))))
+          (finally
+            (d/release conn)))))))
+
+(deftest half-pairs-are-repairable-and-detectable-test
+  (doseq [[label attribute-refs?] modes]
+    (testing label
+      (let [{:keys [conn client relationship]} (seeded attribute-refs?)]
+        (try
+          (let [{:keys [account-eid reverse]}
+                (relationship-state (d/db conn))]
+            (d/transact
+             conn
+             [[:db/retract
+               account-eid
+               schema/reverse-relationship-attr
+               (vec (:v (first reverse)))]])
+            (is (= {:valid? false
+                    :dangling-count 1
+                    :by-half {:forward 1 :reverse 0}
+                    :sample []}
+                   (integrity/dangling-relationship-report
+                    (d/db conn) {:sample-size 0})))
+
+            (eacl/write-relationship!
+             client
+             {:operation :touch
+              :subject (:subject relationship)
+              :relation (:relation relationship)
+              :resource (:resource relationship)})
+            (is (:valid?
+                 (integrity/dangling-relationship-report
+                  (d/db conn))))
+
+            (let [{:keys [user-eid forward]}
+                  (relationship-state (d/db conn))]
+              (d/transact
+               conn
+               [[:db/retract
+                 user-eid
+                 schema/forward-relationship-attr
+                 (vec (:v (first forward)))]])
+              (eacl/delete-relationship! client relationship)
+              (let [{:keys [forward reverse]}
+                    (relationship-state (d/db conn))]
+                (is (empty? forward))
+                (is (empty? reverse)))))
+          (finally
+            (d/release conn)))))))
+
+(deftest delete-object-removes-both-halves-before-entity-retraction-test
+  (doseq [[label attribute-refs?] modes]
+    (testing label
+      (let [{:keys [conn client account]} (seeded attribute-refs?)]
+        (try
+          (let [{:keys [account-eid]} (relationship-state (d/db conn))]
+            (is (= 2
+                   (:retracted-datoms
+                    (eacl/delete-object! client account))))
+            (let [{:keys [forward reverse]}
+                  (relationship-state (d/db conn))]
+              (is (empty? forward))
+              (is (empty? reverse)))
+            (is (ddb/entity-exists? (d/db conn) account-eid)
+                "delete-object! leaves the endpoint entity intact"))
+          (finally
+            (d/release conn)))))))
+
+(deftest delete-object-repairs-a-ghost-test
+  (doseq [[label attribute-refs?] modes]
+    (testing label
+      (let [{:keys [conn client account]} (seeded attribute-refs?)]
+        (try
+          (let [{:keys [account-eid]} (relationship-state (d/db conn))]
+            (d/transact conn [[:db/retractEntity account-eid]])
+            (is (= {:valid? false
+                    :dangling-count 1
+                    :by-half {:forward 1 :reverse 0}
+                    :sample []}
+                   (integrity/dangling-relationship-report
+                    (d/db conn) {:sample-size 0})))
+
+            (is (= 1
+                   (:retracted-datoms
+                    (eacl/delete-object!
+                     client
+                     (assoc account :id account-eid)))))
+            (is (:valid?
+                 (integrity/dangling-relationship-report
+                  (d/db conn))))
+            (is (false?
+                 (eacl/can?
+                  client
+                  (eacl/spice-object :user "user")
+                  :admin
+                  (eacl/spice-object :account account-eid)))))
+          (finally
+            (d/release conn)))))))

--- a/modules/eacl/src/eacl/core.cljc
+++ b/modules/eacl/src/eacl/core.cljc
@@ -60,11 +60,11 @@
 
   (delete-object! [this object])
   ; delete-object! removes every relationship touching `object` in both
-  ; directions, including the halves stored on the peer entities. Datomic's
-  ; :db.fn/retractEntity does NOT do this — v7 relationships name their peer
-  ; inside a tuple value, which retractEntity does not follow — so retracting a
-  ; permissioned entity without calling this first leaves relationship halves
-  ; that keep answering can?/lookup-resources/lookup-subjects.
+  ; directions, including the halves stored on the peer entities. Datomic and
+  ; Datahike retractEntity operations do NOT do this — v7 relationships name
+  ; their peer inside a tuple value, which retractEntity does not follow — so
+  ; retracting a permissioned entity without calling this first leaves
+  ; relationship halves that keep answering authorization queries.
   ; Call it before retracting the entity. It does not retract the entity itself.
 
   (delete-relationship!


### PR DESCRIPTION
## Summary

- replace Datahike's relationship entity, five component attributes, and five derived relationship indexes with the same two cardinality-many heterogeneous endpoint tuples used by Datomic Pro
- adapt authorization adjacency, relationship pagination, relation-in-use checks, object cleanup, direct matching, and database-visible content proofs to the two-tuple layout
- keep DataScript's entity/composite-index storage adapter unchanged until DataScript supports heterogeneous tuples
- add an explicit offline `eacl.datahike.integrity/dangling-relationship-report`
- enforce EAVT entity/attribute boundaries so a missing forward prefix cannot consume a reverse tuple, or vice versa

This PR is intentionally stacked on #91 and targets its head branch.

## Storage and access impact

One logical relationship now contributes exactly two relationship datoms instead of ten relationship-specific datoms (five components plus five derived tuples), an 80% reduction. Forward tuples live on subject entities and reverse tuples live on resource entities. Hot adjacency reads use endpoint-local EAVT seeks with full-length bounds and explicit entity/attribute guards; global relationship reads and relation-in-use checks use AVET tuple ranges.

Historical `AsOfDB` reads retain an exact, endpoint-local `datoms` fallback. Datahike 0.8.1759 does carry the wrapper's temporal context into `seek-datoms`, but a full-tuple temporal seek can position after a historically visible tuple that was retracted later. The equivalent exact `(entity, attribute)` `datoms` read reconstructs that tuple correctly. Concrete and retained-commit DB values continue to use guarded prefix seeks. Attribute-representation detection now uses Datahike's database protocol, so wrapper values correctly inherit `:attribute-refs?` from their origin DB.

## Integrity contract

The layout deliberately accepts the same ghost-half risk as Datomic: direct entity retraction does not follow refs inside heterogeneous tuple values. Consumers must retract relationships through EACL first. `delete-object!` removes both halves, accepts a raw eid for after-the-fact cleanup, reports actual committed relationship retractions, and publishes the affected relation mutation identities. `:touch` repairs half-pairs; `:delete` retracts both halves unconditionally. Content proofs hash both physical halves, so out-of-band half changes invalidate content-proof cache entries.

The replaced Datahike entity layout existed only on the unreleased v8 branch. Pre-release databases should be recreated; no rollback, dual-read, or migration path is included.

## Validation

All tests were run through the module nREPL:

- Datahike backend, shared v8 contract, recursive engine, mutation journal, consistency/cache, storage, and integrity coverage
- 47 tests, 400 assertions, 0 failures, 0 errors (full module plus shared portable suites)
- tuple-prefix regression covers current and historical `AsOfDB` reads with both keyword attributes and `:attribute-refs? true`
- `clj-kondo` on the Datahike-specific changed Clojure files: 0 errors, 0 warnings
- `git diff --check`: clean

## Claim audit

Every factual statement introduced by this PR was rechecked against the implementation, executable tests, the Datomic tuple schema, and Datahike 0.8.1759 source. Two additional documentation errors were corrected:

- temporal/filter wrappers do not expose `:config` directly; they delegate `IDB/-config` to the origin database, which is what the implementation now uses
- the offline dangling-half report is not strictly `O(H)`; it scans `H` halves and performs one exact peer-half index probe per half (expected `O(H log D)` with logarithmic persistent-index lookup)

The two-datom count, tuple component order/types, endpoint placement, ghost-half behavior, touch/delete repair behavior, relation-in-use ranges, and both physical-half content-proof coverage are asserted by the Datahike storage/consistency tests. The DataScript 1.7.8 schema implementation was also checked: it supports derived `:db/tupleAttrs`, not Datomic/Datahike heterogeneous `:db/tupleTypes`, so retaining its separate relationship adapter is intentional.
