### PR TITLE
Guard the integrated v8 cursor pipeline

### DIFF
--- a/formal/verification/final-assurance-audit.md
+++ b/formal/verification/final-assurance-audit.md
@@ -65,13 +65,13 @@ that the complete v8.0 engine is formally verified.
 
 ## Gate evidence
 
-- Clean checksum-locked Dafny cache: 255 obligations across 12 files, zero
+- Clean checksum-locked Dafny cache: 265 obligations across 13 files, zero
   errors, warnings, timeouts, admitted lemmas, `assume`, `axiom`,
   `{:verify false}`, opaque, or extern declarations.
 - TLA+/Apalache: both models typechecked; compact length 12, detailed length 6,
   scheduled detailed length 3, and all six initiation/consecution/implication
   obligations passed.
-- Counterexample corpus: 10 tests, 108 assertions, zero failures/errors.
+- Counterexample corpus: 10 tests, 119 assertions, zero failures/errors.
 - Mutation controls: 1 test, 22 assertions, all 9 registered mutants killed.
 - Public non-benchmark CLJ suite: 380 tests, 13,214 assertions, zero failures/errors.
 - DataScript CLJS suite: 90 tests, 1,309 assertions, zero failures/errors.

--- a/formal/verification/performance-gates.edn
+++ b/formal/verification/performance-gates.edn
@@ -68,6 +68,7 @@
    :payload-canonical-passes-per-decode 1
    :authentication-passes-per-encode 1
    :authentication-passes-per-decode 1
+   :public-relationship-continuation-decodes-per-request 1
    :framing-growth :linear}}
 
  :shadow-rollout

--- a/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/impl_test.cljc
@@ -2,6 +2,7 @@
   (:require [#?(:clj clojure.test :cljs cljs.test) :refer [deftest is testing]]
             [datascript.core :as ds]
             [eacl.core :as eacl]
+            [eacl.cursor :as cursor]
             [eacl.datascript.core :as datascript]
             [eacl.datascript.impl :as impl]
             [eacl.datascript.schema :as schema]
@@ -340,3 +341,20 @@
         (is (= 20 (:first (first @internal-queries))))
         (is (not (contains? (first @internal-queries) :limit))
             "the public wrapper must not drain an unbounded legacy page")))))
+
+(deftest relationship-continuation-authenticates-cursor-once-test
+  (let [{:keys [conn client]} (seed-bulk-read-db 100)
+        first-page (eacl/read-relationships client
+                                            {:subject/type :user
+                                             :first 20})
+        token (get-in first-page [:page-info :end-cursor])
+        continuation-client (datascript/make-client conn {})
+        work (atom {})]
+    (binding [cursor/*codec-work* work]
+      (let [page (eacl/read-relationships continuation-client
+                                          {:subject/type :user
+                                           :first 20
+                                           :after token})]
+        (is (= 20 (count (:data page))))
+        (is (= 1 (:decode-calls @work))
+            "snapshot selection and relationship keyset internalization must share one authenticated decode")))))

--- a/modules/eacl/test/eacl/characterization_fixture_test.clj
+++ b/modules/eacl/test/eacl/characterization_fixture_test.clj
@@ -106,6 +106,7 @@
             :payload-canonical-passes-per-decode 1
             :authentication-passes-per-encode 1
             :authentication-passes-per-decode 1
+            :public-relationship-continuation-decodes-per-request 1
             :framing-growth :linear}
            (:cursor-codec-work memory-and-token)))
     (is (zero? (:unexplained-differences-max shadow-rollout)))


### PR DESCRIPTION
## Summary
- add a public DataScript relationship-continuation regression proving unknown cursors are authenticated exactly once
- record the public relationship decode-cost boundary in the formal performance gates
- correct stale Dafny and counterexample totals after integrating the stacked formal/cache work

## Validation
- DataScript implementation tests: 7 tests, 43 assertions, 0 failures/errors
- parent stack: 265 Dafny obligations across 13 files, 0 errors
- parent stack: formal CLJ smoke 23 tests / 7,171 assertions; mutation controls 1 / 22; counterexample replay 10 / 119

This is the final integration guard on top of #98.