### PR TITLE
Optimize DataScript relationship storage with endpoint pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,11 @@ Now you can use `can?` to check those arrow permissions:
 => false ; if Bob is not the :owner of the Account for that Product.
 ```
 
-Internally, EACL models Relations, Permissions and Relationships as Datomic entities, along with several tuple indices for efficient querying.
+Internally, EACL models relation and permission definitions as entities.
+Relationships are two endpoint-local datoms: a forward value on the subject
+and a reverse value on the resource. Datomic Pro and Datahike declare
+heterogeneous tuples; DataScript indexes ordinary vectors with the same
+component order.
 
 ## EACL ID Configuration
 
@@ -949,6 +953,14 @@ deletion contract. Its offline detector is
 `eacl.datahike.integrity/dangling-relationship-report`; repair a reported
 endpoint through `eacl/delete-object!` with its raw eid so the v3 mutation
 journal and cache dependencies are advanced atomically.
+
+DataScript uses the same two endpoint values as indexed ordinary vectors, so
+its embedded peer eid is not a ref and has the same deletion contract. Its
+read-only detector is
+`eacl.datascript.integrity/dangling-relationship-report`. DataScript databases
+created from the unreleased relationship-entity v8 branch must be recreated or
+have their relationships reloaded through EACL; there is no dual-read or
+automatic migration.
 
 ## Schema Syntax
 

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -4,10 +4,10 @@ The major version increments because v8.0 adds the database-visible v3 mutation
 journal and authenticated causal tokens/cache entries/cursors, and moves the
 DataScript/Datahike ports to the v8 Relay list/count contract. The relationship
 storage version stays at 7: Datomic keeps its v7 layout, Datahike now uses that
-same two-tuple physical layout, and DataScript keeps its backend-specific
-entity/composite representation. Client construction performs an idempotent
-additive migration that creates the graph family/head, schema mutation
-identity, and identities for existing relations.
+same two-tuple physical layout, and DataScript now uses the same logical
+two-endpoint representation with indexed ordinary vector values. Client
+construction performs an idempotent additive migration that creates the graph
+family/head, schema mutation identity, and identities for existing relations.
 
 ## Modular artifacts
 
@@ -20,7 +20,8 @@ EACL v8.0 is a workspace with independently consumable modules:
 - `modules/eacl-datahike` contains the CLJ Datahike adapter and supports both
   keyword and numeric attribute-reference representations. Its relationship
   storage now matches Datomic's two cardinality-many heterogeneous endpoint
-  tuples; DataScript retains its entity/composite-index storage adapter.
+  tuples. DataScript uses the same component order in ordinary vectors because
+  DataScript 1.7.8 does not support heterogeneous tuple declarations.
 
 Existing Datomic namespace imports do not change. Consumers replace the root
 Git dependency with `:deps/root "modules/eacl-datomic"`; this packaging change
@@ -61,7 +62,8 @@ number equality.
   requires `:coherence-authority :managed`. `:proof-mode :content` commits
   canonical selected-snapshot content and remains safe with out-of-band
   writers. Datomic content proof includes both physical relationship halves
-  and endpoint identity mappings.
+  and endpoint identity mappings; DataScript and Datahike do the same over
+  their endpoint attributes.
 - Cache/provider corruption, races, format mismatch, or proof failure become a
   miss on the already selected immutable snapshot. Token/freshness/exact
   failures remain request errors.
@@ -143,8 +145,8 @@ number equality.
   writers must either use the v3 mutation builder or keep
   `:coherence-authority :unknown`.
 - Consumers should call `delete-relationships!` before retracting an entity.
-  The Datomic and Datahike integrity reports detect ghost tuple halves left by
-  an incorrect deletion sequence.
+  The Datomic, Datahike, and DataScript integrity reports detect ghost endpoint
+  halves left by an incorrect deletion sequence.
 - Relationship update operations are validated before endpoint resolution. `delete-object!`
   reports actual committed relationship-datom retractions across all batches.
 

--- a/docs/reports/2026-08-02-datascript-endpoint-pair-benchmark.md
+++ b/docs/reports/2026-08-02-datascript-endpoint-pair-benchmark.md
@@ -1,0 +1,86 @@
+# DataScript endpoint-pair storage benchmark
+
+This JVM microbenchmark compares the DataScript relationship-entity layout at
+PR #92's head with the endpoint-pair layout. It is reproducible through
+`eacl.bench.datascript-relationship-storage/run-benchmark!`; the namespace is
+under the DataScript module's test tree but is deliberately not a regular test.
+
+## Environment and method
+
+- Date: 2026-08-02
+- Hardware: Apple Silicon (`aarch64`), 12 available processors
+- OS: macOS 26.5.1
+- JVM: OpenJDK 24.0.1
+- Clojure: 1.11.4
+- DataScript: 1.7.8
+- JVM max heap: 4,831,838,208 bytes
+- Graph sizes: 1,024 and 4,096 logical relationships
+- Read/proof warmup: 20 runs
+- Read/proof samples: 30, with 20 invocations per sample
+- Write warmup: 3 runs
+- Write samples: 10
+- Write batch: 100 logical relationships per immutable `ds/with`
+- Latency clock: `System/nanoTime`
+- Allocation: current thread's allocated bytes through
+  `com.sun.management.ThreadMXBean`
+
+Fixtures use the same subject/resource pairs and relation eid. Before timing,
+the runner requires old/new direct matches and forward/reverse adjacency
+results to be equal. The old fixture declares five component attributes, a
+unique full-key tuple, and four derived scan tuples. The new fixture stores one
+ordinary four-element forward value on the subject and one reverse value on the
+resource.
+
+This is a storage/index microbenchmark, not an application throughput claim.
+It excludes cursor signing, cache-store latency, mutation-journal publication,
+networking, garbage-collection attribution, and browser JavaScript timing.
+
+## Results
+
+All latency values are p50 microseconds unless explicitly described otherwise.
+
+| Logical relationships | Workload | Entity layout | Endpoint pair | Change |
+| ---: | --- | ---: | ---: | ---: |
+| 1,024 | direct match | 3.681 | 1.560 | -57.6% |
+| 1,024 | forward adjacency | 13.323 | 7.454 | -44.0% |
+| 1,024 | reverse adjacency | 12.331 | 8.058 | -34.7% |
+| 1,024 | 100-row relationship page | 27.965 | 24.708 | -11.6% |
+| 1,024 | complete content proof | 1,182.973 | 436.890 | -63.1% |
+| 1,024 | create 100 | 5,114.334 | 743.416 | -85.5% |
+| 1,024 | delete 100 | 3,853.541 | 1,212.917 | -68.5% |
+| 4,096 | direct match | 2.748 | 1.144 | -58.4% |
+| 4,096 | forward adjacency | 16.613 | 11.152 | -32.9% |
+| 4,096 | reverse adjacency | 16.500 | 10.940 | -33.7% |
+| 4,096 | 100-row relationship page | 26.963 | 24.608 | -8.7% |
+| 4,096 | complete content proof | 4,564.723 | 1,762.481 | -61.4% |
+| 4,096 | create 100 | 5,042.542 | 744.250 | -85.2% |
+| 4,096 | delete 100 | 3,659.708 | 1,473.542 | -59.7% |
+
+The measured relationship-specific datom counts were exact:
+
+| Relationships | Entity layout | Endpoint pair | Reduction |
+| ---: | ---: | ---: | ---: |
+| 1,024 | 10,240 | 2,048 | 80% |
+| 4,096 | 40,960 | 8,192 | 80% |
+
+Allocation fell in every measured workload. Representative 4,096-edge mean
+allocation changes were:
+
+- direct match: 5,680 to 2,168 bytes/op;
+- forward adjacency: 39,888 to 15,256 bytes/op;
+- complete content proof: 5,134,576 to 1,858,952 bytes/op;
+- create batch: 9,174,085 to 1,526,896 bytes/op;
+- delete batch: 13,433,128 to 3,043,712 bytes/op.
+
+## Regressions and variance
+
+The 4,096-edge relationship-page arithmetic mean regressed by 1.8%
+(27.734 to 28.238 microseconds) despite its p50 improving by 8.7%. The
+4,096-edge reverse-adjacency p95 also regressed from 18.429 to 24.794
+microseconds while p50 and mean improved. These tails are visible in a short,
+single-process microbenchmark and should not be concealed by the lower medians.
+
+No benchmark result establishes a universal production speedup. The defensible
+conclusions are narrower: the new layout uses exactly one fifth of the
+relationship datoms in these fixtures, reduced allocation in every measured
+workload, and improved p50 latency for every listed workload on this machine.

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -10,7 +10,7 @@ the core module.
 | Module | Runtime | Consistency and snapshots | Cursors | Cache proof |
 | --- | --- | --- | --- | --- |
 | `eacl-datomic` | Clojure/JVM | authoritative barrier, local current, causal floor, and exact `d/as-of` | authenticated and encrypted; proof-equivalent current continuation with exact fallback | mutation identity or canonical content over scoped schema and both relationship halves |
-| `eacl-datascript` | Clojure and ClojureScript | serialized local head, local current, causal-anchor wait; optional bounded exact registry | authenticated synchronous cursor; proof-equivalent continuation and optional exact fallback | mutation identity or canonical selected-DB content |
+| `eacl-datascript` | Clojure and ClojureScript | serialized local head, local current, causal-anchor wait; optional bounded exact registry | authenticated synchronous cursor; proof-equivalent continuation and optional exact fallback | mutation identity or canonical selected-DB content over both endpoint halves |
 | `eacl-datahike` | Clojure/JVM | authoritative direct branch head, local current, causal-anchor wait, retained commit/temporal exact | authenticated synchronous cursor; proof-equivalent continuation and exact fallback | mutation identity or canonical store-visible content |
 | `eacl` | Clojure and ClojureScript | supplied by an adapter | supplied by an adapter | portable store/entry validation contract |
 
@@ -78,6 +78,16 @@ Unknown anchors return an empty page or a zero count rather than an unusable
 continuation cursor. `delete-object!` is available on all three v8 adapters and
 removes relationships touching the object without retracting the object
 entity itself.
+
+DataScript's prerelease relationship storage also changes in this candidate.
+It no longer creates a relationship entity with five components and five
+derived tuples. It stores exactly two indexed ordinary vector values, one on
+each endpoint, using Datomic/Datahike component order. There is deliberately no
+dual read or automatic migration for an unreleased representation: recreate
+DataScript explorer/demo databases or reload their relationships through EACL.
+Direct endpoint retraction can leave a ghost peer value, so call
+`delete-object!` first and use
+`eacl.datascript.integrity/dangling-relationship-report` for offline checks.
 
 ## Portable cache and mutation rules
 

--- a/docs/v8-consistency-cache-operations.md
+++ b/docs/v8-consistency-cache-operations.md
@@ -77,7 +77,10 @@ Mutation and content proofs have deliberately different cost models:
   Their worst-case work is `O(G + M log M)`, where `G` is total relationship
   storage scanned and `M` is the matching proof record count. The digest output
   is fixed-size and hashing is incremental; that is a size/memory property, not
-  a constant-time claim.
+  a constant-time claim. Datomic Pro, Datahike, and DataScript all commit both
+  physical endpoint halves plus endpoint public identities; DataScript's
+  halves are indexed ordinary vectors rather than declared heterogeneous
+  tuples.
 
 Permission paths and relation dependencies are memoized within a selected
 schema-proof generation. Recursive routing for all permission nodes shares one

--- a/modules/eacl-datahike/PORTING.md
+++ b/modules/eacl-datahike/PORTING.md
@@ -2,9 +2,9 @@
 
 The first Datahike port was derived from `modules/eacl-datascript`. The v8
 relationship layer now deliberately follows `modules/eacl-datomic`: Datahike
-supports heterogeneous tuples, so it does not need DataScript's relationship
-entity plus derived composite indexes. DataScript keeps that backend-specific
-layout until it gains heterogeneous tuples.
+supports heterogeneous tuples. DataScript cannot declare that tuple type, but
+now stores the same four components as an indexed ordinary vector on each
+endpoint instead of using a relationship entity.
 
 Status: `eacl.datahike.contract-test` runs the shared v8 public API,
 recursive, cache, and independent-oracle contracts **twice**, once per
@@ -59,6 +59,10 @@ branch. Databases created from that branch must be recreated; the adapter does
 not dual-read or migrate the obsolete physical model.
 
 ## What differs from DataScript
+
+The logical relationship value and two-half integrity contract are shared.
+Only the schema declaration and native index/temporal calls differ: Datahike
+declares heterogeneous tuples, while DataScript indexes ordinary vectors.
 
 | | DataScript | Datahike |
 |---|---|---|

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -7,6 +7,7 @@
             [eacl.datahike.mutation :as journal]
             [eacl.datahike.schema :as schema]
             [eacl.mutation :as mutation]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
             [eacl.secure-format :as secure])
   (:import [java.util UUID]))
 
@@ -159,23 +160,25 @@
           (for [{subject :e value :v}
                 (ddb/avet-datoms
                  db schema/forward-relationship-attr)
-                :let [[subject-type relation-id
-                       resource-type resource] value]
-                :when (contains? wanted relation-id)]
-            [:forward relation-id
-             subject-type subject (external-id db subject)
-             resource-type resource (external-id db resource)]))
+                :let [decoded
+                      (endpoint-pair/decode-forward subject value)]
+                :when (contains? wanted (:relation-eid decoded))]
+            [:forward (:relation-eid decoded)
+             (:subject-type decoded) subject (external-id db subject)
+             (:resource-type decoded) (:resource-eid decoded)
+             (external-id db (:resource-eid decoded))]))
         reverse
         (when (seq wanted)
           (for [{resource :e value :v}
                 (ddb/avet-datoms
                  db schema/reverse-relationship-attr)
-                :let [[resource-type relation-id
-                       subject-type subject] value]
-                :when (contains? wanted relation-id)]
-            [:reverse relation-id
-             subject-type subject (external-id db subject)
-             resource-type resource (external-id db resource)]))]
+                :let [decoded
+                      (endpoint-pair/decode-reverse resource value)]
+                :when (contains? wanted (:relation-eid decoded))]
+            [:reverse (:relation-eid decoded)
+             (:subject-type decoded) (:subject-eid decoded)
+             (external-id db (:subject-eid decoded))
+             (:resource-type decoded) resource (external-id db resource)]))]
     {:content-digest
      (secure/canonical-records-digest
       "eacl/datahike/relationship-content-proof/v3"

--- a/modules/eacl-datahike/src/eacl/datahike/impl.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/impl.clj
@@ -5,6 +5,7 @@
             [eacl.datahike.schema :as schema]
             [eacl.engine.indexed :as engine]
             [eacl.engine.relationships :as relationship-engine]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
             [eacl.schema.model :as model]))
 
 (def Relation model/Relation)
@@ -118,11 +119,13 @@
 
 (defn- relationship-tuple
   [{:keys [subject-type relation-id resource-type resource-id]}]
-  [subject-type relation-id resource-type resource-id])
+  (endpoint-pair/forward-value
+   subject-type relation-id resource-type resource-id))
 
 (defn- reverse-relationship-tuple
   [{:keys [resource-type relation-id subject-type subject-id]}]
-  [resource-type relation-id subject-type subject-id])
+  (endpoint-pair/reverse-value
+   resource-type relation-id subject-type subject-id))
 
 (defn- internal-id
   [db value]

--- a/modules/eacl-datascript/README.md
+++ b/modules/eacl-datascript/README.md
@@ -12,6 +12,8 @@ Responsibilities:
 
 - DataScript schema installation and canonical schema storage
 - DataScript SPI implementation for CLJ and CLJS
+- two-datom endpoint-pair relationship storage and guarded EAVT/AVET traversal
+- explicit offline dangling-half detection in `eacl.datascript.integrity`
 - current immutable-snapshot selection and object/reference conversion
 - proof-equivalent authenticated Relay cursors with optional exact fallback
 - database-visible mutation identities plus schema/relation content proofs
@@ -27,7 +29,34 @@ The v7 `:limit`/`:cursor` API is replaced by v8 `:first`/`:after` and
 `:last`/`:before`; see the
 [upgrade guide](../../docs/v8-backend-modules-and-upgrade.md).
 
+## Relationship storage
+
+DataScript stores a relationship as two cardinality-many indexed ordinary
+vector values, with the same logical order as the Datomic Pro and Datahike
+heterogeneous tuples:
+
+```clojure
+[subject-eid
+ :eacl.v7.relationship/subject-type+relation+resource-type+resource
+ [subject-type relation-eid resource-type resource-eid]]
+
+[resource-eid
+ :eacl.v7.relationship/resource-type+relation+subject-type+subject
+ [resource-type relation-eid subject-type subject-eid]]
+```
+
+The peer eid inside an ordinary vector is a value, not a DataScript ref.
+Consumers must remove relationships through EACL before retracting an endpoint
+entity. `delete-object!` removes both halves but retains the endpoint entity;
+`eacl.datascript.integrity/dangling-relationship-report` detects peer halves
+left by direct `:db/retractEntity`.
+
+The unreleased relationship-entity representation is not migrated or
+dual-read. Recreate explorer/demo databases, or reload every relationship
+through the EACL API, after upgrading to this v8 candidate.
+
 Useful workspace test commands:
 
 - `clj-nrepl-eval -p <port> "(do (require 'eacl.datascript.contract-test :reload-all) (clojure.test/run-tests 'eacl.datascript.contract-test))"`
 - `clj-nrepl-eval -p <port> "(do (require '[cljs.main :as cljs] :reload) (cljs/-main \"-re\" \"node\" \"-m\" \"eacl.datascript.cljs-test-runner\"))"`
+- `clj-nrepl-eval -p <port> "(do (require 'eacl.bench.datascript-relationship-storage :reload) (eacl.bench.datascript-relationship-storage/run-benchmark!))"`

--- a/modules/eacl-datascript/src/eacl/datascript/backend.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/backend.cljc
@@ -2,10 +2,12 @@
   "DataScript storage operations for the shared v8 authorization engine."
   (:require [datascript.core :as ds]
             [eacl.backend.v8 :as backend]
+            [eacl.datascript.db :as ddb]
             [eacl.datascript.impl :as impl]
             [eacl.datascript.mutation :as journal]
             [eacl.datascript.schema :as schema]
             [eacl.mutation :as mutation]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
             [eacl.secure-format :as secure]))
 
 (def capabilities
@@ -75,25 +77,6 @@
    :target-type (:eacl.permission/target-type permission)
    :target-name (:eacl.permission/target-name permission)})
 
-(defn- apply-scan-window
-  [ids {:keys [direction bound-eid inclusive-bound?]}]
-  (let [direction (or direction :asc)
-        ordered (sort ids)
-        within-bound?
-        (case direction
-          :asc (if bound-eid
-                 (if inclusive-bound?
-                   #(<= bound-eid %)
-                   #(< bound-eid %))
-                 (constantly true))
-          :desc (if bound-eid
-                  (if inclusive-bound?
-                    #(>= bound-eid %)
-                    #(> bound-eid %))
-                  (constantly true)))]
-    (cond->> (filter within-bound? ordered)
-      (= :desc direction) reverse)))
-
 (defn- schema-proof-records
   [db {:keys [permission-nodes relation-ids] :as scope}]
   (let [{:keys [relation-defs permission-defs]}
@@ -136,26 +119,45 @@
 
 (defn- content-relation-proof
   [db relation-ids external-id]
-  (let [wanted (set relation-ids)]
+  (let [wanted (set relation-ids)
+        forward
+        (when (seq wanted)
+          (for [{subject-eid :e value :v}
+                (ddb/avet-datoms
+                 db schema/forward-relationship-attr)
+                :let [decoded
+                      (endpoint-pair/decode-forward subject-eid value)]
+                :when (contains? wanted (:relation-eid decoded))]
+            [:forward
+             (:relation-eid decoded)
+             (:subject-type decoded)
+             subject-eid
+             (external-id db subject-eid)
+             (:resource-type decoded)
+             (:resource-eid decoded)
+             (external-id db (:resource-eid decoded))
+             (count value)]))
+        reverse
+        (when (seq wanted)
+          (for [{resource-eid :e value :v}
+                (ddb/avet-datoms
+                 db schema/reverse-relationship-attr)
+                :let [decoded
+                      (endpoint-pair/decode-reverse resource-eid value)]
+                :when (contains? wanted (:relation-eid decoded))]
+            [:reverse
+             (:relation-eid decoded)
+             (:subject-type decoded)
+             (:subject-eid decoded)
+             (external-id db (:subject-eid decoded))
+             (:resource-type decoded)
+             resource-eid
+             (external-id db resource-eid)
+             (count value)]))]
     {:content-digest
      (secure/canonical-records-digest
       "eacl/datascript/relationship-content-proof/v3"
-      (->> (ds/q '[:find ?relation ?subject-type ?subject
-                   ?resource-type ?resource
-                   :where
-                   [?relationship :eacl.relationship/relation ?relation]
-                   [?relationship :eacl.relationship/subject-type ?subject-type]
-                   [?relationship :eacl.relationship/subject ?subject]
-                   [?relationship :eacl.relationship/resource-type ?resource-type]
-                   [?relationship :eacl.relationship/resource ?resource]]
-                 db)
-           (filter #(contains? wanted (nth % 0)))
-           sort
-           (map (fn [[relation subject-type subject
-                      resource-type resource]]
-                  [:relationship relation
-                   subject-type subject (external-id db subject)
-                   resource-type resource (external-id db resource)]))))}))
+      (sort (concat forward reverse)))}))
 
 (defn- mutation-schema-proof
   [db]
@@ -297,25 +299,18 @@
 
        :subject->resources
        (fn [subject-type subject-id relation-id resource-type options]
-         (apply-scan-window
-          (impl/subject->resources
-           db subject-type subject-id relation-id resource-type nil)
-          options))
+         (impl/subject->resources
+          db subject-type subject-id relation-id resource-type options))
 
        :resource->subjects
        (fn [resource-type resource-id relation-id subject-type options]
-         (apply-scan-window
-          (impl/resource->subjects
-           db resource-type resource-id relation-id subject-type nil)
-          options))
+         (impl/resource->subjects
+          db resource-type resource-id relation-id subject-type options))
 
        :direct-match?
        (fn [subject-type subject-id relation-id resource-type resource-id]
-         (boolean
-          (ds/entid
-           db
-           [schema/relationship-full-key-attr
-            [subject-type subject-id relation-id resource-type resource-id]])))
+         (impl/direct-match?
+          db subject-type subject-id relation-id resource-type resource-id))
 
        :all-permission-nodes
        (fn []

--- a/modules/eacl-datascript/src/eacl/datascript/core.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/core.cljc
@@ -285,7 +285,10 @@
 
 (defn datascript-write-relationships!
   [conn opts updates]
-  (let [db      (ds/db conn)
+  (let [updates (vec updates)
+        _ (doseq [{:keys [operation]} updates]
+            (impl/validate-relationship-operation! operation))
+        db      (ds/db conn)
         internal-updates
         (S/transform [S/ALL :relationship]
                      #(spice-relationship->internal db opts %)
@@ -320,44 +323,54 @@
         (journal/ensure-migrated! conn)
         (write-response (ds/db conn) opts)))))
 
+(def ^:private relationship-attrs
+  #{schema/forward-relationship-attr
+    schema/reverse-relationship-attr})
+
+(defn- relationship-retraction-count
+  [tx-data]
+  (count
+   (filter
+    (fn [{:keys [a added]}]
+      (and (false? added)
+           (contains? relationship-attrs a)))
+    tx-data)))
+
 (defn datascript-delete-object!
   "Removes every relationship that references `object`, without retracting the
   object entity itself."
   [conn {:keys [object->entid] :as opts} object]
-  (let [db (ds/db conn)]
-    (when-let [object-eid (object->entid db object)]
-      (let [relationship-eids
-            (ds/q '[:find [?relationship ...]
-                    :in $ ?object
-                    :where
-                    (or [?relationship :eacl.relationship/subject ?object]
-                        [?relationship :eacl.relationship/resource ?object])]
-                  db object-eid)
-            relation-ids
-            (ds/q '[:find [?relation ...]
-                    :in $ [?relationship ...]
-                    :where
-                    [?relationship :eacl.relationship/relation ?relation]]
-                  db relationship-eids)]
-        (when (seq relationship-eids)
-          (journal/transact!
-           conn
-           {:mutation-id (mutation/new-id)
-            :kind :object-deletion
-            :canonical-data
-            {:operation :delete-object
-             :object object
-            :relationship-eids (vec (sort relationship-eids))}
-            :relation-ids relation-ids
-            :token-ttl-seconds (:token-ttl-seconds opts)
-            :retention-grace-seconds
-            (:retention-grace-seconds opts)
-            :tx-data
-            (mapv (fn [relationship-eid]
-                    [:db/retractEntity relationship-eid])
-                  relationship-eids)})))))
-  (journal/ensure-migrated! conn)
-  (write-response (ds/db conn) opts))
+  (let [db (ds/db conn)
+        object-eid
+        (or (try
+              (object->entid db object)
+              (catch #?(:clj Exception :cljs :default) _
+                nil))
+            (when (number? (:id object))
+              (:id object)))
+        tx-data (impl/tx-delete-object db object-eid)]
+    (if (seq tx-data)
+      (let [report
+            (journal/transact!
+             conn
+             {:mutation-id (mutation/new-id)
+              :kind :object-deletion
+              :canonical-data
+              {:operation :delete-object
+               :object object
+               :tx-data tx-data}
+              :relation-ids (impl/affected-relation-ids tx-data)
+              :token-ttl-seconds (:token-ttl-seconds opts)
+              :retention-grace-seconds
+              (:retention-grace-seconds opts)
+              :tx-data tx-data})]
+        (assoc (write-response (:db-after report) opts)
+               :retracted-datoms
+               (relationship-retraction-count (:tx-data report))))
+      (do
+        (journal/ensure-migrated! conn)
+        (assoc (write-response (ds/db conn) opts)
+               :retracted-datoms 0)))))
 
 (defn- relationship-seq
   [relationships]

--- a/modules/eacl-datascript/src/eacl/datascript/db.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/db.cljc
@@ -1,0 +1,90 @@
+(ns eacl.datascript.db
+  "Guarded native DataScript index access for endpoint-pair relationship
+  values. DataScript compares vectors by length before components, so every
+  seek and reverse-seek starts from a complete four-element value."
+  (:require [datascript.core :as ds]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]))
+
+(def min-eid 0)
+
+(def max-eid
+  #?(:clj Long/MAX_VALUE
+     :cljs js/Number.MAX_SAFE_INTEGER))
+
+(defn entid
+  [db eid-or-ref]
+  (ds/entid db eid-or-ref))
+
+(defn entity-exists?
+  [db eid]
+  (boolean (seq (ds/datoms db :eavt eid))))
+
+(defn avet-datoms
+  ([db attr]
+   (ds/datoms db :avet attr))
+  ([db attr value]
+   (ds/datoms db :avet attr value)))
+
+(defn eavt-datoms
+  ([db entity attr]
+   (ds/datoms db :eavt entity attr))
+  ([db entity attr value]
+   (ds/datoms db :eavt entity attr value)))
+
+(defn- valid-prefix?
+  [prefix]
+  (and (vector? prefix)
+       (= 3 (count prefix))
+       (keyword? (nth prefix 0))
+       (nat-int? (nth prefix 1))
+       (keyword? (nth prefix 2))))
+
+(defn- matches-prefix?
+  [prefix {:keys [v]}]
+  (endpoint-pair/value-prefix? v prefix))
+
+(defn eavt-endpoint-prefix
+  "Endpoint datoms for an exact three-component value prefix.
+
+  `cursor-eid` is an inclusive lower/upper seek bound; portable cursor logic
+  decides whether to drop the boundary row. Direction is `:asc` or `:desc`."
+  ([db entity attr prefix]
+   (eavt-endpoint-prefix db entity attr prefix nil :asc))
+  ([db entity attr prefix cursor-eid direction]
+   (if-not (and (nat-int? entity)
+                (valid-prefix? prefix)
+                (#{:asc :desc} direction))
+     []
+     (let [tail  (or cursor-eid
+                     (if (= :desc direction) max-eid min-eid))
+           bound (conj prefix tail)
+           scan  (if (= :desc direction)
+                   (ds/rseek-datoms db :eavt entity attr bound)
+                   (ds/seek-datoms db :eavt entity attr bound))]
+       (take-while
+        (fn [{:keys [e a] :as datom}]
+          (and (= entity e)
+               (= attr a)
+               (matches-prefix? prefix datom)))
+        scan)))))
+
+(defn avet-endpoint-prefix
+  "Endpoint datoms across entities for an exact three-component value prefix,
+  using a complete four-component AVET seek bound."
+  ([db attr prefix]
+   (avet-endpoint-prefix db attr prefix nil :asc))
+  ([db attr prefix cursor-eid direction]
+   (if-not (and (valid-prefix? prefix)
+                (#{:asc :desc} direction))
+     []
+     (let [tail  (or cursor-eid
+                     (if (= :desc direction) max-eid min-eid))
+           bound (conj prefix tail)
+           scan  (if (= :desc direction)
+                   (ds/rseek-datoms db :avet attr bound)
+                   (ds/seek-datoms db :avet attr bound))]
+       (take-while
+        (fn [{:keys [a] :as datom}]
+          (and (= attr a)
+               (matches-prefix? prefix datom)))
+        scan)))))

--- a/modules/eacl-datascript/src/eacl/datascript/impl.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/impl.cljc
@@ -1,10 +1,12 @@
 (ns eacl.datascript.impl
   (:require [datascript.core :as ds]
             [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datascript.db :as ddb]
+            [eacl.datascript.schema :as schema]
             [eacl.engine.indexed :as engine]
             [eacl.engine.relationships :as relationship-engine]
-            [eacl.schema.model :as model]
-            [eacl.datascript.schema :as schema]))
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
+            [eacl.schema.model :as model]))
 
 (def Relation model/Relation)
 (def Permission model/Permission)
@@ -81,33 +83,65 @@
            :subject-type (nth v 2)})
         (ds/datoms db :avet :eacl.relation/resource-type+relation-name+subject-type)))
 
-(defn- exclusive-start-id
-  [cursor-id]
-  (if cursor-id
-    (inc cursor-id)
-    0))
-
-(defn- bounded-relationship-target-ids
-  [db attr prefix cursor-id]
-  (->> (ds/index-range db
-                       attr
-                       (conj prefix (exclusive-start-id cursor-id))
-                       (conj prefix max-entid))
-       (map (fn [{:keys [v]}] (peek v)))))
-
 (defn subject->resources
-  [db subject-type subject-id relation-id resource-type cursor-resource-id]
-  (bounded-relationship-target-ids db
-                                   schema/forward-relationship-attr
-                                   [subject-type subject-id relation-id resource-type]
-                                   cursor-resource-id))
+  [db subject-type subject-id relation-id resource-type cursor-or-options]
+  (let [{:keys [direction bound-eid inclusive-bound?]}
+        (if (map? cursor-or-options)
+          (merge {:direction :asc} cursor-or-options)
+          {:direction :asc
+           :bound-eid cursor-or-options
+           :inclusive-bound? false})
+        within-bound?
+        (case direction
+          :asc
+          (if bound-eid
+            (if inclusive-bound?
+              #(<= bound-eid %)
+              #(< bound-eid %))
+            (constantly true))
+
+          :desc
+          (if bound-eid
+            (if inclusive-bound?
+              #(>= bound-eid %)
+              #(> bound-eid %))
+            (constantly true)))]
+    (->> (ddb/eavt-endpoint-prefix
+          db subject-id schema/forward-relationship-attr
+          [subject-type relation-id resource-type]
+          bound-eid direction)
+         (map (comp #(nth % 3) :v))
+         (filter within-bound?))))
 
 (defn resource->subjects
-  [db resource-type resource-id relation-id subject-type cursor-subject-id]
-  (bounded-relationship-target-ids db
-                                   schema/reverse-relationship-attr
-                                   [resource-type resource-id relation-id subject-type]
-                                   cursor-subject-id))
+  [db resource-type resource-id relation-id subject-type cursor-or-options]
+  (let [{:keys [direction bound-eid inclusive-bound?]}
+        (if (map? cursor-or-options)
+          (merge {:direction :asc} cursor-or-options)
+          {:direction :asc
+           :bound-eid cursor-or-options
+           :inclusive-bound? false})
+        within-bound?
+        (case direction
+          :asc
+          (if bound-eid
+            (if inclusive-bound?
+              #(<= bound-eid %)
+              #(< bound-eid %))
+            (constantly true))
+
+          :desc
+          (if bound-eid
+            (if inclusive-bound?
+              #(>= bound-eid %)
+              #(> bound-eid %))
+            (constantly true)))]
+    (->> (ddb/eavt-endpoint-prefix
+          db resource-id schema/reverse-relationship-attr
+          [resource-type relation-id subject-type]
+          bound-eid direction)
+         (map (comp #(nth % 3) :v))
+         (filter within-bound?))))
 
 (defn build-schema-catalog
   [db]
@@ -133,12 +167,14 @@
            (ds/datoms db :avet :eacl.permission/resource-type+permission-name))})
 
 (defn- relationship-tuple
-  [{:keys [subject-type subject-id relation-id resource-type resource-id]}]
-  [subject-type subject-id relation-id resource-type resource-id])
+  [{:keys [subject-type relation-id resource-type resource-id]}]
+  (endpoint-pair/forward-value
+   subject-type relation-id resource-type resource-id))
 
-(defn- relationship-reverse-tuple
-  [{:keys [resource-type resource-id relation-id subject-type subject-id]}]
-  [resource-type resource-id relation-id subject-type subject-id])
+(defn- reverse-relationship-tuple
+  [{:keys [resource-type relation-id subject-type subject-id]}]
+  (endpoint-pair/reverse-value
+   resource-type relation-id subject-type subject-id))
 
 (defn- internal-id
   [db value]
@@ -196,53 +232,111 @@
                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e
                      (when-not (= :eacl/unknown-object (:type (ex-data e)))
                        (throw e))))
-        existing (when resolved
-                   (ds/entid db [schema/relationship-full-key-attr
-                                 (relationship-tuple resolved)]))]
-    (when existing
+        existing? (and resolved
+                       (seq
+                        (ddb/eavt-datoms
+                         db
+                         (:subject-id resolved)
+                         schema/forward-relationship-attr
+                         (relationship-tuple resolved)))
+                       (seq
+                        (ddb/eavt-datoms
+                         db
+                         (:resource-id resolved)
+                         schema/reverse-relationship-attr
+                         (reverse-relationship-tuple resolved))))]
+    (when existing?
       resolved)))
 
 (defn relationship-relation-id
   [db relationship]
   (:relation-id (resolve-relationship db relationship)))
 
+(defn- add-relationship-txes
+  [resolved]
+  [[:db/add
+    (:subject-id resolved)
+    schema/forward-relationship-attr
+    (relationship-tuple resolved)]
+   [:db/add
+    (:resource-id resolved)
+    schema/reverse-relationship-attr
+    (reverse-relationship-tuple resolved)]])
+
+(defn- retract-relationship-txes
+  [resolved]
+  [[:db/retract
+    (:subject-id resolved)
+    schema/forward-relationship-attr
+    (relationship-tuple resolved)]
+   [:db/retract
+    (:resource-id resolved)
+    schema/reverse-relationship-attr
+    (reverse-relationship-tuple resolved)]])
+
+(defn direct-match?
+  [db subject-type subject-id relation-id resource-type resource-id]
+  (boolean
+   (seq
+    (ddb/eavt-datoms
+     db subject-id schema/forward-relationship-attr
+     (endpoint-pair/forward-value
+      subject-type relation-id resource-type resource-id)))))
+
+(defn- reverse-match?
+  [db resource-type resource-id relation-id subject-type subject-id]
+  (boolean
+   (seq
+    (ddb/eavt-datoms
+     db resource-id schema/reverse-relationship-attr
+     (endpoint-pair/reverse-value
+      resource-type relation-id subject-type subject-id)))))
+
+(defn- relationship-exists?
+  [db {:keys [subject-type subject-id relation-id
+              resource-type resource-id]}]
+  (and (direct-match? db subject-type subject-id relation-id
+                      resource-type resource-id)
+       (reverse-match? db resource-type resource-id relation-id
+                       subject-type subject-id)))
+
+(def ^:private supported-relationship-operations
+  #{:create :touch :delete})
+
+(defn validate-relationship-operation!
+  [operation]
+  (when-not (contains? supported-relationship-operations operation)
+    (throw
+     (ex-info
+      (str (pr-str operation)
+           " relationship update is not supported. Use :create, :touch or :delete.")
+      {:type :eacl/unsupported-operation
+       :operation operation})))
+  true)
+
 (defn tx-update-relationship
   [db {:keys [operation relationship]}]
-  (let [resolved  (resolve-relationship db relationship)
-        tuple     (relationship-tuple resolved)
-        existing  (ds/entid db [schema/relationship-full-key-attr tuple])]
+  (validate-relationship-operation! operation)
+  (let [resolved (resolve-relationship db relationship)
+        exists?  (relationship-exists? db resolved)]
     (case operation
       :touch
-      (when-not existing
-        [{:eacl.relationship/subject-type (:subject-type resolved)
-          :eacl.relationship/subject      (:subject-id resolved)
-          :eacl.relationship/relation     (:relation-id resolved)
-          :eacl.relationship/resource-type (:resource-type resolved)
-          :eacl.relationship/resource     (:resource-id resolved)}])
+      (when-not exists?
+        (add-relationship-txes resolved))
 
       :create
-      (if existing
-        (throw (ex-info ":create relationship conflicts with existing tuple relationship"
-                 {:relationship relationship}))
-        [{:eacl.relationship/subject-type (:subject-type resolved)
-          :eacl.relationship/subject      (:subject-id resolved)
-          :eacl.relationship/relation     (:relation-id resolved)
-          :eacl.relationship/resource-type (:resource-type resolved)
-          :eacl.relationship/resource     (:resource-id resolved)}])
+      (if exists?
+        (throw
+         (ex-info
+          ":create conflicts with an existing relationship. Use :touch for idempotent writes."
+          {:type :eacl/relationship-conflict
+           :relationship relationship}))
+        (add-relationship-txes resolved))
 
       :delete
-      (when existing
-        [[:db/retractEntity existing]])
-
-      :unspecified
-      [{:eacl.relationship/subject-type (:subject-type resolved)
-        :eacl.relationship/subject      (:subject-id resolved)
-        :eacl.relationship/relation     (:relation-id resolved)
-        :eacl.relationship/resource-type (:resource-type resolved)
-        :eacl.relationship/resource     (:resource-id resolved)}]
-
-      (throw (ex-info "Unknown relationship operation"
-                      {:operation operation})))))
+      ;; Retraction of an absent DataScript datom is harmless. Always retract
+      ;; both halves so an out-of-band half pair is repairable.
+      (retract-relationship-txes resolved))))
 
 (def ^:private known-relationship-filter-keys
   #{:subject/type :subject/id
@@ -293,107 +387,258 @@
             (and (contains? filters :resource/id) (nil? resource-id')))
       {:data [] :cursor nil}
       (letfn [(relationship-row [spec subject-id resource-id]
-            {:spec-idx    (:idx spec)
-             :subject-id  subject-id
-             :resource-id resource-id
-             :relationship
-             (eacl/->Relationship
-              (spice-object (:subject-type spec) subject-id)
-              (:relation-name spec)
-              (spice-object (:resource-type spec) resource-id))})
-          (drop-until-after-cursor [spec cursor rows]
-            (drop-while #(not (relationship-engine/after-cursor? (:scan-kind spec) cursor %))
-                        rows))
-          (exact-match-row [spec cursor]
-            (let [row (when (and (:subject-id spec) (:resource-id spec))
-                        (when (ds/entid db [schema/relationship-full-key-attr
-                                           [(:subject-type spec)
-                                            (:subject-id spec)
-                                            (:relation-id spec)
-                                            (:resource-type spec)
-                                            (:resource-id spec)]])
-                          (relationship-row spec (:subject-id spec) (:resource-id spec))))]
-              (if row
-                (drop-until-after-cursor spec cursor [row])
-                [])))
-          (scan-forward-anchored [spec cursor]
-            (if (:resource-id spec)
-              (exact-match-row spec cursor)
-              (->> (ds/index-range db
-                                   schema/forward-relationship-attr
-                                   [(:subject-type spec)
-                                    (:subject-id spec)
-                                    (:relation-id spec)
-                                    (:resource-type spec)
-                                    (or (:resource cursor) 0)]
-                                   [(:subject-type spec)
-                                    (:subject-id spec)
-                                    (:relation-id spec)
-                                    (:resource-type spec)
-                                    max-entid])
-                   (map (fn [{:keys [v]}]
-                          (relationship-row spec (nth v 1) (nth v 4))))
-                   (drop-until-after-cursor spec cursor))))
-          (scan-reverse-anchored [spec cursor]
-            (if (:subject-id spec)
-              (exact-match-row spec cursor)
-              (->> (ds/index-range db
-                                   schema/reverse-relationship-attr
-                                   [(:resource-type spec)
-                                    (:resource-id spec)
-                                    (:relation-id spec)
-                                    (:subject-type spec)
-                                    (or (:subject cursor) 0)]
-                                   [(:resource-type spec)
-                                    (:resource-id spec)
-                                    (:relation-id spec)
-                                    (:subject-type spec)
-                                    max-entid])
-                   (map (fn [{:keys [v]}]
-                          (relationship-row spec (nth v 4) (nth v 1))))
-                   (drop-until-after-cursor spec cursor))))
-          (scan-forward-partial [spec cursor]
-            (->> (ds/index-range db
-                                 schema/forward-partial-relationship-attr
-                                 [(:subject-type spec)
-                                  (:relation-id spec)
-                                  (:resource-type spec)
-                                  (or (:resource cursor) 0)
-                                  0]
-                                 [(:subject-type spec)
-                                  (:relation-id spec)
-                                  (:resource-type spec)
-                                  max-entid
-                                  max-entid])
-                 (map (fn [{:keys [v]}]
-                        (relationship-row spec (nth v 4) (nth v 3))))
-                 (drop-until-after-cursor spec cursor)))
-          (scan-reverse-partial [spec cursor]
-            (->> (ds/index-range db
-                                 schema/reverse-partial-relationship-attr
-                                 [(:resource-type spec)
-                                  (:relation-id spec)
-                                  (:subject-type spec)
-                                  (or (:subject cursor) 0)
-                                  0]
-                                 [(:resource-type spec)
-                                  (:relation-id spec)
-                                  (:subject-type spec)
-                                  max-entid
-                                  max-entid])
-                 (map (fn [{:keys [v]}]
-                        (relationship-row spec (nth v 3) (nth v 4))))
-                 (drop-until-after-cursor spec cursor)))
-          (scan-spec [spec cursor]
-            (case (:scan-kind spec)
-              :forward-anchored (scan-forward-anchored spec cursor)
-              :reverse-anchored (scan-reverse-anchored spec cursor)
-              :forward-partial (scan-forward-partial spec cursor)
-              (scan-reverse-partial spec cursor)))]
+                {:spec-idx    (:idx spec)
+                 :subject-id  subject-id
+                 :resource-id resource-id
+                 :relationship
+                 (eacl/->Relationship
+                  (spice-object (:subject-type spec) subject-id)
+                  (:relation-name spec)
+                  (spice-object (:resource-type spec) resource-id))})
+              (drop-until-after-cursor [spec cursor rows]
+                (drop-while
+                 #(not
+                   (relationship-engine/after-cursor?
+                    (:scan-kind spec) cursor %))
+                 rows))
+              (exact-match-row [spec cursor]
+                (let [row
+                      (when (and (:subject-id spec) (:resource-id spec))
+                        (when
+                         (direct-match?
+                          db
+                          (:subject-type spec)
+                          (:subject-id spec)
+                          (:relation-id spec)
+                          (:resource-type spec)
+                          (:resource-id spec))
+                          (relationship-row
+                           spec (:subject-id spec) (:resource-id spec))))]
+                  (if row
+                    (drop-until-after-cursor spec cursor [row])
+                    [])))
+              (scan-forward-anchored [spec cursor]
+                (if (:resource-id spec)
+                  (exact-match-row spec cursor)
+                  (->> (ddb/eavt-endpoint-prefix
+                        db
+                        (:subject-id spec)
+                        schema/forward-relationship-attr
+                        [(:subject-type spec)
+                         (:relation-id spec)
+                         (:resource-type spec)]
+                        (:resource cursor)
+                        :asc)
+                       (map
+                        (fn [{:keys [v]}]
+                          (relationship-row
+                           spec (:subject-id spec) (nth v 3))))
+                       (drop-until-after-cursor spec cursor))))
+              (scan-reverse-anchored [spec cursor]
+                (if (:subject-id spec)
+                  (exact-match-row spec cursor)
+                  (->> (ddb/eavt-endpoint-prefix
+                        db
+                        (:resource-id spec)
+                        schema/reverse-relationship-attr
+                        [(:resource-type spec)
+                         (:relation-id spec)
+                         (:subject-type spec)]
+                        (:subject cursor)
+                        :asc)
+                       (map
+                        (fn [{:keys [v]}]
+                          (relationship-row
+                           spec (nth v 3) (:resource-id spec))))
+                       (drop-until-after-cursor spec cursor))))
+              (scan-forward-partial [spec cursor]
+                (->> (ddb/avet-endpoint-prefix
+                      db
+                      schema/forward-relationship-attr
+                      [(:subject-type spec)
+                       (:relation-id spec)
+                       (:resource-type spec)]
+                      (:resource cursor)
+                      :asc)
+                     (map
+                      (fn [{:keys [e v]}]
+                        (relationship-row spec e (nth v 3))))
+                     (drop-until-after-cursor spec cursor)))
+              (scan-reverse-partial [spec cursor]
+                (->> (ddb/avet-endpoint-prefix
+                      db
+                      schema/reverse-relationship-attr
+                      [(:resource-type spec)
+                       (:relation-id spec)
+                       (:subject-type spec)]
+                      (:subject cursor)
+                      :asc)
+                     (map
+                      (fn [{:keys [e v]}]
+                        (relationship-row spec (nth v 3) e)))
+                     (drop-until-after-cursor spec cursor)))
+              (scan-spec [spec cursor]
+                (case (:scan-kind spec)
+                  :forward-anchored
+                  (scan-forward-anchored spec cursor)
+
+                  :reverse-anchored
+                  (scan-reverse-anchored spec cursor)
+
+                  :forward-partial
+                  (scan-forward-partial spec cursor)
+
+                  (scan-reverse-partial spec cursor)))]
         (relationship-engine/execute-plan
          (relationship-engine/plan-scans (all-relation-defs db) filters')
          filters'
          scan-spec)))))
+
+(defn- relation-triples
+  [db]
+  (mapv (fn [{:keys [e v]}]
+          [(nth v 0) e (nth v 2)])
+        (ddb/avet-datoms
+         db :eacl.relation/resource-type+relation-name+subject-type)))
+
+(defn- relationship-pair-retractions
+  [subject-type subject-id relation-id resource-type resource-id]
+  [[:db/retract
+    subject-id
+    schema/forward-relationship-attr
+    (endpoint-pair/forward-value
+     subject-type relation-id resource-type resource-id)]
+   [:db/retract
+    resource-id
+    schema/reverse-relationship-attr
+    (endpoint-pair/reverse-value
+     resource-type relation-id subject-type subject-id)]])
+
+(defn tx-delete-object
+  "Returns transaction data removing both physical halves of every
+  relationship touching `object-id`. The object entity itself is retained.
+
+  Cross-entity exact AVET probes also find a surviving peer half when the local
+  endpoint entity was already retracted out of band and its numeric eid is
+  supplied for cleanup."
+  [db object-id]
+  (if-let [object-eid (internal-id db object-id)]
+    (let [triples (relation-triples db)]
+      (->>
+       (concat
+        (mapcat
+         (fn [{:keys [v]}]
+           (when-let [{:keys [subject-type relation-eid
+                             resource-type resource-eid]}
+                      (endpoint-pair/decode-forward object-eid v)]
+             (relationship-pair-retractions
+              subject-type object-eid relation-eid
+              resource-type resource-eid)))
+         (ddb/eavt-datoms
+          db object-eid schema/forward-relationship-attr))
+
+        (mapcat
+         (fn [{:keys [v]}]
+           (when-let [{:keys [subject-type subject-eid relation-eid
+                             resource-type]}
+                      (endpoint-pair/decode-reverse object-eid v)]
+             (relationship-pair-retractions
+              subject-type subject-eid relation-eid
+              resource-type object-eid)))
+         (ddb/eavt-datoms
+          db object-eid schema/reverse-relationship-attr))
+
+        (mapcat
+         (fn [[resource-type relation-id subject-type]]
+           (mapcat
+            (fn [{resource-id :e}]
+              (relationship-pair-retractions
+               subject-type object-eid relation-id
+               resource-type resource-id))
+            (ddb/avet-datoms
+             db schema/reverse-relationship-attr
+             (endpoint-pair/reverse-value
+              resource-type relation-id subject-type object-eid))))
+         triples)
+
+        (mapcat
+         (fn [[resource-type relation-id subject-type]]
+           (mapcat
+            (fn [{subject-id :e}]
+              (relationship-pair-retractions
+               subject-type subject-id relation-id
+               resource-type object-eid))
+            (ddb/avet-datoms
+             db schema/forward-relationship-attr
+             (endpoint-pair/forward-value
+              subject-type relation-id resource-type object-eid))))
+         triples))
+       (remove nil?)
+       distinct
+       vec))
+    []))
+
+(defn affected-relation-ids
+  "Every relation named by endpoint-pair retraction operations."
+  [tx-data]
+  (->> tx-data
+       (keep
+        (fn [op]
+          (when (and (vector? op)
+                     (= :db/retract (first op))
+                     (contains?
+                      #{schema/forward-relationship-attr
+                        schema/reverse-relationship-attr}
+                      (nth op 2 nil)))
+            (nth (nth op 3) 1))))
+       distinct
+       sort
+       vec))
+
+(defn orphaned-relationship-halves
+  "Lazy deterministic scan of physical relationship halves whose exact peer
+  half is absent. Malformed values are reported as dangling rather than
+  throwing from the diagnostic."
+  [db]
+  (concat
+   (for [{subject-id :e value :v}
+         (ddb/avet-datoms db schema/forward-relationship-attr)
+         :let [decoded (endpoint-pair/decode-forward subject-id value)
+               peer (endpoint-pair/peer-half :forward subject-id value)]
+         :when
+         (or (nil? decoded)
+             (empty?
+              (ddb/eavt-datoms
+               db (:endpoint-eid peer)
+               schema/reverse-relationship-attr
+               (:value peer))))]
+     {:half :forward
+      :e subject-id
+      :attr schema/forward-relationship-attr
+      :v (if (sequential? value) (vec value) value)
+      :subject-eid subject-id
+      :resource-eid (:resource-eid decoded)
+      :relation-eid (:relation-eid decoded)
+      :value-arity (when (counted? value) (count value))})
+   (for [{resource-id :e value :v}
+         (ddb/avet-datoms db schema/reverse-relationship-attr)
+         :let [decoded (endpoint-pair/decode-reverse resource-id value)
+               peer (endpoint-pair/peer-half :reverse resource-id value)]
+         :when
+         (or (nil? decoded)
+             (empty?
+              (ddb/eavt-datoms
+               db (:endpoint-eid peer)
+               schema/forward-relationship-attr
+               (:value peer))))]
+     {:half :reverse
+      :e resource-id
+      :attr schema/reverse-relationship-attr
+      :v (if (sequential? value) (vec value) value)
+      :subject-eid (:subject-eid decoded)
+      :resource-eid resource-id
+      :relation-eid (:relation-eid decoded)
+      :value-arity (when (counted? value) (count value))})))
 
 (defn- normalize-backend-options
   [cache-stamp-or-opts]
@@ -462,10 +707,10 @@
                           (subject->resources db subject-type subject-id relation-id resource-type cursor-resource-id))
     :resource->subjects (fn [resource-type resource-id relation-id subject-type cursor-subject-id]
                           (resource->subjects db resource-type resource-id relation-id subject-type cursor-subject-id))
-    :direct-match? (fn [subject-type subject-id relation-id resource-type resource-id]
-                     (boolean
-                      (ds/entid db [schema/relationship-full-key-attr
-                                    [subject-type subject-id relation-id resource-type resource-id]])))})))
+	    :direct-match?
+        (fn [subject-type subject-id relation-id resource-type resource-id]
+          (direct-match?
+           db subject-type subject-id relation-id resource-type resource-id))})))
 
 (defn- backend*
   [db-or-backend]

--- a/modules/eacl-datascript/src/eacl/datascript/integrity.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/integrity.cljc
@@ -1,0 +1,40 @@
+(ns eacl.datascript.integrity
+  "Read-only, offline endpoint-pair integrity diagnostics."
+  (:require [eacl.datascript.impl :as impl]))
+
+(defn dangling-relationship-halves
+  "Returns a lazy sequence of relationship halves whose exact peer is absent."
+  [db]
+  (impl/orphaned-relationship-halves db))
+
+(defn dangling-relationship-report
+  "Returns deterministic total/per-half dangling counts and a bounded sample.
+  This scan never mutates the database."
+  ([db]
+   (dangling-relationship-report db {}))
+  ([db {:keys [sample-size] :or {sample-size 20}}]
+   (when-not (and (integer? sample-size)
+                  (not (neg? sample-size)))
+     (throw
+      (ex-info
+       ":sample-size must be a non-negative integer."
+       {:type :eacl.integrity/invalid-options
+        :sample-size sample-size})))
+   (let [{:keys [count by-half sample]}
+         (reduce
+          (fn [{:keys [count] :as report} half]
+            (cond-> (-> report
+                        (assoc :count (inc count))
+                        (update-in
+                         [:by-half (:half half)]
+                         (fnil inc 0)))
+              (< count sample-size)
+              (update :sample conj half)))
+          {:count 0
+           :by-half {:forward 0 :reverse 0}
+           :sample []}
+          (dangling-relationship-halves db))]
+     {:valid? (zero? count)
+      :dangling-count count
+      :by-half by-half
+      :sample sample})))

--- a/modules/eacl-datascript/src/eacl/datascript/schema.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/schema.cljc
@@ -6,19 +6,10 @@
             [eacl.spicedb.parser :as parser]))
 
 (def forward-relationship-attr
-  :eacl.v7.relationship/subject-type+subject+relation+resource-type+resource)
+  :eacl.v7.relationship/subject-type+relation+resource-type+resource)
 
 (def reverse-relationship-attr
-  :eacl.v7.relationship/resource-type+resource+relation+subject-type+subject)
-
-(def forward-partial-relationship-attr
-  :eacl.v7.relationship/subject-type+relation+resource-type+resource+subject)
-
-(def reverse-partial-relationship-attr
-  :eacl.v7.relationship/resource-type+relation+subject-type+subject+resource)
-
-(def relationship-full-key-attr
-  :eacl.relationship/full-key)
+  :eacl.v7.relationship/resource-type+relation+subject-type+subject)
 
 (def max-entid
   #?(:clj Long/MAX_VALUE
@@ -83,50 +74,11 @@
    :eacl.relation/mutation-id {:db/index true}
    :eacl.dependency/mutation-id {:db/index true}
 
-   :eacl.relationship/subject {:db/valueType :db.type/ref}
-   :eacl.relationship/relation {:db/valueType :db.type/ref}
-   :eacl.relationship/resource {:db/valueType :db.type/ref}
-   :eacl.relationship/subject-type {:db/index true}
-   :eacl.relationship/resource-type {:db/index true}
-   :eacl.relationship/full-key
-   {:db/valueType :db.type/tuple
-    :db/tupleAttrs [:eacl.relationship/subject-type
-                    :eacl.relationship/subject
-                    :eacl.relationship/relation
-                    :eacl.relationship/resource-type
-                    :eacl.relationship/resource]
-    :db/unique :db.unique/identity}
-   :eacl.v7.relationship/subject-type+subject+relation+resource-type+resource
-   {:db/valueType :db.type/tuple
-    :db/tupleAttrs [:eacl.relationship/subject-type
-                    :eacl.relationship/subject
-                    :eacl.relationship/relation
-                    :eacl.relationship/resource-type
-                    :eacl.relationship/resource]
+   :eacl.v7.relationship/subject-type+relation+resource-type+resource
+   {:db/cardinality :db.cardinality/many
     :db/index true}
-   :eacl.v7.relationship/resource-type+resource+relation+subject-type+subject
-   {:db/valueType :db.type/tuple
-    :db/tupleAttrs [:eacl.relationship/resource-type
-                    :eacl.relationship/resource
-                    :eacl.relationship/relation
-                    :eacl.relationship/subject-type
-                    :eacl.relationship/subject]
-    :db/index true}
-   :eacl.v7.relationship/subject-type+relation+resource-type+resource+subject
-   {:db/valueType :db.type/tuple
-    :db/tupleAttrs [:eacl.relationship/subject-type
-                    :eacl.relationship/relation
-                    :eacl.relationship/resource-type
-                    :eacl.relationship/resource
-                    :eacl.relationship/subject]
-    :db/index true}
-   :eacl.v7.relationship/resource-type+relation+subject-type+subject+resource
-   {:db/valueType :db.type/tuple
-    :db/tupleAttrs [:eacl.relationship/resource-type
-                    :eacl.relationship/relation
-                    :eacl.relationship/subject-type
-                    :eacl.relationship/subject
-                    :eacl.relationship/resource]
+   :eacl.v7.relationship/resource-type+relation+subject-type+subject
+   {:db/cardinality :db.cardinality/many
     :db/index true}})
 
 (defn merge-schema
@@ -172,23 +124,25 @@
 
 (defn count-relationships-using-relation
   "Counts relationships that reference the given relation, exactly.
-  Scans the forward-partial index whose leading components are
-  [subject-type relation]; a range over the forward index with varying middle
-  components would span other relations of the same subject-type and overcount."
+  Scans the endpoint-pair forward index whose leading components are
+  [subject-type relation resource-type]."
   [db {:eacl.relation/keys [resource-type relation-name subject-type]}]
   (let [relation-id  (str "eacl.relation:" resource-type ":" relation-name ":" subject-type)
         relation-eid (ds/entid db [:eacl/id relation-id])]
     (if-not relation-eid
       0
-      ;; nil-padded to full tuple arity: DataScript sorts vectors length-first.
+      ;; nil-padded to full value arity: DataScript sorts vectors length-first.
       (->> (ds/seek-datoms db :avet
-                           forward-partial-relationship-attr
-                           [subject-type relation-eid nil nil nil])
+                           forward-relationship-attr
+                           [subject-type relation-eid resource-type nil])
            (take-while (fn [datom]
-                         (and (= forward-partial-relationship-attr (:a datom))
+                         (and (= forward-relationship-attr (:a datom))
                               (let [v (:v datom)]
-                                (and (= subject-type (nth v 0))
-                                     (= relation-eid (nth v 1)))))))
+                                (and (vector? v)
+                                     (= 4 (count v))
+                                     (= subject-type (nth v 0))
+                                     (= relation-eid (nth v 1))
+                                     (= resource-type (nth v 2)))))))
            (count)))))
 
 (defn write-schema!

--- a/modules/eacl-datascript/test/eacl/bench/datascript_relationship_storage.clj
+++ b/modules/eacl-datascript/test/eacl/bench/datascript_relationship_storage.clj
@@ -1,0 +1,451 @@
+(ns eacl.bench.datascript-relationship-storage
+  "Reproducible JVM comparison of PR #92's relationship-entity layout and the
+  endpoint-pair layout. Run explicitly through nREPL; this is not a test
+  namespace and is intentionally excluded from the regular suite."
+  (:require [clojure.java.io :as io]
+            [datascript.core :as ds]
+            [eacl.datascript.db :as ddb]
+            [eacl.relationships.endpoint-pair :as endpoint-pair])
+  (:import [com.sun.management ThreadMXBean]
+           [java.lang.management ManagementFactory]
+           [java.time Instant]))
+
+(def old-subject-attr :bench.old/subject)
+(def old-relation-attr :bench.old/relation)
+(def old-resource-attr :bench.old/resource)
+(def old-subject-type-attr :bench.old/subject-type)
+(def old-resource-type-attr :bench.old/resource-type)
+(def old-full-key-attr :bench.old/full-key)
+(def old-forward-attr :bench.old/forward)
+(def old-reverse-attr :bench.old/reverse)
+(def old-forward-partial-attr :bench.old/forward-partial)
+(def old-reverse-partial-attr :bench.old/reverse-partial)
+(def new-forward-attr :bench.new/forward)
+(def new-reverse-attr :bench.new/reverse)
+
+(def old-relationship-attrs
+  [old-subject-attr old-relation-attr old-resource-attr
+   old-subject-type-attr old-resource-type-attr old-full-key-attr
+   old-forward-attr old-reverse-attr
+   old-forward-partial-attr old-reverse-partial-attr])
+
+(def old-schema
+  {:bench/id {:db/unique :db.unique/identity}
+   old-subject-attr {:db/valueType :db.type/ref}
+   old-relation-attr {:db/valueType :db.type/ref}
+   old-resource-attr {:db/valueType :db.type/ref}
+   old-subject-type-attr {:db/index true}
+   old-resource-type-attr {:db/index true}
+   old-full-key-attr
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [old-subject-type-attr old-subject-attr
+                    old-relation-attr old-resource-type-attr
+                    old-resource-attr]
+    :db/unique :db.unique/identity}
+   old-forward-attr
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [old-subject-type-attr old-subject-attr
+                    old-relation-attr old-resource-type-attr
+                    old-resource-attr]
+    :db/index true}
+   old-reverse-attr
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [old-resource-type-attr old-resource-attr
+                    old-relation-attr old-subject-type-attr
+                    old-subject-attr]
+    :db/index true}
+   old-forward-partial-attr
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [old-subject-type-attr old-relation-attr
+                    old-resource-type-attr old-resource-attr
+                    old-subject-attr]
+    :db/index true}
+   old-reverse-partial-attr
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [old-resource-type-attr old-relation-attr
+                    old-subject-type-attr old-subject-attr
+                    old-resource-attr]
+    :db/index true}})
+
+(def new-schema
+  {:bench/id {:db/unique :db.unique/identity}
+   new-forward-attr
+   {:db/cardinality :db.cardinality/many
+    :db/index true}
+   new-reverse-attr
+   {:db/cardinality :db.cardinality/many
+    :db/index true}})
+
+(defn- base-db
+  [schema relationship-count]
+  (let [width (long (Math/ceil (Math/sqrt relationship-count)))
+        conn (ds/create-conn schema)
+        subjects (mapv #(str "subject-" %) (range width))
+        resources (mapv #(str "resource-" %) (range width))]
+    (ds/transact!
+     conn
+     (concat
+      [{:bench/id "relation"}]
+      (map (fn [id] {:bench/id id}) subjects)
+      (map (fn [id] {:bench/id id}) resources)))
+    (let [db (ds/db conn)
+          subject-eids (mapv #(ds/entid db [:bench/id %]) subjects)
+          resource-eids (mapv #(ds/entid db [:bench/id %]) resources)
+          relation-eid (ds/entid db [:bench/id "relation"])
+          pairs
+          (->> (for [subject-eid subject-eids
+                     resource-eid resource-eids]
+                 [subject-eid resource-eid])
+               (take relationship-count)
+               vec)]
+      {:db db
+       :relation-eid relation-eid
+       :subject-eids subject-eids
+       :resource-eids resource-eids
+       :pairs pairs})))
+
+(defn- old-create-tx
+  [relation-eid pairs]
+  (mapv
+   (fn [[subject-eid resource-eid]]
+     {old-subject-type-attr :user
+      old-subject-attr subject-eid
+      old-relation-attr relation-eid
+      old-resource-type-attr :document
+      old-resource-attr resource-eid})
+   pairs))
+
+(defn- new-create-tx
+  [relation-eid pairs]
+  (mapcat
+   (fn [[subject-eid resource-eid]]
+     [[:db/add subject-eid new-forward-attr
+       (endpoint-pair/forward-value
+        :user relation-eid :document resource-eid)]
+      [:db/add resource-eid new-reverse-attr
+       (endpoint-pair/reverse-value
+        :document relation-eid :user subject-eid)]])
+   pairs))
+
+(defn- seeded-layout
+  [layout relationship-count]
+  (let [{:keys [db relation-eid pairs] :as base}
+        (base-db (if (= :old layout) old-schema new-schema)
+                 relationship-count)
+        tx-data ((if (= :old layout) old-create-tx new-create-tx)
+                 relation-eid pairs)
+        report (ds/with db tx-data)]
+    (assoc base
+           :layout layout
+           :base-db db
+           :db (:db-after report)
+           :tx-data tx-data
+           :relationship-eids
+           (when (= :old layout)
+             (mapv
+              #(ds/entid
+                (:db-after report)
+                [old-full-key-attr
+                 [:user (first %) relation-eid :document (second %)]])
+              pairs)))))
+
+(defn- old-direct?
+  [{:keys [db relation-eid pairs]}]
+  (let [[subject-eid resource-eid] (nth pairs (quot (count pairs) 2))]
+    (boolean
+     (ds/entid
+      db
+      [old-full-key-attr
+       [:user subject-eid relation-eid :document resource-eid]]))))
+
+(defn- new-direct?
+  [{:keys [db relation-eid pairs]}]
+  (let [[subject-eid resource-eid] (nth pairs (quot (count pairs) 2))]
+    (boolean
+     (seq
+      (ddb/eavt-datoms
+       db subject-eid new-forward-attr
+       (endpoint-pair/forward-value
+        :user relation-eid :document resource-eid))))))
+
+(defn- old-forward-adjacency
+  [{:keys [db relation-eid subject-eids]}]
+  (let [subject-eid (nth subject-eids (quot (count subject-eids) 2))]
+    (->> (ds/index-range
+          db old-forward-attr
+          [:user subject-eid relation-eid :document 0]
+          [:user subject-eid relation-eid :document Long/MAX_VALUE])
+         (mapv (comp #(nth % 4) :v)))))
+
+(defn- new-forward-adjacency
+  [{:keys [db relation-eid subject-eids]}]
+  (let [subject-eid (nth subject-eids (quot (count subject-eids) 2))]
+    (->> (ddb/eavt-endpoint-prefix
+          db subject-eid new-forward-attr
+          [:user relation-eid :document])
+         (mapv (comp #(nth % 3) :v)))))
+
+(defn- old-reverse-adjacency
+  [{:keys [db relation-eid resource-eids]}]
+  (let [resource-eid (nth resource-eids (quot (count resource-eids) 2))]
+    (->> (ds/index-range
+          db old-reverse-attr
+          [:document resource-eid relation-eid :user 0]
+          [:document resource-eid relation-eid :user Long/MAX_VALUE])
+         (mapv (comp #(nth % 4) :v)))))
+
+(defn- new-reverse-adjacency
+  [{:keys [db relation-eid resource-eids]}]
+  (let [resource-eid (nth resource-eids (quot (count resource-eids) 2))]
+    (->> (ddb/eavt-endpoint-prefix
+          db resource-eid new-reverse-attr
+          [:document relation-eid :user])
+         (mapv (comp #(nth % 3) :v)))))
+
+(defn- old-page
+  [{:keys [db relation-eid]}]
+  (->> (ds/index-range
+        db old-forward-partial-attr
+        [:user relation-eid :document 0 0]
+        [:user relation-eid :document Long/MAX_VALUE Long/MAX_VALUE])
+       (take 100)
+       (mapv :v)))
+
+(defn- new-page
+  [{:keys [db relation-eid]}]
+  (->> (ddb/avet-endpoint-prefix
+        db new-forward-attr [:user relation-eid :document])
+       (take 100)
+       (mapv (juxt :e :v))))
+
+(defn- old-content-proof
+  [{:keys [db]}]
+  (->> (ds/q
+        '[:find ?relation ?subject-type ?subject ?resource-type ?resource
+          :where
+          [?relationship :bench.old/relation ?relation]
+          [?relationship :bench.old/subject-type ?subject-type]
+          [?relationship :bench.old/subject ?subject]
+          [?relationship :bench.old/resource-type ?resource-type]
+          [?relationship :bench.old/resource ?resource]]
+        db)
+       sort
+       hash))
+
+(defn- new-content-proof
+  [{:keys [db]}]
+  (hash
+   (sort
+    (concat
+     (map (fn [{:keys [e v]}] [:forward e v])
+          (ddb/avet-datoms db new-forward-attr))
+     (map (fn [{:keys [e v]}] [:reverse e v])
+          (ddb/avet-datoms db new-reverse-attr))))))
+
+(defn- old-delete-tx
+  [{:keys [relationship-eids]} batch-size]
+  (mapv (fn [eid] [:db/retractEntity eid])
+        (take batch-size relationship-eids)))
+
+(defn- new-delete-tx
+  [{:keys [relation-eid pairs]} batch-size]
+  (mapcat
+   (fn [[subject-eid resource-eid]]
+     [[:db/retract subject-eid new-forward-attr
+       (endpoint-pair/forward-value
+        :user relation-eid :document resource-eid)]
+      [:db/retract resource-eid new-reverse-attr
+       (endpoint-pair/reverse-value
+        :document relation-eid :user subject-eid)]])
+   (take batch-size pairs)))
+
+(defn- relationship-datom-count
+  [{:keys [layout db]}]
+  (if (= :old layout)
+    (reduce + (map #(count (ds/datoms db :aevt %))
+                   old-relationship-attrs))
+    (+ (count (ddb/avet-datoms db new-forward-attr))
+       (count (ddb/avet-datoms db new-reverse-attr)))))
+
+(defn- allocated-bytes
+  []
+  (let [bean (ManagementFactory/getThreadMXBean)]
+    (when (instance? ThreadMXBean bean)
+      (let [bean ^ThreadMXBean bean]
+        (when (.isThreadAllocatedMemorySupported bean)
+          (when-not (.isThreadAllocatedMemoryEnabled bean)
+            (.setThreadAllocatedMemoryEnabled bean true))
+          (.getThreadAllocatedBytes bean (.getId (Thread/currentThread))))))))
+
+(defn- datascript-version
+  []
+  (when-let [resource
+             (io/resource
+              "META-INF/maven/datascript/datascript/pom.properties")]
+    (some-> (re-find #"(?m)^version=(.+)$" (slurp resource))
+            second)))
+
+(defn- percentile
+  [sorted-values fraction]
+  (nth sorted-values
+       (min (dec (count sorted-values))
+            (long (Math/floor (* fraction (count sorted-values)))))))
+
+(defn- measure
+  [f {:keys [warmup samples iterations]}]
+  (dotimes [_ warmup]
+    (dotimes [_ iterations] (hash (f))))
+  (let [observations
+        (mapv
+         (fn [_]
+           (let [before-bytes (allocated-bytes)
+                 start (System/nanoTime)
+                 sink
+                 (loop [i 0
+                        value 0]
+                   (if (= i iterations)
+                     value
+                     (recur (inc i) (unchecked-add value (hash (f))))))
+                 elapsed (- (System/nanoTime) start)
+                 after-bytes (allocated-bytes)]
+             (when (= Long/MIN_VALUE sink)
+               (throw (ex-info "Unreachable benchmark sink." {})))
+             {:ns-per-op (/ (double elapsed) iterations)
+              :bytes-per-op
+              (when (and before-bytes after-bytes)
+                (/ (double (- after-bytes before-bytes)) iterations))}))
+         (range samples))
+        latency (sort (map :ns-per-op observations))
+        allocation (sort (keep :bytes-per-op observations))]
+    {:p50-ns (percentile latency 0.50)
+     :p95-ns (percentile latency 0.95)
+     :mean-ns (/ (reduce + latency) (count latency))
+     :mean-bytes
+     (when (seq allocation)
+       (/ (reduce + allocation) (count allocation)))}))
+
+(defn- correctness!
+  [old new]
+  (doseq [[label old-fn new-fn]
+          [[:direct old-direct? new-direct?]
+           [:forward-adjacency old-forward-adjacency new-forward-adjacency]
+           [:reverse-adjacency old-reverse-adjacency new-reverse-adjacency]]]
+    (when-not (= (old-fn old) (new-fn new))
+      (throw
+       (ex-info "Old/new benchmark fixtures are not logically equivalent."
+                {:operation label
+                 :old (old-fn old)
+                 :new (new-fn new)})))))
+
+(defn run-benchmark!
+  "Runs old/new workloads and returns a printable EDN report.
+
+  Options:
+  - `:graph-sizes` relationship counts (default [1024 4096])
+  - `:warmup`, `:samples`, `:iterations` for reads/proofs
+  - `:write-*` equivalents for immutable create/delete batches
+  - `:batch-size` relationships per measured write (default 100)"
+  ([]
+   (run-benchmark! {}))
+  ([{:keys [graph-sizes warmup samples iterations
+            write-warmup write-samples write-iterations batch-size]
+     :or {graph-sizes [1024 4096]
+          warmup 20
+          samples 30
+          iterations 20
+          write-warmup 3
+          write-samples 10
+          write-iterations 1
+          batch-size 100}}]
+   (let [read-method {:warmup warmup
+                      :samples samples
+                      :iterations iterations}
+         write-method {:warmup write-warmup
+                       :samples write-samples
+                       :iterations write-iterations}
+         results
+         (mapv
+          (fn [relationship-count]
+            (let [old (seeded-layout :old relationship-count)
+                  new (seeded-layout :new relationship-count)
+                  _ (correctness! old new)
+                  old-create
+                  #(-> (ds/with
+                        (:base-db old)
+                        (take batch-size (:tx-data old)))
+                       :db-after :max-tx)
+                  new-create
+                  #(-> (ds/with
+                        (:base-db new)
+                        (take (* 2 batch-size) (:tx-data new)))
+                       :db-after :max-tx)
+                  old-delete
+                  #(-> (ds/with
+                        (:db old)
+                        (old-delete-tx old batch-size))
+                       :db-after :max-tx)
+                  new-delete
+                  #(-> (ds/with
+                        (:db new)
+                        (new-delete-tx new batch-size))
+                       :db-after :max-tx)
+                  workloads
+                  {:direct [#(old-direct? old) #(new-direct? new)
+                            read-method]
+                   :forward-adjacency
+                   [#(old-forward-adjacency old)
+                    #(new-forward-adjacency new)
+                    read-method]
+                   :reverse-adjacency
+                   [#(old-reverse-adjacency old)
+                    #(new-reverse-adjacency new)
+                    read-method]
+                   :relationship-page
+                   [#(old-page old) #(new-page new) read-method]
+                   :content-proof
+                   [#(old-content-proof old)
+                    #(new-content-proof new)
+                    read-method]
+                   :create-batch
+                   [old-create new-create write-method]
+                   :delete-batch
+                   [old-delete new-delete write-method]}]
+              {:relationships relationship-count
+               :storage-datoms
+               {:old (relationship-datom-count old)
+                :new (relationship-datom-count new)}
+               :workloads
+               (into
+                {}
+                (map
+                 (fn [[operation [old-fn new-fn method]]]
+                   [operation
+                    {:old (measure old-fn method)
+                     :new (measure new-fn method)}]))
+                workloads)}))
+          graph-sizes)]
+     {:benchmark :datascript-relationship-storage
+      :generated-at (str (Instant/now))
+      :hardware
+      {:os (System/getProperty "os.name")
+       :os-version (System/getProperty "os.version")
+       :arch (System/getProperty "os.arch")
+       :processors (.availableProcessors (Runtime/getRuntime))
+       :max-memory-bytes (.maxMemory (Runtime/getRuntime))}
+      :runtime
+      {:java (System/getProperty "java.version")
+       :clojure (clojure-version)
+       :datascript (datascript-version)}
+      :methodology
+      {:read {:warmup warmup
+              :samples samples
+              :iterations-per-sample iterations}
+       :write {:warmup write-warmup
+               :samples write-samples
+               :iterations-per-sample write-iterations
+               :batch-size batch-size}
+       :correctness
+       "Old/new direct and forward/reverse adjacency results compared before timing."
+       :measurement
+       "System/nanoTime wall latency; per-thread allocated bytes when supported."}
+      :results results})))

--- a/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
+++ b/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
@@ -6,20 +6,22 @@
             [eacl.causal-model-test]
             [eacl.consistency-test]
             [eacl.mutation-test]
+            [eacl.relationships.endpoint-pair-test]
             [eacl.secure-format-test]
             [eacl.datascript.consistency-v3-test]
             [eacl.datascript.contract-test]
-            [eacl.datascript.mutation-test]))
+            [eacl.datascript.mutation-test]
+            [eacl.datascript.storage-test]))
 
 (nodejs/enable-util-print!)
 
 (defmethod t/report [::t/default :end-run-tests] [m]
   (let [failures (+ (:fail m 0) (:error m 0))]
     (.log js/console
-      (str "EACL DataScript CLJS tests complete. failures="
-           (:fail m 0)
-           " errors="
-           (:error m 0)))
+          (str "EACL DataScript CLJS tests complete. failures="
+               (:fail m 0)
+               " errors="
+               (:error m 0)))
     (js/process.exit failures)))
 
 (defn -main []
@@ -28,9 +30,11 @@
                'eacl.causal-model-test
                'eacl.consistency-test
                'eacl.mutation-test
+               'eacl.relationships.endpoint-pair-test
                'eacl.secure-format-test
                'eacl.datascript.consistency-v3-test
                'eacl.datascript.contract-test
-               'eacl.datascript.mutation-test))
+               'eacl.datascript.mutation-test
+               'eacl.datascript.storage-test))
 
 (set! *main-cli-fn* -main)

--- a/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
@@ -7,6 +7,7 @@
             [eacl.core :as eacl]
             [eacl.datascript.backend :as datascript-backend]
             [eacl.datascript.core :as datascript]
+            [eacl.datascript.schema :as datascript-schema]
             [eacl.spicedb.consistency :as consistency]))
 
 (def schema
@@ -198,11 +199,42 @@
         schema-proof (backend/invoke before-adapter :schema-proof)
         before-proof
         (backend/invoke before-adapter :relation-proof [relation-id])
-        user-eid (ds/entid (ds/db conn) [:eacl/id "user"])]
+        user-eid (ds/entid (ds/db conn) [:eacl/id "user"])
+        document-eid (ds/entid (ds/db conn) [:eacl/id "document"])
+        reverse-datom
+        (first
+         (ds/datoms
+          (ds/db conn) :eavt document-eid
+          datascript-schema/reverse-relationship-attr))]
     (is (= #{:content-digest} (set (keys schema-proof))))
     (is (= 43 (count (:content-digest schema-proof))))
     (is (= #{:content-digest} (set (keys before-proof))))
     (is (= 43 (count (:content-digest before-proof))))
+    (testing "one out-of-band physical-half change invalidates the proof"
+      (ds/transact!
+       conn
+       [[:db/retract
+         document-eid
+         datascript-schema/reverse-relationship-attr
+         (:v reverse-datom)]])
+      (let [half-changed-adapter
+            (datascript-backend/snapshot-adapter
+             (ds/db conn) (:opts authorization))]
+        (is (not=
+             before-proof
+             (backend/invoke
+              half-changed-adapter :relation-proof [relation-id]))))
+      (ds/transact!
+       conn
+       [[:db/add
+         document-eid
+         datascript-schema/reverse-relationship-attr
+         (:v reverse-datom)]])
+      (is (= before-proof
+             (backend/invoke
+              (datascript-backend/snapshot-adapter
+               (ds/db conn) (:opts authorization))
+              :relation-proof [relation-id]))))
     ;; The stored relationship keeps the same endpoint eid. Only its public
     ;; identity changes, so this specifically proves the identity boundary is
     ;; part of full-content cache and cursor equivalence.

--- a/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
@@ -4,7 +4,8 @@
             [eacl.cache :as cache]
             [eacl.contract-support :as contract]
             [eacl.core :as eacl]
-            [eacl.datascript.core :as datascript]))
+            [eacl.datascript.core :as datascript]
+            [eacl.secure-format :as secure]))
 
 (defn- seed-objects!
   [conn]
@@ -98,20 +99,32 @@
               :owner
               (contract/->server (nth server-ids index))))
            (range relationship-count)))
-    (let [page-1
-          (eacl/read-relationships
-           client
-           {:subject/type :user
-            :first 1000})
-          page-2
-          (eacl/read-relationships
-           client
+    (let [proof-count (atom 0)
+          canonical-records-digest secure/canonical-records-digest
+          read-page
+          (fn [filters]
+            (reset! proof-count 0)
+            (let [page
+                  (with-redefs
+                    [secure/canonical-records-digest
+                     (fn [& args]
+                       (swap! proof-count inc)
+                       (apply canonical-records-digest args))]
+                    (eacl/read-relationships client filters))]
+              [page @proof-count]))
+          [page-1 page-1-proof-count]
+          (read-page {:subject/type :user
+                      :first 1000})
+          [page-2 page-2-proof-count]
+          (read-page
            {:subject/type :user
             :first 1000
             :after (get-in page-1 [:page-info :end-cursor])})]
       (is (= 1000 (count (:data page-1))))
       (is (= 505 (count (:data page-2))))
-      (is (false? (get-in page-2 [:page-info :has-next-page?]))))))
+      (is (false? (get-in page-2 [:page-info :has-next-page?])))
+      (is (= 1 page-1-proof-count))
+      (is (= 1 page-2-proof-count)))))
 
 (defn- seeded-client
   []

--- a/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
@@ -69,6 +69,50 @@
                             :reboot
                             (contract/->server "server-1")))))))
 
+(deftest datascript-large-relationship-cursor-proof-test
+  (let [relationship-count 1505
+        conn (datascript/create-conn)
+        client (datascript/make-client conn {})
+        user-ids (mapv #(str "bulk-user-" %) (range relationship-count))
+        server-ids (mapv #(str "bulk-server-" %) (range relationship-count))
+        object-ids (into user-ids server-ids)]
+    (eacl/write-schema!
+     client
+     "definition user {}
+
+      definition server {
+        relation owner: user
+      }")
+    (ds/transact!
+     conn
+     (map-indexed
+      (fn [index object-id]
+        {:db/id (- (inc index))
+         :eacl/id object-id})
+      object-ids))
+    (eacl/create-relationships!
+     client
+     (mapv (fn [index]
+             (eacl/->Relationship
+              (contract/->user (nth user-ids index))
+              :owner
+              (contract/->server (nth server-ids index))))
+           (range relationship-count)))
+    (let [page-1
+          (eacl/read-relationships
+           client
+           {:subject/type :user
+            :first 1000})
+          page-2
+          (eacl/read-relationships
+           client
+           {:subject/type :user
+            :first 1000
+            :after (get-in page-1 [:page-info :end-cursor])})]
+      (is (= 1000 (count (:data page-1))))
+      (is (= 505 (count (:data page-2))))
+      (is (false? (get-in page-2 [:page-info :has-next-page?]))))))
+
 (defn- seeded-client
   []
   (let [conn   (datascript/create-conn)

--- a/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
@@ -283,17 +283,27 @@
              (set (map (comp :id :resource) server-relations)))))))
 
 (deftest read-relationships-default-limit-test
-  (let [{:keys [client]} (seed-bulk-read-db 1005)
+  (let [{:keys [client]} (seed-bulk-read-db 2005)
         {page-1 :data page-info :page-info}
         (eacl/read-relationships client {:subject/type :user})
-        cursor (:end-cursor page-info)
-        {page-2 :data}
+        cursor-1 (:end-cursor page-info)
+        {page-2 :data page-2-info :page-info}
         (eacl/read-relationships client {:subject/type :user
                                          :first        1000
-                                         :after        cursor})]
+                                         :after        cursor-1})
+        cursor-2 (:end-cursor page-2-info)
+        {page-3 :data}
+        (eacl/read-relationships client {:subject/type :user
+                                         :first        1000
+                                         :after        cursor-2})
+        all-pages (into [] (concat page-1 page-2 page-3))
+        subject-ids (mapv #(get-in % [:subject :id]) all-pages)]
     (is (= 1000 (count page-1)))
-    (is (= 5 (count page-2)))
-    (is (string? cursor))
+    (is (= 1000 (count page-2)))
+    (is (= 5 (count page-3)))
+    (is (= 2005 (count (distinct subject-ids))))
+    (is (string? cursor-1))
+    (is (string? cursor-2))
     (is (= "bulk-user-0" (get-in (first page-1) [:subject :id])))
-    (is (= "bulk-user-995" (get-in (first page-2) [:subject :id]))
+    (is (= subject-ids (vec (sort subject-ids)))
         "portable relationship order is lexicographic by public object id")))

--- a/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
@@ -87,20 +87,24 @@
 
 (defn- forward-reference
   [db subject-type subject-id relation-id resource-type cursor-resource-id]
-  (->> (ds/index-range db
-                       schema/forward-relationship-attr
-                       [subject-type subject-id relation-id resource-type (if cursor-resource-id (inc cursor-resource-id) 0)]
-                       [subject-type subject-id relation-id resource-type schema/max-entid])
-       (map (fn [datom] (nth (:v datom) 4)))
+  (->> (ds/datoms db :eavt subject-id schema/forward-relationship-attr)
+       (keep (fn [{:keys [v]}]
+               (when (= [subject-type relation-id resource-type]
+                        (subvec v 0 3))
+                 (nth v 3))))
+       (filter #(or (nil? cursor-resource-id)
+                    (< cursor-resource-id %)))
        vec))
 
 (defn- reverse-reference
   [db resource-type resource-id relation-id subject-type cursor-subject-id]
-  (->> (ds/index-range db
-                       schema/reverse-relationship-attr
-                       [resource-type resource-id relation-id subject-type (if cursor-subject-id (inc cursor-subject-id) 0)]
-                       [resource-type resource-id relation-id subject-type schema/max-entid])
-       (map (fn [datom] (nth (:v datom) 4)))
+  (->> (ds/datoms db :eavt resource-id schema/reverse-relationship-attr)
+       (keep (fn [{:keys [v]}]
+               (when (= [resource-type relation-id subject-type]
+                        (subvec v 0 3))
+                 (nth v 3))))
+       (filter #(or (nil? cursor-subject-id)
+                    (< cursor-subject-id %)))
        vec))
 
 (deftest datascript-bounded-scan-parity-test
@@ -121,6 +125,27 @@
       (is (= (forward-reference db :account account-id account-relation :server server-1-id)
              (vec (impl/subject->resources db :account account-id account-relation :server server-1-id)))))
 
+    (testing "forward scans use native reverse seeks for descending windows"
+      (is (= [server-2-id server-1-id]
+             (vec
+              (impl/subject->resources
+               db :account account-id account-relation :server
+               {:direction :desc}))))
+      (is (= [server-1-id]
+             (vec
+              (impl/subject->resources
+               db :account account-id account-relation :server
+               {:direction :desc
+                :bound-eid server-2-id
+                :inclusive-bound? false}))))
+      (is (= [server-2-id server-1-id]
+             (vec
+              (impl/subject->resources
+               db :account account-id account-relation :server
+               {:direction :desc
+                :bound-eid server-2-id
+                :inclusive-bound? true})))))
+
     (testing "forward scans stop at tuple-prefix boundaries"
       (is (= [server-1-id server-2-id]
              (vec (impl/subject->resources db :account account-id account-relation :server nil))))
@@ -138,6 +163,13 @@
              (vec (impl/resource->subjects db :server server-1-id account-relation :account account-id))))
       (is (= (reverse-reference db :server server-1-id account-relation :account account-id)
              (vec (impl/resource->subjects db :server server-1-id account-relation :account account-id)))))
+
+    (testing "reverse scans use native reverse seeks"
+      (is (= [account-id]
+             (vec
+              (impl/resource->subjects
+               db :server server-1-id account-relation :account
+               {:direction :desc})))))
 
     (testing "reverse scans stop at tuple-prefix boundaries"
       (is (= [account-id]

--- a/modules/eacl-datascript/test/eacl/datascript/storage_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/storage_test.cljc
@@ -1,0 +1,268 @@
+(ns eacl.datascript.storage-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [datascript.core :as ds]
+            [eacl.core :as eacl]
+            [eacl.datascript.core :as datascript]
+            [eacl.datascript.db :as ddb]
+            [eacl.datascript.integrity :as integrity]
+            [eacl.datascript.schema :as schema]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
+            [eacl.schema.model :as model]))
+
+(def relationship-schema
+  "definition user {}
+   definition account {
+     relation owner: user
+     permission admin = owner
+   }")
+
+(defn- seeded
+  []
+  (let [conn (datascript/create-conn)
+        client (datascript/make-client conn {})
+        user (eacl/spice-object :user "user")
+        account (eacl/spice-object :account "account")
+        relationship (eacl/->Relationship user :owner account)]
+    (eacl/write-schema! client relationship-schema)
+    (ds/transact! conn [{:eacl/id "user"}
+                        {:eacl/id "account"}])
+    (eacl/create-relationship! client relationship)
+    {:conn conn
+     :client client
+     :user user
+     :account account
+     :relationship relationship}))
+
+(defn- relationship-state
+  [db]
+  (let [user-eid (ddb/entid db [:eacl/id "user"])
+        account-eid (ddb/entid db [:eacl/id "account"])
+        relation-eid
+        (ddb/entid
+         db
+         [:eacl/id
+          (model/->relation-id :account :owner :user)])]
+    {:user-eid user-eid
+     :account-eid account-eid
+     :relation-eid relation-eid
+     :forward
+     (vec
+      (ddb/eavt-datoms
+       db user-eid schema/forward-relationship-attr))
+     :reverse
+     (vec
+      (ddb/eavt-datoms
+       db account-eid schema/reverse-relationship-attr))}))
+
+(deftest endpoint-attributes-are-two-indexed-ordinary-values-test
+  (let [forward-definition
+        (get schema/datascript-schema schema/forward-relationship-attr)
+        reverse-definition
+        (get schema/datascript-schema schema/reverse-relationship-attr)
+        removed-attributes
+        [:eacl.relationship/subject
+         :eacl.relationship/relation
+         :eacl.relationship/resource
+         :eacl.relationship/subject-type
+         :eacl.relationship/resource-type
+         :eacl.relationship/full-key
+         :eacl.v7.relationship/subject-type+subject+relation+resource-type+resource
+         :eacl.v7.relationship/resource-type+resource+relation+subject-type+subject
+         :eacl.v7.relationship/subject-type+relation+resource-type+resource+subject
+         :eacl.v7.relationship/resource-type+relation+subject-type+subject+resource]]
+    (is (= {:db/cardinality :db.cardinality/many
+            :db/index true}
+           forward-definition))
+    (is (= forward-definition reverse-definition))
+    (is (not (contains? forward-definition :db/valueType)))
+    (is (not (contains? forward-definition :db/tupleAttrs)))
+    (is (every? #(not (contains? schema/datascript-schema %))
+                removed-attributes))))
+
+(deftest full-arity-index-boundaries-test
+  (let [conn (schema/create-conn)
+        _ (ds/transact! conn [{:eacl/id "subject-a"}
+                              {:eacl/id "subject-b"}
+                              {:eacl/id "resource-a"}
+                              {:eacl/id "resource-b"}])
+        initial (ds/db conn)
+        subject-a (ddb/entid initial [:eacl/id "subject-a"])
+        subject-b (ddb/entid initial [:eacl/id "subject-b"])
+        resource-a (ddb/entid initial [:eacl/id "resource-a"])
+        resource-b (ddb/entid initial [:eacl/id "resource-b"])
+        relation-eid 100
+        prefix [:user relation-eid :document]
+        values [(endpoint-pair/forward-value
+                 :user relation-eid :document resource-a)
+                (endpoint-pair/forward-value
+                 :user relation-eid :document resource-b)]
+        _ (ds/transact!
+           conn
+           (concat
+            (map (fn [value]
+                   [:db/add subject-a
+                    schema/forward-relationship-attr value])
+                 values)
+            [[:db/add subject-a schema/forward-relationship-attr
+              [:user (inc relation-eid) :document resource-a]]
+             [:db/add subject-a schema/forward-relationship-attr
+              [:user relation-eid :folder resource-a]]
+             [:db/add subject-b schema/forward-relationship-attr
+              [:user relation-eid :document resource-a]]
+             [:db/add resource-a schema/reverse-relationship-attr
+              [:document relation-eid :user subject-a]]]))
+        db (ds/db conn)
+        eavt-values
+        (fn [direction cursor]
+          (mapv :v
+                (ddb/eavt-endpoint-prefix
+                 db subject-a schema/forward-relationship-attr
+                 prefix cursor direction)))
+        avet-values
+        (fn [direction cursor]
+          (mapv :v
+                (ddb/avet-endpoint-prefix
+                 db schema/forward-relationship-attr
+                 prefix cursor direction)))]
+    (testing "equal-length vectors traverse in component order"
+      (is (= values (eavt-values :asc nil)))
+      (is (= (vec (reverse values)) (eavt-values :desc nil)))
+      (is (= [(first values) (first values) (second values)]
+             (avet-values :asc nil)))
+      (is (= [(second values) (first values) (first values)]
+             (avet-values :desc nil))))
+    (testing "cursor bounds are inclusive at the primitive layer"
+      (is (= [(second values)]
+             (eavt-values :asc resource-b)))
+      (is (= [(first values)]
+             (eavt-values :desc resource-a))))
+    (testing "missing and adjacent prefixes terminate exactly"
+      (is (empty?
+           (ddb/eavt-endpoint-prefix
+            db subject-a schema/forward-relationship-attr
+            [:user 99 :document])))
+      (is (empty?
+           (ddb/eavt-endpoint-prefix
+            db subject-a schema/reverse-relationship-attr prefix))))
+    (testing "EAVT isolates the endpoint while AVET intentionally spans it"
+      (is (= 2 (count (eavt-values :asc nil))))
+      (is (= 3 (count (avet-values :asc nil)))))))
+
+(deftest relationships-cost-two-datoms-and-pairs-repair-test
+  (let [{:keys [conn client relationship]} (seeded)
+        db (ds/db conn)
+        {:keys [user-eid account-eid relation-eid forward reverse]}
+        (relationship-state db)]
+    (is (= [[user-eid
+             [[:user relation-eid :account account-eid]]]]
+           [[(:e (first forward)) (mapv :v forward)]]))
+    (is (= [[account-eid
+             [[:account relation-eid :user user-eid]]]]
+           [[(:e (first reverse)) (mapv :v reverse)]]))
+    (is (= 2 (+ (count forward) (count reverse))))
+    (is (= 1
+           (schema/count-relationships-using-relation
+            db
+            {:eacl.relation/resource-type :account
+             :eacl.relation/relation-name :owner
+             :eacl.relation/subject-type :user})))
+    (is (= :eacl/relationship-conflict
+           (:type
+            (try
+              (eacl/create-relationship! client relationship)
+              nil
+              (catch #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core.ExceptionInfo) error
+                (ex-data error))))))
+    (is (= :eacl/unsupported-operation
+           (:type
+            (try
+              (eacl/write-relationship!
+               client
+               {:operation :merge
+                :subject (:subject relationship)
+                :relation (:relation relationship)
+                :resource (:resource relationship)})
+              nil
+              (catch #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core.ExceptionInfo) error
+                (ex-data error))))))
+    (is (= :eacl/unknown-object
+           (:type
+            (try
+              (eacl/create-relationship!
+               client
+               (eacl/->Relationship
+                (:subject relationship)
+                (:relation relationship)
+                (eacl/spice-object :account "missing")))
+              nil
+              (catch #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core.ExceptionInfo) error
+                (ex-data error))))))
+
+    (ds/transact!
+     conn
+     [[:db/retract
+       account-eid schema/reverse-relationship-attr
+       (:v (first reverse))]])
+    (is (= {:valid? false
+            :dangling-count 1
+            :by-half {:forward 1 :reverse 0}
+            :sample []}
+           (integrity/dangling-relationship-report
+            (ds/db conn) {:sample-size 0})))
+
+    (eacl/write-relationship!
+     client
+     {:operation :touch
+      :subject (:subject relationship)
+      :relation (:relation relationship)
+      :resource (:resource relationship)})
+    (is (:valid?
+         (integrity/dangling-relationship-report (ds/db conn))))
+    (eacl/write-relationships!
+     client
+     [(eacl/->RelationshipUpdate :touch relationship)
+      (eacl/->RelationshipUpdate :touch relationship)])
+    (let [{:keys [forward reverse]} (relationship-state (ds/db conn))]
+      (is (= 1 (count forward)))
+      (is (= 1 (count reverse))))
+
+    (let [{:keys [forward]} (relationship-state (ds/db conn))]
+      (ds/transact!
+       conn
+       [[:db/retract
+         user-eid schema/forward-relationship-attr
+         (:v (first forward))]]))
+    (eacl/delete-relationship! client relationship)
+    (let [{:keys [forward reverse]} (relationship-state (ds/db conn))]
+      (is (empty? forward))
+      (is (empty? reverse)))))
+
+(deftest delete-object-and-ghost-cleanup-test
+  (let [{:keys [conn client account]} (seeded)
+        {:keys [account-eid]} (relationship-state (ds/db conn))]
+    (is (= 2 (:retracted-datoms
+              (eacl/delete-object! client account))))
+    (let [{:keys [forward reverse]} (relationship-state (ds/db conn))]
+      (is (empty? forward))
+      (is (empty? reverse)))
+    (is (ddb/entity-exists? (ds/db conn) account-eid)))
+
+  (let [{:keys [conn client account]} (seeded)
+        {:keys [account-eid]} (relationship-state (ds/db conn))]
+    (ds/transact! conn [[:db/retractEntity account-eid]])
+    (is (= {:valid? false
+            :dangling-count 1
+            :by-half {:forward 1 :reverse 0}
+            :sample []}
+           (integrity/dangling-relationship-report
+            (ds/db conn) {:sample-size 0})))
+    (is (= 1
+           (:retracted-datoms
+            (eacl/delete-object!
+             client (assoc account :id account-eid)))))
+    (is (:valid?
+         (integrity/dangling-relationship-report (ds/db conn))))))

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -5,7 +5,8 @@
             [eacl.backend.v8 :as backend]
             [eacl.datomic.db :as ddb]
             [eacl.datomic.mutation :as journal]
-            [eacl.mutation :as mutation])
+            [eacl.mutation :as mutation]
+            [eacl.relationships.endpoint-pair :as endpoint-pair])
   (:import [java.nio.charset StandardCharsets]
            [java.security MessageDigest]
            [java.util Base64]))
@@ -123,22 +124,24 @@
         (when (and (seq wanted) (d/entid db forward-attr))
           (for [{subject :e value :v}
                 (d/datoms db :aevt forward-attr)
-                :let [[subject-type relation-id
-                       resource-type resource] value]
-                :when (contains? wanted relation-id)]
-            [:forward relation-id
-             subject-type subject (external-id db subject)
-             resource-type resource (external-id db resource)]))
+                :let [decoded
+                      (endpoint-pair/decode-forward subject value)]
+                :when (contains? wanted (:relation-eid decoded))]
+            [:forward (:relation-eid decoded)
+             (:subject-type decoded) subject (external-id db subject)
+             (:resource-type decoded) (:resource-eid decoded)
+             (external-id db (:resource-eid decoded))]))
         reverse
         (when (and (seq wanted) (d/entid db reverse-attr))
           (for [{resource :e value :v}
                 (d/datoms db :aevt reverse-attr)
-                :let [[resource-type relation-id
-                       subject-type subject] value]
-                :when (contains? wanted relation-id)]
-            [:reverse relation-id
-             subject-type subject (external-id db subject)
-             resource-type resource (external-id db resource)]))]
+                :let [decoded
+                      (endpoint-pair/decode-reverse resource value)]
+                :when (contains? wanted (:relation-eid decoded))]
+            [:reverse (:relation-eid decoded)
+             (:subject-type decoded) (:subject-eid decoded)
+             (external-id db (:subject-eid decoded))
+             (:resource-type decoded) resource (external-id db resource)]))]
     ;; Preserve both physical halves. Direct/forward evaluation reads the
     ;; forward tuple and reverse lookup reads the reverse tuple, so a
     ;; corruption or out-of-band half-write must invalidate whichever

--- a/modules/eacl-datomic/src/eacl/datomic/impl.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/impl.clj
@@ -6,7 +6,8 @@
    [eacl.datomic.backend :as backend]
    [eacl.datomic.impl.base :as base]
    [eacl.datomic.impl.indexed :as impl.indexed]
-   [eacl.engine.v8 :as engine]))
+   [eacl.engine.v8 :as engine]
+   [eacl.relationships.endpoint-pair :as endpoint-pair]))
 
 (def Relation base/Relation)
 (def Permission base/Permission)
@@ -203,11 +204,13 @@
 
 (defn- relationship-tuple
   [{:keys [subject-type relation-eid resource-type resource-eid]}]
-  [subject-type relation-eid resource-type resource-eid])
+  (endpoint-pair/forward-value
+   subject-type relation-eid resource-type resource-eid))
 
 (defn- reverse-relationship-tuple
   [{:keys [resource-type relation-eid subject-type subject-eid]}]
-  [resource-type relation-eid subject-type subject-eid])
+  (endpoint-pair/reverse-value
+   resource-type relation-eid subject-type subject-eid))
 
 (defn- add-relationship-txes
   [resolved]

--- a/modules/eacl/src/eacl/relationships/endpoint_pair.cljc
+++ b/modules/eacl/src/eacl/relationships/endpoint_pair.cljc
@@ -1,0 +1,90 @@
+(ns eacl.relationships.endpoint-pair
+  "Pure, backend-neutral representation of EACL's two endpoint relationship
+  halves. Database adapters own index access and transaction semantics; this
+  namespace only owns the value shape and its symmetry.")
+
+(def value-arity 4)
+
+(defn forward-value
+  [subject-type relation-eid resource-type resource-eid]
+  [subject-type relation-eid resource-type resource-eid])
+
+(defn reverse-value
+  [resource-type relation-eid subject-type subject-eid]
+  [resource-type relation-eid subject-type subject-eid])
+
+(defn endpoint-value?
+  "True for a stored endpoint value with the expected heterogeneous shape.
+  Eids are non-negative integers in committed Datomic, Datahike, and
+  DataScript database values."
+  [value]
+  (and (vector? value)
+       (= value-arity (count value))
+       (keyword? (nth value 0))
+       (nat-int? (nth value 1))
+       (keyword? (nth value 2))
+       (nat-int? (nth value 3))))
+
+(defn value-prefix?
+  "Whether a valid endpoint value begins with `prefix`. Oversized prefixes and
+  malformed stored values never match."
+  [value prefix]
+  (let [prefix (vec prefix)
+        prefix-size (count prefix)]
+    (and (endpoint-value? value)
+         (<= prefix-size value-arity)
+         (= prefix (subvec value 0 prefix-size)))))
+
+(defn decode-forward
+  [subject-eid value]
+  (when (endpoint-value? value)
+    (let [[subject-type relation-eid resource-type resource-eid] value]
+      {:subject-type subject-type
+       :subject-eid subject-eid
+       :relation-eid relation-eid
+       :resource-type resource-type
+       :resource-eid resource-eid})))
+
+(defn decode-reverse
+  [resource-eid value]
+  (when (endpoint-value? value)
+    (let [[resource-type relation-eid subject-type subject-eid] value]
+      {:subject-type subject-type
+       :subject-eid subject-eid
+       :relation-eid relation-eid
+       :resource-type resource-type
+       :resource-eid resource-eid})))
+
+(defn peer-half
+  "Returns the exact peer endpoint and value for one decoded physical half."
+  [direction endpoint-eid value]
+  (case direction
+    :forward
+    (when-let [{:keys [subject-type subject-eid relation-eid
+                       resource-type resource-eid] :as decoded}
+               (decode-forward endpoint-eid value)]
+      (assoc decoded
+             :direction :reverse
+             :endpoint-eid resource-eid
+             :value (reverse-value resource-type relation-eid
+                                   subject-type subject-eid)))
+
+    :reverse
+    (when-let [{:keys [subject-type subject-eid relation-eid
+                       resource-type resource-eid] :as decoded}
+               (decode-reverse endpoint-eid value)]
+      (assoc decoded
+             :direction :forward
+             :endpoint-eid subject-eid
+             :value (forward-value subject-type relation-eid
+                                   resource-type resource-eid)))
+
+    nil))
+
+(defn half-identity
+  "Stable identity of one physical half, independent of backend datom type."
+  [direction endpoint-eid value]
+  (when (and (#{:forward :reverse} direction)
+             (nat-int? endpoint-eid)
+             (endpoint-value? value))
+    [direction endpoint-eid value]))

--- a/modules/eacl/src/eacl/relationships/relay.cljc
+++ b/modules/eacl/src/eacl/relationships/relay.cljc
@@ -49,18 +49,14 @@
 
 (defn- items-proof
   [items]
-  (secure/canonical-digest
-   "eacl/cursor/relationship-items/v3"
-   {:count (count items)
-    ;; Digest each bounded relationship independently before committing the
-    ;; ordered vector. A legal 10k-item page otherwise exceeds the secure
-    ;; format's global entry bound even though no individual value is large.
-    ;; Count plus ordered leaf digests preserves multiplicity and order.
-    :leaf-digests
-    (mapv #(secure/canonical-digest
-            "eacl/cursor/relationship-item/v3"
-            %)
-          items)}))
+  ;; Relationship scans may legally contain more canonical data than the
+  ;; secure format accepts in one bounded value. Stream the ordered records
+  ;; into a length-framed digest so the proof still commits to every item,
+  ;; including its order and multiplicity, without constructing an oversized
+  ;; intermediate leaf-digest vector.
+  (secure/canonical-records-digest
+   "eacl/cursor/relationship-items/v4"
+   items))
 
 (defn- decode-envelope
   [opts operation filters snapshot-context token]

--- a/modules/eacl/src/eacl/relationships/relay.cljc
+++ b/modules/eacl/src/eacl/relationships/relay.cljc
@@ -131,7 +131,8 @@
              :graph-head (backend/invoke exact :graph-head)
              :adapter-fingerprint (backend/fingerprint exact)
              :identity-contract (backend/identity-contract exact)}
-            exact-items (vec (materialize exact))]
+            exact-items (vec (materialize exact))
+            exact-items-proof (items-proof exact-items)]
         (when-not
          (and
           (= (secure/canonicalize (:source-scope current-context))
@@ -139,24 +140,26 @@
           (= (get-in envelope [:graph-head :graph-anchor])
              (get-in exact-context [:graph-head :graph-anchor]))
           (= (:items-proof envelope)
-             (items-proof exact-items)))
+             exact-items-proof))
          (throw
           (ex-info
            "The relationship cursor exact locator resolved to another graph."
            {:type :eacl.consistency/history-divergence
             :eacl/error :eacl.consistency/history-divergence})))
         {:snapshot-context exact-context
-         :items exact-items}))))
+         :items exact-items
+         :items-proof exact-items-proof}))))
 
 (defn- select-items
-  [opts operation filters snapshot-context items token]
+  [opts operation filters snapshot-context items current-items-proof token]
   (if-let [envelope
            (decode-envelope
             opts operation filters snapshot-context token)]
     (cond
-      (= (items-proof items) (:items-proof envelope))
+      (= current-items-proof (:items-proof envelope))
       {:snapshot-context snapshot-context
        :items items
+       :items-proof current-items-proof
        :bound (:offset envelope)}
 
       (= :at-least-as-fresh
@@ -172,17 +175,18 @@
              :bound (:offset envelope)))
     {:snapshot-context snapshot-context
      :items items
+     :items-proof current-items-proof
      :bound nil}))
 
 (defn- encode-bound
-  [opts operation filters snapshot-context items offset]
+  [opts operation filters snapshot-context proof offset]
   (cursor/cursor->token
    (merge
     snapshot-context
     {:v 9
      :kind :relationships
      :scope (scope operation filters)
-     :items-proof (items-proof items)
+     :items-proof proof
      :offset offset})
    opts))
 
@@ -190,13 +194,15 @@
   "Applies a Relay window to a canonical vector of public relationships."
   [opts operation filters snapshot-context items]
   (let [current-items (vec items)
-        {:keys [snapshot-context items bound]}
+        current-items-proof (items-proof current-items)
+        {:keys [snapshot-context items items-proof bound]}
         (select-items
          opts
          operation
          filters
          snapshot-context
          current-items
+         current-items-proof
          (:token (page-request filters)))
         n (count items)
         {:keys [direction size token]} (page-request filters)
@@ -217,10 +223,10 @@
      {:start-cursor
       (when start-offset
         (encode-bound
-         opts operation filters snapshot-context items start-offset))
+         opts operation filters snapshot-context items-proof start-offset))
       :end-cursor
       (when end-offset
         (encode-bound
-         opts operation filters snapshot-context items end-offset))
+         opts operation filters snapshot-context items-proof end-offset))
       :has-next-page? (boolean (and any? (< end n)))
       :has-previous-page? (boolean (and any? (pos? start)))}}))

--- a/modules/eacl/test/eacl/relationships/endpoint_pair_test.cljc
+++ b/modules/eacl/test/eacl/relationships/endpoint_pair_test.cljc
@@ -1,0 +1,80 @@
+(ns eacl.relationships.endpoint-pair-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [eacl.relationships.endpoint-pair :as pair]))
+
+(def cases
+  [{:subject-type :user
+    :subject-eid 1
+    :relation-eid 2
+    :resource-type :document
+    :resource-eid 3}
+   {:subject-type :team/member
+    :subject-eid 10
+    :relation-eid 11
+    :resource-type :folder/item
+    :resource-eid 12}
+   {:subject-type :z
+    :subject-eid 0
+    :relation-eid 9007199254740991
+    :resource-type :A/namespaced
+    :resource-eid 42}])
+
+(deftest endpoint-pair-round-trip-and-symmetry-test
+  (doseq [{:keys [subject-type subject-eid relation-eid
+                  resource-type resource-eid] :as expected}
+          cases]
+    (let [forward (pair/forward-value subject-type relation-eid
+                                      resource-type resource-eid)
+          reverse (pair/reverse-value resource-type relation-eid
+                                      subject-type subject-eid)]
+      (is (= expected (pair/decode-forward subject-eid forward)))
+      (is (= expected (pair/decode-reverse resource-eid reverse)))
+      (is (= {:direction :reverse
+              :endpoint-eid resource-eid
+              :value reverse}
+             (select-keys (pair/peer-half :forward subject-eid forward)
+                          [:direction :endpoint-eid :value])))
+      (is (= {:direction :forward
+              :endpoint-eid subject-eid
+              :value forward}
+             (select-keys (pair/peer-half :reverse resource-eid reverse)
+                          [:direction :endpoint-eid :value])))
+      (is (= [:forward subject-eid forward]
+             (pair/half-identity :forward subject-eid forward)))
+      (is (= [:reverse resource-eid reverse]
+             (pair/half-identity :reverse resource-eid reverse))))))
+
+(deftest endpoint-value-validation-test
+  (let [valid [:user 1 :document 2]]
+    (is (pair/endpoint-value? valid))
+    (is (= pair/value-arity (count valid)))
+    (doseq [malformed
+            [nil
+             '(:user 1 :document 2)
+             [:user 1 :document]
+             [:user 1 :document 2 :extra]
+             ["user" 1 :document 2]
+             [:user "1" :document 2]
+             [:user -1 :document 2]
+             [:user 1 "document" 2]
+             [:user 1 :document -2]]]
+      (is (not (pair/endpoint-value? malformed))
+          (pr-str malformed))
+      (is (nil? (pair/decode-forward 7 malformed)))
+      (is (nil? (pair/decode-reverse 7 malformed))))))
+
+(deftest exact-prefix-predicate-test
+  (let [value [:user 11 :document 22]]
+    (doseq [prefix [[] [:user] [:user 11]
+                    [:user 11 :document]
+                    [:user 11 :document 22]]]
+      (is (pair/value-prefix? value prefix)))
+    (testing "adjacent and oversized prefixes do not leak"
+      (doseq [prefix [[:team]
+                      [:user 10]
+                      [:user 11 :folder]
+                      [:user 11 :document 21]
+                      [:user 11 :document 22 :extra]]]
+        (is (not (pair/value-prefix? value prefix)))))
+    (is (not (pair/value-prefix? [:user 11 :document] [:user])))))

--- a/openspec/changes/optimize-datascript-relationship-storage/.openspec.yaml
+++ b/openspec/changes/optimize-datascript-relationship-storage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/optimize-datascript-relationship-storage/design.md
+++ b/openspec/changes/optimize-datascript-relationship-storage/design.md
@@ -1,0 +1,203 @@
+## Context
+
+PR #92 changes Datahike from a relationship entity with component and derived
+index datoms to the Datomic Pro endpoint-pair layout. DataScript remains on the
+older shape: one entity contributes five relationship components plus a unique
+full key and four scan tuples. DataScript 1.7.8 supports only derived
+`:db/tupleAttrs`, not heterogeneous `:db/tupleTypes`, so it cannot declare the
+Datomic schema literally.
+
+That schema limitation does not prevent the logical layout. An ordinary
+cardinality-many DataScript attribute can contain a vector and participate in
+EAVT and AVET when indexed. DataScript's CLJC comparator orders sequential
+values by length and then component values. A JVM probe confirmed exact,
+forward, and reverse traversal of four-component values using `datoms`,
+`seek-datoms`, and `rseek-datoms`.
+
+The implementation is stacked on PR #92. V8 is unreleased, DataScript is mainly
+used for the explorer and demonstrations, and no compatibility machinery is
+required for the prerelease relationship-entity layout.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce one DataScript relationship from ten relationship-specific datoms to
+  exactly two endpoint datoms.
+- Give DataScript, Datahike, and Datomic Pro one logical relationship encoding
+  and one pair-integrity contract.
+- Use native ordered indexes for direct matching, adjacency, filtering,
+  pagination, relation-in-use checks, deletion, and proofs.
+- Share pure endpoint encoding and decoding logic without leaking a backend
+  dependency into `eacl`.
+- Preserve shared public API, cursor, mutation-journal, cache-proof, and
+  recursive-authorization behavior on the JVM and ClojureScript.
+- Measure storage and latency changes rather than inferring speed from datom
+  count alone.
+
+**Non-Goals:**
+
+- Add heterogeneous tuple support to DataScript.
+- Make embedded peer eids behave as DataScript refs.
+- Preserve, migrate, or dual-read the unreleased DataScript relationship-entity
+  representation.
+- Eliminate the accepted ghost-half risk after consumers bypass EACL.
+- Force backend-specific temporal or index APIs behind one artificial database
+  abstraction.
+
+## Decisions
+
+### Store ordinary four-component vectors on endpoint entities
+
+The DataScript schema will define the Datomic/Datahike forward and reverse
+relationship attributes as cardinality-many and indexed, without
+`:db/valueType :db.type/tuple`:
+
+- forward on the subject entity:
+  `[subject-type relation-eid resource-type resource-eid]`
+- reverse on the resource entity:
+  `[resource-type relation-eid subject-type subject-eid]`
+
+The attribute idents will match PR #92's Datahike/Datomic idents:
+`:eacl.v7.relationship/subject-type+relation+resource-type+resource` and
+`:eacl.v7.relationship/resource-type+relation+subject-type+subject`.
+
+The endpoint eid is represented by the datom's `:e`, so including it again in
+the value would recreate redundant storage. DataScript set semantics make each
+`[e a v]` half naturally idempotent.
+
+Alternatives rejected:
+
+- Keep relationship entities: preserves unnecessary component and derived
+  datoms and leaves DataScript structurally divergent.
+- Use EDN maps: maps have no useful component ordering for bounded index
+  traversal.
+- Encode sortable strings or bytes: duplicates a comparator and coercion layer,
+  expands stored values, and weakens eid/type fidelity.
+- Wait for heterogeneous tuples: there is no need; the required ordering
+  already exists for ordinary vectors.
+
+### Use EAVT locally and AVET for cross-entity scans
+
+Known-subject and known-resource adjacency will seek within the endpoint
+entity's EAVT range. Relation/type scans, relation-in-use checks, integrity
+enumeration, and content proofs will use AEVT or AVET as appropriate.
+
+Every seek start will be a four-element vector. DataScript compares vector
+length before contents, so a short prefix does not position at the start of
+equal-length stored values. Prefix scans will pad the remaining components with
+`nil`, `0`, or `max-entid` according to the known component types and then
+terminate with explicit entity, attribute, and component checks. Code will not
+invent a "maximum keyword" sentinel.
+
+`rseek-datoms` will be used for descending traversal where the requested prefix
+fixes the keyword components and the cursor supplies the varying eid. Exact
+membership will use a full EAVT value.
+
+### Treat a relationship as a physical pair
+
+Existence requires both halves. `:touch` writes both values when the pair is
+incomplete, `:create` conflicts with a complete pair, and `:delete` retracts
+both values unconditionally. Adding an already present DataScript datom and
+retracting an absent datom are safe, so the same transaction repairs incomplete
+pairs without a special migration entity.
+
+Both halves and relation mutation identities are written in one EACL
+transaction. This prevents EACL-created half pairs while retaining recovery
+from out-of-band damage.
+
+### Preserve explicit ghost-half handling
+
+An ordinary vector's numeric peer eid is not a ref. Retracting an entity removes
+its local relationship values but cannot cascade through values on peer
+entities. This matches the risk explicitly accepted for the Datomic and
+Datahike endpoint tuples.
+
+`delete-object!` will enumerate all touching values before mutation, retract
+both halves explicitly, preserve the existing DataScript object-retention
+semantics, and stamp every affected relation. A read-only
+`eacl.datascript.integrity/dangling-relationship-report` will mirror the
+Datahike diagnostic and report the precise missing peer half.
+
+### Hash the database-visible pair, not a logical reconstruction alone
+
+Content proofs will enumerate forward and reverse values independently,
+normalize each physical half, and include endpoint public identities. A missing
+or changed half must change the digest even if the surviving half still
+describes a plausible logical relationship.
+
+Managed mutation proofs remain relation-identity based and therefore
+dependency-sized. This storage change does not alter consistency token
+semantics.
+
+### Share pure representation logic, retain native data access
+
+A small backend-neutral CLJC namespace will own resolved relationship value
+construction, reverse construction, decoding, prefix predicates, and peer-half
+identity. DataScript, Datahike, and Datomic will adopt those functions where
+their logical values are identical.
+
+Database operations remain adapter-specific:
+
+- Datomic uses Datomic indexes and historical database values.
+- Datahike retains its wrapper-sensitive exact historical fallback and native
+  attribute representation handling.
+- DataScript uses its CLJC `datoms`/`seek-datoms`/`rseek-datoms` APIs and
+  immutable exact snapshots.
+
+This is the narrowest abstraction that removes real duplication without hiding
+material backend semantics.
+
+### Validate cost explicitly
+
+Tests will assert exactly two relationship datoms and the absence of active
+relationship entities/derived indexes. A reproducible benchmark will compare
+the old and new DataScript implementations for direct authorization,
+forward/reverse adjacency, relationship pagination, create/delete batches, and
+content-proof construction at representative graph sizes on the JVM. CLJS will
+receive correctness and ordering tests; timing claims will not be inferred
+across runtimes.
+
+## Risks / Trade-offs
+
+- [Ordinary vectors receive no tuple component type validation] → Construct
+  values only from resolved internal relationships and validate vector arity
+  and component kinds at adapter boundaries and in integrity tooling.
+- [Vector length-first ordering makes naive prefix seeks incorrect] → Centralize
+  full-arity bound construction and require boundary regression tests for
+  adjacent types, relations, entities, and both directions.
+- [Direct endpoint retraction leaves peer values] → Preserve the mandatory EACL
+  deletion contract, explicitly clean both halves, and provide offline
+  detection.
+- [Two physical halves can be damaged independently by out-of-band writers] →
+  Make touch/delete repairable and include both halves in content proofs.
+- [AVET scans could accidentally cross into another attribute or prefix] →
+  Guard every scan by attribute and exact known components; do not rely only on
+  the starting key.
+- [Refactoring all three adapters could broaden review scope] → Share only pure
+  encoding/decoding logic, keep database access local, and run each isolated
+  module plus the full shared contract.
+- [Fewer datoms do not guarantee lower latency] → Record old/new benchmarks and
+  report regressions rather than claiming improvement from storage count.
+
+## Migration Plan
+
+1. Branch from PR #92's head.
+2. Introduce and test the shared pure endpoint-pair representation.
+3. Replace the active DataScript relationship schema and adapter paths.
+4. Add integrity, proof, deletion, cursor, and CLJS boundary coverage.
+5. Run isolated module, full JVM, and DataScript ClojureScript suites through
+   the project nREPL/CI workflow.
+6. Benchmark the old PR #92 head against the optimized branch and publish the
+   results in the new stacked PR.
+7. Recreate explorer/demo databases or reload their relationships through EACL.
+
+There is no rollback or dual-read path. Before merge, rollback is branch
+reversion. After adoption, consumers of unreleased builds must recreate their
+DataScript database if they return to the relationship-entity implementation.
+
+## Open Questions
+
+None. Feasibility of indexed ordinary vectors and bidirectional seeks is
+verified against DataScript 1.7.8; implementation benchmarks will determine the
+size of the performance benefit, not the storage design.

--- a/openspec/changes/optimize-datascript-relationship-storage/proposal.md
+++ b/openspec/changes/optimize-datascript-relationship-storage/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+DataScript currently stores each relationship as an entity with five component
+datoms and five derived tuple datoms, while Datomic Pro and Datahike on PR #92
+store the same logical relationship as two endpoint-local datoms. DataScript
+1.7.8 cannot declare heterogeneous tuples, but it can index ordinary vector
+values and traverse them in either direction, making the heavier relationship
+entity unnecessary.
+
+## What Changes
+
+- Store each DataScript relationship as exactly two cardinality-many indexed
+  vector values: a forward value on the subject entity and a reverse value on
+  the resource entity, with the same component order used by Datomic Pro and
+  Datahike.
+- Replace relationship-entity queries and five derived relationship indexes
+  with guarded EAVT and AVET `datoms`, `seek-datoms`, `rseek-datoms`, and
+  prefix scans over the two endpoint attributes.
+- Converge DataScript relationship mutation, direct matching, adjacency,
+  pagination, relation-in-use, object cleanup, integrity reporting, and content
+  proof behavior with the Datomic/Datahike endpoint-pair implementation.
+- Preserve the accepted ghost-half contract: consumers must remove
+  relationships through EACL before retracting endpoint entities, while
+  `:touch`, `:delete`, object cleanup, and an offline integrity report detect or
+  repair incomplete pairs.
+- Add JVM and ClojureScript regression coverage for index boundaries,
+  forward/reverse seek behavior, cursor order, half-pair repair, content-proof
+  invalidation, and shared backend conformance.
+- Benchmark storage cardinality and representative read/write paths against the
+  relationship-entity implementation.
+- **BREAKING**: prerelease DataScript databases using relationship entities are
+  not dual-read or migrated. Recreate demo databases or reload relationships
+  through the EACL API.
+
+## Capabilities
+
+### New Capabilities
+
+- `converged-relationship-storage`: Defines the two-value endpoint-pair storage,
+  index access, mutation, integrity, proof, compatibility, and validation
+  contract shared logically by DataScript, Datahike, and Datomic Pro.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects `modules/eacl-datascript` schema, storage adapter, backend proof
+  adapter, object deletion, relationship APIs, tests, and documentation.
+- Reuses backend-neutral relationship planning and shared conformance suites;
+  no DataScript dependency is introduced into the core module.
+- Removes DataScript relationship component attributes, the unique full-key
+  tuple, and four relationship scan tuples from the active v8 schema.
+- Targets a new stacked PR whose base is PR #92
+  (`codex/datahike-datomic-relationship-tuples`).

--- a/openspec/changes/optimize-datascript-relationship-storage/specs/converged-relationship-storage/spec.md
+++ b/openspec/changes/optimize-datascript-relationship-storage/specs/converged-relationship-storage/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Two-value endpoint representation
+Each DataScript relationship SHALL be represented by exactly two
+cardinality-many indexed ordinary values: a forward value on the subject entity
+and a reverse value on the resource entity. The values SHALL use the same
+four-component order as the Datomic Pro and Datahike endpoint tuples:
+`[subject-type relation-eid resource-type resource-eid]` forward and
+`[resource-type relation-eid subject-type subject-eid]` reverse.
+
+#### Scenario: Relationship creation
+- **WHEN** EACL creates a relationship between existing subject and resource endpoints
+- **THEN** DataScript stores exactly one forward endpoint datom and one reverse endpoint datom and stores no relationship entity or derived relationship tuple
+
+#### Scenario: Duplicate physical value
+- **WHEN** the same endpoint value is added more than once in one DataScript database value
+- **THEN** DataScript set semantics retain one datom for that endpoint value
+
+### Requirement: Ordered endpoint index access
+The DataScript adapter SHALL implement exact matching, adjacency, relationship
+filtering, relation-in-use checks, and forward and reverse pagination using
+guarded EAVT or AVET access to the endpoint values. Every vector seek bound
+SHALL have the full stored arity because DataScript orders vectors by length
+before comparing their components.
+
+#### Scenario: Forward endpoint scan
+- **WHEN** authorization or relationship pagination scans outward from a known subject
+- **THEN** the adapter seeks the subject's forward endpoint values and stops at the exact entity, attribute, and requested component prefix
+
+#### Scenario: Reverse endpoint scan
+- **WHEN** authorization or relationship pagination scans inward from a known resource
+- **THEN** the adapter seeks the resource's reverse endpoint values and stops at the exact entity, attribute, and requested component prefix
+
+#### Scenario: Reverse-order continuation
+- **WHEN** a descending scan resumes from a relationship cursor
+- **THEN** `rseek-datoms` starts from a full-arity bound and returns only values inside the cursor's requested endpoint prefix
+
+#### Scenario: Adjacent prefix is absent
+- **WHEN** no value exists for a requested forward or reverse prefix but an adjacent prefix does exist
+- **THEN** explicit entity, attribute, and component guards prevent the adjacent value from being returned
+
+### Requirement: Atomic pair mutation and repair
+Relationship mutation through EACL SHALL add or retract both endpoint values in
+one DataScript transaction and SHALL preserve the public `:create`, `:touch`,
+and `:delete` semantics shared with Datomic Pro and Datahike.
+
+#### Scenario: Complete relationship conflict
+- **WHEN** `:create` targets a relationship whose forward and reverse values both exist
+- **THEN** EACL reports a relationship conflict
+
+#### Scenario: Incomplete relationship repair
+- **WHEN** `:touch` targets a relationship with either endpoint value missing
+- **THEN** EACL writes both values so the complete pair exists after the transaction
+
+#### Scenario: Unconditional deletion
+- **WHEN** `:delete` targets a complete, incomplete, or absent pair
+- **THEN** EACL issues retractions for both endpoint values without requiring a relationship entity
+
+### Requirement: Endpoint deletion and integrity
+The DataScript adapter SHALL treat peer eids embedded in ordinary vectors as
+values rather than DataScript refs. EACL object cleanup SHALL explicitly remove
+every touching pair before endpoint retraction, and the module SHALL expose an
+offline report for forward or reverse values whose peer half is absent.
+
+#### Scenario: EACL object cleanup
+- **WHEN** `delete-object!` is called for an endpoint
+- **THEN** it removes local and peer endpoint values for every touching relationship, retains the existing DataScript object-deletion API semantics, and publishes every affected relation mutation identity
+
+#### Scenario: Direct endpoint retraction
+- **WHEN** a consumer retracts an endpoint entity without first using the EACL relationship API
+- **THEN** peer endpoint values can remain as detectable ghost halves because embedded peer eids are not refs
+
+#### Scenario: Integrity scan
+- **WHEN** the offline DataScript relationship integrity report scans the database
+- **THEN** it reports each endpoint value lacking its exact peer value without mutating the database
+
+### Requirement: Database-visible proof coverage
+Unknown-writer relationship content proofs SHALL commit to both physical
+endpoint values and the public identities of their endpoints so that any
+answer-affecting out-of-band change invalidates a cached answer.
+
+#### Scenario: One half changes out of band
+- **WHEN** a writer adds, retracts, or changes only one endpoint value for a relation in a cached permission's dependency set
+- **THEN** the next content-proof validation does not reuse the previous cached answer
+
+#### Scenario: Endpoint identity changes out of band
+- **WHEN** an endpoint's public identity changes while its stored eid remains the same
+- **THEN** the content proof changes and the previous cached answer is rejected
+
+### Requirement: Shared logical storage layer
+The core workspace SHALL provide backend-neutral pure functions for endpoint
+value construction, decoding, and prefix validation wherever Datomic Pro,
+Datahike, and DataScript have identical logical behavior. Backend-specific
+index, temporal, transaction, and schema calls SHALL remain inside their
+adapter modules.
+
+#### Scenario: Equivalent relationship
+- **WHEN** all three adapters encode the same resolved logical relationship
+- **THEN** their forward and reverse values have identical component order and decode to the same logical endpoints
+
+#### Scenario: Backend-specific database access
+- **WHEN** an adapter reads endpoint values
+- **THEN** it uses its native database API without introducing Datomic, Datahike, or DataScript dependencies into the backend-neutral core module
+
+### Requirement: Prerelease compatibility boundary
+The optimized DataScript adapter SHALL use only the endpoint-pair layout and
+SHALL NOT add dual reads, rollback support, or an automatic migration for the
+unreleased relationship-entity layout.
+
+#### Scenario: Existing prerelease demo database
+- **WHEN** a DataScript database created from the relationship-entity branch is opened with the optimized adapter
+- **THEN** its old relationship entities are not treated as active relationships and documentation directs the user to recreate the database or reload relationships through EACL
+
+### Requirement: Cross-runtime validation
+The endpoint-pair adapter SHALL satisfy the shared v8 backend contract and its
+DataScript-specific storage, pagination, consistency, mutation, and integrity
+tests on both the JVM and ClojureScript runtimes.
+
+#### Scenario: JVM suite
+- **WHEN** the DataScript JVM tests run
+- **THEN** direct and recursive authorization, forward and reverse lookup, count, relationship read/write, cache proof, deletion, and integrity behavior pass
+
+#### Scenario: ClojureScript suite
+- **WHEN** the compiled DataScript ClojureScript tests run under Node
+- **THEN** ordinary vector ordering, `seek-datoms`, `rseek-datoms`, endpoint mutation, and the shared authorization contract pass with the same logical results as the JVM suite

--- a/openspec/changes/optimize-datascript-relationship-storage/tasks.md
+++ b/openspec/changes/optimize-datascript-relationship-storage/tasks.md
@@ -1,0 +1,51 @@
+## 1. Baseline and Shared Representation
+
+- [x] 1.1 Branch from the latest green head of PR #92, record the base SHA, and run the existing DataScript JVM/CLJS and shared contract suites through nREPL/CI to establish the pre-change baseline.
+- [x] 1.2 Add a backend-neutral CLJC endpoint-pair namespace with pure forward/reverse value construction, decoding, peer-half identity, arity validation, and prefix predicates.
+- [x] 1.3 Add shared unit/property cases covering round-trip encoding, forward/reverse symmetry, malformed ordinary values, adjacent prefixes, and JVM/CLJS equality.
+- [x] 1.4 Replace duplicate pure tuple construction/decoding in Datomic and Datahike with the shared helpers without changing either backend's schema or index-access behavior.
+- [x] 1.5 Run the focused Datomic and Datahike endpoint storage, authorization, deletion, integrity, and content-proof tests to prove the shared-helper refactor is behavior-neutral.
+
+## 2. DataScript Schema and Index Primitives
+
+- [x] 2.1 Replace the DataScript relationship component, full-key, and four derived scan tuple definitions with the two Datomic/Datahike attribute idents configured as cardinality-many indexed ordinary values.
+- [x] 2.2 Update schema constants and tests to assert that the active relationship layout has only the forward and reverse endpoint attributes and no relationship entity/full-key derivation.
+- [x] 2.3 Implement DataScript EAVT/AVET helpers for exact endpoint values and guarded full-arity `seek-datoms`/`rseek-datoms` prefix traversal.
+- [x] 2.4 Add JVM and ClojureScript boundary tests proving equal-length vector ordering, ascending/descending scans, exact prefix termination, missing-prefix behavior, and attribute/entity isolation.
+
+## 3. Authorization and Relationship Reads
+
+- [x] 3.1 Port `subject->resources`, `resource->subjects`, and `direct-match?` to endpoint-local values using the shared encoding and bounded index helpers.
+- [x] 3.2 Port exact, forward-anchored, reverse-anchored, forward-partial, and reverse-partial relationship scan plans to the two attributes while preserving portable cursor order.
+- [x] 3.3 Replace relation-in-use counting with a guarded AVET prefix scan over forward endpoint values.
+- [x] 3.4 Replace remaining relationship-entity queries in schema catalogs, reads, counts, and helper functions, and verify that anchored reads never perform a graph-wide query.
+- [x] 3.5 Run shared direct, arrow, recursive, lookup, count, read-relationships, and cursor continuation tests on both ascending and descending paths.
+
+## 4. Mutation, Deletion, and Integrity
+
+- [x] 4.1 Rework relationship resolution and existence checks so a complete relationship requires its exact forward and reverse endpoint values.
+- [x] 4.2 Implement pair transactions for `:create`, `:touch`, and `:delete`, including complete-pair conflicts, incomplete-pair repair, unconditional two-half deletion, unknown endpoint errors, and affected relation mutation identities.
+- [x] 4.3 Rework `delete-object!` to enumerate touching endpoint values, retract local and peer halves, preserve DataScript's existing object-retention behavior, report committed relationship retractions, and stamp every affected relation.
+- [x] 4.4 Add `eacl.datascript.integrity/dangling-relationship-report` with deterministic records for missing forward or reverse peer halves and no database mutation.
+- [x] 4.5 Add regression tests for direct endpoint retraction, ghost detection, touch repair, complete and partial deletion, raw cleanup inputs where supported, batch writes, and concurrent/idempotent datom set behavior.
+
+## 5. Consistency and Cache Proofs
+
+- [x] 5.1 Replace DataScript relationship-entity content queries with deterministic physical-half proof records over both endpoint attributes.
+- [x] 5.2 Include relation identity, endpoint types/eids, endpoint public identities, half direction, and value arity in the normalized content proof so one-half or identity changes invalidate cached answers.
+- [x] 5.3 Verify managed relation mutation proofs remain dependency-sized and unchanged by the physical storage refactor.
+- [x] 5.4 Add current, at-least-as-fresh, exact-snapshot, cursor proof-equivalence, out-of-band half mutation, and endpoint identity mutation regressions.
+
+## 6. Cost and Compatibility Validation
+
+- [x] 6.1 Add storage assertions showing exactly two relationship datoms per logical relationship and no active relationship entity or derived relationship indexes.
+- [x] 6.2 Build a reproducible JVM benchmark comparing PR #92's DataScript entity layout with the endpoint-pair layout for direct authorization, forward/reverse adjacency, relationship pagination, create/delete batches, and content-proof construction at representative graph sizes.
+- [x] 6.3 Record hardware, runtime, warmup, sample, graph-size, correctness, storage-count, latency, and allocation methodology, and publish measured regressions as plainly as improvements.
+- [x] 6.4 Update DataScript module, backend extension, release, explorer/demo, deletion, and cache-proof documentation with the ordinary-vector layout, mandatory EACL cleanup contract, ghost tooling, and prerelease database recreation instructions.
+
+## 7. Final Verification and Stacked PR
+
+- [x] 7.1 Run all changed Clojure and ClojureScript namespaces through clj-kondo and resolve every new warning or error; run `git diff --check`.
+- [x] 7.2 Run the full non-benchmark JVM suite and the DataScript ClojureScript suite, plus isolated `eacl`, `eacl-datomic`, `eacl-datahike`, and `eacl-datascript` module verification.
+- [x] 7.3 Run strict OpenSpec validation and mark each task complete only after its implementation and verification evidence exists.
+- [ ] 7.4 Commit and push a `codex/` feature branch, open a new PR targeting PR #92's head branch, and document the exact storage reduction, benchmark results, compatibility boundary, ghost-half contract, shared-code convergence, and validation counts without unsupported performance claims.

--- a/openspec/changes/optimize-datascript-relationship-storage/tasks.md
+++ b/openspec/changes/optimize-datascript-relationship-storage/tasks.md
@@ -48,4 +48,4 @@
 - [x] 7.1 Run all changed Clojure and ClojureScript namespaces through clj-kondo and resolve every new warning or error; run `git diff --check`.
 - [x] 7.2 Run the full non-benchmark JVM suite and the DataScript ClojureScript suite, plus isolated `eacl`, `eacl-datomic`, `eacl-datahike`, and `eacl-datascript` module verification.
 - [x] 7.3 Run strict OpenSpec validation and mark each task complete only after its implementation and verification evidence exists.
-- [ ] 7.4 Commit and push a `codex/` feature branch, open a new PR targeting PR #92's head branch, and document the exact storage reduction, benchmark results, compatibility boundary, ghost-half contract, shared-code convergence, and validation counts without unsupported performance claims.
+- [x] 7.4 Commit and push a `codex/` feature branch, open a new PR targeting PR #92's head branch, and document the exact storage reduction, benchmark results, compatibility boundary, ghost-half contract, shared-code convergence, and validation counts without unsupported performance claims.


### PR DESCRIPTION
## Stack

Stacked on #92 and targeted at its head branch. The branch starts exactly at b3275eafc13a86ae45da4834fadea23db2ad85ec, the current #92 head.

## What changed

- Replaces the DataScript relationship entity, full-key tuple, and four derived scan tuples with two cardinality-many indexed ordinary vector values: one forward half on the subject and one reverse half on the resource.
- Adds guarded full-arity EAVT/AVET seek and reverse-seek primitives, including ascending and descending cursor continuation.
- Ports direct checks, adjacency, relationship scans, relation-use counts, mutation, object deletion, integrity checks, and cache content proofs to the endpoint-pair representation.
- Adds deterministic dangling-half detection. A complete logical relationship requires both physical halves; touch repairs an incomplete pair and delete retracts both halves unconditionally.
- Moves pure endpoint-pair construction, decoding, arity, prefix, and peer-half logic into shared CLJC code used by DataScript, Datomic Pro, and Datahike. Datomic and Datahike retain their tuple schemas and index behavior.

## Storage and compatibility boundary

Measured relationship-specific storage falls exactly from 10 datoms to 2 datoms per logical relationship, an 80% reduction at both 1,024 and 4,096 relationships.

This is a prerelease-only format change. There is intentionally no dual-read path or migration for the unreleased DataScript entity layout. Explorer/demo databases must be recreated or relationships reloaded through EACL. Because peer eids are ordinary values rather than refs, consumers must use the EACL API to retract relationships before directly retracting endpoint entities; eacl.datascript.integrity/dangling-relationship-report detects violations.

## Benchmark

The reproducible JVM microbenchmark records environment, warmup, samples, correctness gates, storage, latency, and allocation. On the measured Apple Silicon/JDK 24/DataScript 1.7.8 process, endpoint pairs improved p50 for every listed workload and reduced allocation for every listed workload. At 4,096 relationships, representative p50 changes were direct match -58.4%, forward adjacency -32.9%, reverse adjacency -33.7%, 100-row page -8.7%, content proof -61.4%, create-100 -85.2%, and delete-100 -59.7%.

The report also preserves the observed regressions: the 4,096-row page mean was 1.8% slower and reverse-adjacency p95 increased from 18.429 to 24.794 microseconds. These are microbenchmark results, not a universal production speedup claim.

## Validation

- Root non-benchmark JVM groups: 313 tests, 11,954 assertions, zero failures/errors
- DataScript ClojureScript: 49 tests, 357 assertions, zero failures/errors
- Isolated core: 29 tests, 198 assertions, zero failures/errors
- Isolated DataScript plus core: 55 tests, 394 assertions, zero failures/errors
- Isolated Datomic plus core: 266 tests, 11,502 assertions, zero failures/errors
- Isolated Datahike plus core: 50 tests, 458 assertions, zero failures/errors
- Strict OpenSpec validation passes
- clj-kondo reports zero errors and no warnings in new files; git diff --check passes

The Datahike mutation suite still emits the inherited concurrent migration CAS-loser diagnostic while verifying recovery, and completes green.