### PR TITLE
Cache recursive plans and bound page prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,14 @@ principal's grants, visited graph, or final answer. EACL v8 does not implement
 SpiceDB-style cached authorization subproblems; backend indexes still serve
 every graph edge needed by a cache miss.
 
+Recursive Relay pages also size backend scan batches to the requested window:
+16 datoms for pages up to 32 results, 32 for pages up to 256, and 64 beyond
+that. Small UI pages therefore avoid most of the former 64-datom over-read,
+while large pages and counts retain larger batches to amortize index seeks.
+`:fetched-stream-datoms` and `:stream-fills` in the optional recursive
+traversal stats expose the actual batch work for deterministic regression
+tests; `:advanced-stream-datoms` remains the number consumed by the engine.
+
 Reach for `no-cache` when the same permission check is essentially never asked
 twice — a batch job sweeping distinct resources, say — or when direct
 evaluation is cheaper than authenticated completed-answer validation. Repeated

--- a/README.md
+++ b/README.md
@@ -681,6 +681,24 @@ The native completed-answer cache cannot be shared between clients. Legacy
 portable stores remain compatibility/test surfaces but are not trusted as
 authorization-answer providers.
 
+Cache granularity is deliberately split:
+
+- completed-answer entries are keyed by the complete semantic operation and
+  query, including the principal; they do not reuse graph results across
+  different principals or different permission questions;
+- page-navigation and recursive-continuation state is likewise scoped to one
+  authenticated query and snapshot proof;
+- schema-derived permission paths, dependency closures, recursive routing,
+  and immutable recursive traversal plans are shared by every query in the
+  same client/schema generation.
+
+The last layer gives recursive queries a safe compilation network effect: once
+one principal queries `server/view`, another principal querying `server/view`
+reuses its compiled worklist rules and indexes. It does **not** reuse either
+principal's grants, visited graph, or final answer. EACL v8 does not implement
+SpiceDB-style cached authorization subproblems; backend indexes still serve
+every graph edge needed by a cache miss.
+
 Reach for `no-cache` when the same permission check is essentially never asked
 twice — a batch job sweeping distinct resources, say — or when direct
 evaluation is cheaper than authenticated completed-answer validation. Repeated

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -63,7 +63,7 @@ starts no test JVM and only evaluates a supplied form in an existing server.
 | `PageWindow.dfy` | total page normalization, windows, keyset page decisions, cursor continuation decisions |
 | `CacheKernel.dfy` | dependency closure, cache validation, telemetry CAS laws |
 | `CurrentCache.dfy` | exact/current admission, lifecycle isolation, scalar stamps, least-fixed-point dependency frame, selected-snapshot rendering |
-| `SchemaPlanCost.dfy` | one recursive-plan compilation per permission root and schema generation |
+| `SchemaPlanCost.dfy` | one recursive-plan compilation per permission root/schema generation and bounded page-sensitive stream batches |
 | `TemporalSafety.dfy` | unbounded cache/cursor transition predicates |
 | `WireFormat.dfy` | strict abstract boundary variants and bounds |
 

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -63,6 +63,7 @@ starts no test JVM and only evaluates a supplied form in an existing server.
 | `PageWindow.dfy` | total page normalization, windows, keyset page decisions, cursor continuation decisions |
 | `CacheKernel.dfy` | dependency closure, cache validation, telemetry CAS laws |
 | `CurrentCache.dfy` | exact/current admission, lifecycle isolation, scalar stamps, least-fixed-point dependency frame, selected-snapshot rendering |
+| `SchemaPlanCost.dfy` | one recursive-plan compilation per permission root and schema generation |
 | `TemporalSafety.dfy` | unbounded cache/cursor transition predicates |
 | `WireFormat.dfy` | strict abstract boundary variants and bounds |
 

--- a/formal/dafny/SchemaPlanCost.dfy
+++ b/formal/dafny/SchemaPlanCost.dfy
@@ -85,4 +85,42 @@ module SchemaPlanCost {
     ensures CompileWork(cache, selectedGeneration, root) == 1
   {
   }
+
+  // This mirrors the page-window-sensitive backend scan batching in the
+  // production recursive engine. It is a deterministic operation-count
+  // boundary, not a claim about backend or wall-clock latency.
+  function PageStreamChunkSize(pageSize: nat): nat
+    requires 0 < pageSize
+  {
+    if pageSize <= 32 then
+      16
+    else if pageSize <= 256 then
+      32
+    else
+      64
+  }
+
+  lemma PageStreamChunkIsBounded(pageSize: nat)
+    requires 0 < pageSize
+    ensures 16 <= PageStreamChunkSize(pageSize) <= 64
+  {
+  }
+
+  lemma SmallPageAvoidsTheLargeBatch(pageSize: nat)
+    requires 0 < pageSize <= 32
+    ensures PageStreamChunkSize(pageSize) == 16
+  {
+  }
+
+  lemma MediumPageUsesTheMiddleBatch(pageSize: nat)
+    requires 32 < pageSize <= 256
+    ensures PageStreamChunkSize(pageSize) == 32
+  {
+  }
+
+  lemma LargePageKeepsScanAmortization(pageSize: nat)
+    requires 256 < pageSize
+    ensures PageStreamChunkSize(pageSize) == 64
+  {
+  }
 }

--- a/formal/dafny/SchemaPlanCost.dfy
+++ b/formal/dafny/SchemaPlanCost.dfy
@@ -1,0 +1,88 @@
+module SchemaPlanCost {
+  // This models expensive recursive-plan compilation work, not wall time or
+  // the complexity of the host map lookup. Production exposes the matching
+  // :compiled-recursive-plans counter.
+  datatype PlanCache = PlanCache(
+    schemaGeneration: nat,
+    compiledRoots: set<int>
+  )
+
+  function ActiveRoots(
+    cache: PlanCache,
+    selectedGeneration: nat
+  ): set<int> {
+    if cache.schemaGeneration == selectedGeneration
+    then cache.compiledRoots
+    else {}
+  }
+
+  function CompileWork(
+    cache: PlanCache,
+    selectedGeneration: nat,
+    root: int
+  ): nat {
+    if root in ActiveRoots(cache, selectedGeneration) then 0 else 1
+  }
+
+  function AfterLookup(
+    cache: PlanCache,
+    selectedGeneration: nat,
+    root: int
+  ): PlanCache {
+    PlanCache(
+      selectedGeneration,
+      ActiveRoots(cache, selectedGeneration) + {root}
+    )
+  }
+
+  lemma CacheHitDoesNoCompilation(
+    cache: PlanCache,
+    selectedGeneration: nat,
+    root: int
+  )
+    requires root in ActiveRoots(cache, selectedGeneration)
+    ensures CompileWork(cache, selectedGeneration, root) == 0
+  {
+  }
+
+  lemma CacheMissCompilesExactlyOnce(
+    cache: PlanCache,
+    selectedGeneration: nat,
+    root: int
+  )
+    requires root !in ActiveRoots(cache, selectedGeneration)
+    ensures CompileWork(cache, selectedGeneration, root) == 1
+    ensures root in
+              ActiveRoots(
+                AfterLookup(cache, selectedGeneration, root),
+                selectedGeneration
+              )
+  {
+  }
+
+  lemma RepeatedRootCompilesAtMostOnce(
+    cache: PlanCache,
+    selectedGeneration: nat,
+    root: int
+  )
+    ensures
+      CompileWork(cache, selectedGeneration, root) +
+      CompileWork(
+        AfterLookup(cache, selectedGeneration, root),
+        selectedGeneration,
+        root
+      ) <= 1
+  {
+  }
+
+  lemma NewSchemaGenerationCannotReuseAnOldPlan(
+    cache: PlanCache,
+    selectedGeneration: nat,
+    root: int
+  )
+    requires cache.schemaGeneration != selectedGeneration
+    ensures ActiveRoots(cache, selectedGeneration) == {}
+    ensures CompileWork(cache, selectedGeneration, root) == 1
+  {
+  }
+}

--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -5,9 +5,11 @@
  [{:operation :can?
    :entry-points ['eacl.core/can?]
    :theorems [:authorization-membership-iff
-              :limit-fails-closed]
+              :limit-fails-closed
+              :one-recursive-plan-compilation-per-root-generation]
    :dafny ["formal/dafny/AcyclicEngine.dfy"
            "formal/dafny/RecursiveEngine.dfy"
+           "formal/dafny/SchemaPlanCost.dfy"
            "formal/dafny/Semantics.dfy"]
    :adapter-obligations [:immutable-snapshot :identity-round-trip
                          :schema-completeness :direct-scan-equivalence]
@@ -20,11 +22,13 @@
               :reverse-projection-exact
               :unique-deterministic-sequence
               :page-walk-complete
-              :limit-fails-closed]
+              :limit-fails-closed
+              :one-recursive-plan-compilation-per-root-generation]
    :dafny ["formal/dafny/AcyclicEngine.dfy"
            "formal/dafny/OrderedMerge.dfy"
            "formal/dafny/Pagination.dfy"
-           "formal/dafny/RecursiveEngine.dfy"]
+           "formal/dafny/RecursiveEngine.dfy"
+           "formal/dafny/SchemaPlanCost.dfy"]
    :adapter-obligations [:immutable-snapshot :identity-round-trip
                          :schema-completeness :ordered-complete-scans
                          :permission-node-completeness]
@@ -34,9 +38,11 @@
    :entry-points ['eacl.core/count-resources
                   'eacl.core/count-subjects]
    :theorems [:count-equals-lookup-cardinality :bounded-count-law
-              :limit-fails-closed]
+              :limit-fails-closed
+              :one-recursive-plan-compilation-per-root-generation]
    :dafny ["formal/dafny/AcyclicEngine.dfy"
-           "formal/dafny/RecursiveEngine.dfy"]
+           "formal/dafny/RecursiveEngine.dfy"
+           "formal/dafny/SchemaPlanCost.dfy"]
    :adapter-obligations [:immutable-snapshot :identity-round-trip
                          :schema-completeness :ordered-complete-scans]
    :runtime-targets [:clj-java :cljs-javascript]

--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -23,6 +23,7 @@
               :unique-deterministic-sequence
               :page-walk-complete
               :limit-fails-closed
+              :bounded-page-stream-prefetch
               :one-recursive-plan-compilation-per-root-generation]
    :dafny ["formal/dafny/AcyclicEngine.dfy"
            "formal/dafny/OrderedMerge.dfy"

--- a/formal/verification/manifest.edn
+++ b/formal/verification/manifest.edn
@@ -55,6 +55,11 @@
    :verified-obligations 3
    :source "formal/dafny/CursorCost.dfy"
    :claim :conditional-operation-count-bound}
+  :recursive-plan-cost-model
+  {:status :passed
+   :verified-obligations 5
+   :source "formal/dafny/SchemaPlanCost.dfy"
+   :claim :conditional-operation-count-bound}
   :cache-decision-kernel
   {:status :passed
    :verified-obligations 17

--- a/formal/verification/manifest.edn
+++ b/formal/verification/manifest.edn
@@ -55,9 +55,9 @@
    :verified-obligations 3
    :source "formal/dafny/CursorCost.dfy"
    :claim :conditional-operation-count-bound}
-  :recursive-plan-cost-model
+  :recursive-engine-cost-model
   {:status :passed
-   :verified-obligations 5
+   :verified-obligations 14
    :source "formal/dafny/SchemaPlanCost.dfy"
    :claim :conditional-operation-count-bound}
   :cache-decision-kernel

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -908,6 +908,11 @@
   (when *recursive-traversal-stats*
     (swap! *recursive-traversal-stats* update k (fnil inc 0))))
 
+(defn- add-stat!
+  [k n]
+  (when *recursive-traversal-stats*
+    (swap! *recursive-traversal-stats* update k (fnil + 0) n)))
+
 (defn- increment-counter
   [state counter-key limit-key]
   (let [n (inc (get-in state [:counters counter-key] 0))
@@ -1352,7 +1357,20 @@
         (catch #?(:clj Exception :cljs :default) _
           false)))))
 
-(def ^:private stream-chunk-size 64)
+(def ^:dynamic ^:private *stream-chunk-size*
+  "Backend scan batch size selected by the enclosing recursive page.
+
+  Small Relay windows use smaller batches to avoid realizing graph edges the
+  caller did not ask for. Count operations and large pages keep the larger
+  batch so index-seek overhead remains amortized."
+  64)
+
+(defn- page-stream-chunk-size
+  [page-size]
+  (cond
+    (<= page-size 32) 16
+    (<= page-size 256) 32
+    :else 64))
 
 (defn- subject-resource-scan
   [subject-type subject-eid relation-eid resource-type]
@@ -1401,11 +1419,13 @@
 
 (defn- fill-stream
   [db {:keys [scan] :as work}]
-  (let [realized (vec (take (inc stream-chunk-size)
+  (let [realized (vec (take (inc *stream-chunk-size*)
                             (scan-eids db scan)))
-        more? (> (count realized) stream-chunk-size)
+        _ (inc-stat! :stream-fills)
+        _ (add-stat! :fetched-stream-datoms (count realized))
+        more? (> (count realized) *stream-chunk-size*)
         eids (if more?
-               (subvec realized 0 stream-chunk-size)
+               (subvec realized 0 *stream-chunk-size*)
                realized)]
     (assoc work
            :eids eids
@@ -1687,59 +1707,60 @@
                  continuation-cache :forward :resource bound size))]
     (or
      cached-page
-     (let [continuation (when (and bound (= :asc direction))
-                          (note-continuation-miss!
-                           bound
-                           (cached-continuation continuation-cache
-                                                bound :forward :resource)))
-           state (or (:state continuation)
-                     (when subject-eid
-                       (initial-forward-state
-                        db subject-type subject-eid root-node)))
-           replay-bound (when-not continuation bound)]
-       (if-not state
-         (page-response {:items []
-                         :has-next? false
-                         :has-previous? (boolean bound)})
-         (case direction
-           :asc
-           (let [{:keys [items complete? page-end-state]}
-                 (collect-forward-after
-                  db root-node result-type state replay-bound size)
-                 page-items (vec (take size items))
-                 has-sentinel? (> (count items) size)
-                 has-next? (and has-sentinel? (not complete?))
-                 page (page-response {:items page-items
-                                      :has-next? has-next?
-                                      :has-previous? (boolean bound)})
-                 continuation-stored?
-                 (when has-next?
-                   (store-continuation!
-                    continuation-cache
-                    (some-> page-items last :cursor)
-                    :forward :resource page-end-state))
-                 page-stored?
-                 (store-recursive-page!
-                  continuation-cache :forward :resource :asc bound size page)]
-             ;; Keep the input continuation until both retry data and the next
-             ;; frontier are safely published. A cache failure must not consume
-             ;; an otherwise usable cursor.
-             (when (and continuation
-                        page-stored?
-                        (or (not has-next?) continuation-stored?))
-               (evict-continuation! continuation-cache bound))
-             page)
+     (binding [*stream-chunk-size* (page-stream-chunk-size size)]
+       (let [continuation (when (and bound (= :asc direction))
+                            (note-continuation-miss!
+                             bound
+                             (cached-continuation continuation-cache
+                                                  bound :forward :resource)))
+             state (or (:state continuation)
+                       (when subject-eid
+                         (initial-forward-state
+                          db subject-type subject-eid root-node)))
+             replay-bound (when-not continuation bound)]
+         (if-not state
+           (page-response {:items []
+                           :has-next? false
+                           :has-previous? (boolean bound)})
+           (case direction
+             :asc
+             (let [{:keys [items complete? page-end-state]}
+                   (collect-forward-after
+                    db root-node result-type state replay-bound size)
+                   page-items (vec (take size items))
+                   has-sentinel? (> (count items) size)
+                   has-next? (and has-sentinel? (not complete?))
+                   page (page-response {:items page-items
+                                        :has-next? has-next?
+                                        :has-previous? (boolean bound)})
+                   continuation-stored?
+                   (when has-next?
+                     (store-continuation!
+                      continuation-cache
+                      (some-> page-items last :cursor)
+                      :forward :resource page-end-state))
+                   page-stored?
+                   (store-recursive-page!
+                    continuation-cache :forward :resource :asc bound size page)]
+               ;; Keep the input continuation until both retry data and the next
+               ;; frontier are safely published. A cache failure must not consume
+               ;; an otherwise usable cursor.
+               (when (and continuation
+                          page-stored?
+                          (or (not has-next?) continuation-stored?))
+                 (evict-continuation! continuation-cache bound))
+               page)
 
-           :desc
-           (let [{:keys [items has-sentinel?]}
-                 (collect-forward-before
-                  db root-node result-type state bound size)
-                 page (page-response {:items items
-                                      :has-next? true
-                                      :has-previous? has-sentinel?})]
-             (store-recursive-page!
-              continuation-cache :forward :resource :desc bound size page)
-             page)))))))
+             :desc
+             (let [{:keys [items has-sentinel?]}
+                   (collect-forward-before
+                    db root-node result-type state bound size)
+                   page (page-response {:items items
+                                        :has-next? true
+                                        :has-previous? has-sentinel?})]
+               (store-recursive-page!
+                continuation-cache :forward :resource :desc bound size page)
+               page))))))))
 
 (defn- reverse-consumer-key
   [node resource-eid]
@@ -2044,57 +2065,58 @@
                  continuation-cache :reverse :subject bound size))]
     (or
      cached-page
-     (let [continuation (when (and bound (= :asc direction))
-                          (note-continuation-miss!
-                           bound
-                           (cached-continuation continuation-cache
-                                                bound :reverse :subject)))
-           state (or (:state continuation)
-                     (when resource-eid
-                       (initial-reverse-state
-                        db subject-type root-node resource-eid)))
-           replay-bound (when-not continuation bound)]
-       (if-not state
-         (page-response {:items []
-                         :has-next? false
-                         :has-previous? (boolean bound)})
-         (case direction
-           :asc
-           (let [{:keys [items complete? page-end-state]}
-                 (collect-reverse-after db root-node resource-eid
-                                        subject-type state replay-bound size)
-                 page-items (vec (take size items))
-                 has-sentinel? (> (count items) size)
-                 has-next? (and has-sentinel? (not complete?))
-                 page (page-response {:items page-items
-                                      :has-next? has-next?
-                                      :has-previous? (boolean bound)})
-                 continuation-stored?
-                 (when has-next?
-                   (store-continuation!
-                    continuation-cache
-                    (some-> page-items last :cursor)
-                    :reverse :subject page-end-state))
-                 page-stored?
-                 (store-recursive-page!
-                  continuation-cache :reverse :subject :asc bound size page)]
-             (when (and continuation
-                        page-stored?
-                        (or (not has-next?) continuation-stored?))
-               (evict-continuation! continuation-cache bound))
-             page)
+     (binding [*stream-chunk-size* (page-stream-chunk-size size)]
+       (let [continuation (when (and bound (= :asc direction))
+                            (note-continuation-miss!
+                             bound
+                             (cached-continuation continuation-cache
+                                                  bound :reverse :subject)))
+             state (or (:state continuation)
+                       (when resource-eid
+                         (initial-reverse-state
+                          db subject-type root-node resource-eid)))
+             replay-bound (when-not continuation bound)]
+         (if-not state
+           (page-response {:items []
+                           :has-next? false
+                           :has-previous? (boolean bound)})
+           (case direction
+             :asc
+             (let [{:keys [items complete? page-end-state]}
+                   (collect-reverse-after db root-node resource-eid
+                                          subject-type state replay-bound size)
+                   page-items (vec (take size items))
+                   has-sentinel? (> (count items) size)
+                   has-next? (and has-sentinel? (not complete?))
+                   page (page-response {:items page-items
+                                        :has-next? has-next?
+                                        :has-previous? (boolean bound)})
+                   continuation-stored?
+                   (when has-next?
+                     (store-continuation!
+                      continuation-cache
+                      (some-> page-items last :cursor)
+                      :reverse :subject page-end-state))
+                   page-stored?
+                   (store-recursive-page!
+                    continuation-cache :reverse :subject :asc bound size page)]
+               (when (and continuation
+                          page-stored?
+                          (or (not has-next?) continuation-stored?))
+                 (evict-continuation! continuation-cache bound))
+               page)
 
-           :desc
-           (let [{:keys [items has-sentinel?]}
-                 (collect-reverse-before db root-node
-                                         resource-eid subject-type
-                                         state bound size)
-                 page (page-response {:items items
-                                      :has-next? true
-                                      :has-previous? has-sentinel?})]
-             (store-recursive-page!
-              continuation-cache :reverse :subject :desc bound size page)
-             page)))))))
+             :desc
+             (let [{:keys [items has-sentinel?]}
+                   (collect-reverse-before db root-node
+                                           resource-eid subject-type
+                                           state bound size)
+                   page (page-response {:items items
+                                        :has-next? true
+                                        :has-previous? has-sentinel?})]
+               (store-recursive-page!
+                continuation-cache :reverse :subject :desc bound size page)
+               page))))))))
 
 (declare traverse-permission-path lookup-subject-eids* can*)
 

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -301,6 +301,7 @@
     :traversal-permissions (atom {})
     :traversal-analysis (atom nil)
     :relationship-dependencies (atom {})
+    :recursive-plans (atom {})
     :direct-grant-relations (atom {})}))
 
 (defn schema-cache-key
@@ -350,6 +351,7 @@
    (reset! (:traversal-permissions schema-cache) {})
    (some-> (:traversal-analysis schema-cache) (reset! nil))
    (reset! (:relationship-dependencies schema-cache) {})
+   (some-> (:recursive-plans schema-cache) (reset! {}))
    (some-> (:direct-grant-relations schema-cache) (reset! {}))
    nil))
 
@@ -1019,6 +1021,58 @@
          (sort-by :id)
          vec)))
 
+(defn- forward-consumers
+  [rules]
+  (->> rules
+       (keep (fn [rule]
+               (case (:rule rule)
+                 :self-permission
+                 [(:target-node rule) rule]
+                 :arrow-permission
+                 [(:target-node rule) rule]
+                 nil)))
+       (group-by first)
+       (into {}
+             (map (fn [[node pairs]]
+                    [node (mapv second (sort-by (comp :id second) pairs))])))))
+
+(defn- rules-by-node
+  [rules]
+  (->> rules
+       (group-by :node)
+       (into {}
+             (map (fn [[node node-rules]]
+                    [node (vec (sort-by :id node-rules))])))))
+
+(defn- compile-recursive-plan
+  [db root-node]
+  (inc-stat! :compiled-recursive-plans)
+  (let [rules (compile-recursive-rules db root-node)]
+    {:rules rules
+     :forward-consumers (forward-consumers rules)
+     :rules-by-node (rules-by-node rules)}))
+
+(defn- recursive-plan
+  "Returns the immutable traversal plan for one permission root.
+
+  Compilation depends only on the schema proof, never on graph relationships,
+  subject, resource, direction, or page boundary. A client generation may
+  therefore share the plan across principals and requests without sharing an
+  authorization answer or request-local traversal state."
+  [db root-node]
+  (let [cache-atom (:recursive-plans *schema-cache*)]
+    (if-not (and cache-atom (some? (:schema-version *schema-cache*)))
+      (compile-recursive-plan db root-node)
+      (let [candidate (delay (compile-recursive-plan db root-node))
+            plan-delay
+            (get
+             (swap! cache-atom
+                    #(if (contains? % root-node)
+                       %
+                       (assoc % root-node candidate)))
+             root-node)]
+        @plan-delay))))
+
 (defn- recursive-edge
   [direction result-kind ordinal result-type result-eid]
   {:kind :recursive-traversal
@@ -1378,25 +1432,10 @@
           state'))
       state)))
 
-(defn- forward-consumers
-  [rules]
-  (->> rules
-       (keep (fn [rule]
-               (case (:rule rule)
-                 :self-permission
-                 [(:target-node rule) rule]
-                 :arrow-permission
-                 [(:target-node rule) rule]
-                 nil)))
-       (group-by first)
-       (into {}
-             (map (fn [[node pairs]]
-                    [node (mapv second (sort-by (comp :id second) pairs))])))))
-
 (defn- forward-seed-state
-  [db subject-type subject-eid rules]
-  (let [consumers (forward-consumers rules)]
-    (reduce
+  [db subject-type subject-eid
+   {:keys [rules forward-consumers]}]
+  (reduce
      (fn [state rule]
        (case (:rule rule)
          :relation
@@ -1438,9 +1477,9 @@
       :emitted-root #{}
       :ordinal 0
       :counters {}
-      :consumers consumers
-      :consumer-count (reduce + 0 (map count (vals consumers)))}
-     rules)))
+      :consumers forward-consumers
+      :consumer-count (reduce + 0 (map count (vals forward-consumers)))}
+     rules))
 
 (defn- forward-consumer-work
   [db grant rule]
@@ -1492,8 +1531,8 @@
 
 (defn- initial-forward-state
   [db subject-type subject-eid root-node]
-  (let [rules (compile-recursive-rules db root-node)]
-    (forward-seed-state db subject-type subject-eid rules)))
+  (forward-seed-state
+   db subject-type subject-eid (recursive-plan db root-node)))
 
 (defn- next-forward-item
   [db root-node result-type state]
@@ -1702,14 +1741,6 @@
               continuation-cache :forward :resource :desc bound size page)
              page)))))))
 
-(defn- rules-by-node
-  [rules]
-  (->> rules
-       (group-by :node)
-       (into {}
-             (map (fn [[node node-rules]]
-                    [node (vec (sort-by :id node-rules))])))))
-
 (defn- reverse-consumer-key
   [node resource-eid]
   [node resource-eid])
@@ -1853,8 +1884,7 @@
 
 (defn- initial-reverse-state
   [db subject-type root-node root-resource-eid]
-  (let [rules (compile-recursive-rules db root-node)
-        indexed-rules (rules-by-node rules)]
+  (let [{:keys [rules rules-by-node]} (recursive-plan db root-node)]
     (enqueue-reverse-goal
      {:queue empty-queue
       :seen-goals #{}
@@ -1865,7 +1895,7 @@
       :ordinal 0
       :counters {}
       :subject-type subject-type
-      :rules-by-node indexed-rules
+      :rules-by-node rules-by-node
       :rule-count (count rules)
       :consumer-count 0}
      root-node

--- a/modules/eacl/test/eacl/backend/v8_test.cljc
+++ b/modules/eacl/test/eacl/backend/v8_test.cljc
@@ -335,3 +335,88 @@
                             adapter (query 1003))))))
         (is (= 2 (:compiled-recursive-plans @stats))
             "schema-cache eviction forces plan recompilation")))))
+
+(deftest recursive-page-stream-batches-track-the-requested-window-test
+  (let [permission-defs
+        [{:permission-id 1
+          :resource-type :node
+          :permission-name :read
+          :source-relation-name :self
+          :target-type :relation
+          :target-name :reader}
+         {:permission-id 2
+          :resource-type :node
+          :permission-name :read
+          :source-relation-name :self
+          :target-type :permission
+          :target-name :read}]
+        operations
+        (merge
+         (operation-map)
+         {:snapshot-id (fn [] {:database-id :test :basis-t 1})
+          :source-scope (fn [] {:source-id :test :branch nil})
+          :schema-proof (fn
+                          ([] :schema-proof)
+                          ([_] :schema-proof))
+          :object-id->internal identity
+          :internal-id->object identity
+          :permission-defs
+          (fn [resource-type permission-name]
+            (if (= [:node :read]
+                   [resource-type permission-name])
+              permission-defs
+              []))
+          :relation-defs
+          (fn [resource-type relation-name]
+            (if (= [:node :reader]
+                   [resource-type relation-name])
+              [{:relation-id 3
+                :resource-type :node
+                :relation-name :reader
+                :subject-type :user}]
+              []))
+          :subject->resources
+          (fn [_subject-type _subject-id _relation-id _resource-type
+               {:keys [bound-eid]}]
+            (range (inc (or bound-eid 0)) 2001))
+          :all-permission-nodes
+          (fn [] #{[:node :read]})})
+        adapter
+        (backend/make-adapter
+         {:id :test
+          :capabilities
+          {:consistency #{:fully-consistent}
+           :snapshots #{:current}
+           :cursor #{:forward :reverse}
+           :transactions #{}
+           :cache-proofs #{:schema :relations :snapshot-bound}
+           :runtime #{#?(:clj :clj :cljs :cljs)}}
+          :operations operations})
+        schema-cache (engine/make-schema-cache adapter :schema-proof)
+        query
+        (fn [page-size]
+          {:subject {:type :user :id 1001}
+           :permission :read
+           :resource/type :node
+           :first page-size})
+        run-page
+        (fn [page-size]
+          (let [stats (atom {})
+                page
+                (binding [engine/*schema-cache* schema-cache
+                          engine/*recursive-traversal-stats* stats]
+                  (engine/lookup-resources
+                   adapter (query page-size)))]
+            {:page page
+             :stats @stats}))]
+    (doseq [[page-size expected-fills expected-fetched]
+            [[20 2 34]
+             [100 4 132]
+             [300 5 325]]]
+      (testing (str "page size " page-size)
+        (let [{:keys [page stats]} (run-page page-size)]
+          (is (= page-size (count (:data page))))
+          (is (= expected-fills (:stream-fills stats)))
+          (is (= expected-fetched (:fetched-stream-datoms stats))))))
+    (is (= 1 (count @(:recursive-plans schema-cache)))
+        "batch tuning never changes the schema-derived traversal plan")))

--- a/modules/eacl/test/eacl/backend/v8_test.cljc
+++ b/modules/eacl/test/eacl/backend/v8_test.cljc
@@ -314,4 +314,24 @@
                      adapter :node :edit)))
         (is (identical? analysis-delay
                         @(:traversal-analysis schema-cache))
-            "another permission root reuses the generation-wide analysis")))))
+            "another permission root reuses the generation-wide analysis"))
+      (let [stats (atom {})
+            query (fn [subject-eid]
+                    {:subject {:type :user :id subject-eid}
+                     :permission :read
+                     :resource/type :node
+                     :first 1})]
+        (binding [engine/*recursive-traversal-stats* stats]
+          (is (= [] (:data (engine/lookup-resources
+                            adapter (query 1001)))))
+          (is (= [] (:data (engine/lookup-resources
+                            adapter (query 1002))))))
+        (is (= 1 (:compiled-recursive-plans @stats))
+            "different principals share one immutable recursive plan")
+        (is (= 1 (count @(:recursive-plans schema-cache))))
+        (engine/evict-permission-paths-cache! schema-cache)
+        (binding [engine/*recursive-traversal-stats* stats]
+          (is (= [] (:data (engine/lookup-resources
+                            adapter (query 1003))))))
+        (is (= 2 (:compiled-recursive-plans @stats))
+            "schema-cache eviction forces plan recompilation")))))


### PR DESCRIPTION
## What changed

- cache immutable recursive traversal plans by permission root inside the selected schema-proof generation
- share schema-only compilation across principals while keeping grants, visited graph state, continuations, and completed answers query-scoped
- evict plans with the rest of derived schema state
- adapt recursive backend scan batches to the Relay window: 16 datoms through page size 32, 32 through 256, and 64 for larger pages/counts
- expose fetched-stream and stream-fill counters so prefetch regressions are deterministic rather than timing-only
- document the exact cache granularity and the absence of SpiceDB-style graph-subproblem caching
- extend the Dafny operation-count model with at-most-once plan compilation and bounded page-sensitive stream batches

## Root cause

Recursive queries reused schema path and routing classification caches, but rebuilt traversal rules, forward-consumer indexes, and reverse rule indexes on every cache miss or cache-disabled request. That repeated work depends only on immutable schema, not graph data or the principal.

Separately, every recursive graph stream prefetched 64 datoms even for a 20-result UI page. The engine consumed only 93 datoms for the Explorer page but could realize substantially more backend data. Page-sensitive batches preserve 64-datom amortization for large scans while removing most small-page over-read.

## Safety boundary

A plan is keyed inside a backend/source/schema-proof generation. It contains only schema-derived rules and indexes. Authorization answers and request-local traversal state are never shared. Raw or arbitrary DB evaluation without a trusted schema proof still compiles per request.

The formal release gate intentionally remains withheld: the complete public Clojure/CLJS engine is not generated from the proof kernel. `SchemaPlanCost.dfy` proves deterministic operation-count properties and is paired with runtime counters; it does not claim wall-clock verification or full-engine refinement.

## Performance

DataScript browser benchmark on the Explorer recursive 10k-server seed, 20-result page, 20 samples after warmup:

- release/v8.0 before: 4.549 ms mean, 4.460 ms p50
- this PR: 3.255 ms mean, 3.200 ms p50
- improvement: 28.4% mean, 28.3% p50
- completed-cache hit: 0.146 ms mean

The schema-plan cache is a safe cross-principal compilation network effect. The measured small-page gain comes primarily from bounded prefetch. Large page scans retain the 64-datom batch.

## Validation

- JVM: 397 tests, 13,369 assertions, 0 failures/errors
- DataScript CLJS: 103 tests, 1,388 assertions, 0 failures/errors
- heavy pagination/load suite: 9 tests, 3,403 assertions, 0 failures/errors
- generated Java differential boundary: 18 tests, 7,143 assertions, 0 failures/errors in a fresh nREPL
- Dafny: every source report verified with 0 errors; `SchemaPlanCost.dfy` has 14 verified obligations
- generated Java, JavaScript, and browser bundles built successfully
- Dafny formatting and git diff checks pass

Explorer consumer: theronic/eacl-explorer#3