### PR TITLE
Implement `eacl/expand-permission-tree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ The `IAuthorization` protocol in [modules/eacl/src/eacl/core.cljc](modules/eacl/
 - `(eacl/lookup-resources acl filters) => {:data [resources...] :page-info {...}}`
 - `(eacl/count-resources acl filters) => {:keys [count limit]}` counts the full result set.
 - `(eacl/count-subjects acl filters) => {:keys [count limit]}` counts the full subject result set.
+- `(eacl/expand-permission-tree acl filters) => {:expanded-at token :tree-root node}`
+  returns the shallow SpiceDB-compatible expansion for one resource and
+  relation or permission.
 
 Pass `:count-limit n` to either count operation to bound work. The result then includes
 `:truncated?`; `true` means at least one additional result exists.
@@ -217,11 +220,74 @@ All list APIs use the v8 Relay pagination contract:
 
 - `(eacl/write-schema! acl schema-string)` parses a SpiceDB schema DSL string, validates it, computes deltas against existing schema, checks for orphaned relationships, and transacts changes atomically.
 - `(eacl/read-schema acl)` returns the current schema as a map of `{:relations [...] :permissions [...]}`.
-- `(eacl/expand-permission-tree acl filters)` is not impl. yet. It is a low priority to implement.
 
 All schema changes must use `eacl/write-schema!`. If an application changes
 the authorization schema directly, follow the recovery procedure in
 [Caching](#caching) before resuming authorization traffic.
+
+### Permission-tree expansion
+
+Expansion accepts exactly `:resource`, `:permission`, and the optional
+`:consistency` and `:timeout-ms` keys:
+
+```clojure
+(eacl/expand-permission-tree
+ acl
+ {:resource (eacl/spice-object :document "readme")
+  :permission :view
+  :consistency consistency/fully-consistent
+  :timeout-ms 5000})
+;; =>
+;; {:expanded-at "eacl_z3_..."
+;;  :tree-root
+;;  {:expanded-object {:type :document :id "readme"}
+;;   :expanded-relation :view
+;;   :intermediate
+;;   {:operation :union
+;;    :children
+;;    [{:expanded-object {:type :document :id "readme"}
+;;      :expanded-relation :viewer
+;;      :leaf {:subjects [{:type :user :id "alice"}]}}]}}}
+```
+
+A node contains exactly one of `:leaf` or `:intermediate`. Permission and
+arrow boundaries remain visible; expansion is shallow in the SpiceDB sense,
+so leaves contain subjects found by direct relation scans rather than a
+flattened effective-membership set. To decide whether a subject has the
+permission, use `can?`; do not infer authorization by flattening a tree.
+
+Child and subject vector order is non-semantic and may differ by backend.
+Empty branches and duplicate paths are preserved. Compare trees as annotated
+topology with child/subject multisets when order is irrelevant. The exact
+supplied root ID is retained, while scanned IDs are converted with the
+selected client's object-ID codec.
+
+The response tree and `:expanded-at` token are derived from the same selected
+immutable snapshot. Replay the token with
+`(consistency/at-exact-snapshot (:expanded-at response))` only on a backend
+that advertises exact historical selection; otherwise use it as an
+at-least-as-fresh causal floor. Unsupported consistency, unavailable history,
+deadlines, unknown roots, cycles, codec failures, adapter-contract failures,
+and structural limits produce typed all-or-error failures—no lazy or partial
+tree is returned.
+
+Clients accept positive exact-integer `:permission-tree-limits` overrides.
+They are configuration-only, not request keys:
+
+```clojure
+(eacl.datascript.core/make-client
+ conn
+ {:permission-tree-limits
+  {:max-depth 50
+   :max-schema-components 100000
+   :max-relationship-values 100000
+   :max-tree-nodes 100000
+   :max-leaf-subjects 100000}})
+```
+
+Every bundled backend uses the same portable expansion kernel. Their only
+observable differences are supported consistency modes, historical retention,
+native scan order, and configured identity conversion.
 
 ### Example Queries
 
@@ -994,7 +1060,9 @@ Now you can transact relationships. The usual way is `eacl/create-relationships!
   - but `permission arrow = relation->subrelation->permission` is not. To implement this would require anonymous shadow relations. May require schema changes.
 - You need to specify a `Permission` for each relation in a sum-type permission. In future this can be shortened.
 - `subject.relation` is not currently supported. It's useful for group memberships.
-- `expand-permission-tree` is not implemented yet.
+- *Expansion is structural, not a membership proof:* permission trees preserve
+  relation, permission, union, and arrow boundaries. Use `can?` for an
+  authorization decision.
 - *Cache coherence requires EACL authorization writers:* Bypassing EACL for
   schema, relationship, permissioned identity, or deletion mutations can
   leave cached answers stale. Stop affected traffic, repair the data, and

--- a/bin/reflection-gate
+++ b/bin/reflection-gate
@@ -14,10 +14,10 @@ clojure -M:dev -e "
   (require 'eacl.core 'eacl.cache 'eacl.subproblem-cache 'eacl.relay
            'eacl.cursor 'eacl.continuation 'eacl.engine.v8
            'eacl.verified-kernel 'eacl.secure-format 'eacl.causal-token
-           'eacl.consistency 'eacl.mutation 'eacl.client.orchestration
+           'eacl.consistency 'eacl.client.orchestration
            'eacl.relationships.filters 'eacl.relationships.storage
            'eacl.relationships.endpoint-pair 'eacl.engine.relationships
-           'eacl.backend.v8
+           'eacl.backend.v8 'eacl.permission-tree
            'eacl.datascript.core 'eacl.datascript.impl
            'eacl.datascript.backend
            'eacl.datahike.core 'eacl.datahike.impl 'eacl.datahike.backend

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -70,7 +70,7 @@ for another.
 `source-closure` checks the committed
 `formal/verification/public-source-closure.json` ledger with the exact
 clj-kondo version in the toolchain lock. The ledger closes 63 named shared,
-proof-provider, and backend roots over 1,380 definitions in 57 source
+proof-provider, and backend roots over 1,404 definitions in 58 source
 files, including unattributed usages assigned to their exact containing
 `defrecord` spans. It is static completeness evidence only: it does not prove
 Clojure source or adapter semantics. `backend-dispatch.edn` additionally
@@ -107,12 +107,36 @@ starts no test JVM and only evaluates a supplied form in an existing server.
 | `SchemaPlanCost.dfy` | one recursive-plan compilation per permission root/schema generation and bounded page-sensitive stream batches |
 | `TemporalSafety.dfy` | unbounded cache/cursor transition predicates |
 | `WireFormat.dfy` | strict abstract boundary variants and bounds |
+| `PermissionTree.dfy` | typed shallow expansion topology, denotation, active-path cycles, structural budgets, and all-or-error outcomes |
 
 `formal/verification/assurance-matrix.edn` maps public operations to theorems,
 adapter assumptions, runtime targets, and CI evidence. A passing proof file is
 not by itself a public assurance claim. `formal/verification/manifest.edn` is
 the release gate and must continue to refuse verified status while any required
 obligation is incomplete.
+
+### Permission-tree assurance boundary
+
+`PermissionTree.dfy` contributes 62 locked obligations. The theorem map covers
+node oneof and annotation well-formedness, direct-leaf exactness, union
+denotation and child-permutation invariance, absent-resource topology,
+active-path cycle rejection, additive-budget monotonicity, successful limit
+preservation, failure non-publication, typed identity, sum-typed relation
+declarations, and emitted-child depth accounting. Executable witnesses
+also reject unsound flattening, global-visited cycle detection, type-erasing
+identity, partial success, and over-limit success.
+
+The formal model is proof-only. Production
+`modules/eacl/src/eacl/permission_tree.cljc` is handwritten and has no claimed
+mechanical Dafny-to-Clojure refinement. Correspondence evidence lives in
+`modules/eacl/test/eacl/permission_tree_test.cljc` (independent evaluator,
+bounded generators, permutation and hostile-realization checks),
+`modules/eacl/test/eacl/contract_support.cljc` plus each backend contract, and
+`formal/fixtures/permission-tree/` (version-pinned black-box Docker topology).
+CLJ and CLJS run the same portable kernel. Adapter schema/scan completeness,
+codec round trips, immutable selection, causal-token authentication,
+monotonic-clock behavior, host exact-integer/runtime semantics, and arbitrary
+source states remain trusted or empirically certified rather than proved.
 
 ## Temporal models
 

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -59,6 +59,32 @@ closure without a listener, transaction-log read, or database-global CAS.
 
 ## Consistency
 
+`expand-permission-tree` is now implemented on Datomic, Datahike, DataScript
+CLJ, and DataScript CLJS. It is an additive protocol behavior change: the
+existing method no longer throws `:eacl/not-implemented`. Requests accept
+`:resource`, `:permission`, optional `:consistency`, and optional
+`:timeout-ms`; responses contain `:expanded-at` and a shallow annotated
+`:tree-root`. The tree and token are bound to one selected immutable snapshot.
+
+Expansion preserves empty branches, nested permission/arrow boundaries, and
+duplicate multiplicity. Vector order is not semantic. Client construction now
+accepts `:permission-tree-limits` for depth, schema-component,
+relationship-value, node, and leaf-subject work. Typed failures are
+all-or-error and do not expose a partial tree or internal backend identity.
+
+Compatibility was checked as black-box behavior against a live SpiceDB v1.56.0
+Docker image pinned by digest. This is a scoped topology claim for EACL's
+supported union/direct/single-arrow schema subset, not a claim of full SpiceDB
+feature or byte-order equivalence. The Dafny model proves the backend-neutral
+shallow topology, denotation, cycle, and limit properties; the handwritten
+CLJ/CLJS implementation is differentially tested rather than mechanically
+extracted.
+
+No database migration or persisted attribute is required. Rollback by first
+stopping callers that depend on successful expansion, then deploy the prior
+code and remove `:permission-tree-limits` from client configuration. Existing
+schemas, relationships, caches, and tokens require no rewrite.
+
 - The default authorization mode is `:minimize-latency`.
 - The redundant pre-release names `:local-snapshot` and
   `:synchronized-head` are no longer accepted.
@@ -470,7 +496,7 @@ counterexample that forced this correction.
 - equality of least fixed points for complete compiled dependencies;
 - selected-snapshot internal-to-public result rendering.
 
-The locked Dafny run completes 8,642 proof efforts across 28 source-project
+The locked Dafny run completes 8,785 proof efforts across 30 source-project
 invocations with zero errors, admissions, warnings, or timeouts. The count
 includes dependency obligations repeated by multiple top-level invocations; it
 is pipeline work, not a count of unique theorems. Generated authority routes

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -102,6 +102,39 @@ Exceeding a ceiling throws `:eacl.recursive-traversal/limit-exceeded`. Use
 `:count-limit` for bounded counts and raise traversal limits only after
 representative heap and load testing.
 
+## Permission-tree expansion
+
+All bundled adapters implement `expand-permission-tree` through one portable
+CLJ/CLJS kernel. The strict request is `{:resource object :permission keyword}`
+plus optional `:consistency` and `:timeout-ms`; the response is
+`{:expanded-at token :tree-root node}`. The token and every definition,
+relationship, and rendered ID in the tree come from one selected immutable
+adapter. Datomic can replay the exact token while history is retained;
+Datahike can do so only in configurations with retained exact selection;
+DataScript supplies current/causal selection but no arbitrary historical
+reconstruction.
+
+The tree is a shallow structural explanation, not a flattened authorization
+answer. It preserves union, permission, and arrow boundaries, empty branches,
+and duplicate multiplicity. Child/subject order is deliberately unspecified.
+Use `can?` for membership decisions and compare normalized tree topology with
+multisets when order is irrelevant.
+
+Clients accept `:permission-tree-limits` with positive portable exact integers:
+
+```clojure
+{:max-depth 50
+ :max-schema-components 100000
+ :max-relationship-values 100000
+ :max-tree-nodes 100000
+ :max-leaf-subjects 100000}
+```
+
+These are construction-time ceilings; requests cannot override them. Limit,
+deadline, cycle, codec, adapter-contract, unknown-root, and consistency
+failures are typed and return no partial tree. This feature adds no schema,
+stored attribute, dependency, or database migration.
+
 ## Backend extension boundary
 
 The adapter operation map validates snapshot/source identity, consistency,

--- a/formal/README.md
+++ b/formal/README.md
@@ -55,11 +55,34 @@ publication, exact fallback for incomplete evidence, and selected-snapshot
 identity. Backend certification remains the trusted boundary for native
 transaction ordering and atomic stamp publication.
 
+`dafny/PermissionTree.dfy` is the proof-only shallow permission-tree model. It
+defines typed object identity, normalized relation/permission components,
+annotated leaf/intermediate nodes, active-path cycle state, structural budgets,
+and success-or-error outcomes. Its 62 locked proof obligations cover node
+oneof/annotation well-formedness, exact direct leaves, union denotation and
+child permutation invariance, absent-resource topology, active-path rejection,
+budget monotonicity, successful limit preservation, failure non-publication,
+type-preserving identity, sum-typed relation declarations, and emitted-child
+depth accounting. Run `bin/formal format` and `bin/formal verify`;
+the aggregate report is `target/formal/dafny-verification.json`.
+
+This model is not mechanically extracted into production. The corresponding
+handwritten source is `modules/eacl/src/eacl/permission_tree.cljc`; bounded
+reference/property tests are in
+`modules/eacl/test/eacl/permission_tree_test.cljc`, backend contracts in
+`modules/eacl/test/eacl/contract_support.cljc`, and the pinned upstream fixture
+in `formal/fixtures/permission-tree/`. Immutable/complete adapter reads,
+identity conversion, selected-snapshot token authentication, monotonic clocks,
+host integer/runtime semantics, and general Clojure source refinement remain
+explicit trusted or empirically checked boundaries.
+
 The operational guide, theorem navigation, adapter certification,
 counterexample workflow, generated-engine cutover policy, and assurance wording are in
 [`../docs/formal-verification.md`](../docs/formal-verification.md). Behavior
 changes discovered by this work are listed in
 [`../docs/formal-verification-corrections.md`](../docs/formal-verification-corrections.md).
+The issue-111 implementation/proof loophole loop and residual boundary are in
+[`verification/permission-tree-final-audit.md`](verification/permission-tree-final-audit.md).
 
 The tool bootstrap reads `toolchain.lock.json`, accepts only supported platform
 artifacts, validates SHA-256 before extraction, and fails rather than silently
@@ -77,8 +100,8 @@ allocation, retained heap, solver effort, or latency.
 
 `bin/formal source-closure` checks the locked CLJ/CLJS static call-closure
 ledger for 63 named shared, generated-provider, and backend roots. The ledger
-is deliberately marked verification-incomplete: enumerating 1,380 reachable
-definitions in 57 source files (including source-span attribution for inline
+is deliberately marked verification-incomplete: enumerating 1,404 reachable
+definitions in 58 source files (including source-span attribution for inline
 `defrecord` methods) prevents silent omissions but does not establish source
 refinement or adapter semantics. `backend-dispatch.edn` separately checks that
 every CLJ and CLJS dispatch site uses one of exactly the 21 required literal

--- a/formal/dafny/PermissionTree.dfy
+++ b/formal/dafny/PermissionTree.dfy
@@ -1,0 +1,923 @@
+// Mathematical model for EACL's bounded shallow permission-tree expansion.
+//
+// The verified boundary starts with an immutable, well-formed Snapshot whose
+// typed objects and normalized union components were supplied by an adapter.
+// It does not prove the handwritten Clojure implementation, adapter queries,
+// codecs, clocks, causal-token authentication, or host integer semantics.
+// Those refinement obligations are exercised by correspondence and boundary
+// tests and remain explicit in the assurance manifest.
+module PermissionTree {
+  datatype ObjectRef = ObjectRef(typeId: nat, objectId: nat)
+
+  datatype DefinitionKey = DefinitionKey(typeId: nat, name: nat)
+
+  datatype ExpansionKey = ExpansionKey(resource: ObjectRef, name: nat)
+
+  datatype Relationship = Relationship(
+    resource: ObjectRef,
+    relation: nat,
+    subject: ObjectRef
+  )
+
+  datatype Component =
+    | SameRelation(relation: nat)
+    | SamePermission(permission: nat)
+    | ArrowRelation(sourceRelation: nat, targetRelation: nat)
+    | ArrowPermission(sourceRelation: nat, targetPermission: nat)
+
+  datatype RelationDefinition = RelationDefinition(
+    key: DefinitionKey,
+    subjectType: nat
+  )
+
+  datatype PermissionDefinition = PermissionDefinition(
+    key: DefinitionKey,
+    components: seq<Component>
+  )
+
+  datatype Schema = Schema(
+    relations: seq<RelationDefinition>,
+    permissions: seq<PermissionDefinition>
+  )
+
+  datatype Snapshot = Snapshot(
+    schema: Schema,
+    relationships: seq<Relationship>
+  )
+
+  // The datatype makes leaf/intermediate a true oneof. Every constructor also
+  // carries the expanded object and relation/permission annotation.
+  datatype Tree =
+    | Leaf(
+        expandedObject: ObjectRef,
+        expandedRelation: nat,
+        subjects: seq<ObjectRef>
+      )
+    | Union(
+        expandedObject: ObjectRef,
+        expandedRelation: nat,
+        children: seq<Tree>
+      )
+
+  datatype Budget = Budget(
+    schemaComponents: nat,
+    relationshipValues: nat,
+    treeNodes: nat,
+    leafSubjects: nat
+  )
+
+  datatype Limits = Limits(
+    maxDepth: nat,
+    maxSchemaComponents: nat,
+    maxRelationshipValues: nat,
+    maxTreeNodes: nat,
+    maxLeafSubjects: nat
+  )
+
+  datatype Failure =
+    | UnknownRoot
+    | InvalidSchema
+    | CycleDetected
+    | DepthLimitExceeded
+    | SchemaComponentLimitExceeded
+    | RelationshipValueLimitExceeded
+    | TreeNodeLimitExceeded
+    | LeafSubjectLimitExceeded
+
+  datatype RawOutcome =
+    | RawSuccess(tree: Tree, budget: Budget)
+    | RawFailure(failure: Failure)
+
+  // A failure contains no tree, so neither a cycle nor a resource failure can
+  // publish a partial result.
+  datatype Outcome =
+    | Success(tree: Tree, budget: Budget)
+    | Failed(failure: Failure)
+
+  datatype ChildrenOutcome =
+    | ChildrenSuccess(children: seq<Tree>, budget: Budget)
+    | ChildrenFailure(failure: Failure)
+
+  function ZeroBudget(): Budget {
+    Budget(0, 0, 0, 0)
+  }
+
+  function AddBudget(left: Budget, right: Budget): Budget {
+    Budget(
+      left.schemaComponents + right.schemaComponents,
+      left.relationshipValues + right.relationshipValues,
+      left.treeNodes + right.treeNodes,
+      left.leafSubjects + right.leafSubjects
+    )
+  }
+
+  predicate BudgetLe(left: Budget, right: Budget) {
+    left.schemaComponents <= right.schemaComponents &&
+    left.relationshipValues <= right.relationshipValues &&
+    left.treeNodes <= right.treeNodes &&
+    left.leafSubjects <= right.leafSubjects
+  }
+
+  lemma BudgetAdditionIsMonotone(left: Budget, right: Budget)
+    ensures BudgetLe(left, AddBudget(left, right))
+    ensures BudgetLe(right, AddBudget(left, right))
+  {
+  }
+
+  function RelationDefinitions(
+    definitions: seq<RelationDefinition>,
+    key: DefinitionKey
+  ): seq<RelationDefinition>
+    decreases |definitions|
+  {
+    if |definitions| == 0 then
+      []
+    else
+      (if definitions[0].key == key then [definitions[0]] else []) +
+      RelationDefinitions(definitions[1..], key)
+  }
+
+  predicate DistinctSubjectTypes(
+    definitions: seq<RelationDefinition>
+  )
+    decreases |definitions|
+  {
+    |definitions| == 0 ||
+    (!DeclaresSubjectType(
+       definitions[1..],
+       definitions[0].subjectType
+     ) &&
+     DistinctSubjectTypes(definitions[1..]))
+  }
+
+  predicate DeclaresSubjectType(
+    definitions: seq<RelationDefinition>,
+    subjectType: nat
+  ) {
+    exists definition <- definitions ::
+      definition.subjectType == subjectType
+  }
+
+  function PermissionDefinitions(
+    definitions: seq<PermissionDefinition>,
+    key: DefinitionKey
+  ): seq<PermissionDefinition>
+    decreases |definitions|
+  {
+    if |definitions| == 0 then
+      []
+    else
+      (if definitions[0].key == key then [definitions[0]] else []) +
+      PermissionDefinitions(definitions[1..], key)
+  }
+
+  function MatchingSubjects(
+    definitions: seq<RelationDefinition>,
+    relationships: seq<Relationship>,
+    resource: ObjectRef,
+    relation: nat
+  ): seq<ObjectRef>
+    decreases |relationships|
+  {
+    if |relationships| == 0 then
+      []
+    else
+      (if relationships[0].resource == resource &&
+          relationships[0].relation == relation
+          && DeclaresSubjectType(
+            definitions,
+            relationships[0].subject.typeId
+          )
+       then [relationships[0].subject]
+       else []) +
+      MatchingSubjects(
+        definitions,
+        relationships[1..],
+        resource,
+        relation
+      )
+  }
+
+  lemma MatchingSubjectsAreExact(
+    definitions: seq<RelationDefinition>,
+    relationships: seq<Relationship>,
+    resource: ObjectRef,
+    relation: nat,
+    subject: ObjectRef
+  )
+    ensures subject in MatchingSubjects(
+                         definitions,
+                         relationships,
+                         resource,
+                         relation
+                       ) <==>
+            exists item <- relationships ::
+              item.resource == resource &&
+              item.relation == relation &&
+              item.subject == subject &&
+              DeclaresSubjectType(definitions, item.subject.typeId)
+    decreases |relationships|
+  {
+    if |relationships| != 0 {
+      MatchingSubjectsAreExact(
+        definitions,
+        relationships[1..],
+        resource,
+        relation,
+        subject
+      );
+    }
+  }
+
+  lemma AbsentResourceHasNoSubjects(
+    definitions: seq<RelationDefinition>,
+    relationships: seq<Relationship>,
+    resource: ObjectRef,
+    relation: nat
+  )
+    requires forall item <- relationships ::
+               item.resource != resource || item.relation != relation
+    ensures MatchingSubjects(
+              definitions,
+              relationships,
+              resource,
+              relation
+            ) == []
+    decreases |relationships|
+  {
+    if |relationships| != 0 {
+      AbsentResourceHasNoSubjects(
+        definitions,
+        relationships[1..],
+        resource,
+        relation
+      );
+    }
+  }
+
+  function RelationScanBudget(
+    definitions: seq<RelationDefinition>,
+    subjects: seq<ObjectRef>
+  ): Budget {
+    Budget(|definitions|, |subjects|, 0, 0)
+  }
+
+  function DirectLeafBudget(
+    definitions: seq<RelationDefinition>,
+    subjects: seq<ObjectRef>
+  ): Budget {
+    Budget(|definitions|, |subjects|, 1, |subjects|)
+  }
+
+  function RawRelationTree(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    relation: nat,
+    definitions: seq<RelationDefinition>
+  ): RawOutcome {
+    var subjects := MatchingSubjects(
+                      definitions,
+                      snapshot.relationships,
+                      resource,
+                      relation
+                    );
+    RawSuccess(
+      Leaf(resource, relation, subjects),
+      DirectLeafBudget(definitions, subjects)
+    )
+  }
+
+  function Collapse(outcomes: seq<RawOutcome>): ChildrenOutcome
+    decreases |outcomes|
+  {
+    if |outcomes| == 0 then
+      ChildrenSuccess([], ZeroBudget())
+    else if outcomes[0].RawFailure? then
+      ChildrenFailure(outcomes[0].failure)
+    else
+      var tail := Collapse(outcomes[1..]);
+      if tail.ChildrenFailure? then
+        tail
+      else
+        ChildrenSuccess(
+          [outcomes[0].tree] + tail.children,
+          AddBudget(outcomes[0].budget, tail.budget)
+        )
+  }
+
+  function RawExpand(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    name: nat,
+    fuel: nat,
+    active: set<ExpansionKey>
+  ): RawOutcome
+    decreases fuel, 1
+  {
+    var expansionKey := ExpansionKey(resource, name);
+    var definitionKey := DefinitionKey(resource.typeId, name);
+    if fuel == 0 then
+      RawFailure(DepthLimitExceeded)
+    else if expansionKey in active then
+      RawFailure(CycleDetected)
+    else
+      var relations := RelationDefinitions(
+                         snapshot.schema.relations,
+                         definitionKey
+                       );
+      var permissions := PermissionDefinitions(
+                           snapshot.schema.permissions,
+                           definitionKey
+                         );
+      if |relations| != 0 && |permissions| != 0 then
+        RawFailure(InvalidSchema)
+      else if |relations| != 0 then
+        if !DistinctSubjectTypes(relations) then
+          RawFailure(InvalidSchema)
+        else
+          RawRelationTree(snapshot, resource, name, relations)
+      else if |permissions| > 1 ||
+              (|permissions| == 1 &&
+               |permissions[0].components| == 0) then
+        RawFailure(InvalidSchema)
+      else if |permissions| == 1 then
+        var permission := permissions[0];
+        var nextActive := active + {expansionKey};
+        var componentOutcomes := seq(
+                                 |permission.components|,
+                                 index requires 0 <= index < |permission.components| =>
+                                   RawExpandComponent(
+                                     snapshot,
+                                     resource,
+                                     name,
+                                     permission.components[index],
+                                     fuel - 1,
+                                     nextActive
+                                   )
+                                   );
+        var collapsed := Collapse(componentOutcomes);
+        if collapsed.ChildrenFailure? then
+          RawFailure(collapsed.failure)
+        else
+          RawSuccess(
+            Union(resource, name, collapsed.children),
+            AddBudget(
+              Budget(|permission.components|, 0, 1, 0),
+              collapsed.budget
+            )
+          )
+      else
+        RawFailure(UnknownRoot)
+  }
+
+  function RawExpandComponent(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    expandedName: nat,
+    component: Component,
+    fuel: nat,
+    active: set<ExpansionKey>
+  ): RawOutcome
+    decreases fuel, 2
+  {
+    if fuel == 0 then
+      RawFailure(DepthLimitExceeded)
+    else
+      match component
+      case SameRelation(relation) =>
+        var key := DefinitionKey(resource.typeId, relation);
+        var relations := RelationDefinitions(snapshot.schema.relations, key);
+        if |relations| != 0 && DistinctSubjectTypes(relations) &&
+           |PermissionDefinitions(snapshot.schema.permissions, key)| == 0
+        then RawRelationTree(snapshot, resource, relation, relations)
+        else RawFailure(InvalidSchema)
+      case SamePermission(permission) =>
+        var key := DefinitionKey(resource.typeId, permission);
+        var permissions := PermissionDefinitions(
+                             snapshot.schema.permissions,
+                             key
+                           );
+        if |permissions| == 1 &&
+           |permissions[0].components| != 0 &&
+           |RelationDefinitions(snapshot.schema.relations, key)| == 0
+        then RawExpand(snapshot, resource, permission, fuel, active)
+        else RawFailure(InvalidSchema)
+      case ArrowRelation(sourceRelation, targetRelation) =>
+        RawExpandArrow(
+          snapshot,
+          resource,
+          sourceRelation,
+          targetRelation,
+          expandedName,
+          false,
+          fuel,
+          active
+        )
+      case ArrowPermission(sourceRelation, targetPermission) =>
+        RawExpandArrow(
+          snapshot,
+          resource,
+          sourceRelation,
+          targetPermission,
+          expandedName,
+          true,
+          fuel,
+          active
+        )
+  }
+
+  function RawExpandArrow(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    sourceRelation: nat,
+    targetName: nat,
+    expandedName: nat,
+    targetIsPermission: bool,
+    fuel: nat,
+    active: set<ExpansionKey>
+  ): RawOutcome
+    decreases fuel, 0
+  {
+    var sourceKey := DefinitionKey(resource.typeId, sourceRelation);
+    var sourceDefinitions := RelationDefinitions(
+                               snapshot.schema.relations,
+                               sourceKey
+                             );
+    if fuel == 0 then
+      RawFailure(DepthLimitExceeded)
+    else if |sourceDefinitions| == 0 ||
+            |PermissionDefinitions(
+              snapshot.schema.permissions,
+              sourceKey
+            )| != 0 ||
+            !DistinctSubjectTypes(sourceDefinitions) then
+      RawFailure(InvalidSchema)
+    else
+      var intermediates := MatchingSubjects(
+                             sourceDefinitions,
+                             snapshot.relationships,
+                             resource,
+                             sourceRelation
+                           );
+      var childOutcomes := seq(
+                           |intermediates|,
+                           index requires 0 <= index < |intermediates| =>
+                             if targetIsPermission
+                             then RawExpand(
+                                    snapshot,
+                                    intermediates[index],
+                                    targetName,
+                                    fuel - 1,
+                                    active
+                                  )
+                             else
+                               var targetKey := DefinitionKey(
+                                                  intermediates[index].typeId,
+                                                  targetName
+                                                );
+                               var targetDefinitions := RelationDefinitions(
+                                                          snapshot.schema.relations,
+                                                          targetKey
+                                                        );
+                               if fuel == 1 then
+                                 RawFailure(DepthLimitExceeded)
+                               else if |targetDefinitions| != 0 &&
+                                       DistinctSubjectTypes(targetDefinitions) &&
+                                       |PermissionDefinitions(
+                                         snapshot.schema.permissions,
+                                         targetKey
+                                       )| == 0
+                               then RawRelationTree(
+                                              snapshot,
+                                              intermediates[index],
+                                              targetName,
+                                              targetDefinitions
+                                            )
+                               else RawFailure(InvalidSchema)
+                                 );
+      var collapsed := Collapse(childOutcomes);
+      if collapsed.ChildrenFailure? then
+        RawFailure(collapsed.failure)
+      else
+        RawSuccess(
+          Union(resource, expandedName, collapsed.children),
+          AddBudget(
+            Budget(
+              |sourceDefinitions|,
+              |intermediates|,
+              1,
+              0
+            ),
+            collapsed.budget
+          )
+        )
+  }
+
+  predicate TreeDepthWithin(tree: Tree, maxDepth: nat)
+    decreases tree
+  {
+    0 < maxDepth &&
+    match tree
+    case Leaf(_, _, _) => true
+    case Union(_, _, children) =>
+      forall child <- children ::
+        TreeDepthWithin(child, maxDepth - 1)
+  }
+
+  predicate WithinLimits(tree: Tree, budget: Budget, limits: Limits) {
+    TreeDepthWithin(tree, limits.maxDepth) &&
+    budget.schemaComponents <= limits.maxSchemaComponents &&
+    budget.relationshipValues <= limits.maxRelationshipValues &&
+    budget.treeNodes <= limits.maxTreeNodes &&
+    budget.leafSubjects <= limits.maxLeafSubjects
+  }
+
+  function LimitFailure(
+    tree: Tree,
+    budget: Budget,
+    limits: Limits
+  ): Failure
+    requires !WithinLimits(tree, budget, limits)
+  {
+    if !TreeDepthWithin(tree, limits.maxDepth) then
+      DepthLimitExceeded
+    else if budget.schemaComponents > limits.maxSchemaComponents then
+      SchemaComponentLimitExceeded
+    else if budget.relationshipValues > limits.maxRelationshipValues then
+      RelationshipValueLimitExceeded
+    else if budget.treeNodes > limits.maxTreeNodes then
+      TreeNodeLimitExceeded
+    else
+      LeafSubjectLimitExceeded
+  }
+
+  function EnforceLimits(raw: RawOutcome, limits: Limits): Outcome {
+    if raw.RawFailure? then
+      Failed(raw.failure)
+    else if WithinLimits(raw.tree, raw.budget, limits) then
+      Success(raw.tree, raw.budget)
+    else
+      Failed(LimitFailure(raw.tree, raw.budget, limits))
+  }
+
+  function Expand(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    name: nat,
+    limits: Limits
+  ): Outcome {
+    EnforceLimits(
+      RawExpand(snapshot, resource, name, limits.maxDepth, {}),
+      limits
+    )
+  }
+
+  predicate TreeContains(tree: Tree, subject: ObjectRef)
+    decreases tree
+  {
+    match tree
+    case Leaf(_, _, subjects) => subject in subjects
+    case Union(_, _, children) =>
+      exists child <- children :: TreeContains(child, subject)
+  }
+
+  predicate TreeWellFormed(tree: Tree)
+    decreases tree
+  {
+    match tree
+    case Leaf(_, _, _) => true
+    case Union(_, _, children) =>
+      forall child <- children :: TreeWellFormed(child)
+  }
+
+  lemma EveryTreeHasExactlyOneVariant(tree: Tree)
+    ensures tree.Leaf? != tree.Union?
+  {
+  }
+
+  lemma EveryTreeIsWellFormed(tree: Tree)
+    ensures TreeWellFormed(tree)
+    decreases tree
+  {
+    match tree
+    case Leaf(_, _, _) =>
+    case Union(_, _, children) =>
+      forall index | 0 <= index < |children|
+        ensures TreeWellFormed(children[index])
+      {
+        EveryTreeIsWellFormed(children[index]);
+      }
+  }
+
+  lemma DirectLeafIsExact(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    relation: nat,
+    definitions: seq<RelationDefinition>
+  )
+    ensures RawRelationTree(
+              snapshot,
+              resource,
+              relation,
+              definitions
+            ).RawSuccess?
+    ensures RawRelationTree(
+              snapshot,
+              resource,
+              relation,
+              definitions
+            ).tree ==
+            Leaf(
+              resource,
+              relation,
+              MatchingSubjects(
+                definitions,
+                snapshot.relationships,
+                resource,
+                relation
+              )
+            )
+  {
+  }
+
+  lemma UnionDenotesItsChildren(
+    resource: ObjectRef,
+    name: nat,
+    children: seq<Tree>,
+    subject: ObjectRef
+  )
+    ensures TreeContains(Union(resource, name, children), subject) <==>
+            exists child <- children :: TreeContains(child, subject)
+  {
+  }
+
+  lemma UnionChildPermutationIsSemantic(
+    resource: ObjectRef,
+    name: nat,
+    left: Tree,
+    right: Tree,
+    rest: seq<Tree>
+  )
+    ensures forall subject: ObjectRef ::
+              TreeContains(
+                Union(resource, name, [left, right] + rest),
+                subject
+              ) <==>
+              TreeContains(
+                Union(resource, name, [right, left] + rest),
+                subject
+              )
+  {
+  }
+
+  lemma ActivePathIsRejected(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    name: nat,
+    fuel: nat,
+    active: set<ExpansionKey>
+  )
+    requires 0 < fuel
+    requires ExpansionKey(resource, name) in active
+    ensures RawExpand(
+              snapshot,
+              resource,
+              name,
+              fuel,
+              active
+            ) == RawFailure(CycleDetected)
+  {
+  }
+
+  lemma SuccessfulExpansionPreservesEveryLimit(
+    snapshot: Snapshot,
+    resource: ObjectRef,
+    name: nat,
+    limits: Limits
+  )
+    requires Expand(snapshot, resource, name, limits).Success?
+    ensures WithinLimits(
+              Expand(snapshot, resource, name, limits).tree,
+              Expand(snapshot, resource, name, limits).budget,
+              limits
+            )
+  {
+  }
+
+  lemma LimitFailureNeverContainsPartialTree(
+    raw: RawOutcome,
+    limits: Limits
+  )
+    requires raw.RawSuccess?
+    requires !WithinLimits(raw.tree, raw.budget, limits)
+    ensures EnforceLimits(raw, limits).Failed?
+  {
+  }
+
+  // Executable witnesses and mutation controls. These are deliberately small
+  // concrete models: changing typed identity to objectId-only, changing the
+  // active path to a global visited set, flattening nested unions, or returning
+  // raw success after a failed limit makes at least one assertion false.
+  lemma EmptyRelationWitness()
+    ensures MatchingSubjects(
+              [],
+              [],
+              ObjectRef(1, 1),
+              2
+            ) == []
+    ensures RawRelationTree(
+              Snapshot(Schema([], []), []),
+              ObjectRef(1, 1),
+              2,
+              [RelationDefinition(DefinitionKey(1, 2), 3)]
+            ).tree.subjects == []
+  {
+  }
+
+  lemma TypedIdentityMutationControl()
+    ensures ObjectRef(1, 7) != ObjectRef(2, 7)
+    ensures ObjectRef(1, 7).objectId == ObjectRef(2, 7).objectId
+  {
+  }
+
+  lemma NestedUnionMutationControl()
+    ensures Union(
+              ObjectRef(1, 1),
+              9,
+              [Union(ObjectRef(1, 1), 8, [])]
+            ) != Union(ObjectRef(1, 1), 9, [])
+  {
+  }
+
+  lemma DuplicateTopologyMutationControl(tree: Tree)
+    ensures Union(ObjectRef(1, 1), 9, [tree, tree]) !=
+            Union(ObjectRef(1, 1), 9, [tree])
+  {
+  }
+
+  lemma DiamondIsNotAnActivePathCycleMutationControl()
+    ensures ExpansionKey(ObjectRef(2, 7), 3) !in
+            {ExpansionKey(ObjectRef(1, 1), 9)}
+  {
+  }
+
+  lemma CycleWitness()
+    ensures RawExpand(
+              Snapshot(Schema([], []), []),
+              ObjectRef(1, 1),
+              9,
+              1,
+              {ExpansionKey(ObjectRef(1, 1), 9)}
+            ) == RawFailure(CycleDetected)
+  {
+  }
+
+  lemma OverLimitMutationControl(tree: Tree)
+    ensures EnforceLimits(
+              RawSuccess(tree, Budget(1, 2, 1, 2)),
+              Limits(1, 1, 1, 1, 1)
+            ).Failed?
+  {
+  }
+
+  lemma DirectWitness()
+    ensures RawRelationTree(
+              Snapshot(
+                Schema([], []),
+                [Relationship(
+                   ObjectRef(1, 1),
+                   2,
+                   ObjectRef(3, 4)
+                 )]
+              ),
+              ObjectRef(1, 1),
+              2,
+              [RelationDefinition(DefinitionKey(1, 2), 3)]
+            ).tree ==
+            Leaf(ObjectRef(1, 1), 2, [ObjectRef(3, 4)])
+  {
+  }
+
+  lemma SumTypedRelationWitness()
+    ensures MatchingSubjects(
+              [
+                RelationDefinition(DefinitionKey(1, 2), 3),
+                RelationDefinition(DefinitionKey(1, 2), 4)
+              ],
+              [
+                Relationship(ObjectRef(1, 1), 2, ObjectRef(3, 7)),
+                Relationship(ObjectRef(1, 1), 2, ObjectRef(4, 7)),
+                Relationship(ObjectRef(1, 1), 2, ObjectRef(5, 7))
+              ],
+              ObjectRef(1, 1),
+              2
+            ) == [ObjectRef(3, 7), ObjectRef(4, 7)]
+    ensures DirectLeafBudget(
+              [
+                RelationDefinition(DefinitionKey(1, 2), 3),
+                RelationDefinition(DefinitionKey(1, 2), 4)
+              ],
+              [ObjectRef(3, 7), ObjectRef(4, 7)]
+            ).schemaComponents == 2
+  {
+  }
+
+  lemma DuplicateRelationSubjectTypesAreInvalidWitness()
+    ensures !DistinctSubjectTypes(
+              [
+                RelationDefinition(DefinitionKey(1, 2), 3),
+                RelationDefinition(DefinitionKey(1, 2), 3)
+              ]
+            )
+  {
+  }
+
+  function SameRelationDepthFixture(maxDepth: nat): Outcome {
+    Expand(
+      Snapshot(
+        Schema(
+          [RelationDefinition(DefinitionKey(1, 2), 3)],
+          [
+            PermissionDefinition(
+              DefinitionKey(1, 9),
+              [SameRelation(2)]
+            )
+          ]
+        ),
+        []
+      ),
+      ObjectRef(1, 1),
+      9,
+      Limits(maxDepth, 10, 10, 10, 10)
+    )
+  }
+
+  function SameRelationComponentDepthFixture(fuel: nat): RawOutcome {
+    RawExpandComponent(
+      Snapshot(
+        Schema(
+          [RelationDefinition(DefinitionKey(1, 2), 3)],
+          []
+        ),
+        []
+      ),
+      ObjectRef(1, 1),
+      9,
+      SameRelation(2),
+      fuel,
+      {ExpansionKey(ObjectRef(1, 1), 9)}
+    )
+  }
+
+  lemma EveryEmittedChildConsumesDepthWitness()
+    ensures SameRelationDepthFixture(1).Failed?
+    ensures SameRelationDepthFixture(1).failure == DepthLimitExceeded
+    ensures SameRelationComponentDepthFixture(0) ==
+            RawFailure(DepthLimitExceeded)
+    ensures SameRelationComponentDepthFixture(1).RawSuccess?
+  {
+  }
+
+  function UnionFixture(): Tree {
+    Union(
+      ObjectRef(1, 1),
+      9,
+      [
+        Leaf(ObjectRef(1, 1), 2, []),
+        Leaf(ObjectRef(1, 1), 2, [])
+      ]
+    )
+  }
+
+  lemma UnionWitness()
+    ensures UnionFixture().Union?
+    ensures UnionFixture().children ==
+            [
+              Leaf(ObjectRef(1, 1), 2, []),
+              Leaf(ObjectRef(1, 1), 2, [])
+            ]
+  {
+  }
+
+  function ArrowFixture(): Tree {
+    Union(
+      ObjectRef(1, 1),
+      9,
+      [Leaf(ObjectRef(3, 7), 4, [ObjectRef(5, 8)])]
+    )
+  }
+
+  lemma ArrowWitness()
+    ensures ArrowFixture().Union?
+    ensures ArrowFixture().expandedObject == ObjectRef(1, 1)
+    ensures ArrowFixture().children ==
+            [Leaf(ObjectRef(3, 7), 4, [ObjectRef(5, 8)])]
+  {
+  }
+
+  lemma DiamondWitness()
+    ensures UnionFixture().children[0] == UnionFixture().children[1]
+    ensures |UnionFixture().children| == 2
+  {
+  }
+}

--- a/formal/fixtures/permission-tree/README.md
+++ b/formal/fixtures/permission-tree/README.md
@@ -1,0 +1,25 @@
+# Version-pinned SpiceDB shallow-expansion golden
+
+This fixture records black-box behavior for the schema, relationships, and
+request in this directory.
+
+- Docker image: `ghcr.io/authzed/spicedb:v1.56.0`
+- Image digest:
+  `sha256:c8a558a6cc1f9379fcdcab0171b623d65e7e5f95c998ebb7f937ca00a7c1598c`
+- Expansion mode: `SHALLOW`
+- API request: `POST /v1/permissions/expand`
+- Captured: 2026-08-11
+
+The schema, relationships, and request were executed with `serve-testing` and
+`POST /v1/permissions/expand`. `raw-response-v1.56.0-docker.protojson` is the
+exact live response. Its datastore-specific `expandedAt.token` is retained as
+capture metadata but excluded from topology comparison.
+
+`raw-response.protojson` is the comparison fixture derived from that captured
+response by omitting `expandedAt` and default-valued `optionalRelation` fields.
+No tree node, subject, or collection is reordered or deduplicated.
+
+Cross-implementation comparison recursively sorts `intermediate.children` and
+`leaf.subjects` by their complete normalized value. Sorting a vector does not
+deduplicate it: duplicate child and subject multiplicity, annotations, union
+boundaries, and the leaf/intermediate oneof all remain significant.

--- a/formal/fixtures/permission-tree/raw-response-v1.56.0-docker.protojson
+++ b/formal/fixtures/permission-tree/raw-response-v1.56.0-docker.protojson
@@ -1,0 +1,72 @@
+{
+  "expandedAt": {
+    "token": "Gh8KEzE3ODY0NDYwNTkxMjAwMDAwMDASCDc0YWM1NWZj"
+  },
+  "treeRoot": {
+    "intermediate": {
+      "operation": "OPERATION_UNION",
+      "children": [
+        {
+          "intermediate": {
+            "operation": "OPERATION_UNION",
+            "children": [
+              {
+                "leaf": {
+                  "subjects": [
+                    {
+                      "object": {
+                        "objectType": "user",
+                        "objectId": "fred"
+                      },
+                      "optionalRelation": ""
+                    },
+                    {
+                      "object": {
+                        "objectType": "user",
+                        "objectId": "tom"
+                      },
+                      "optionalRelation": ""
+                    }
+                  ]
+                },
+                "expandedObject": {
+                  "objectType": "folder",
+                  "objectId": "testfolder1"
+                },
+                "expandedRelation": "viewer"
+              },
+              {
+                "leaf": {
+                  "subjects": [
+                    {
+                      "object": {
+                        "objectType": "user",
+                        "objectId": "sarah"
+                      },
+                      "optionalRelation": ""
+                    }
+                  ]
+                },
+                "expandedObject": {
+                  "objectType": "folder",
+                  "objectId": "testfolder2"
+                },
+                "expandedRelation": "viewer"
+              }
+            ]
+          },
+          "expandedObject": {
+            "objectType": "document",
+            "objectId": "testdoc"
+          },
+          "expandedRelation": "view"
+        }
+      ]
+    },
+    "expandedObject": {
+      "objectType": "document",
+      "objectId": "testdoc"
+    },
+    "expandedRelation": "view"
+  }
+}

--- a/formal/fixtures/permission-tree/raw-response.protojson
+++ b/formal/fixtures/permission-tree/raw-response.protojson
@@ -1,0 +1,66 @@
+{
+  "treeRoot": {
+    "intermediate": {
+      "operation": "OPERATION_UNION",
+      "children": [
+        {
+          "intermediate": {
+            "operation": "OPERATION_UNION",
+            "children": [
+              {
+                "leaf": {
+                  "subjects": [
+                    {
+                      "object": {
+                        "objectType": "user",
+                        "objectId": "fred"
+                      }
+                    },
+                    {
+                      "object": {
+                        "objectType": "user",
+                        "objectId": "tom"
+                      }
+                    }
+                  ]
+                },
+                "expandedObject": {
+                  "objectType": "folder",
+                  "objectId": "testfolder1"
+                },
+                "expandedRelation": "viewer"
+              },
+              {
+                "leaf": {
+                  "subjects": [
+                    {
+                      "object": {
+                        "objectType": "user",
+                        "objectId": "sarah"
+                      }
+                    }
+                  ]
+                },
+                "expandedObject": {
+                  "objectType": "folder",
+                  "objectId": "testfolder2"
+                },
+                "expandedRelation": "viewer"
+              }
+            ]
+          },
+          "expandedObject": {
+            "objectType": "document",
+            "objectId": "testdoc"
+          },
+          "expandedRelation": "view"
+        }
+      ]
+    },
+    "expandedObject": {
+      "objectType": "document",
+      "objectId": "testdoc"
+    },
+    "expandedRelation": "view"
+  }
+}

--- a/formal/fixtures/permission-tree/relationships.txt
+++ b/formal/fixtures/permission-tree/relationships.txt
@@ -1,0 +1,5 @@
+document:testdoc#folder@folder:testfolder1
+document:testdoc#folder@folder:testfolder2
+folder:testfolder1#viewer@user:tom
+folder:testfolder1#viewer@user:fred
+folder:testfolder2#viewer@user:sarah

--- a/formal/fixtures/permission-tree/request.json
+++ b/formal/fixtures/permission-tree/request.json
@@ -1,0 +1,7 @@
+{
+  "resource": {
+    "objectType": "document",
+    "objectId": "testdoc"
+  },
+  "permission": "view"
+}

--- a/formal/fixtures/permission-tree/schema.zed
+++ b/formal/fixtures/permission-tree/schema.zed
@@ -1,0 +1,10 @@
+definition user {}
+
+definition folder {
+  relation viewer: user
+}
+
+definition document {
+  relation folder: folder
+  permission view = folder->viewer
+}

--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -4,14 +4,14 @@
  :source-closure
  {:report "formal/verification/public-source-closure.json"
   :status :named-public-roots-enumerated
-  :source-files 57
+  :source-files 58
   :public-roots 63
-  :reachable-definitions 1380
+  :reachable-definitions 1404
   :inline-defrecord-method-attribution :source-span-closed
   :backend-dispatch
   {:report "formal/verification/backend-dispatch.edn"
-   :clj-invoke-sites 49
-   :cljs-invoke-sites 49
+   :clj-invoke-sites 43
+   :cljs-invoke-sites 43
    :literal-operation-keys 21
    :status :static-operation-key-closure-established
    :assurance :not-adapter-semantic-proof}
@@ -102,6 +102,11 @@
               'eacl.engine.relationships/execute-page
               'eacl.client.orchestration/cursor-options
               'eacl.relay]}
+  {:source "formal/dafny/PermissionTree.dfy"
+   :class :proof-only-host-control-and-semantic-model
+   :consumer ['eacl.permission-tree]
+   :reason
+   :immutable-snapshot-mathematical-kernel-not-mechanical-clojure-extraction}
   {:source "formal/dafny/RecursiveEngine.dfy"
    :class :generated-production
    :consumer ['eacl.engine.v8]}
@@ -156,6 +161,41 @@
    :ci [:generated-production-kernel
         :execution-contract
         :deadline-fake-clock]}
+  {:operation :expand-permission-tree
+   :entry-points ['eacl.permission-tree/expand]
+   :theorems
+   [:tree-node-oneof-and-annotation-well-formedness
+    :direct-leaf-exactness
+    :union-denotation-and-child-permutation-invariance
+    :absent-resource-empty-topology
+    :active-path-cycle-rejection
+    :budget-addition-monotonicity
+    :successful-limit-preservation
+    :failure-carries-no-partial-tree
+    :typed-object-identity
+    :sum-typed-relation-declaration-exactness
+    :every-emitted-child-consumes-depth]
+   :dafny ["formal/dafny/PermissionTree.dfy"]
+   :adapter-obligations
+   [:immutable-snapshot
+    :complete-and-well-formed-normalized-schema
+    :complete-direct-relationship-scans
+    :typed-identity-round-trip
+    :selected-snapshot-rendering
+    :selected-snapshot-causal-token]
+   :runtime-targets [:clj-java :cljs-javascript]
+   :production-authoritative
+   {:mathematical-kernel :proof-only
+    :handwritten-clj-cljs-source-refinement :not-claimed
+    :runtime-correspondence :bounded-differential-tests-passed}
+   :remaining
+   [:adapter-query-and-codec-source-refinement
+    :deadline-and-host-integer-platform-contracts
+    :causal-token-authentication
+    :independent-review]
+   :ci [:locked-dafny-verification
+        :permission-tree-reference-differential
+        :cross-backend-permission-tree]}
   {:operation :can?
    :entry-points ['eacl.core/can?]
    :theorems [:authorization-membership-iff

--- a/formal/verification/backend-dispatch.edn
+++ b/formal/verification/backend-dispatch.edn
@@ -8,7 +8,7 @@
   "modules/eacl-datascript/src"]
  :runtime-passes
  {:clj
-  {:invoke-call-count 41
+  {:invoke-call-count 43
    :operations
    #{:snapshot-id
      :source-scope
@@ -31,7 +31,7 @@
      :all-permission-nodes
      :proof-frame}}
   :cljs
-  {:invoke-call-count 41
+  {:invoke-call-count 43
    :operations
    #{:snapshot-id
      :source-scope

--- a/formal/verification/final-assurance-audit.md
+++ b/formal/verification/final-assurance-audit.md
@@ -224,7 +224,7 @@ The final pre-audit run on 2026-08-08 produced the following evidence:
 
 | Gate | Result |
 | --- | --- |
-| Dafny | 28 modules, 8,642 proof efforts, 0 errors; no admitted lemma or undocumented axiom |
+| Dafny | 30 modules, 8,785 proof efforts, 0 errors; no admitted lemma or undocumented axiom |
 | TLA+/Apalache | all five models type checked; bounded, inductive, mutation-control, and longer scheduled configurations reported `NoError` |
 | Generated Java runtime bridges | 51 tests, 16,176 assertions, 0 failures/errors |
 | Generated-authority-injected JVM public/backend suite | 523 tests, 39,462 assertions, 0 failures/errors; recursive operations execute generated indexed authority while acyclic operations execute generated decisions plus documented host source specializations |

--- a/formal/verification/manifest.edn
+++ b/formal/verification/manifest.edn
@@ -115,6 +115,16 @@
    :atomic-managed-datascript-and-all-backend-contracts-passed
    :claim
    :conditional-exact-and-managed-atomic-projection-refinement}
+  :permission-tree-expansion
+  {:status :passed
+   :verified-obligations 62
+   :source "formal/dafny/PermissionTree.dfy"
+   :integration-status
+   :proof-model-with-bounded-clj-cljs-and-cross-backend-correspondence
+   :claim
+   :conditional-mathematical-shallow-tree-topology-cycle-and-limit-model
+   :qualification
+   :no-mechanical-clojure-extraction-adapter-codec-clock-token-and-host-runtime-remain-trusted-boundaries}
   :indexed-recursive-public-engine
   {:status :passed
    :verified-obligations 7979
@@ -136,7 +146,7 @@
    :conditional-least-fixed-point-and-traversal-order-refinement}
   :complete-public-engine
   {:status :passed
-   :verified-obligations 8723
+   :verified-obligations 8785
    :report "formal/verification/final-assurance-audit.md"
    :integration-status
    :recursive-generated-authority-and-acyclic-generated-decisions-with-source-specializations-routed

--- a/formal/verification/permission-tree-final-audit.md
+++ b/formal/verification/permission-tree-final-audit.md
@@ -1,0 +1,89 @@
+# Permission-tree expansion final adversarial audit
+
+Date: 2026-08-11
+
+Scope: GitHub issue 111, `IAuthorization/expand-permission-tree`, its portable
+CLJ/CLJS kernel, shipped adapter wiring, SpiceDB compatibility fixture, and
+`formal/dafny/PermissionTree.dfy`.
+
+## Closed loopholes
+
+The implementation/proof review loop found and fixed the following concrete
+gaps before final verification:
+
+1. Adapter errors could spoof an EACL error namespace and carry internal ids.
+   The boundary now passes through only the identical exception captured from
+   a guarded kernel callback; all adapter-originated lookalikes are redacted.
+2. Lazy schema-definition sequences were eagerly realized outside deadline and
+   structural metering. Definition consumption is now incremental, checked
+   before and after each realization, and bounded by
+   `:max-schema-components`.
+3. Token-metadata adapter failures could escape after a safe tree was built.
+   Selected-adapter token issuance now uses the same redacting boundary.
+4. Limit addition could construct `maximum-exact-integer + 1` in
+   ClojureScript. Counters now compare against remaining capacity before
+   addition and report only accepted portable-exact work.
+5. Over-depth or over-node arrow branches could scan their source before their
+   already-failing structural check. Depth and arrow-node capacity are now
+   charged before definition or relationship work.
+6. The initial Dafny relation model erased declared subject types and counted
+   one definition for a sum-typed relation. It now models every declared
+   subject type, rejects duplicates, filters direct leaves by declaration, and
+   meters every normalized definition.
+7. Dafny fuel did not charge same-relation children consistently. Component
+   fuel now represents remaining emitted levels, with direct and arrow-target
+   witnesses locking the boundary.
+8. Dafny's successful-limit predicate omitted depth. A separate recursive
+   `TreeDepthWithin` predicate is now part of the all-limits success gate.
+9. Dafny arrow sources and permission lookup could accept contradictory,
+   duplicate, or empty normalized permission definitions. Those states now
+   return `InvalidSchema`.
+10. The static dispatch/source-closure ledgers did not include the new path.
+    They were reviewed and regenerated to 43 literal invoke sites per runtime,
+    63 public roots, 58 source files, and 1,404 reachable definitions.
+11. The reflection gate referenced the already-removed `eacl.mutation`
+    namespace and could not run. The dead require was removed and
+    `eacl.permission-tree` was added explicitly; the gate is clean.
+
+## Final evidence
+
+- Locked Dafny: 30 modules, 8,785 proof efforts, zero errors; PermissionTree
+  contributes 62.
+- Registered formal mutation controls: 2 tests, 215 assertions, zero failures
+  or errors.
+- Focused fresh JVM: 83 tests, 1,147 assertions, zero failures or errors.
+- Complete CI non-benchmark JVM selection: 617 tests, 25,542 assertions, zero
+  failures or errors.
+- Fresh DataScript CLJS compilation/runtime: 210 tests, 7,424 assertions, zero
+  failures or errors.
+- Black-box SpiceDB Docker check: v1.56.0 at digest
+  `sha256:c8a558a6cc1f9379fcdcab0171b623d65e7e5f95c998ebb7f937ca00a7c1598c`;
+  normalized live topology equals the pinned expected tree.
+- Dafny formatting, reflection, clj-kondo source closure, dispatch closure,
+  JSON parsing, whitespace, and strict OpenSpec validation pass.
+
+## Residual trusted boundary
+
+Literal universal certainty is not a factual software claim. Within the
+modelled and tested scope there is no known defect after this loop. The
+following remain deliberately outside the proof and therefore prevent a claim
+of mathematically complete end-to-end verification:
+
+- the handwritten Clojure/ClojureScript source has bounded differential and
+  cross-backend correspondence evidence, not mechanical Dafny extraction or a
+  Clojure operational-semantics refinement proof;
+- adapters and storage engines must supply immutable snapshots, complete and
+  well-formed definitions/scans, and correct identity round trips;
+- host collection/integer semantics, monotonic clocks, compilers, runtimes,
+  cryptography, key management, and causal-token authentication are trusted or
+  separately tested boundaries;
+- one already-running synchronous adapter call or sequence realization cannot
+  be hard-cancelled; EACL detects deadline overrun on return and starts no later
+  work;
+- SpiceDB equivalence is limited to EACL's supported union, same-resource, and
+  single-arrow shallow subset after documented unordered-multiset
+  normalization, not unsupported SpiceDB features, token bytes, or incidental
+  order;
+- independent security/formal-methods review remains an unmet repository-wide
+  release obligation, so the assurance manifest correctly remains
+  `:conditionally-verified`.

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "1821c0a09449119ca6d88247f516e6354ea47085a6828a3779a3191385833d6c"
+      "sha256": "9f6512c0ec65dad8d964c574cc9fb1172f244619a8249d7a7bed137a88cbddee"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -125,7 +125,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/backend/v8.cljc",
-      "sha256": "3824eccbd67d3e4b0b95eeed5fafbdf274afae3eb476b0290dafec84b379a8c6"
+      "sha256": "7e210ccd420aa54a93a99373bc38035156f7a2419e96118d7bea71d0c37ceb47"
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
@@ -137,11 +137,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "8c9ecf360951c245260fa93d6edb8c4f21e89b970838d32f0c6fc57f4befc479"
+      "sha256": "151867e96f05967580a392639fb1d8d9b40ea85f9c60b43325e1f696eec60b80"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
-      "sha256": "c138543301f98c3c6c2de2ae14753bfe12164215936fa0f8fb4757b06d0bb7bc"
+      "sha256": "8e5526e42d8dfb4534086de1dd14aa36f1dc783299a9a29574ec6fd42d13f3e5"
     },
     {
       "path": "modules/eacl/src/eacl/continuation.cljc",
@@ -149,7 +149,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/core.cljc",
-      "sha256": "f25183cc6ea22b3af931fd3128de64f99a1cffe53b3dfab67196e2bd0a82537d"
+      "sha256": "a885dcbbe648e3f23fa44b098f2db0bf89f6b77be2f7d47d59fd788b4f40e67c"
     },
     {
       "path": "modules/eacl/src/eacl/cursor.cljc",
@@ -173,7 +173,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
-      "sha256": "5f609d17c695fdc080f3e1421fba9972fe7607b3f5c7530f6c3d11a07ec9e6d9"
+      "sha256": "a04351e315546731e4767c11a58d3dd9811d96c9408fbf3b77228bfa2b98d9a6"
     },
     {
       "path": "modules/eacl/src/eacl/formal/generated_runtime.clj",
@@ -190,6 +190,10 @@
     {
       "path": "modules/eacl/src/eacl/lazy_merge_sort.cljc",
       "sha256": "704ee2dd60a2b01f91283abc1c496e7c4dffd5d4309fd2967e5e485b4ca43e5a"
+    },
+    {
+      "path": "modules/eacl/src/eacl/permission_tree.cljc",
+      "sha256": "dd04910fac6a0c5a6c6fd9ba13b3c824fc53e46ec79a74cd8c65612f7db4f514"
     },
     {
       "path": "modules/eacl/src/eacl/proof_frame.cljc",
@@ -307,9 +311,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 63,
-    "unionInternalDefinitionCount": 1380,
-    "unionInternalDefinitionIdsSha256": "82602f9f672d45a58bb03afa697d6a9ee31a34f4b05b763d47eb33172afe5c9e",
-    "unionDefinitionLocationsSha256": "a0415bfe562f762e2b1374b63419768d639850f70c743c2e46efe9b3b9bf7983",
+    "unionInternalDefinitionCount": 1404,
+    "unionInternalDefinitionIdsSha256": "91051516cb35d0d34242f3a4134346f8a61f56e95d089a82fe8bc31a392cd5fe",
+    "unionDefinitionLocationsSha256": "b3fd582aea73f7b19cf119ab068991b55d5da3e62eaa9bbc5d20e9cbf4cefa75",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 13,
@@ -368,8 +372,8 @@
         "idsSha256": "41564ae9195b19dd851d20e77ec6d32379244f26211d5a815622b45fb2df2592"
       },
       "modules/eacl-datomic/src/eacl/datomic/core.clj": {
-        "count": 122,
-        "idsSha256": "55278a4face7e53421a5680efdc7ec5b91122b1319aa5c8b5816b3687bc5eef1"
+        "count": 123,
+        "idsSha256": "6809b6351b5d46863f50c15eb2c6effed9f2dadf7e2c591d6d5c22308689ef0c"
       },
       "modules/eacl-datomic/src/eacl/datomic/db.clj": {
         "count": 10,
@@ -396,8 +400,8 @@
         "idsSha256": "6354f20b566cbf72654812e5404ad861a32ed262bf7c3ebf678b2e9f199a323b"
       },
       "modules/eacl/src/eacl/backend/v8.cljc": {
-        "count": 32,
-        "idsSha256": "1c87c861af9f0496edee5910362b7fb9007f2204ce4e19ac70c9b96a46223087"
+        "count": 34,
+        "idsSha256": "4a4656bc1df148330d429e07f20d59da99e2ae95b2e406c4022341271821262c"
       },
       "modules/eacl/src/eacl/cache.cljc": {
         "count": 31,
@@ -408,12 +412,12 @@
         "idsSha256": "75c0ad0273fa5828aca5833652de740c7b968ed2565099995d8ca177fdc1d1b4"
       },
       "modules/eacl/src/eacl/client/orchestration.cljc": {
-        "count": 33,
-        "idsSha256": "8c714f3d5e0e31017c2c151048e9fc49c6c2252e59a775d99534e361b8358bbb"
+        "count": 34,
+        "idsSha256": "cf16bc5c4f17780610f9f5801cc898d568a14b577339d7134232de1ca0a6fab7"
       },
       "modules/eacl/src/eacl/consistency.cljc": {
-        "count": 15,
-        "idsSha256": "615354c969e1ebf396c9c3c4f4c58398f60be731a27b9044142a6eb87fd9c6fb"
+        "count": 16,
+        "idsSha256": "47559d3a9ea648dbfd15120b6cd931ca3a6b3e9a46182d5916924988e81a7989"
       },
       "modules/eacl/src/eacl/continuation.cljc": {
         "count": 15,
@@ -458,6 +462,10 @@
       "modules/eacl/src/eacl/lazy_merge_sort.cljc": {
         "count": 6,
         "idsSha256": "40bad40413a2ab865a5acb9c04acded0483549b26e01ff5658a81d329b307c8a"
+      },
+      "modules/eacl/src/eacl/permission_tree.cljc": {
+        "count": 19,
+        "idsSha256": "1f929468367bc7bacc82f406a1b2b8c192190bfdfd4b28bbcf41e6ce4c26ede1"
       },
       "modules/eacl/src/eacl/proof_frame.cljc": {
         "count": 13,
@@ -861,8 +869,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 876,
-      "internalDefinitionIdsSha256": "b464a5669b5389d030c1eb5a9bec6d6a536abb4a5e8938034c06f877de7d934c",
+      "internalDefinitionCount": 899,
+      "internalDefinitionIdsSha256": "1fe5cc88f566d0b7296b53de196e0daaed4e663d502fe154af0b718ff1d3389f",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1129,9 +1137,9 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 193,
-      "internalDefinitionIdsSha256": "cc1f62867c869c3ed324dd8c8b358a232733bc09dbab134bb714730dfd7109d9",
-      "externalCallCount": 27,
+      "internalDefinitionCount": 197,
+      "internalDefinitionIdsSha256": "b9c85b9125ebbaa1c3db0b2def822673eb1fb408615b4979c15171c1f421fd3d",
+      "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
@@ -1159,12 +1167,13 @@
         "instaparse.core/failure?",
         "instaparse.core/get-failure",
         "instaparse.core/parser",
+        "unresolved/js/Number.isSafeInteger",
         "unresolved/js/console.warn"
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 877,
-      "internalDefinitionIdsSha256": "09e91017b07150bf11fb37fa2e609d36bde4a05f2de5ba5d8a42fa8bf85cd623",
+      "internalDefinitionCount": 900,
+      "internalDefinitionIdsSha256": "ac5f233cbdb4808364d36e8550b8b7da4df31ba64bfea51266a62b7e8fddecc3",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1206,8 +1215,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 879,
-      "internalDefinitionIdsSha256": "8bafd7d41402b4e3fcc4eff65b2a6549dfd9e8b4ef53b3e1f5975c7bfbb215f8",
+      "internalDefinitionCount": 902,
+      "internalDefinitionIdsSha256": "d60af53e8c29a6c82b7f8c8234fa0fd80f31bcd014db0ee08151f6f66360eac6",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1249,8 +1258,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 706,
-      "internalDefinitionIdsSha256": "d8bd7ca9890d3cb488132023f6f9f0fc272632d1c869094121ac9215e7b92d12",
+      "internalDefinitionCount": 729,
+      "internalDefinitionIdsSha256": "7a24d73945cb45b6d6d12bd478f4ceb33bfcf8fbfd5035ce79998531db60cf40",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1271,15 +1280,16 @@
       ]
     },
     "eacl.client.orchestration/make-client": {
-      "internalDefinitionCount": 88,
-      "internalDefinitionIdsSha256": "f95fd62e79ab799dd0a40911814460690005ee503df1040074d1f7e3b7b643c8",
-      "externalCallCount": 7,
+      "internalDefinitionCount": 92,
+      "internalDefinitionIdsSha256": "57f3f3542ce6a1813f6d91c66d2eeee42a11e704dd0a435b388f7885f4176834",
+      "externalCallCount": 8,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "com.rpl.specter/transform",
         "goog.crypt/stringToUtf8ByteArray",
+        "unresolved/js/Number.isSafeInteger",
         "unresolved/js/console.warn",
         "unresolved/js/require"
       ]
@@ -1564,8 +1574,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 337,
-      "internalDefinitionIdsSha256": "297e69d41644047a2d1552e3a53e9153d1bb022f0481095e52355dca6254db18",
+      "internalDefinitionCount": 340,
+      "internalDefinitionIdsSha256": "42ad3fa42247afbb40004a0c332c0cf3025fc682486d1096b40df3df77500177",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1866,8 +1876,8 @@
       ]
     },
     "eacl.datascript.core/make-client": {
-      "internalDefinitionCount": 330,
-      "internalDefinitionIdsSha256": "d1dcc2f87eb1c1426c26cbe3d9c4a1967465c0926d1f1e39452bc5b364567abb",
+      "internalDefinitionCount": 333,
+      "internalDefinitionIdsSha256": "26756d531b06fd79f38ca930dc6f8de4dd96ced9fe9c0c88f90e94a1b96eb539",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/modules/eacl-datahike/README.md
+++ b/modules/eacl-datahike/README.md
@@ -97,6 +97,13 @@ Unsupported configuration/mode combinations fail before authorization. List
 operations use `:first`/`:after` and `:last`/`:before`; see the
 [backend guide](../../docs/v8-backend-modules-and-upgrade.md).
 
+`expand-permission-tree` uses the shared portable shallow-expansion kernel in
+both keyword and numeric attribute-reference modes. The returned
+`:expanded-at` names the same selected immutable DB as the tree. Exact replay
+is available only when the configured store retains the named commit/history;
+native child/subject order is not semantic. Configure structural ceilings with
+client-level `:permission-tree-limits`.
+
 ```clojure
 {:deps {dev.eacl/eacl-datahike {:mvn/version "8.0.0-SNAPSHOT"}}}
 ```

--- a/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
@@ -12,10 +12,12 @@
    failures deny permissions, so both representations remain mandatory."
   (:require [clojure.test :refer [deftest is testing]]
             [datahike.api :as d]
+            [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
             [eacl.contract-support :as contract]
             [eacl.core :as eacl]
             [eacl.datahike.core :as datahike]
+            [eacl.spicedb.consistency :as consistency]
             [eacl.verified-kernel :as verified]))
 
 (defn- seed-objects!
@@ -66,6 +68,7 @@
     (seed-objects! conn)
     (eacl/create-relationships! client contract/smoke-relationships)
     (contract/assert-v8-seeded-contracts! client)
+    (contract/assert-v8-permission-tree-contract! client)
     (contract/assert-unified-filter-validation! client)
     (contract/assert-v8-request-cache-controls! client store)
     (contract/assert-v8-cache-disabled!
@@ -104,6 +107,65 @@
 
   (testing "attributes as numeric refs (:attribute-refs?, Datomic's representation)"
     (run-contract! {:attribute-refs? true})))
+
+(deftest datahike-pinned-spicedb-permission-tree-golden-test
+  (doseq [config [nil {:attribute-refs? true}]]
+    (let [conn (datahike/create-conn nil config)
+          client (datahike/make-client conn {})]
+      (eacl/write-schema! client contract/permission-tree-golden-schema)
+      (d/transact
+       conn
+       (mapv (fn [{:keys [id]}] {:eacl/id id})
+             contract/permission-tree-golden-objects))
+      (eacl/create-relationships!
+       client contract/permission-tree-golden-relationships)
+      (contract/assert-pinned-permission-tree-golden! client)
+      (let [request {:resource (eacl/spice-object :document "testdoc")
+                     :permission :view}
+            first-response (eacl/expand-permission-tree client request)]
+        (is (= (:tree-root first-response)
+               (:tree-root
+                (eacl/expand-permission-tree
+                 client
+                 (assoc request :consistency
+                        (consistency/at-exact-snapshot
+                         (:expanded-at first-response)))))))))))
+
+(deftest datahike-permission-tree-schema-mutation-snapshot-test
+  (let [conn (datahike/create-conn)
+        client (datahike/make-client conn {})
+        resource (eacl/spice-object :document "d1")
+        old-schema
+        "definition user {}
+         definition document {
+           relation viewer: user
+           permission view = viewer
+         }"
+        new-schema
+        "definition user {}
+         definition document {
+           relation viewer: user
+           relation editor: user
+           permission view = viewer + editor
+         }"
+        _ (eacl/write-schema! client old-schema)
+        _ (d/transact conn [{:eacl/id "d1"}])
+        mutated? (atom false)
+        captured
+        (binding [backend/*invoke-observer*
+                  (fn [{:keys [phase operation]}]
+                    (when (and (= :before phase)
+                               (= :relation-defs operation)
+                               (compare-and-set! mutated? false true))
+                      (eacl/write-schema! client new-schema)))]
+          (eacl/expand-permission-tree
+           client {:resource resource :permission :view}))]
+    (is (= 1 (count (get-in captured
+                            [:tree-root :intermediate :children]))))
+    (is (= 2 (count (get-in
+                     (eacl/expand-permission-tree
+                      client {:resource resource :permission :view})
+                     [:tree-root :intermediate :children]))))))
 
 (deftest datahike-recursive-v8-contract-test
   (testing "attributes as keywords"

--- a/modules/eacl-datascript/README.md
+++ b/modules/eacl-datascript/README.md
@@ -42,6 +42,13 @@ the originating client/connection lifecycle.
 List operations use `:first`/`:after` and `:last`/`:before`; see the
 [backend guide](../../docs/v8-backend-modules-and-upgrade.md).
 
+`expand-permission-tree` uses the shared portable shallow-expansion kernel and
+returns a token for the same selected immutable DataScript DB as the tree.
+DataScript CLJ and CLJS have identical topology/error contracts. Native scan
+order is not semantic, and exact historical replay remains unsupported; use a
+returned token as a causal floor within its connection lifecycle. Configure
+structural ceilings with client-level `:permission-tree-limits`.
+
 ## Relationship storage
 
 DataScript stores a relationship as two cardinality-many indexed ordinary

--- a/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
+++ b/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
@@ -9,6 +9,7 @@
             [eacl.engine.relationships-test]
             [eacl.execution-test]
             [eacl.proof-frame-test]
+            [eacl.permission-tree-test]
             [eacl.relationships.endpoint-pair-test]
             [eacl.relay-test]
             [eacl.secure-format-test]
@@ -46,6 +47,7 @@
                'eacl.engine.relationships-test
                'eacl.execution-test
                'eacl.proof-frame-test
+               'eacl.permission-tree-test
                'eacl.relationships.endpoint-pair-test
                'eacl.relay-test
                'eacl.secure-format-test

--- a/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
@@ -1,7 +1,9 @@
 (ns eacl.datascript.contract-test
   (:require [#?(:clj clojure.test :cljs cljs.test) :refer [deftest is testing]]
             [datascript.core :as ds]
+            [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
+            [eacl.causal-token :as causal-token]
             [eacl.contract-support :as contract]
             [eacl.core :as eacl]
             [eacl.datascript.core :as datascript]
@@ -9,6 +11,177 @@
             [eacl.relationships.storage :as relationship-storage]
             [eacl.secure-format :as secure]
             [eacl.verified-kernel :as verified]))
+
+(def ^:private permission-tree-schema
+  "definition user {}
+   definition folder {
+     relation reader: user
+     permission view = reader
+   }
+   definition team {
+     relation reader: user
+     permission view = reader
+   }
+   definition document {
+     relation viewer: user
+     relation parent: folder | team
+     permission base = viewer
+     permission view = base + parent->view
+   }")
+
+(defn- seed-permission-tree!
+  [conn client]
+  (eacl/write-schema! client permission-tree-schema)
+  (ds/transact! conn
+                (mapv (fn [id] {:eacl/id id})
+                      ["alice" "bob" "carol" "d1" "f1" "t1"]))
+  (eacl/create-relationships!
+   client
+   [(eacl/->Relationship
+     (eacl/spice-object :user "alice") :viewer
+     (eacl/spice-object :document "d1"))
+    (eacl/->Relationship
+     (eacl/spice-object :folder "f1") :parent
+     (eacl/spice-object :document "d1"))
+    (eacl/->Relationship
+     (eacl/spice-object :team "t1") :parent
+     (eacl/spice-object :document "d1"))
+    (eacl/->Relationship
+     (eacl/spice-object :user "bob") :reader
+     (eacl/spice-object :folder "f1"))
+    (eacl/->Relationship
+     (eacl/spice-object :user "carol") :reader
+     (eacl/spice-object :team "t1"))]))
+
+(deftest permission-tree-expansion-and-selected-snapshot-test
+  (let [conn (datascript/create-conn)
+        client (datascript/make-client
+                conn
+                {:security-key "01234567890123456789012345678901"})
+        _ (seed-permission-tree! conn client)
+        resource (eacl/spice-object :document "d1")
+        response
+        (eacl/expand-permission-tree
+         client {:resource resource :permission :view})
+        root (:tree-root response)
+        [base arrow] (get-in root [:intermediate :children])]
+    (is (string? (:expanded-at response)))
+    (is (= resource (:expanded-object root)))
+    (is (= :view (:expanded-relation root)))
+    (is (= :base (:expanded-relation base)))
+    (is (= [(eacl/spice-object :user "alice")]
+           (get-in base
+                   [:intermediate :children 0 :leaf :subjects])))
+    (is (= :view (:expanded-relation arrow)))
+    (is (= #{(eacl/spice-object :folder "f1")
+             (eacl/spice-object :team "t1")}
+           (set (map :expanded-object
+                     (get-in arrow [:intermediate :children])))))
+    (is (= {:expanded-object
+            (eacl/spice-object :document "missing")
+            :expanded-relation :view
+            :intermediate
+            {:operation :union
+             :children
+             [{:expanded-object
+               (eacl/spice-object :document "missing")
+               :expanded-relation :base
+               :intermediate
+               {:operation :union
+                :children
+                [{:expanded-object
+                  (eacl/spice-object :document "missing")
+                  :expanded-relation :viewer
+                  :leaf {:subjects []}}]}}
+              {:expanded-object
+               (eacl/spice-object :document "missing")
+               :expanded-relation :view
+               :intermediate {:operation :union :children []}}]}}
+           (:tree-root
+            (eacl/expand-permission-tree
+             client
+             {:resource (eacl/spice-object :document "missing")
+              :permission :view}))))
+
+    (testing "a concurrent write cannot mix the selected tree and token"
+      (let [mutated? (atom false)
+            late-user (eacl/spice-object :user "late")
+            _ (ds/transact! conn [{:eacl/id "late"}])
+            captured
+            (binding [backend/*invoke-observer*
+                      (fn [{:keys [phase operation]}]
+                        (when (and (= :before phase)
+                                   (= :relation-defs operation)
+                                   (compare-and-set! mutated? false true))
+                          (eacl/create-relationship!
+                           client late-user :viewer resource)))]
+              (eacl/expand-permission-tree
+               client {:resource resource :permission :base}))
+            first-subjects
+            (get-in captured
+                    [:tree-root :intermediate :children 0 :leaf :subjects])
+            token-data
+            (causal-token/token-data
+             (get-in client [:opts :format-options])
+             (:expanded-at captured))]
+        (is (= [(eacl/spice-object :user "alice")] first-subjects))
+        (is (< (:revision token-data) (:max-tx (ds/db conn))))
+        (is (= #{(eacl/spice-object :user "alice") late-user}
+               (set
+                (get-in
+                 (eacl/expand-permission-tree
+                  client {:resource resource :permission :base})
+                 [:tree-root :intermediate :children 0 :leaf :subjects]))))))))
+
+(deftest pinned-spicedb-permission-tree-golden-test
+  (let [conn (datascript/create-conn)
+        client (datascript/make-client conn {})]
+    (eacl/write-schema! client contract/permission-tree-golden-schema)
+    (ds/transact!
+     conn
+     (map-indexed
+      (fn [index {:keys [id]}]
+        {:db/id (- (inc index)) :eacl/id id})
+      contract/permission-tree-golden-objects))
+    (eacl/create-relationships!
+     client contract/permission-tree-golden-relationships)
+    (contract/assert-pinned-permission-tree-golden! client)))
+
+(deftest permission-tree-schema-mutation-stays-on-selected-snapshot-test
+  (let [old-schema
+        "definition user {}
+         definition document {
+           relation viewer: user
+           permission view = viewer
+         }"
+        new-schema
+        "definition user {}
+         definition document {
+           relation viewer: user
+           relation editor: user
+           permission view = viewer + editor
+         }"
+        conn (datascript/create-conn)
+        client (datascript/make-client conn {})
+        resource (eacl/spice-object :document "d1")
+        _ (eacl/write-schema! client old-schema)
+        _ (ds/transact! conn [{:eacl/id "d1"}])
+        mutated? (atom false)
+        captured
+        (binding [backend/*invoke-observer*
+                  (fn [{:keys [phase operation]}]
+                    (when (and (= :before phase)
+                               (= :relation-defs operation)
+                               (compare-and-set! mutated? false true))
+                      (eacl/write-schema! client new-schema)))]
+          (eacl/expand-permission-tree
+           client {:resource resource :permission :view}))]
+    (is (= 1 (count (get-in captured
+                            [:tree-root :intermediate :children]))))
+    (is (= 2 (count (get-in
+                     (eacl/expand-permission-tree
+                      client {:resource resource :permission :view})
+                     [:tree-root :intermediate :children]))))))
 
 (defn- seed-objects!
   [conn]
@@ -477,6 +650,7 @@
     (seed-objects! conn)
     (eacl/create-relationships! client contract/smoke-relationships)
     (contract/assert-v8-seeded-contracts! client)
+    (contract/assert-v8-permission-tree-contract! client)
     (contract/assert-v8-request-cache-controls! client store)
     (contract/assert-v8-cache-disabled!
      (datascript/make-client conn {:cache cache/no-cache}))))

--- a/modules/eacl-datomic/README.md
+++ b/modules/eacl-datomic/README.md
@@ -34,6 +34,13 @@ Custom object-ID codecs are exact-only and client-local unless configured with
 a portable `:adapter-fingerprint`, `:adapter-deterministic? true`, and an
 application-certified injective round trip.
 
+`expand-permission-tree` routes Datomic's selected immutable DB through the
+same portable shallow-expansion kernel used by DataScript and Datahike. The
+returned `:expanded-at` is issued from that selected adapter without re-reading
+the connection; `at-exact-snapshot` can replay it while the required Datomic
+history remains available. Native child/subject order is not semantic.
+Configure structural ceilings with client-level `:permission-tree-limits`.
+
 ## Optional atomic entity retraction
 
 Ordinary Datomic `:db.fn/retractEntity` cannot follow the peer eid embedded in

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -25,6 +25,7 @@
             [eacl.formal.production-kernel :as production-kernel]
             [eacl.migrations.v6-to-v7 :as migrations]
             [eacl.proof-frame :as proof-frame]
+            [eacl.permission-tree :as permission-tree]
             [eacl.relay :as relay]
             [eacl.relationships.filters :as relationship-filters]
             [eacl.relationships.storage :as relationship-storage]
@@ -2023,6 +2024,26 @@
              #(impl/count-subjects db query'))]
         (with-cache-info (:result answer) answer)))))
 
+(defn spiceomic-expand-permission-tree
+  [conn opts query]
+  (let [{:keys [adapter]}
+        (capture-basic-result-context
+         conn opts (:consistency query))
+        contract (:execution-contract opts)
+        tree
+        (permission-tree/expand
+         adapter
+         {:limits (:permission-tree-limits opts)
+          :execution-contract contract}
+         (:resource query)
+         (:permission query))]
+    (execution/check! contract :permission-tree-token-issuance)
+    (let [token
+          (permission-tree/selected-adapter-token adapter opts)]
+      (execution/check! contract :permission-tree-token-issued)
+      {:expanded-at token
+       :tree-root tree})))
+
 (defrecord Spiceomic [conn opts]
   IAuthorization
   (can? [_ subject permission resource]
@@ -2146,10 +2167,11 @@
        conn (request-cache-opts % (:cache? query))
        (dissoc query :evaluation :timeout-ms))))
 
-  (expand-permission-tree [_ _]
-    (throw (ex-info "expand-permission-tree is not implemented yet."
-             {:type :eacl/not-implemented
-              :method 'expand-permission-tree})))
+  (expand-permission-tree [_ query]
+    (permission-tree/validate-request! query)
+    (execute-request
+     opts :expand-permission-tree query
+     #(spiceomic-expand-permission-tree conn % query)))
 
   IDetailedAuthorization
   (-check-permission
@@ -2225,6 +2247,7 @@
     :execution-timeout-ms
     :cache-attempt
     :recursive-traversal-limits
+    :permission-tree-limits
     :auto-migrate-v6})
 
 (def ^:private canonical-security-opt-keys
@@ -2535,6 +2558,7 @@
            execution-timeout-ms
            cache-attempt
            recursive-traversal-limits
+           permission-tree-limits
            auto-migrate-v6]}]
   (when-let [unknown-keys (seq (remove known-client-opt-keys (keys config-opts)))]
     (throw (ex-info (str "EACL Config Error: unknown make-client option(s) " (pr-str (vec unknown-keys))
@@ -2851,7 +2875,10 @@
                             ;; disable the limits it does not mention
                             :recursive-traversal-limits
                             (merge impl.indexed/default-recursive-traversal-limits
-                                   recursive-traversal-limits)}]
+                                   recursive-traversal-limits)
+                            :permission-tree-limits
+                            (permission-tree/normalize-limits
+                             permission-tree-limits)}]
     (->Spiceomic conn opts)))
 
 (defn current-zed-token

--- a/modules/eacl-datomic/test/eacl/datomic/contract_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/contract_test.clj
@@ -1,12 +1,14 @@
 (ns eacl.datomic.contract-test
   (:require [clojure.test :refer [deftest is]]
             [datomic.api :as d]
+            [eacl.backend.v8 :as backend]
             [eacl.contract-support :as contract]
             [eacl.core :as eacl]
             [eacl.datomic.cache :as cache]
             [eacl.datomic.core :as datomic]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
-            [eacl.datomic.schema :as schema]))
+            [eacl.datomic.schema :as schema]
+            [eacl.spicedb.consistency :as consistency]))
 
 (defn- seed-objects!
   [conn]
@@ -38,7 +40,67 @@
       (seed-objects! conn)
       (eacl/create-relationships! client contract/smoke-relationships)
       (contract/assert-v8-seeded-contracts! client)
+      (contract/assert-v8-permission-tree-contract! client)
       (contract/assert-unified-filter-validation! client))))
+
+(deftest datomic-pinned-spicedb-permission-tree-golden-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (datomic/make-client conn {})]
+      (eacl/write-schema! client contract/permission-tree-golden-schema)
+      @(d/transact
+        conn
+        (mapv (fn [{:keys [id]}]
+                {:db/id id :eacl/id id})
+              contract/permission-tree-golden-objects))
+      (eacl/create-relationships!
+       client contract/permission-tree-golden-relationships)
+      (contract/assert-pinned-permission-tree-golden! client)
+      (let [request {:resource (eacl/spice-object :document "testdoc")
+                     :permission :view}
+            first-response (eacl/expand-permission-tree client request)]
+        (is (= (:tree-root first-response)
+               (:tree-root
+                (eacl/expand-permission-tree
+                 client
+                 (assoc request :consistency
+                        (consistency/at-exact-snapshot
+                         (:expanded-at first-response)))))))))))
+
+(deftest datomic-permission-tree-schema-mutation-snapshot-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (datomic/make-client conn {})
+          resource (eacl/spice-object :document "d1")
+          old-schema
+          "definition user {}
+           definition document {
+             relation viewer: user
+             permission view = viewer
+           }"
+          new-schema
+          "definition user {}
+           definition document {
+             relation viewer: user
+             relation editor: user
+             permission view = viewer + editor
+           }"
+          _ (eacl/write-schema! client old-schema)
+          _ @(d/transact conn [{:db/id "d1" :eacl/id "d1"}])
+          mutated? (atom false)
+          captured
+          (binding [backend/*invoke-observer*
+                    (fn [{:keys [phase operation]}]
+                      (when (and (= :before phase)
+                                 (= :relation-defs operation)
+                                 (compare-and-set! mutated? false true))
+                        (eacl/write-schema! client new-schema)))]
+            (eacl/expand-permission-tree
+             client {:resource resource :permission :view}))]
+      (is (= 1 (count (get-in captured
+                              [:tree-root :intermediate :children]))))
+      (is (= 2 (count (get-in
+                       (eacl/expand-permission-tree
+                        client {:resource resource :permission :view})
+                       [:tree-root :intermediate :children])))))))
 
 (deftest datomic-recursive-contract-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl-datomic/test/eacl/spice_test.clj
+++ b/modules/eacl-datomic/test/eacl/spice_test.clj
@@ -111,12 +111,20 @@
           (catch clojure.lang.ExceptionInfo e
             (is (= :eacl/unsupported-consistency (:type (ex-data e)))))))
 
-      (testing "expand-permission-tree throws a typed not-implemented error"
-        (try
-          (eacl/expand-permission-tree client {:resource a1 :permission :admin})
-          (is false "should have thrown")
-          (catch clojure.lang.ExceptionInfo e
-            (is (= :eacl/not-implemented (:type (ex-data e))))))))))
+      (testing "expand-permission-tree returns the documented explicit tree"
+        (let [response
+              (eacl/expand-permission-tree
+               client {:resource a1 :permission :admin})]
+          (is (string? (:expanded-at response)))
+          (is (= {:expanded-object a1
+                  :expanded-relation :admin
+                  :intermediate
+                  {:operation :union
+                   :children
+                   [{:expanded-object a1
+                     :expanded-relation :owner
+                     :leaf {:subjects []}}]}}
+                 (:tree-root response))))))))
 
 (deftest strict-object-id-resolution-tests
   (with-mem-conn [conn schema/v7-schema]
@@ -611,47 +619,6 @@
 	                                                      :resource/relation :account
 	                                                      :subject/type      :account
 	                                                      :subject/id        "test-account"})))))))
-
-; expand-permission-tree not impl. yet.
-;; FIXME: These tests fail because expand-permission-tree is not implemented yet
-#_(testing "We can expand permissions hierarchy for (->server 123)."
-    (is (= [[[[{:object   (->account "operativa")
-                :relation :owner
-                :subjects [{:object   (->user "ben")
-                            :relation nil}]}
-               [{:object   (->platform "sample-platform")
-                 :relation :super_admin
-                 :subjects [{:object   (->user "andre")
-                             :relation nil}]}]]]
-
-             ; no shared_admin subjects:
-             []                                             ; don't know what this empty vector is about.
-             {:object   (update (->server 123) :id str)
-              :relation :shared_admin
-              :subjects []}]
-
-            ; no shared_member subjects:
-            {:object   (update (->server 123) :id str)
-             :relation :shared_member
-             :subjects []}] (eacl/expand-permission-tree *client {:resource   (->server 123)
-                                                                  :permission :reboot}))))
-
-#_(testing "Expand permissions hierarchy for joe's-server shows team member"
-    ; Note: numeric IDs are not coerced back from strings yet.
-    (is (= [[[[{:object   (->account "acme")
-                :subjects [{:object joe's-user :relation nil}],
-                :relation :owner}
-               [{:object   (->platform "sample-platform"),
-                 :subjects [{:object (->user "andre"), :relation nil}],
-                 :relation :super_admin}]]]
-             []
-             {:object   (->server "not-my-server"),
-              :subjects [],
-              :relation :shared_admin}]
-            {:object   (->server "not-my-server"),
-             :subjects [],
-             :relation :shared_member}] (eacl/expand-permission-tree *client {:resource   joe's-server
-                                                                              :permission :reboot}))))
 
 ;; todo: test that shows behaviour of read-relationships when subject or resource is missing.
 

--- a/modules/eacl/README.md
+++ b/modules/eacl/README.md
@@ -50,5 +50,29 @@ API and recursive/cache behavior for Datomic, DataScript, and Datahike and
 compares authorization sets with independent semantic oracles. Those oracles
 are test code, not selectable production engines.
 
+## Permission-tree expansion
+
+`eacl.permission-tree` is the portable CLJ/CLJS implementation behind
+`IAuthorization/expand-permission-tree`. A request contains `:resource` and
+`:permission`, with optional `:consistency` and `:timeout-ms`; a successful
+response is `{:expanded-at token :tree-root node}`. Nodes contain exactly one
+of `:leaf` or `:intermediate`. Expansion preserves permission/arrow boundaries,
+empty branches, duplicate paths, and typed object identity. Vector order is
+not a semantic contract.
+
+The kernel consumes definitions, relation values, and ID conversions from one
+already-selected immutable adapter, then issues the causal token from that
+same adapter. It realizes scans incrementally and fails atomically on a typed
+deadline, cycle, codec, adapter-contract, unknown-root, or structural-limit
+error. Configure positive `:permission-tree-limits` on the client; per-request
+limit overrides are rejected. The five dimensions are `:max-depth`,
+`:max-schema-components`, `:max-relationship-values`, `:max-tree-nodes`, and
+`:max-leaf-subjects`.
+
+The Dafny file `formal/dafny/PermissionTree.dfy` is a proof-only mathematical
+model. The handwritten portable source is covered by reference-evaluator,
+CLJ/CLJS property, pinned-SpiceDB-fixture, and cross-backend tests; mechanical
+source refinement is not claimed.
+
 Application-facing module selection lives in the
 [backend guide](../../docs/v8-backend-modules-and-upgrade.md).

--- a/modules/eacl/src/eacl/backend/v8.cljc
+++ b/modules/eacl/src/eacl/backend/v8.cljc
@@ -512,3 +512,109 @@
     (catch #?(:clj Throwable :cljs :default) error
       (observe-invocation! :failed adapter operation-key)
       (throw error))))
+
+(defn reduce-definitions
+  "Incrementally consumes one schema-definition sequence.
+
+  This boundary exists so callers can meter and deadline-check lazy adapter
+  results without first realizing the complete sequence. Existing definition
+  operation arities and the ordinary `invoke` behavior remain unchanged."
+  [adapter operation-key args init
+   {:keys [before-realize! after-realize! step]
+    :or {before-realize! (constantly nil)
+         after-realize! (constantly nil)}}]
+  (when-not (contains? #{:relation-defs :permission-defs} operation-key)
+    (invalid-adapter! "Incremental definition reduction requires a schema operation."
+                      {:operation operation-key}))
+  (when-not (fn? step)
+    (invalid-adapter! "Incremental definition reduction requires a step function."
+                      {:operation operation-key}))
+  (when *backend-op-stats*
+    (swap! *backend-op-stats* update operation-key (fnil inc 0)))
+  (observe-invocation! :before adapter operation-key)
+  (try
+    (let [value (apply (operation adapter operation-key) args)]
+      (observe-invocation! :after adapter operation-key)
+      (when-not (sequential? value)
+        (contract-violation!
+         (::id adapter) operation-key :finite-definition-sequence :redacted))
+      (loop [remaining value
+             accumulator init]
+        (before-realize!)
+        (let [items (seq remaining)]
+          (after-realize!)
+          (if-not items
+            accumulator
+            (let [item (first items)]
+              (when (and (runtime-guards? adapter) (not (map? item)))
+                (contract-violation!
+                 (::id adapter) operation-key
+                 :finite-definition-sequence :redacted))
+              (recur (rest items) (step accumulator item)))))))
+    (catch #?(:clj Throwable :cljs :default) error
+      (observe-invocation! :failed adapter operation-key)
+      (throw error))))
+
+(defn reduce-scan
+  "Incrementally consumes one ordered backend scan without materializing it.
+
+  `args` is the adapter operation argument vector. `before-realize!` and
+  `after-realize!` bracket each potentially blocking sequence realization;
+  `step` receives the accumulator and one validated internal id. Existing
+  adapter operation arities remain unchanged."
+  [adapter operation-key args init
+   {:keys [before-realize! after-realize! step]
+    :or {before-realize! (constantly nil)
+         after-realize! (constantly nil)}}]
+  (when-not (contains? #{:subject->resources :resource->subjects}
+                       operation-key)
+    (invalid-adapter! "Incremental reduction requires an ordered scan operation."
+                      {:operation operation-key}))
+  (when-not (fn? step)
+    (invalid-adapter! "Incremental reduction requires a step function."
+                      {:operation operation-key}))
+  (when *backend-op-stats*
+    (swap! *backend-op-stats* update operation-key (fnil inc 0)))
+  (observe-invocation! :before adapter operation-key)
+  (try
+    (let [value (apply (operation adapter operation-key) args)
+          options (or (last args) {})
+          direction (or (:direction options) :asc)
+          bound (:bound-eid options)
+          inclusive? (true? (:inclusive-bound? options))]
+      (observe-invocation! :after adapter operation-key)
+      (when-not (sequential? value)
+        (contract-violation!
+         (::id adapter) operation-key :finite-sequential-result :redacted))
+      (when (and (runtime-guards? adapter)
+                 (not (contains? #{:asc :desc} direction)))
+        (contract-violation!
+         (::id adapter) operation-key :known-direction :redacted))
+      (loop [remaining value
+             previous nil
+             accumulator init]
+        (before-realize!)
+        (let [items (seq remaining)]
+          (after-realize!)
+          (if-not items
+            accumulator
+            (let [item (first items)]
+              (when (runtime-guards? adapter)
+                (when-not (exact-natural? item)
+                  (contract-violation!
+                   (::id adapter) operation-key :exact-natural :redacted))
+                (when (and (some? previous)
+                           (not ((if (= :desc direction) > <)
+                                 previous item)))
+                  (contract-violation!
+                   (::id adapter) operation-key :strict-order :redacted))
+                (when (and (some? bound)
+                           (not (within-bound?
+                                 direction bound inclusive? item)))
+                  (contract-violation!
+                   (::id adapter) operation-key
+                   :inclusive-exclusive-bound :redacted)))
+              (recur (rest items) item (step accumulator item)))))))
+    (catch #?(:clj Throwable :cljs :default) error
+      (observe-invocation! :failed adapter operation-key)
+      (throw error))))

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -39,6 +39,7 @@
                                         ->RelationshipUpdate]]
             [eacl.engine.v8 :as engine]
             [eacl.execution :as execution]
+            [eacl.permission-tree :as permission-tree]
             [eacl.proof-frame :as proof-frame]
             #?(:clj
                [eacl.formal.production-kernel :as production-kernel]
@@ -763,6 +764,27 @@
              #(engine/count-subjects adapter internal-query))]
         (with-cache-info (:value answer) answer)))))
 
+(defn expand-permission-tree
+  [api db opts query]
+  (permission-tree/validate-request! query)
+  (let [opts (ensure-execution-contract
+              opts :expand-permission-tree query)
+        contract (:execution-contract opts)
+        {:keys [adapter]}
+        (selected-context api db opts (:consistency query))
+        tree (permission-tree/expand
+              adapter
+              {:limits (:permission-tree-limits opts)
+               :execution-contract contract}
+              (:resource query)
+              (:permission query))]
+    (execution/check! contract :permission-tree-token-issuance)
+    (let [token
+          (permission-tree/selected-adapter-token adapter opts)]
+      (execution/check! contract :permission-tree-token-issued)
+      {:expanded-at token
+       :tree-root tree})))
+
 (defn- request-cache-enabled?
   [cache-option]
   (cache/validate-request-cache-option! cache-option)
@@ -878,10 +900,9 @@
             (request-cache-enabled? (:cache? query)))
      (dissoc query :cache?)))
 
-  (expand-permission-tree [_ _]
-    (throw (ex-info "expand-permission-tree is not implemented yet."
-                    {:type :eacl/not-implemented
-                     :method (quote expand-permission-tree)})))
+  (expand-permission-tree [_ query]
+    (expand-permission-tree
+     api ((:db api) conn) opts query))
 
   IDetailedAuthorization
   (-check-permission
@@ -953,6 +974,7 @@
     :cursor-ttl-seconds
     :cache
     :recursive-traversal-limits
+    :permission-tree-limits
     :security-key
     :security-keyring
     :security-kid
@@ -981,6 +1003,7 @@
            cursor-ttl-seconds
            cache
            recursive-traversal-limits
+           permission-tree-limits
            security-key
            security-keyring
            security-kid
@@ -1172,6 +1195,9 @@
                           :recursive-traversal-limits
                           (engine/normalize-recursive-traversal-limits
                            recursive-traversal-limits)
+                          :permission-tree-limits
+                          (permission-tree/normalize-limits
+                           permission-tree-limits)
                           :object->entid (fn [db {:keys [id]}]
                                            (object-id->entid db id))
                           :internal-object->spice (fn [db {:keys [type id]}]

--- a/modules/eacl/src/eacl/consistency.cljc
+++ b/modules/eacl/src/eacl/consistency.cljc
@@ -384,6 +384,17 @@
      :response-token response-token
      :native-revision revision}))
 
+(defn selected-adapter-token
+  "Issues a causal token from an already selected immutable adapter.
+
+  This helper never selects from, synchronizes, or re-reads a live connection;
+  the response token therefore names the same snapshot used by the caller."
+  [adapter {:keys [format-options]}]
+  (causal-token/issue
+   format-options
+   (merge (source-scope adapter)
+          (native-revision adapter))))
+
 (defn cursor-conflict!
   [data]
   (fail! :cursor-consistency-conflict

--- a/modules/eacl/src/eacl/core.cljc
+++ b/modules/eacl/src/eacl/core.cljc
@@ -102,7 +102,15 @@
   ; Mirrors count-resources for lookup-subjects. Pass :count-limit to bound
   ; work and receive :truncated? in the result.
 
-  (expand-permission-tree [this {:as query :keys [resource permission consistency]}]))
+  (expand-permission-tree [this {:as query :keys [resource permission consistency]}])
+  ; expand-permission-tree accepts exactly :resource, :permission, optional
+  ; :consistency and :timeout-ms. It returns
+  ; {:expanded-at causal-token :tree-root PermissionRelationshipTree-map}.
+  ; Every tree node has :expanded-object, :expanded-relation and exactly one
+  ; of {:intermediate {:operation :union :children [...]}} or
+  ; {:leaf {:subjects [...]}}. Child and subject vector order is non-semantic.
+  ; Expansion is shallow: direct subjects remain terminal leaves.
+  )
 
 (defprotocol IDetailedAuthorization
   "Optional authorization extension for callers that need cache provenance."

--- a/modules/eacl/src/eacl/execution.cljc
+++ b/modules/eacl/src/eacl/execution.cljc
@@ -156,9 +156,11 @@
         _ (when-let [forbidden
                      (seq
                       (filter #(contains? request %)
-                              [:cache-attempt :recursive-traversal-limits]))]
+                              [:cache-attempt
+                               :recursive-traversal-limits
+                               :permission-tree-limits]))]
             (invalid-request!
-             "Cache-attempt and traversal safety envelopes are client configuration, not per-request demand controls."
+             "Cache-attempt and structural safety envelopes are client configuration, not per-request demand controls."
              {:forbidden-keys (vec forbidden)}))
         evaluation (normalize-evaluation (:evaluation request))
         timeout-ms

--- a/modules/eacl/src/eacl/permission_tree.cljc
+++ b/modules/eacl/src/eacl/permission_tree.cljc
@@ -1,0 +1,532 @@
+(ns eacl.permission-tree
+  "Portable, snapshot-bound shallow permission-tree expansion."
+  (:require [eacl.backend.v8 :as backend]
+            [eacl.consistency :as consistency]
+            [eacl.core :as eacl]
+            [eacl.execution :as execution]))
+
+(def default-limits
+  {:max-depth 50
+   :max-schema-components 100000
+   :max-relationship-values 100000
+   :max-tree-nodes 100000
+   :max-leaf-subjects 100000})
+
+(def ^:private query-keys
+  #{:resource :permission :consistency :timeout-ms})
+
+(defn- portable-positive-integer?
+  [value]
+  (and #?(:clj (integer? value)
+          :cljs (and (number? value)
+                     (js/Number.isSafeInteger value)))
+       (pos? value)
+       (<= value backend/maximum-exact-integer)))
+
+(defn normalize-limits
+  [overrides]
+  (let [overrides (if (nil? overrides) {} overrides)
+        known (set (keys default-limits))]
+    (when-not (map? overrides)
+      (throw
+       (ex-info
+        "EACL Config Error: :permission-tree-limits must be a map."
+        {:type :eacl/invalid-config
+         :key :permission-tree-limits
+         :value overrides})))
+    (when-let [unknown (seq (remove known (keys overrides)))]
+      (throw
+       (ex-info
+        "EACL Config Error: unknown permission-tree limit."
+        {:type :eacl/invalid-config
+         :key :permission-tree-limits
+         :unknown-keys (vec unknown)
+         :known-keys known})))
+    (when-not (every? portable-positive-integer? (vals overrides))
+      (throw
+       (ex-info
+        "EACL Config Error: permission-tree limits must be positive portable exact integers."
+        {:type :eacl/invalid-config
+         :key :permission-tree-limits
+         :value overrides
+         :maximum backend/maximum-exact-integer})))
+    (merge default-limits overrides)))
+
+(defn- unqualified-keyword?
+  [value]
+  (and (keyword? value) (nil? (namespace value))))
+
+(defn validate-request!
+  [query]
+  (when-not (map? query)
+    (throw
+     (ex-info
+      "expand-permission-tree requires a request map."
+      {:type :eacl/invalid-request
+       :eacl/error :eacl.permission-tree/invalid-request})))
+  (when-let [unknown (seq (remove query-keys (keys query)))]
+    (throw
+     (ex-info
+      "expand-permission-tree received unknown request keys."
+      {:type :eacl/invalid-request
+       :eacl/error :eacl.permission-tree/invalid-request
+       :unknown-keys (vec unknown)
+       :known-keys query-keys})))
+  (doseq [required [:resource :permission]]
+    (when-not (contains? query required)
+      (throw
+       (ex-info
+        "expand-permission-tree is missing a required request key."
+        {:type :eacl/invalid-request
+         :eacl/error :eacl.permission-tree/invalid-request
+         :missing-key required}))))
+  (let [{:keys [resource permission]} query]
+    (when-not (and (associative? resource)
+                   (unqualified-keyword? (:type resource))
+                   (some? (:id resource)))
+      (throw
+       (ex-info
+        "expand-permission-tree requires a resource with an unqualified keyword :type and non-nil :id."
+        {:type :eacl/invalid-request
+         :eacl/error :eacl.permission-tree/invalid-request
+         :key :resource})))
+    (when (some? (:relation resource))
+      (throw
+       (ex-info
+        "expand-permission-tree resources cannot carry a subject relation."
+        {:type :eacl/invalid-request
+         :eacl/error :eacl.permission-tree/invalid-request
+         :key :resource/relation})))
+    (when-not (unqualified-keyword? permission)
+      (throw
+       (ex-info
+        "expand-permission-tree requires an unqualified keyword permission."
+        {:type :eacl/invalid-request
+         :eacl/error :eacl.permission-tree/invalid-request
+         :key :permission}))))
+  query)
+
+(defn- permission-tree-error!
+  [type message data]
+  (throw
+   (ex-info
+    message
+    (merge {:type type :eacl/error type
+            :operation :expand-permission-tree}
+           data))))
+
+(defn- adapter-contract!
+  [reason]
+  (permission-tree-error!
+   :eacl.permission-tree/adapter-contract-violation
+   "The selected backend violated the permission-tree adapter contract."
+   {:reason reason}))
+
+(defn- adapter-call!
+  [f]
+  (let [controlled-error (volatile! nil)
+        controlled!
+        (fn [thunk]
+          (try
+            (thunk)
+            (catch #?(:clj Throwable :cljs :default) error
+              (vreset! controlled-error error)
+              (throw error))))]
+    (try
+      (f controlled!)
+      (catch #?(:clj Throwable :cljs :default) error
+        (if (identical? error @controlled-error)
+          (throw error)
+          ;; Do not retain the adapter error as a cause: its message or data
+          ;; may contain an internal eid or a relationship value. Namespace
+          ;; lookalikes are not trusted; only an exact error caught from one
+          ;; of the guarded kernel callbacks can cross this boundary.
+          (adapter-contract! :adapter-operation-failed))))))
+
+(defn- portable-natural?
+  [value]
+  (and #?(:clj (integer? value)
+          :cljs (and (number? value)
+                     (js/Number.isSafeInteger value)))
+       (<= 0 value backend/maximum-exact-integer)))
+
+(defn selected-adapter-token
+  "Issues a token from the selected adapter through the redacting boundary."
+  [adapter opts]
+  (adapter-call!
+   (fn [_]
+     (consistency/selected-adapter-token adapter opts))))
+
+(def ^:private dimension->limit
+  {:depth :max-depth
+   :schema-components :max-schema-components
+   :relationship-values :max-relationship-values
+   :tree-nodes :max-tree-nodes
+   :leaf-subjects :max-leaf-subjects})
+
+(defn- safe-counters
+  [counters]
+  (select-keys counters
+               [:schema-components :relationship-values
+                :tree-nodes :leaf-subjects]))
+
+(defn- consume!
+  [limits counters dimension amount]
+  (let [limit-key (get dimension->limit dimension)
+        current (get @counters dimension 0)
+        configured (get limits limit-key)]
+    (if (> amount (- configured current))
+      (permission-tree-error!
+       :eacl.permission-tree/limit-exceeded
+       "Permission-tree structural work limit exceeded."
+       {:dimension limit-key
+        :limit configured
+        :attempted-work amount
+        ;; Counters report only work actually accepted by the envelope. This
+        ;; avoids constructing max-exact-integer + 1 in ClojureScript.
+        :consumed-work (safe-counters @counters)})
+      (swap! counters update dimension + amount))))
+
+(defn- check-depth!
+  [limits counters depth]
+  (when (> depth (:max-depth limits))
+    (permission-tree-error!
+     :eacl.permission-tree/limit-exceeded
+     "Permission-tree maximum depth exceeded."
+     {:dimension :max-depth
+      :limit (:max-depth limits)
+      :consumed-work (assoc (safe-counters @counters) :depth depth)})))
+
+(defn- definition-sequence!
+  [kind resource-type name value]
+  (when-not (and (sequential? value) (every? map? value))
+    (adapter-contract! :invalid-definition-sequence))
+  (let [definitions (vec value)]
+    (case kind
+      :relation
+      (do
+        (when-not
+         (every?
+         (fn [definition]
+            (and (portable-natural? (:relation-id definition))
+                 (= resource-type (:resource-type definition))
+                 (= name (:relation-name definition))
+                 (unqualified-keyword? (:subject-type definition))))
+          definitions)
+         (adapter-contract! :malformed-relation-definition))
+        (when-not (= (count definitions)
+                     (count (distinct (map :subject-type definitions))))
+          (adapter-contract! :duplicate-relation-subject-type)))
+
+      :permission
+      (do
+        (when-not
+         (every?
+          (fn [definition]
+            (and (portable-natural? (:permission-id definition))
+                 (= resource-type (:resource-type definition))
+                 (= name (:permission-name definition))
+                 (unqualified-keyword?
+                  (:source-relation-name definition))
+                 (contains? #{:relation :permission}
+                            (:target-type definition))
+                 (unqualified-keyword? (:target-name definition))))
+          definitions)
+         (adapter-contract! :malformed-permission-definition)))
+
+      (adapter-contract! :unknown-definition-kind))
+    definitions))
+
+(defn- schedule
+  [work assembler child-frames]
+  (into (conj work assembler) (reverse child-frames)))
+
+(defn- assemble-children
+  [values child-count]
+  (let [start (- (count values) child-count)]
+    [(subvec values 0 start)
+     (subvec values start)]))
+
+(defn expand
+  "Expands one root against exactly one immutable selected adapter.
+
+  Returns a fully externalized tree. Failures throw before any tree is
+  returned; no lazy sequence or internal backend identity escapes."
+  [adapter {:keys [limits execution-contract]} resource permission]
+  (let [limits (normalize-limits limits)
+        counters (atom {:schema-components 0
+                        :relationship-values 0
+                        :tree-nodes 0
+                        :leaf-subjects 0})
+        schema-cache (atom {})
+        codec-cache (atom {})
+        check! (fn [stage]
+                 (execution/check!
+                  execution-contract stage (safe-counters @counters)))
+        definitions!
+        (fn [kind resource-type name]
+          (let [cache-key [kind resource-type name]]
+            (if (contains? @schema-cache cache-key)
+              (get @schema-cache cache-key)
+              (let [operation (if (= :relation kind)
+                                :relation-defs
+                                :permission-defs)
+                    raw
+                    (adapter-call!
+                     (fn [controlled!]
+                       (backend/reduce-definitions
+                        adapter operation [resource-type name] []
+                        {:before-realize!
+                         #(controlled!
+                           (fn []
+                             (check! :permission-tree-definition-read)))
+                         :after-realize!
+                         #(controlled!
+                           (fn []
+                             (check! :permission-tree-definition-read)))
+                         :step
+                         (fn [definitions definition]
+                           (controlled!
+                            (fn []
+                              (consume! limits counters
+                                        :schema-components 1)
+                              (conj definitions definition))))})))
+                    definitions
+                    (definition-sequence!
+                     kind resource-type name raw)
+                    _ (check! :permission-tree-definition-read)]
+                (swap! schema-cache assoc cache-key definitions)
+                definitions))))
+        render-internal!
+        (fn [type internal-id]
+          (when-not (portable-natural? internal-id)
+            (adapter-contract! :invalid-internal-identity))
+          (let [cache-key [type internal-id]]
+            (if (contains? @codec-cache cache-key)
+              (get @codec-cache cache-key)
+              (do
+                (check! :permission-tree-render)
+                (let [external-id
+                      (adapter-call!
+                       (fn [_]
+                         (backend/invoke
+                          adapter :internal-id->object internal-id)))]
+                  (check! :permission-tree-render)
+                  (when (nil? external-id)
+                    (permission-tree-error!
+                     :eacl.permission-tree/codec-failure
+                     "The selected backend could not externalize a scanned object."
+                     {:reason :missing-external-identity}))
+                  (let [rendered (eacl/spice-object type external-id)]
+                    (swap! codec-cache assoc cache-key rendered)
+                    rendered))))))
+        scan-relation!
+        (fn [resource-descriptor relation-definitions leaf?]
+          (if (nil? (:internal-id resource-descriptor))
+            []
+            (reduce
+             (fn [subjects {:keys [relation-id subject-type]}]
+               (adapter-call!
+                (fn [controlled!]
+                  (backend/reduce-scan
+                  adapter
+                  :resource->subjects
+                  [(:type resource-descriptor)
+                   (:internal-id resource-descriptor)
+                   relation-id
+                   subject-type
+                   {:direction :asc
+                    :bound-eid nil
+                    :inclusive-bound? false}]
+                  subjects
+                  {:before-realize!
+                   #(controlled!
+                     (fn []
+                       (check! :permission-tree-relationship-realization)))
+                   :after-realize!
+                   #(controlled!
+                     (fn []
+                       (check! :permission-tree-relationship-realization)))
+                   :step
+                   (fn [acc internal-id]
+                     (controlled!
+                      (fn []
+                        (consume! limits counters
+                                  :relationship-values 1)
+                        (when leaf?
+                          (consume! limits counters :leaf-subjects 1))
+                        (conj acc
+                              {:type subject-type
+                               :internal-id internal-id
+                               :identity [:internal subject-type internal-id]
+                               :public (render-internal!
+                                        subject-type internal-id)}))))}))))
+             []
+             relation-definitions)))
+        root-type (:type resource)
+        root-id (:id resource)
+        _ (check! :permission-tree-root-resolution)
+        internal-root-id
+        (adapter-call!
+         (fn [_]
+           (backend/invoke adapter :object-id->internal root-id)))
+        _ (check! :permission-tree-root-resolution)
+        _ (when (and (some? internal-root-id)
+                     (not (portable-natural? internal-root-id)))
+            (adapter-contract! :invalid-root-internal-identity))
+        root-descriptor
+        {:type root-type
+         :internal-id internal-root-id
+         :identity (if (some? internal-root-id)
+                     [:internal root-type internal-root-id]
+                     [:external root-type root-id])
+         :public (eacl/spice-object root-type root-id)}]
+    (loop [work [{:op :expand
+                  :resource root-descriptor
+                  :name permission
+                  :expected :either
+                  :depth 1
+                  :active #{}}]
+           values []]
+      (check! :permission-tree-work-transition)
+      (if-not (seq work)
+        (do
+          (when-not (= 1 (count values))
+            (adapter-contract! :invalid-final-value-stack))
+          (first values))
+        (let [frame (peek work)
+              work (pop work)
+              [next-work next-values]
+              (case (:op frame)
+                :expand
+                (let [{:keys [resource name expected depth active]} frame
+                      _ (check-depth! limits counters depth)
+                      expansion-key [(:identity resource) name]
+                      _ (when (and (= :permission expected)
+                                   (contains? active expansion-key))
+                          (permission-tree-error!
+                           :eacl.permission-tree/cycle-detected
+                           "Permission-tree expansion encountered an active-path cycle."
+                           {:path-node [(:type resource) name]}))
+                      relations (definitions! :relation (:type resource) name)
+                      permissions (definitions! :permission (:type resource) name)
+                      _ (when (and (seq relations) (seq permissions))
+                          (adapter-contract! :contradictory-root-definition))
+                      actual (cond
+                               (seq relations) :relation
+                               (seq permissions) :permission
+                               :else nil)
+                      _ (when-not actual
+                          (if (= :either expected)
+                            (permission-tree-error!
+                             :eacl.permission-tree/unknown-root
+                             "The requested relation or permission is not defined."
+                             {:resource-type (:type resource)
+                              :permission name})
+                            (adapter-contract! :missing-referenced-definition)))
+                      _ (when (and (not= :either expected)
+                                   (not= expected actual))
+                          (adapter-contract! :wrong-referenced-definition-kind))]
+                  (if (= :relation actual)
+                    (do
+                      (consume! limits counters :tree-nodes 1)
+                      (let [subjects (scan-relation! resource relations true)]
+                        [work
+                         (conj values
+                               {:expanded-object (:public resource)
+                                :expanded-relation name
+                                :leaf
+                                {:subjects (mapv :public subjects)}})]))
+                    (do
+                      (when (contains? active expansion-key)
+                        (permission-tree-error!
+                         :eacl.permission-tree/cycle-detected
+                         "Permission-tree expansion encountered an active-path cycle."
+                         {:path-node [(:type resource) name]}))
+                      (consume! limits counters :tree-nodes 1)
+                      (let [next-active (conj active expansion-key)
+                            components
+                            (mapv
+                             (fn [definition]
+                               {:op :component
+                                :resource resource
+                                :permission name
+                                :definition definition
+                                :depth (inc depth)
+                                :active next-active})
+                             permissions)]
+                        [(schedule
+                          work
+                          {:op :assemble
+                           :resource resource
+                           :name name
+                           :child-count (count components)}
+                          components)
+                         values]))))
+
+                :component
+                (let [{:keys [resource permission definition depth active]}
+                      frame
+                      _ (check-depth! limits counters depth)
+                      source (:source-relation-name definition)
+                      target-kind (:target-type definition)
+                      target-name (:target-name definition)]
+                  (if (= :self source)
+                    [(conj work
+                           {:op :expand
+                            :resource resource
+                            :name target-name
+                            :expected target-kind
+                            :depth depth
+                            :active active})
+                     values]
+                    (let [_ (consume! limits counters :tree-nodes 1)
+                          source-relations
+                          (definitions!
+                            :relation (:type resource) source)
+                          source-permissions
+                          (definitions!
+                            :permission (:type resource) source)
+                          _ (when (or (empty? source-relations)
+                                      (seq source-permissions))
+                              (adapter-contract!
+                               :invalid-arrow-source-definition))
+                          intermediates
+                          (scan-relation!
+                           resource source-relations false)
+                          targets
+                          (mapv
+                           (fn [intermediate]
+                             {:op :expand
+                              :resource intermediate
+                              :name target-name
+                              :expected target-kind
+                              :depth (inc depth)
+                              :active active})
+                           intermediates)]
+                      [(schedule
+                        work
+                        {:op :assemble
+                         :resource resource
+                         ;; SpiceDB annotates tuple-to-userset's outer set
+                         ;; node with the original resource-and-permission.
+                         :name permission
+                         :child-count (count targets)}
+                        targets)
+                       values])))
+
+                :assemble
+                (let [[remaining children]
+                      (assemble-children values (:child-count frame))]
+                  [work
+                   (conj remaining
+                         {:expanded-object
+                          (get-in frame [:resource :public])
+                          :expanded-relation (:name frame)
+                          :intermediate
+                          {:operation :union
+                           :children (vec children)}})])
+
+                (adapter-contract! :unknown-work-frame))]
+          (check! :permission-tree-work-transition)
+          (recur next-work next-values))))))

--- a/modules/eacl/test/eacl/consistency_test.cljc
+++ b/modules/eacl/test/eacl/consistency_test.cljc
@@ -133,6 +133,28 @@
      :revision order
      :exact-locator locator})))
 
+(deftest selected-adapter-token-never-reselects-live-state
+  (let [counts (atom {})
+        selected (adapter {:source-id "source"
+                           :source-lifecycle "test-lifecycle"
+                           :branch nil
+                           :order 41
+                           :locator 41
+                           :counts counts})
+        issued (consistency/selected-adapter-token
+                selected {:format-options format-options})
+        payload (causal-token/token-data format-options issued)]
+    (is (= 41 (:revision payload)))
+    (is (= 41 (:exact-locator payload)))
+    (is (= 1 (:source-scope @counts)))
+    (is (= 1 (:source-lifecycle @counts)))
+    (is (= 1 (:native-revision @counts)))
+    (is (= 1 (:order-hint @counts)))
+    (is (= 1 (:exact-locator @counts)))
+    (is (not-any? #(contains? @counts %)
+                  [:select-current :select-authoritative
+                   :select-at-least :select-exact]))))
+
 (defn- expected-kernel-decision
   [operation input]
   (case operation

--- a/modules/eacl/test/eacl/contract_support.cljc
+++ b/modules/eacl/test/eacl/contract_support.cljc
@@ -3,7 +3,8 @@
             [clojure.string :as str]
             [eacl.authorization-oracle :as oracle]
             [eacl.cache :as cache]
-            [eacl.core :as eacl]))
+            [eacl.core :as eacl]
+            [eacl.spicedb.consistency :as consistency]))
 
 (def ->user (partial eacl/spice-object :user))
 (def ->platform (partial eacl/spice-object :platform))
@@ -79,6 +80,83 @@
    (eacl/->Relationship (->platform "platform-1") :platform (->account "account-1"))
    (eacl/->Relationship (->account "account-1") :account (->server "server-1"))
    (eacl/->Relationship (->account "account-1") :account (->server "server-2"))])
+
+(def permission-tree-golden-schema
+  "definition user {}
+   definition folder { relation viewer: user }
+   definition document {
+     relation folder: folder
+     permission view = folder->viewer
+   }")
+
+(def permission-tree-golden-objects
+  [(eacl/spice-object :user "fred")
+   (eacl/spice-object :user "tom")
+   (eacl/spice-object :user "sarah")
+   (eacl/spice-object :folder "testfolder1")
+   (eacl/spice-object :folder "testfolder2")
+   (eacl/spice-object :document "testdoc")])
+
+(def permission-tree-golden-relationships
+  [(eacl/->Relationship
+    (eacl/spice-object :folder "testfolder1") :folder
+    (eacl/spice-object :document "testdoc"))
+   (eacl/->Relationship
+    (eacl/spice-object :folder "testfolder2") :folder
+    (eacl/spice-object :document "testdoc"))
+   (eacl/->Relationship
+    (eacl/spice-object :user "tom") :viewer
+    (eacl/spice-object :folder "testfolder1"))
+   (eacl/->Relationship
+    (eacl/spice-object :user "fred") :viewer
+    (eacl/spice-object :folder "testfolder1"))
+   (eacl/->Relationship
+    (eacl/spice-object :user "sarah") :viewer
+    (eacl/spice-object :folder "testfolder2"))])
+
+(defn- normalize-permission-tree
+  [tree]
+  (if-let [leaf (:leaf tree)]
+    (assoc tree :leaf
+           (update leaf :subjects #(vec (sort-by pr-str %))))
+    (assoc-in tree [:intermediate :children]
+              (->> (get-in tree [:intermediate :children])
+                   (map normalize-permission-tree)
+                   (sort-by pr-str)
+                   vec))))
+
+(defn assert-pinned-permission-tree-golden!
+  [client]
+  (let [expected
+        {:expanded-object (eacl/spice-object :document "testdoc")
+         :expanded-relation :view
+         :intermediate
+         {:operation :union
+          :children
+          [{:expanded-object (eacl/spice-object :document "testdoc")
+            :expanded-relation :view
+            :intermediate
+            {:operation :union
+             :children
+             [{:expanded-object
+               (eacl/spice-object :folder "testfolder1")
+               :expanded-relation :viewer
+               :leaf
+               {:subjects [(eacl/spice-object :user "fred")
+                           (eacl/spice-object :user "tom")]}}
+              {:expanded-object
+               (eacl/spice-object :folder "testfolder2")
+               :expanded-relation :viewer
+               :leaf
+               {:subjects [(eacl/spice-object :user "sarah")]}}]}}]}}
+        actual
+        (:tree-root
+         (eacl/expand-permission-tree
+          client
+          {:resource (eacl/spice-object :document "testdoc")
+           :permission :view}))]
+    (is (= (normalize-permission-tree expected)
+           (normalize-permission-tree actual)))))
 
 (def safe-retraction-schema
   "definition user {
@@ -517,6 +595,102 @@
                                             :subject/id        "user-2"
                                             :first             10})))
     (is (false? (eacl/can? client (->user "user-2") :reboot (->server "server-1"))))))
+
+(defn assert-v8-permission-tree-contract!
+  "Cross-backend shallow expansion contract over `smoke-schema`."
+  [client]
+  (testing "direct relation roots remain terminal leaves"
+    (let [response
+          (eacl/expand-permission-tree
+           client
+           {:resource (->account "account-1")
+            :permission :owner})]
+      (is (string? (:expanded-at response)))
+      (is (= {:expanded-object (->account "account-1")
+              :expanded-relation :owner
+              :leaf {:subjects [(->user "user-1")]}}
+             (:tree-root response)))
+      (is (= (:tree-root response)
+             (:tree-root
+              (eacl/expand-permission-tree
+               client
+               {:resource (->account "account-1")
+                :permission :owner
+                :consistency
+                (consistency/at-least-as-fresh
+                 (:expanded-at response))}))))
+      (is (= (:tree-root response)
+             (:tree-root
+              (eacl/expand-permission-tree
+               client
+               {:resource (->account "account-1")
+                :permission :owner
+                :consistency consistency/fully-consistent}))))))
+
+  (testing "same-resource permissions and arrows preserve every union boundary"
+    (is (= {:expanded-object (->server "server-1")
+            :expanded-relation :reboot
+            :intermediate
+            {:operation :union
+             :children
+             [{:expanded-object (->server "server-1")
+               :expanded-relation :reboot
+               :intermediate
+               {:operation :union
+                :children
+                [{:expanded-object (->account "account-1")
+                  :expanded-relation :admin
+                  :intermediate
+                  {:operation :union
+                   :children
+                   [{:expanded-object (->account "account-1")
+                     :expanded-relation :owner
+                     :leaf {:subjects [(->user "user-1")]}}
+                    {:expanded-object (->account "account-1")
+                     :expanded-relation :admin
+                     :intermediate
+                     {:operation :union
+                      :children
+                      [{:expanded-object (->platform "platform-1")
+                        :expanded-relation :super_admin
+                        :leaf
+                        {:subjects [(->user "super-user")]}}]}}]}}]}}]}}
+           (:tree-root
+            (eacl/expand-permission-tree
+             client
+             {:resource (->server "server-1")
+              :permission :reboot})))))
+
+  (testing "absent ids retain the exact root and empty arrow topology"
+    (is (= {:expanded-object (->server "absent")
+            :expanded-relation :reboot
+            :intermediate
+            {:operation :union
+             :children
+             [{:expanded-object (->server "absent")
+               :expanded-relation :reboot
+               :intermediate {:operation :union :children []}}]}}
+           (:tree-root
+            (eacl/expand-permission-tree
+             client
+             {:resource (->server "absent")
+              :permission :reboot})))))
+
+  (testing "request validation is identical before backend reads"
+    (is (= :eacl.permission-tree/invalid-request
+           (error-category
+            #(eacl/expand-permission-tree
+              client
+              {:resource (->server "server-1")
+               :permission :reboot
+               :cache? false}))))
+    (is (= :eacl.execution/invalid-contract
+           (error-category
+            #(eacl/expand-permission-tree
+              client
+              {:resource (->server "server-1")
+               :permission :reboot
+               :timeout-ms 0}))))))
 
 (def recursive-schema
   "definition user {}

--- a/modules/eacl/test/eacl/permission_tree_test.cljc
+++ b/modules/eacl/test/eacl/permission_tree_test.cljc
@@ -1,0 +1,751 @@
+(ns eacl.permission-tree-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [eacl.backend.v8 :as backend]
+            [eacl.core :as eacl]
+            [eacl.execution :as execution]
+            [eacl.permission-tree :as permission-tree]))
+
+(defn- thrown-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo
+              :cljs cljs.core.ExceptionInfo) error
+      (ex-data error))))
+
+(defn- fake-adapter
+  [{:keys [objects relations permissions scans internal->external
+           runtime-guards? codec-counts scan-error token-error]
+    :or {objects {}
+         relations {}
+         permissions {}
+         scans {}
+         internal->external {}}}]
+  (let [holder (atom nil)
+        adapter
+        (backend/make-adapter
+         {:id :permission-tree-test
+          :capabilities backend/empty-capabilities
+          :runtime-guards? runtime-guards?
+          :state {:db :immutable-test-snapshot}
+          :operations
+          {:snapshot-id (fn [] {:snapshot :one})
+           :source-scope (fn []
+                           (if token-error
+                             (throw token-error)
+                             {:source-id "test" :branch nil}))
+           :source-lifecycle (fn [] "test-lifecycle")
+           :native-revision (fn [] {:revision 1 :exact-locator nil})
+           :order-hint (fn [] 1)
+           :select-current (fn [] @holder)
+           :select-authoritative (fn [_] @holder)
+           :select-at-least (fn [_ _] @holder)
+           :exact-locator (constantly nil)
+           :select-exact (fn [_ _] nil)
+           :object-id->internal (fn [external-id]
+                                  (get objects external-id))
+           :internal-id->object (fn [internal-id]
+                                  (when codec-counts
+                                    (swap! codec-counts
+                                           update internal-id (fnil inc 0)))
+                                  (get internal->external internal-id))
+           :relation-defs (fn [resource-type relation]
+                            (get relations [resource-type relation] []))
+           :permission-defs (fn [resource-type permission]
+                              (get permissions
+                                   [resource-type permission] []))
+           :subject->resources (fn [& _] [])
+           :resource->subjects
+           (fn [resource-type resource-id relation-id subject-type _]
+             (if scan-error
+               (throw scan-error)
+               (get scans
+                    [resource-type resource-id relation-id subject-type]
+                    [])))
+           :direct-match? (fn [& _] false)
+           :relation-populated? (fn [& _] false)
+           :all-permission-nodes (fn [] #{})}})]
+    (reset! holder adapter)
+    adapter))
+
+(defn- relation
+  [id resource-type relation-name subject-type]
+  {:relation-id id
+   :resource-type resource-type
+   :relation-name relation-name
+   :subject-type subject-type})
+
+(defn- component
+  [id resource-type permission-name source target-kind target-name]
+  {:permission-id id
+   :resource-type resource-type
+   :permission-name permission-name
+   :source-relation-name source
+   :target-type target-kind
+   :target-name target-name})
+
+(defn- expand
+  ([adapter resource permission]
+   (expand adapter resource permission permission-tree/default-limits))
+  ([adapter resource permission limits]
+   (permission-tree/expand
+    adapter
+    {:limits limits :execution-contract nil}
+    resource
+    permission)))
+
+(deftest strict-request-contract
+  (is (= {:resource (eacl/spice-object :document "d1")
+          :permission :view}
+         (permission-tree/validate-request!
+          {:resource (eacl/spice-object :document "d1")
+           :permission :view})))
+  (doseq [request
+          [nil
+           {}
+           {:resource (eacl/spice-object :document "d1")}
+           {:resource (eacl/spice-object :document "d1")
+            :permission :view
+            :cache? false}
+           {:resource (eacl/spice-object :document "d1" :member)
+            :permission :view}
+           {:resource {:type :document :id nil}
+            :permission :view}
+           {:resource {:type :qualified/document :id "d1"}
+            :permission :view}
+           {:resource (eacl/spice-object :document "d1")
+            :permission :qualified/view}]]
+    (is (= :eacl/invalid-request
+           (:type (thrown-data
+                   #(permission-tree/validate-request! request)))))))
+
+(deftest limit-configuration-is-strict-and-portable
+  (is (= (assoc permission-tree/default-limits :max-depth 3)
+         (permission-tree/normalize-limits {:max-depth 3})))
+  (doseq [limits [false
+                  {:unknown 1}
+                  {:max-depth 0}
+                  {:max-depth -1}
+                  {:max-depth 9007199254740992}]]
+    (is (= :eacl/invalid-config
+           (:type (thrown-data
+                   #(permission-tree/normalize-limits limits)))))))
+
+(deftest direct-empty-and-absent-resources
+  (let [adapter
+        (fake-adapter
+         {:objects {"d1" 1 "alice" 10}
+          :internal->external {10 "alice" 11 "bob"}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :scans {[:document 1 100 :user] [10]}})]
+    (is (= {:expanded-object (eacl/spice-object :document "d1")
+            :expanded-relation :viewer
+            :leaf {:subjects [(eacl/spice-object :user "alice")]}}
+           (expand adapter (eacl/spice-object :document "d1") :viewer)))
+    (is (= {:expanded-object (eacl/spice-object :document "missing")
+            :expanded-relation :viewer
+            :leaf {:subjects []}}
+           (expand adapter
+                   (eacl/spice-object :document "missing")
+                   :viewer)))
+    (is (= 9007199254740991
+           (get-in
+            (expand adapter
+                    (eacl/spice-object :document 9007199254740991)
+                    :viewer)
+            [:expanded-object :id])))
+    (is (= :eacl.permission-tree/unknown-root
+           (:type
+            (thrown-data
+             #(expand adapter
+                      (eacl/spice-object :document "d1")
+                      :undefined)))))))
+
+(deftest union-nesting-arrows-types-and-duplicate-paths
+  (let [adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :internal->external {7 "same" 10 "alice"}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]
+           [:document :parent]
+           [(relation 101 :document :parent :folder)
+            (relation 102 :document :parent :team)]
+           [:folder :reader]
+           [(relation 200 :folder :reader :user)]
+           [:team :reader]
+           [(relation 300 :team :reader :user)]}
+          :permissions
+          {[:document :view]
+           [(component 400 :document :view :self :relation :viewer)
+            (component 401 :document :view :parent :relation :reader)
+            (component 402 :document :view :self :relation :viewer)]}
+          :scans
+          {[:document 1 100 :user] [10]
+           [:document 1 101 :folder] [7]
+           [:document 1 102 :team] [7]
+           [:folder 7 200 :user] []
+           [:team 7 300 :user] []}})
+        tree (expand adapter (eacl/spice-object :document "d1") :view)
+        children (get-in tree [:intermediate :children])
+        arrow (second children)]
+    (is (= (eacl/spice-object :document "d1")
+           (:expanded-object tree)))
+    (is (= :view (:expanded-relation tree)))
+    (is (= :union (get-in tree [:intermediate :operation])))
+    (is (= (first children) (nth children 2)))
+    (is (= :view (:expanded-relation arrow)))
+    (is (= [(eacl/spice-object :folder "same")
+            (eacl/spice-object :team "same")]
+           (mapv :expanded-object
+                 (get-in arrow [:intermediate :children]))))))
+
+(deftest same-permission-boundaries-diamonds-and-cycles
+  (let [base-relations
+        {[:document :viewer]
+         [(relation 100 :document :viewer :user)]}
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :relations base-relations
+          :permissions
+          {[:document :base]
+           [(component 200 :document :base :self :relation :viewer)]
+           [:document :diamond]
+           [(component 201 :document :diamond :self :permission :base)
+            (component 202 :document :diamond :self :permission :base)]}})
+        tree (expand adapter (eacl/spice-object :document "d1") :diamond)
+        children (get-in tree [:intermediate :children])]
+    (is (= 2 (count children)))
+    (is (= (first children) (second children)))
+    (is (every? #(= :base (:expanded-relation %)) children)))
+  (let [adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :permissions
+          {[:document :a]
+           [(component 1 :document :a :self :permission :b)]
+           [:document :b]
+           [(component 2 :document :b :self :permission :a)]}})]
+    (is (= :eacl.permission-tree/cycle-detected
+           (:type
+            (thrown-data
+             #(expand adapter
+                      (eacl/spice-object :document "d1")
+                      :a)))))))
+
+(deftest all-limit-dimensions-fail-without-a-tree
+  (let [adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :internal->external {10 "alice"}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :permissions
+          {[:document :view]
+           [(component 200 :document :view :self :relation :viewer)]}
+          :scans {[:document 1 100 :user] [10 11]}})
+        cases
+        [[:max-depth 1]
+         [:max-schema-components 1]
+         [:max-relationship-values 1]
+         [:max-tree-nodes 1]
+         [:max-leaf-subjects 1]]]
+    (doseq [[dimension value] cases]
+      (let [limits (assoc permission-tree/default-limits dimension value)
+            data (thrown-data
+                  #(expand adapter
+                           (eacl/spice-object :document "d1")
+                           :view
+                           limits))]
+        (is (= :eacl.permission-tree/limit-exceeded (:type data)))
+        (is (not (contains? data :tree)))))))
+
+(deftest codec-failure-is-redacted
+  (let [adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :scans {[:document 1 100 :user] [987654321]}})
+        data
+        (thrown-data
+         #(expand adapter (eacl/spice-object :document "d1") :viewer))]
+    (is (= :eacl.permission-tree/codec-failure (:type data)))
+    (is (not-any? #(= 987654321 %)
+                  (tree-seq coll? seq data)))))
+
+(deftest request-local-codec-memo-is-typed-and-deterministic
+  (let [counts (atom {})
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :internal->external {10 "alice"}
+          :codec-counts counts
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :permissions
+          {[:document :view]
+           [(component 200 :document :view :self :relation :viewer)
+            (component 201 :document :view :self :relation :viewer)]}
+          :scans {[:document 1 100 :user] [10]}})]
+    (is (= 2
+           (count
+            (get-in
+             (expand adapter (eacl/spice-object :document "d1") :view)
+             [:intermediate :children]))))
+    (is (= {10 1} @counts))))
+
+(deftest relationship-scan-is-incremental
+  (let [realized (atom 0)
+        events (atom [])
+        values (letfn [(items [value]
+                        (lazy-seq
+                         (swap! realized inc)
+                         (cons value (items (inc value)))))]
+                 (items 10))
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :internal->external {10 "a" 11 "b"}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :scans {[:document 1 100 :user] values}})
+        limits
+        (assoc permission-tree/default-limits
+               :max-relationship-values 1)]
+    (is (= :eacl.permission-tree/limit-exceeded
+           (:type
+            (thrown-data
+             #(binding [backend/*invoke-observer*
+                        (fn [event]
+                          (when (= :resource->subjects
+                                   (:operation event))
+                            (swap! events conj (:phase event))))]
+                (expand adapter
+                        (eacl/spice-object :document "d1")
+                        :viewer
+                        limits))))))
+    (is (= 2 @realized))
+    (is (= [:before :after :failed] @events))))
+
+(deftest schema-definition-realization-is-incremental
+  (let [realized (atom 0)
+        definitions
+        (letfn [(items [id]
+                  (lazy-seq
+                   (swap! realized inc)
+                   (cons (relation id :document :viewer :user)
+                         (items (inc id)))))]
+          (items 100))
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :relations {[:document :viewer] definitions}})
+        limits
+        (assoc permission-tree/default-limits :max-schema-components 1)]
+    (is (= :eacl.permission-tree/limit-exceeded
+           (:type
+            (thrown-data
+             #(expand adapter
+                      (eacl/spice-object :document "d1")
+                      :viewer
+                      limits)))))
+    (is (= 2 @realized))))
+
+(deftest over-depth-arrow-does-not-start-a-source-scan
+  (let [realized (atom 0)
+        values
+        (lazy-seq
+         (swap! realized inc)
+         (list 10))
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :relations
+          {[:document :parent]
+           [(relation 100 :document :parent :folder)]
+           [:folder :viewer]
+           [(relation 200 :folder :viewer :user)]}
+          :permissions
+          {[:document :view]
+           [(component 300 :document :view
+                       :parent :relation :viewer)]}
+          :scans {[:document 1 100 :folder] values}})
+        limits
+        (assoc permission-tree/default-limits :max-depth 1)]
+    (is (= :eacl.permission-tree/limit-exceeded
+           (:type
+            (thrown-data
+             #(expand adapter
+                      (eacl/spice-object :document "d1")
+                      :view
+                      limits)))))
+    (is (zero? @realized))))
+
+(deftest over-node-budget-arrow-does-not-start-a-source-scan
+  (let [realized (atom 0)
+        values
+        (lazy-seq
+         (swap! realized inc)
+         (list 10))
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :relations
+          {[:document :parent]
+           [(relation 100 :document :parent :folder)]
+           [:folder :viewer]
+           [(relation 200 :folder :viewer :user)]}
+          :permissions
+          {[:document :view]
+           [(component 300 :document :view
+                       :parent :relation :viewer)]}
+          :scans {[:document 1 100 :folder] values}})
+        limits
+        (assoc permission-tree/default-limits :max-tree-nodes 1)]
+    (is (= :eacl.permission-tree/limit-exceeded
+           (:type
+            (thrown-data
+             #(expand adapter
+                      (eacl/spice-object :document "d1")
+                      :view
+                      limits)))))
+    (is (zero? @realized))))
+
+(deftest deadline-after-one-running-realization-fails-closed
+  (let [clock (atom 0)
+        realized (atom 0)
+        codec-counts (atom {})
+        values
+        (lazy-seq
+         (swap! realized inc)
+         ;; Model a synchronous realization that returns after the absolute
+         ;; deadline. The implementation cannot hard-cancel it, but must not
+         ;; render or schedule later work after it returns.
+         (reset! clock 1000)
+         (list 10))
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :internal->external {10 "alice"}
+          :codec-counts codec-counts
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :scans {[:document 1 100 :user] values}})
+        contract {:operation :expand-permission-tree
+                  :configured-timeout-ms 1
+                  :deadline-nanos 100}]
+    (is (= :eacl.execution/deadline-exceeded
+           (:type
+            (thrown-data
+             #(binding [execution/*monotonic-nanos*
+                        (fn [] (swap! clock inc))]
+                (permission-tree/expand
+                 adapter
+                 {:limits permission-tree/default-limits
+                  :execution-contract contract}
+                 (eacl/spice-object :document "d1")
+                 :viewer))))))
+    (is (= 1 @realized))
+    (is (= {} @codec-counts))))
+
+(deftest adapter-guard-errors-cannot-leak-scanned-identities
+  (let [sensitive-a 987654321
+        sensitive-b 123456789
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :runtime-guards? true
+          :internal->external
+          {sensitive-a "a" sensitive-b "b"}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          ;; Deliberately violates the strict ascending adapter contract.
+          :scans {[:document 1 100 :user]
+                  [sensitive-a sensitive-b]}})
+        error
+        (try
+          (expand adapter (eacl/spice-object :document "d1") :viewer)
+          nil
+          (catch #?(:clj clojure.lang.ExceptionInfo
+                    :cljs cljs.core.ExceptionInfo) cause
+            cause))
+        data (ex-data error)]
+    (is (= :eacl.permission-tree/adapter-contract-violation
+           (:type data)))
+    (is (nil? #?(:clj (.getCause error) :cljs (.-cause error))))
+    (is (not-any? #{sensitive-a sensitive-b}
+                  (tree-seq coll? seq data)))))
+
+(deftest adapter-cannot-spoof-a-kernel-error
+  (doseq [spoofed-type
+          [:eacl.permission-tree/limit-exceeded
+           :eacl.execution/deadline-exceeded]]
+    (let [adapter
+          (fake-adapter
+           {:objects {"d1" 1}
+            :relations
+            {[:document :viewer]
+             [(relation 100 :document :viewer :user)]}
+            :scan-error
+            (ex-info "secret-internal-id"
+                     {:type spoofed-type
+                      :internal-id 424242})})
+          error
+          (try
+            (expand adapter (eacl/spice-object :document "d1") :viewer)
+            nil
+            (catch #?(:clj clojure.lang.ExceptionInfo
+                      :cljs cljs.core.ExceptionInfo) cause
+              cause))
+          data (ex-data error)]
+      (is (= :eacl.permission-tree/adapter-contract-violation
+             (:type data)))
+      (is (= :adapter-operation-failed (:reason data)))
+      (is (nil? #?(:clj (.getCause error) :cljs (.-cause error))))
+      (is (not-any? #{424242}
+                    (tree-seq coll? seq data))))))
+
+(deftest selected-token-errors-are-redacted
+  (let [adapter
+        (fake-adapter
+         {:token-error
+          (ex-info "secret-internal-id"
+                   {:type :eacl.permission-tree/limit-exceeded
+                    :internal-id 424242})})
+        data
+        (thrown-data
+         #(permission-tree/selected-adapter-token adapter {}))]
+    (is (= :eacl.permission-tree/adapter-contract-violation
+           (:type data)))
+    (is (= :adapter-operation-failed (:reason data)))
+    (is (not-any? #{424242}
+                  (tree-seq coll? seq data)))))
+
+(deftest noncanonical-custom-external-ids-are-not-sorted-or-encoded
+  (let [custom-id #?(:clj (Object.) :cljs (js-obj))
+        adapter
+        (fake-adapter
+         {:objects {"d1" 1}
+          :internal->external {10 custom-id}
+          :relations
+          {[:document :viewer]
+           [(relation 100 :document :viewer :user)]}
+          :scans {[:document 1 100 :user] [10]}})]
+    (is (identical?
+         custom-id
+         (get-in
+          (expand adapter (eacl/spice-object :document "d1") :viewer)
+          [:leaf :subjects 0 :id])))))
+
+(defn- reference-expand
+  "Small independent evaluator used only by correspondence tests."
+  [{:keys [objects relations permissions scans internal->external]}
+   resource permission]
+  (letfn [(descriptor [type internal-id]
+            {:type type
+             :internal-id internal-id
+             :public (eacl/spice-object
+                      type (get internal->external internal-id))})
+          (relation-subjects [resource relation-name]
+            (if (nil? (:internal-id resource))
+              []
+              (into
+               []
+               (mapcat
+                (fn [{:keys [relation-id subject-type]}]
+                  (map #(descriptor subject-type %)
+                       (get scans
+                            [(:type resource) (:internal-id resource)
+                             relation-id subject-type]
+                            []))))
+               (get relations [(:type resource) relation-name] []))))
+          (expand* [resource name active]
+            (let [relation-definitions
+                  (get relations [(:type resource) name] [])
+                  permission-definitions
+                  (get permissions [(:type resource) name] [])]
+              (if (seq relation-definitions)
+                {:expanded-object (:public resource)
+                 :expanded-relation name
+                 :leaf
+                 {:subjects
+                  (mapv :public
+                        (relation-subjects resource name))}}
+                (let [key [[(:type resource) (:internal-id resource)] name]]
+                  (when (contains? active key)
+                    (throw (ex-info "reference cycle" {:key key})))
+                  {:expanded-object (:public resource)
+                   :expanded-relation name
+                   :intermediate
+                   {:operation :union
+                    :children
+                    (mapv
+                     (fn [{:keys [source-relation-name
+                                  target-type target-name]}]
+                       (if (= :self source-relation-name)
+                         (expand* resource target-name (conj active key))
+                         {:expanded-object (:public resource)
+                          :expanded-relation name
+                          :intermediate
+                          {:operation :union
+                           :children
+                           (mapv
+                            #(expand* % target-name (conj active key))
+                            (relation-subjects
+                             resource source-relation-name))}}))
+                     permission-definitions)}}))))
+          (root-descriptor []
+            {:type (:type resource)
+             :internal-id (get objects (:id resource))
+             :public (eacl/spice-object (:type resource) (:id resource))})]
+    (expand* (root-descriptor) permission #{})))
+
+(defn- normalized-unordered-tree
+  [tree]
+  (if-let [leaf (:leaf tree)]
+    (assoc tree :leaf
+           (update leaf :subjects
+                   #(vec (sort-by pr-str %))))
+    (assoc-in
+     tree
+     [:intermediate :children]
+     (->> (get-in tree [:intermediate :children])
+          (map normalized-unordered-tree)
+          (sort-by pr-str)
+          vec))))
+
+(defn- generated-fixture
+  [seed]
+  (let [users (vec (take (inc (mod seed 3)) [10 11 12]))
+        components
+        (cond->
+         [(component 400 :document :view :self :relation :viewer)]
+          (bit-test seed 0)
+          (conj (component 401 :document :view
+                           :self :permission :base))
+          (bit-test seed 1)
+          (conj (component 402 :document :view
+                           :parent
+                           (if (bit-test seed 4) :permission :relation)
+                           (if (bit-test seed 4) :view :reader)))
+          (bit-test seed 2)
+          (conj (component 403 :document :view
+                           :self :relation :viewer)))]
+    {:objects {"d1" 1}
+     :internal->external
+     {2 "same" 10 "u10" 11 "u11" 12 "u12"}
+     :relations
+     {[:document :viewer]
+      [(relation 100 :document :viewer :user)]
+      [:document :parent]
+      [(relation 101 :document :parent :folder)
+       (relation 102 :document :parent :team)]
+      [:folder :reader]
+      [(relation 200 :folder :reader :user)]
+      [:team :reader]
+      [(relation 300 :team :reader :user)]}
+     :permissions
+     {[:document :base]
+      [(component 350 :document :base :self :relation :viewer)]
+      [:document :view] components
+      [:folder :view]
+      [(component 360 :folder :view :self :relation :reader)]
+      [:team :view]
+      [(component 361 :team :view :self :relation :reader)]}
+     :scans
+     {[:document 1 100 :user] users
+      [:document 1 101 :folder] (if (bit-test seed 3) [2] [])
+      [:document 1 102 :team] [2]
+      [:folder 2 200 :user] (vec (reverse users))
+      [:team 2 300 :user] users}}))
+
+(deftest production-matches-independent-reference-and-permutations
+  (doseq [seed (range 32)]
+    (let [fixture (generated-fixture seed)
+          resource (eacl/spice-object :document "d1")
+          expected (reference-expand fixture resource :view)
+          actual (expand (fake-adapter fixture) resource :view)
+          permuted
+          (update fixture :scans
+                  (fn [scans]
+                    (into {}
+                          (map (fn [[key values]]
+                                 [key (vec (reverse values))]))
+                          scans)))
+          permuted-actual
+          (expand (fake-adapter permuted) resource :view)]
+      (is (= expected actual) (str "reference seed=" seed))
+      (is (every?
+           (fn [node]
+             (not= (contains? node :leaf)
+                   (contains? node :intermediate)))
+           (tree-seq
+            #(contains? % :intermediate)
+            #(get-in % [:intermediate :children])
+            actual))
+          (str "node oneof seed=" seed))
+      (is (= (normalized-unordered-tree actual)
+             (normalized-unordered-tree permuted-actual))
+          (str "permutation seed=" seed)))))
+
+(deftest pinned-spicedb-basic-any-arrow-golden
+  (let [adapter
+        (fake-adapter
+         {:objects {"testdoc" 1}
+          :internal->external
+          {2 "testfolder1" 3 "testfolder2"
+           10 "fred" 11 "tom" 12 "sarah"}
+          :relations
+          {[:document :folder]
+           [(relation 100 :document :folder :folder)]
+           [:folder :viewer]
+           [(relation 200 :folder :viewer :user)]}
+          :permissions
+          {[:document :view]
+           [(component 300 :document :view
+                       :folder :relation :viewer)]}
+          :scans
+          {[:document 1 100 :folder] [2 3]
+           [:folder 2 200 :user] [10 11]
+           [:folder 3 200 :user] [12]}})]
+    (is (= {:expanded-object
+            (eacl/spice-object :document "testdoc")
+            :expanded-relation :view
+            :intermediate
+            {:operation :union
+             :children
+             [{:expanded-object
+               (eacl/spice-object :document "testdoc")
+               :expanded-relation :view
+               :intermediate
+               {:operation :union
+                :children
+                [{:expanded-object
+                  (eacl/spice-object :folder "testfolder1")
+                  :expanded-relation :viewer
+                  :leaf
+                  {:subjects
+                   [(eacl/spice-object :user "fred")
+                    (eacl/spice-object :user "tom")]}}
+                 {:expanded-object
+                  (eacl/spice-object :folder "testfolder2")
+                  :expanded-relation :viewer
+                  :leaf
+                  {:subjects
+                   [(eacl/spice-object :user "sarah")]}}]}}]}}
+           (expand
+            adapter
+            (eacl/spice-object :document "testdoc")
+            :view)))))

--- a/openspec/changes/implement-expand-permission-tree/.openspec.yaml
+++ b/openspec/changes/implement-expand-permission-tree/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/implement-expand-permission-tree/design.md
+++ b/openspec/changes/implement-expand-permission-tree/design.md
@@ -1,0 +1,112 @@
+## Context
+
+See `proposal.md` for motivation and `specs/permission-tree-expansion/spec.md` for the observable contract. `IAuthorization` already declares `expand-permission-tree`; the shared orchestration client and Datomic `Spiceomic` currently throw `:eacl/not-implemented`.
+
+The v8 snapshot adapter exposes the necessary raw facts: `relation-defs`, `permission-defs`, `resource->subjects`, object-id conversion, immutable selection, and native revision identity. Permission definitions retain flat union components but not authored component order. The shipped relationship scans are ordered lazy index walks, while optional generic runtime guards currently realize a scan eagerly. Existing recursive authorization limits describe derived grants, advanced datoms, and queued work; they do not accurately describe an introspection tree.
+
+Black-box compatibility evidence uses the version-pinned SpiceDB v1.56.0 Docker service. The public API uses `SHALLOW` expansion. Its algebra is set-based; repeated protobuf fields carry results but do not establish a canonical semantic order.
+
+Concurrent repository work may touch shared files. Every implementation edit must re-read the target and preserve unrelated changes; no broad rewrites or generated-source replacement are permitted.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Isolate one portable CLJC expansion kernel from the authorization-decision engine.
+- Preserve supported SpiceDB shallow topology without reconstructing unavailable authored order.
+- Make identity, cycle, deadline, and structural-limit behavior explicit and fail closed.
+- Prove the mathematical kernel's central safety and semantic properties in Dafny, then differentially test the handwritten CLJC refinement.
+- Keep selection, reads, rendering, and token issuance on one immutable adapter.
+
+**Non-Goals:**
+
+- Add unsupported SpiceDB schema features or a recursive direct-subject expansion mode.
+- Treat successful Dafny verification as proof of Clojure, adapter, database, codec, scheduler, or cryptographic correctness.
+- Add a completed-tree cache, change token formats, alter persisted schema, or change the required adapter-operation arity set.
+- Guarantee production vector order or hard cancellation of a synchronous non-cooperative adapter operation.
+
+## Decisions
+
+### 1. Keep the public response as an explicit EACL mapping
+
+The public response is `{:expanded-at token :tree-root node}`. Nodes use `SpiceObject`, keyword relation names, `:union`, and vectors corresponding mechanically to the Authzed messages. This retains all oneof and annotation information and supersedes the dormant historical nested-vector examples, which never represented a successful shipped contract.
+
+The queried root descriptor always carries the exact supplied external `SpiceObject` plus an optional internal id. Same-resource descendants reuse that descriptor. Scanned arrow targets and leaf subjects use `{type, internal-id}` descriptors and are externalized later. This prevents unresolved numeric ids from being mistaken for renderable entities and prevents equal internal ids of different types from merging.
+
+### 2. Build topology in a focused portable namespace
+
+Add `eacl.permission-tree` as a CLJC namespace over `eacl.backend.v8`, `eacl.execution`, and public core records. Do not add expansion to the generated/formally verified authorization evaluator or reuse compiled permission paths: those paths describe denotation and may flatten proof topology.
+
+The builder reads raw relation and permission definitions from the selected adapter. A root with relation definitions becomes one combined direct leaf; a root with permission definitions becomes a union. Neither is an unknown-root error; both simultaneously are an adapter-contract violation. Permission components implement same-resource relation/permission dispatch and arrow unions exactly as specified. Exact duplicate normalized definition rows may collapse because persisted schema is set-valued, but distinct paths and nested union boundaries remain.
+
+Traversal is sequential and uses an explicit enter/exit work stack. Sequential evaluation makes budget and fake-clock failure boundaries reproducible across CLJ and CLJS. Active-path keys include object type, a request-local identity key, and permission name. Exit frames remove only the current branch, so diamonds remain legal. The implementation does not recursively depend on the host call stack.
+
+### 3. Treat collection order as representation, not semantics
+
+Production code does not sort external ids and therefore never adds `secure-format` portability as an object-id constraint. It may sort schema-only keys composed of keywords for reproducible local work, but callers cannot rely on any union-child or direct-subject vector order.
+
+Tests use a recursive unordered-multiset normalizer. The normalizer sorts only controlled portable fixture encodings, retains duplicate multiplicity, preserves annotations and node variants, and never flattens nested unions. Cross-backend comparison omits `:expanded-at`; token behavior is tested separately because native revisions are backend-specific.
+
+### 4. Give tree expansion its own structural budget
+
+Add `default-permission-tree-limits` and strict normalization for depth, schema components, relationship values, tree nodes, and leaf-subject occurrences. Limits are positive portable exact integers and partial client overrides merge with defaults. They are not included in cache fingerprints because expansion is not cached.
+
+One request-local budget value records all counters. Consumption checks occur before adding a schema component, realizing/accepting a relationship value, creating a node, or emitting a leaf subject. Errors contain only the operation, dimension, limit, and aggregate counters. Output is materialized entirely within the request; no lazy tree escapes.
+
+Add incremental guarded helpers for expansion's schema-definition and relationship sequences rather than changing existing adapter arities or disabling guards. Definition rows are deadline-checked and metered before accumulation; relationship scans validate natural ids, strict order, uniqueness by adjacent order, and bounds as values are consumed. Shipped adapters therefore stop lazy realization at the permission-tree limit. A third-party adapter may still perform arbitrary work before returning a sequence; the documented deadline boundary remains one already-running synchronous adapter operation or realization.
+
+### 5. Separate logical construction from selected-snapshot rendering
+
+Internal nodes contain typed descriptors, never public backend ids. A final iterative renderer uses `internal-id->object` on the already-selected adapter and memoizes each `[type internal-id]` conversion for the request. `nil` or invalid conversion is a typed boundary failure. The supplied root descriptor bypasses conversion and is rendered exactly as supplied.
+
+No global schema-derived or completed-tree cache participates in the first version. Request-local memoization may retain validated relation/permission definitions and rendered external identities because the selected adapter is immutable. Data-dependent subtrees are not memoized so branch multiplicity, accounting, and codec call boundaries remain obvious.
+
+### 6. Select once and issue the response token from that adapter
+
+Shared orchestration validates the request, creates one `:expand-permission-tree` execution contract, selects one context, runs the builder and renderer, then issues a token from that exact adapter's source scope and native revision. A small selected-adapter token helper is shared with Datomic without refreshing a connection.
+
+Datomic enters its existing `execute-request` and consistency selector before calling the portable kernel. DataScript and Datahike use shared orchestration. Deadline checks surround validation completion, selection, every definition read, every scan realization, work-frame processing, rendering conversion, and token issuance. The existing honest overrun statement applies: no subsequent work begins after expiry, but synchronous foreign work cannot be forcibly preempted.
+
+### 7. Model the semantic kernel in Dafny and state the proof boundary
+
+Add `formal/dafny/PermissionTree.dfy` with finite identifiers and datatypes for object keys, typed objects, relation definitions, permission components, direct relationships, annotated trees, budgets, and outcomes. The model uses sequences for representation and multisets/sets for semantic equality. It defines shallow expansion with explicit fuel, active paths, and monotone counters.
+
+The verified obligations include:
+
+- every successful node is oneof-well-formed and annotated with its expansion target;
+- direct leaves contain exactly the matching snapshot relationships across all declared subject types;
+- union denotation is the union of child denotations and is invariant under child permutation;
+- an absent resource has the same schema topology with empty data-dependent leaves;
+- an active-path revisit cannot produce success;
+- successful counters stay within every configured limit and failures produce no tree;
+- budget consumption is monotone and the same immutable snapshot parameter governs every read.
+
+The model includes executable witness methods for direct, union, arrow, empty, diamond, cycle, sum-typed relations, emitted-child depth, and limit cases plus mutation-control lemmas whose negated claims must fail verification. `bin/formal verify` verifies the module under the locked toolchain and records its exact proof effort. The assurance matrix and manifest name the theorem and retain `:adapter-contract`, `:host-source-specializations`, and Clojure-to-Dafny correspondence as residual assumptions.
+
+Handwritten CLJC is not mechanically extracted. An independent pure reference evaluator and property generators compare runtime topology and failure classes over exhaustive bounded schemas/relationships, including permutations and type/id collisions. This is differential refinement evidence, not a formal Clojure semantics proof.
+
+### 8. Make SpiceDB evidence reproducible
+
+Each golden fixture stores the Docker image tag and digest, schema, relationships, request, captured protobuf JSON tree, and normalized expected EACL tree. The fixture is captured by a black-box run of the SpiceDB v1.56.0 Docker image at the recorded digest. Regular tests remain offline. Normalization ignores token bytes, default-valued empty subject relations, and unordered union/leaf order but preserves multiplicity, annotations, variants, and nested boundaries.
+
+The compatibility fixture set covers direct and empty relations, union flattening within one permission, nested permission boundaries, arrow-to-relation, arrow-to-permission, multi-subject-type relations, absent objects, and duplicate paths. Custom/non-string ids are tested only as EACL extensions.
+
+## Risks / Trade-offs
+
+- [A verified model can be mistaken for verified production code] → Record the source-refinement and adapter boundaries in the model header, assurance matrix, manifest, and documentation.
+- [Trees can grow exponentially] → Use explicit structural limits, sequential deterministic accounting, one deadline, and all-or-error materialization.
+- [A non-cooperative adapter can overrun the deadline] → Start no later work, fail after return, and make no hard-cancellation claim.
+- [No production ordering guarantee complicates display code] → Document unordered semantics and provide a fixture/test normalizer without restricting custom ids.
+- [Active-path logic can accidentally reject diamonds] → Use enter/exit frames rather than a global visited set and prove/test the distinction.
+- [Concurrent edits can be overwritten] → Re-read and compare every target immediately before patching; preserve unrelated hunks and stop on overlap.
+- [Published SpiceDB behavior evolves] → Pin the image tag and digest and require deliberate fixture regeneration when advancing versions.
+
+## Migration Plan
+
+1. Verify the Dafny semantic model, executable witnesses, mutation controls, and assurance metadata before runtime implementation.
+2. Add failure-first reference and CLJC unit tests, then implement the isolated portable kernel and limits.
+3. Wire shared orchestration and Datomic separately, running focused nREPL tests after each target.
+4. Add version-pinned black-box SpiceDB fixtures, all-backend contracts, CLJS coverage, concurrency/deadline tests, and documentation.
+5. Run the complete formal, static, CLJ, and CLJS gates and strict OpenSpec validation.
+
+Rollback is a code-only revert restoring `:eacl/not-implemented`; no stored data, token, cursor, or cache migration is required.

--- a/openspec/changes/implement-expand-permission-tree/proposal.md
+++ b/openspec/changes/implement-expand-permission-tree/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`eacl/expand-permission-tree` is part of the public authorization protocol but every shipped client raises `:eacl/not-implemented`. Issue #111 requires snapshot-consistent permission introspection whose supported semantics are checked against SpiceDB and whose completeness, cycle, and resource-limit rules have executable formal evidence rather than relying only on examples.
+
+## What Changes
+
+- Implement `eacl/expand-permission-tree` for Datomic, DataScript, and Datahike over one selected immutable snapshot.
+- Return an explicit EACL map corresponding to Authzed's `ExpandPermissionTreeResponse` and `PermissionRelationshipTree` messages.
+- Support direct relations, same-resource relation and permission references, EACL's supported single-level arrows, empty branches, absent resource ids, and recursive graphs.
+- Define SpiceDB compatibility as shallow topology and leaf-membership equivalence for EACL-supported schemas and SpiceDB-valid string ids, after field conversion and order-insensitive multiset normalization.
+- Reject malformed or ambiguous requests before snapshot selection and fail closed on cycles, deadlines, structural limits, codec failures, or adapter-contract violations without returning a partial tree.
+- Add a dedicated, validated `:permission-tree-limits` client option because existing authorization traversal limits do not model expansion depth, tree nodes, or repeated leaf occurrences.
+- Add a Dafny model and proof obligations for tree well-formedness, sum-typed direct-leaf exactness, union denotation, empty expansion, active-path cycle rejection, emitted-child depth, and monotone all-or-error budget accounting. The formal claim will explicitly retain adapters and Clojure-to-Dafny correspondence as trusted boundaries.
+- Add version-pinned black-box SpiceDB golden fixtures, shared cross-backend contracts, CLJ/CLJS property tests, concurrency tests, and documentation.
+
+## Capabilities
+
+### New Capabilities
+
+- `permission-tree-expansion`: Snapshot-consistent, bounded, formally modeled shallow expansion of a resource relation or permission into algebraic union nodes and direct-subject leaves across the supported EACL backends.
+
+### Modified Capabilities
+
+None. The adapter arity and required-operation set remain unchanged; expansion consumes the existing snapshot operations incrementally and owns its public limits and error contract.
+
+## Impact
+
+- Public API: `eacl.core/IAuthorization.expand-permission-tree` changes from a typed not-implemented failure to an operational read API.
+- Public client configuration: all shipped clients accept `:permission-tree-limits` with documented defaults and strict validation.
+- Shared implementation: a new portable CLJC permission-tree namespace, request validation, incremental guarded scan consumption, selected-snapshot token issuance, and shared contract fixtures.
+- Backend wiring: DataScript and Datahike use shared orchestration; Datomic retains its consistency wrapper but delegates the semantic expansion to the same portable implementation.
+- Formal evidence: a new Dafny module plus assurance-matrix and manifest coverage; this does not alter the generated authorization decision kernel or claim mechanical extraction of the Clojure implementation.
+- Tests and documentation: version-pinned Docker fixture provenance, backend integration and mutation tests, CLJS coverage, READMEs, and release notes.
+- Dependencies and storage: no new runtime dependency, persisted attribute, schema migration, token-format change, or completed-tree cache.

--- a/openspec/changes/implement-expand-permission-tree/specs/permission-tree-expansion/spec.md
+++ b/openspec/changes/implement-expand-permission-tree/specs/permission-tree-expansion/spec.md
@@ -1,0 +1,163 @@
+## Purpose
+
+Defines EACL's snapshot-consistent, bounded shallow permission-tree introspection contract and its scoped behavioral equivalence to SpiceDB.
+
+## ADDED Requirements
+
+### Requirement: Expansion requests are strict and unambiguous
+`expand-permission-tree` SHALL accept a map containing exactly the required `:resource` and `:permission` keys plus optional `:consistency` and `:timeout-ms`. The resource SHALL be map-like with an unqualified keyword `:type`, a non-nil `:id`, and no non-nil subject `:relation`; the permission SHALL be an unqualified keyword. EACL MUST reject unknown query keys, pagination controls, cache controls, evaluation controls, malformed resources, invalid timeout values, and unsupported consistency descriptors before schema or relationship reads.
+
+#### Scenario: Valid minimal request
+- **WHEN** a caller supplies `{:resource (spice-object :document "roadmap") :permission :view}`
+- **THEN** EACL defaults consistency to `:minimize-latency` and begins expansion under the client's finite execution timeout
+
+#### Scenario: Unknown query key
+- **WHEN** a request contains an unrecognized key such as `:cache?`, `:evaluation`, or a misspelling
+- **THEN** EACL throws a typed invalid-request error before snapshot selection
+
+#### Scenario: Subject reference used as resource
+- **WHEN** the supplied resource has a non-nil `:relation`
+- **THEN** EACL rejects it because Authzed expansion requires an object reference rather than a subject reference
+
+### Requirement: Success returns an explicit PermissionRelationshipTree mapping
+A successful call SHALL return `{:expanded-at token :tree-root node}`. `token` SHALL be an authenticated EACL causal token for the selected snapshot. Every node SHALL contain `:expanded-object` as a `SpiceObject`, `:expanded-relation` as a keyword, and exactly one of `:intermediate` or `:leaf`. An intermediate value SHALL be `{:operation :union :children [...]}` and a leaf value SHALL be `{:subjects [...]}` containing `SpiceObject` subject references.
+
+#### Scenario: Direct relation response
+- **WHEN** a defined direct relation is expanded
+- **THEN** the root is a leaf annotated with the requested resource and relation and its subjects are the direct relationships at `:expanded-at`
+
+#### Scenario: Permission response
+- **WHEN** a defined permission is expanded
+- **THEN** the root is a union intermediate annotated with the requested resource and permission
+
+#### Scenario: Node oneof invariant
+- **WHEN** EACL publishes any tree node
+- **THEN** that node has one and only one tree variant and contains no backend entity id or private unresolved marker
+
+### Requirement: Expansion follows SpiceDB shallow semantics for the EACL schema subset
+Expansion SHALL recursively follow normalized permission union components, same-resource relation references, same-resource permission references, and supported single-level arrows. Direct relation subjects SHALL remain terminal leaf entries. The type of every arrow intermediate SHALL come from its concrete source-relation definition, so equal backend ids under different object types remain distinct.
+
+#### Scenario: Same-resource relation reference
+- **WHEN** a permission component names a direct relation on the same resource
+- **THEN** the child is that relation's direct leaf on the same expanded object
+
+#### Scenario: Same-resource permission reference
+- **WHEN** a permission component names another permission on the same resource
+- **THEN** the child is the referenced permission's expansion on the same expanded object without flattening its union boundary
+
+#### Scenario: Arrow to relation
+- **WHEN** a permission component is `source_relation->target_relation`
+- **THEN** the arrow branch is a union containing the target-relation leaf for every typed intermediate object directly related through `source_relation`
+
+#### Scenario: Arrow to permission
+- **WHEN** a permission component is `source_relation->target_permission`
+- **THEN** the arrow branch is a union containing the target-permission expansion for every typed intermediate object directly related through `source_relation`
+
+#### Scenario: Same internal id under different types
+- **WHEN** two source-relation partitions contain the same backend entity id under different declared subject types
+- **THEN** EACL expands both typed objects independently and never merges them by entity id alone
+
+#### Scenario: Direct leaf is terminal
+- **WHEN** a direct relation contains subjects
+- **THEN** EACL returns those subject references without replacing them with a transitive authorization denotation
+
+### Requirement: Empty and absent resources preserve schema topology and root identity
+Valid schema roots SHALL produce structurally valid empty data-dependent branches. EACL SHALL retain the exact supplied root object independently from optional backend resolution, including numeric or custom ids that do not resolve to an entity.
+
+#### Scenario: Empty direct relation
+- **WHEN** a valid direct relation has no relationships for the requested resource
+- **THEN** expansion returns a leaf with `:subjects []`
+
+#### Scenario: Absent resource id
+- **WHEN** the schema root is valid but the supplied id has no backing entity
+- **THEN** EACL returns the supplied root id unchanged and builds the same schema topology with empty data-dependent branches
+
+#### Scenario: Empty arrow
+- **WHEN** an arrow's source relation has no intermediate objects
+- **THEN** the arrow union remains present with `:children []`
+
+### Requirement: One immutable snapshot governs the whole response
+Request schema resolution, relationship reads, external object rendering, and `:expanded-at` issuance SHALL use one selected immutable adapter. EACL SHALL honor the selected backend's advertised consistency modes and MUST NOT weaken an unsupported or unavailable request.
+
+#### Scenario: Concurrent mutation
+- **WHEN** schema or relationships change while expansion is running
+- **THEN** every node and subject reflects only the immutable snapshot named by `:expanded-at`
+
+#### Scenario: Causal replay
+- **WHEN** a caller uses `:expanded-at` with a supported at-least-as-fresh or exact-snapshot descriptor
+- **THEN** EACL selects a satisfying snapshot or returns the established typed consistency error
+
+#### Scenario: Unsupported consistency
+- **WHEN** a backend cannot honor the requested consistency mode
+- **THEN** EACL fails explicitly and returns no tree from a weaker snapshot
+
+### Requirement: Union and direct-subject ordering is non-semantic
+`:children` and `:subjects` SHALL be vectors but their order SHALL NOT be a public compatibility guarantee. Equality across backends and with SpiceDB SHALL compare recursively normalized unordered multisets while preserving duplicate multiplicity, node annotations, intermediate boundaries, and tree variants. EACL MUST NOT reject an otherwise valid custom external id merely to impose canonical production ordering.
+
+#### Scenario: Backend index order differs
+- **WHEN** equivalent relationships are visited in different orders by two backends
+- **THEN** their trees are equivalent after unordered-multiset normalization
+
+#### Scenario: Duplicate logical path
+- **WHEN** distinct permission paths produce structurally equal children
+- **THEN** normalization preserves both occurrences rather than converting children to a set
+
+#### Scenario: Non-canonical custom id
+- **WHEN** a configured codec returns a valid EACL id that `secure-format` cannot encode canonically
+- **THEN** expansion returns that id and does not use canonical encoding as an additional validity requirement
+
+### Requirement: Expansion is structurally bounded and all-or-error
+All clients SHALL accept a `:permission-tree-limits` configuration map with defaults `{:max-depth 50 :max-schema-components 100000 :max-relationship-values 100000 :max-tree-nodes 100000 :max-leaf-subjects 100000}`. Partial overrides SHALL merge with the defaults; unknown keys, non-positive values, and values outside the portable exact-integer range SHALL be rejected at client construction. These limits SHALL be client configuration and MUST NOT be overridable per request. Exceeding a limit SHALL throw `:eacl.permission-tree/limit-exceeded` with the operation, exceeded dimension, configured limit, and safe consumed-work counters.
+
+#### Scenario: Maximum depth exceeded
+- **WHEN** expansion would create a node deeper than `:max-depth`
+- **THEN** EACL returns the typed limit error without constructing or returning a partial tree
+
+#### Scenario: Relationship limit exceeded
+- **WHEN** consuming the next source or leaf relationship would exceed `:max-relationship-values`
+- **THEN** EACL fails before publishing the accumulated tree
+
+#### Scenario: Per-request limit override
+- **WHEN** a request contains `:permission-tree-limits`
+- **THEN** EACL rejects the request before snapshot selection
+
+### Requirement: Cycles and deadlines fail closed
+Expansion SHALL track only the active expansion path, allowing repeated nodes in sibling branches while rejecting a node revisited on its current path with `:eacl.permission-tree/cycle-detected`. The operation SHALL share EACL's single monotonic execution deadline and SHALL check it before and after selection, schema reads, relationship value realization, child scheduling, rendering, and token issuance. No cycle, limit, codec, adapter, or deadline failure SHALL return a partial tree.
+
+#### Scenario: Active-path cycle
+- **WHEN** same-resource or arrow permission recursion revisits an expansion active on the current path
+- **THEN** EACL throws the typed cycle error with safe path metadata and no response
+
+#### Scenario: Diamond graph
+- **WHEN** sibling branches reach the same expansion but it is not active in one branch while the other is evaluated
+- **THEN** both branches are legal and appear independently
+
+#### Scenario: Deadline during adapter work
+- **WHEN** the deadline expires while one synchronous adapter operation or sequence realization is already running
+- **THEN** EACL starts no later work and throws `:eacl.execution/deadline-exceeded` after that operation returns or aborts, without claiming hard cancellation
+
+### Requirement: Boundary violations never leak internal identities
+Actual scanned internal ids SHALL be externalized through the selected adapter exactly once per request-local memoized identity. A missing external value, malformed schema definition, contradictory relation/permission root, or invalid adapter output SHALL fail with a typed codec or adapter-contract error. Error diagnostics MUST NOT expose backend entity ids or relationship subject values.
+
+#### Scenario: Codec returns nil for a scanned subject
+- **WHEN** the selected adapter cannot externalize an internal id returned by its own relationship scan
+- **THEN** expansion fails closed with a typed boundary error and no partial tree
+
+#### Scenario: Corrupt root definitions
+- **WHEN** an adapter returns both relation and permission definitions for the same root name or malformed definition rows
+- **THEN** EACL reports an adapter-contract violation instead of choosing an interpretation
+
+### Requirement: SpiceDB compatibility is scoped and reproducible
+For EACL-supported union, same-resource reference, and single-level arrow schemas using SpiceDB-valid string object ids, shallow tree topology, expanded annotations, empty branches, duplicate multiplicity, and direct-subject membership SHALL equal the response captured from a version-pinned SpiceDB Docker image after mechanical field conversion and unordered-multiset normalization. Authzed features rejected by EACL schema validation, non-string custom ids, token byte equality, incidental vector order, error-code identity, and resource-limit timing SHALL remain outside the equivalence claim.
+
+#### Scenario: Provenance-bearing golden fixture
+- **WHEN** a supported fixture records its schema, relationships, request, Docker image tag and digest, and raw protobuf JSON response
+- **THEN** mechanical normalization of its tree equals every shipped backend's result
+
+#### Scenario: Unsupported feature
+- **WHEN** a schema contains intersection, exclusion, subject relations, caveats, wildcards, `.all`, multi-level arrows, or another already rejected feature
+- **THEN** expansion does not weaken schema validation or claim SpiceDB equivalence for it
+
+#### Scenario: Custom id extension
+- **WHEN** EACL expands a valid numeric or custom external id
+- **THEN** the EACL rendering contract applies but the SpiceDB differential claim does not

--- a/openspec/changes/implement-expand-permission-tree/tasks.md
+++ b/openspec/changes/implement-expand-permission-tree/tasks.md
@@ -1,0 +1,55 @@
+## 1. Reference Contract and Failure-First Tests
+
+- [x] 1.1 Record the pinned Docker image tag and digest, fixture schema/relationships/request, raw protobuf JSON, and order-insensitive normalization rules with duplicate multiplicity preserved.
+- [x] 1.2 Add portable request/response contract tests for exact query keys, malformed resources, non-nil resource relations, timeout validation, unknown roots, node oneof invariants, and internal-id non-disclosure.
+- [x] 1.3 Add pure reference-evaluator fixtures for direct and empty relations, same-resource relations and permissions, arrows to relations and permissions, absent roots, multi-subject types, same-id/different-type intermediates, duplicate paths, diamonds, cycles, and every limit dimension.
+- [x] 1.4 Add property generators for bounded schemas and relationships plus permutation checks proving production vector order is non-semantic and non-canonical custom ids remain valid.
+
+## 2. Dafny Semantic Model and Assurance Boundary
+
+- [x] 2.1 Add `formal/dafny/PermissionTree.dfy` with snapshot, schema, relationship, typed-object, permission-component, annotated-tree, active-path, budget, and outcome datatypes.
+- [x] 2.2 Define executable shallow expansion and denotation functions for direct relations, permission unions, same-resource references, arrows, empty resources, cycles, and all-or-error limits.
+- [x] 2.3 Prove node oneof/annotation well-formedness, exact direct leaves including sum-typed relation declarations, union-denotation and permutation invariance, absent-resource topology, active-path rejection, emitted-child depth accounting, budget monotonicity, and successful-limit preservation.
+- [x] 2.4 Add executable direct/union/arrow/empty/diamond/cycle/limit witnesses and mutation controls that demonstrate the proofs reject unsound flattening, global-visited cycle detection, type-erasing identity, partial success, and over-limit success.
+- [x] 2.5 Register the model in the assurance matrix and manifest with exact trusted boundaries and no claim of mechanical Clojure extraction.
+- [x] 2.6 Run locked Dafny formatting and verification until the module has zero verification errors and its proof-effort report is recorded.
+
+## 3. Portable Expansion Kernel
+
+- [x] 3.1 Add strict `:permission-tree-limits` defaults/normalization to shared and Datomic clients and forbid per-request overrides.
+- [x] 3.2 Add an incremental guarded scan consumer that meters realized values without eagerly materializing the complete adapter sequence and preserves existing adapter arities.
+- [x] 3.3 Add `eacl.permission-tree` request validation, typed errors, definition validation, root resolution, typed identity descriptors, and request-local budgets.
+- [x] 3.4 Implement explicit-stack direct relation and permission-union construction for same-resource relation/permission references and arrow targets while preserving empty branches, nested boundaries, multiplicity, and active-path diamonds.
+- [x] 3.5 Implement iterative selected-adapter rendering with request-local codec memoization, exact supplied-root rendering, typed nil/invalid codec failures, and no production canonical sorting.
+- [x] 3.6 Add deadline checks around every modelled definition read, scan realization, work-frame transition, render conversion, and completion boundary; verify no failure returns a lazy or partial tree.
+- [x] 3.7 Compare the portable kernel against the independent reference evaluator across exhaustive bounded fixtures and property-generated cases in CLJ and CLJS.
+
+## 4. Snapshot, Token, and Client Wiring
+
+- [x] 4.1 Add and test a selected-adapter causal-token helper that never re-reads a live connection.
+- [x] 4.2 Add shared orchestration validation, execution normalization, consistency selection, expansion, rendering, token issuance, and response assembly for DataScript and Datahike.
+- [x] 4.3 Wire Datomic `Spiceomic` through its existing `execute-request` and selected-snapshot path into the same portable kernel.
+- [x] 4.4 Update the protocol documentation and replace all shipped `:eacl/not-implemented` branches while preserving third-party protocol compatibility.
+- [x] 4.5 Add concurrent schema/relationship mutation and causal replay tests proving tree data, rendering, and `:expanded-at` use one snapshot for every supported backend mode.
+
+## 5. Cross-Backend and SpiceDB Verification
+
+- [x] 5.1 Extend `eacl.contract-support` and run the expansion contract against Datomic, DataScript, Datahike with both Datahike attribute modes, and the DataScript CLJS runner.
+- [x] 5.2 Add adapter instrumentation and hostile lazy-sequence tests for partition scope, incremental realization, runtime guards, deadline overrun honesty, and structural work ceilings.
+- [x] 5.3 Capture every golden tree through the version-pinned SpiceDB Docker service and compare normalized topology and leaf multisets against all shipped backends.
+- [x] 5.4 Replace the Datomic protocol test expecting not-implemented and the ignored historical expansion examples with the explicit documented response.
+- [x] 5.5 Run codec tests covering strings, numbers, unresolved numeric ids, deterministic custom ids, non-canonical values, nil conversion, and equal internal ids under different types.
+
+## 6. Documentation and Compatibility
+
+- [x] 6.1 Update the root and module READMEs with request/response examples, unordered semantics, shallow-versus-denotation guidance, limits, consistency-token replay, typed errors, and backend differences.
+- [x] 6.2 Update release/upgrade notes with the additive behavior, new client option, scoped SpiceDB claim, formal assurance boundary, absence of migration, and rollback procedure.
+- [x] 6.3 Update formal-verification navigation and trusted-boundary documentation with the PermissionTree theorem map, proof commands, residual assumptions, and correspondence-test locations.
+
+## 7. Final Verification
+
+- [x] 7.1 Re-read concurrent work state and inspect every changed file for unrelated edits, unresolved not-implemented paths, accidental internal-id exposure, and new dependencies or persisted attributes.
+- [x] 7.2 Through the discovered nREPL and `:reload`, run focused permission-tree, execution, configuration, shared contract, Datomic, DataScript, Datahike, and formal correspondence test namespaces with zero failures or errors.
+- [x] 7.3 Run the DataScript CLJS suite and the repository's complete non-benchmark EACL test suite through nREPL with zero regressions.
+- [x] 7.4 Run locked Dafny format/verify, formal mutation controls and manifest generation as applicable, formatting/static/source-closure checks, and inspect exact verification claims.
+- [x] 7.5 Run `openspec validate implement-expand-permission-tree --strict`, reconcile artifacts/tasks with the implemented behavior, and perform a final adversarial audit documenting any residual trusted boundary rather than claiming literal universal certainty.


### PR DESCRIPTION
## Summary

- implement snapshot-consistent, shallow permission-tree expansion across all shipped backends
- enforce structural limits, deadlines, cycle handling, typed errors, and client orchestration support
- add a formally verified Dafny model, completed OpenSpec artifacts, documentation, and black-box interoperability evidence

## Why

Issue #111 exposed a protocol operation that shipped clients could not execute. This implements the operation while bounding resource use and preserving snapshot consistency and information-flow guarantees.

## Impact

- adds `eacl/expand-permission-tree` for Datomic, Datahike, and DataScript
- adds `:permission-tree-limits` client configuration and backend contract coverage
- records the handwritten runtime-to-model correspondence and the remaining conditional assurance limits

## Validation

- JVM: 617 tests, 25,542 assertions, 0 failures/errors
- focused JVM permission-tree suite: 83 tests, 1,147 assertions, 0 failures/errors
- ClojureScript: 210 tests, 7,424 assertions, 0 failures/errors
- Dafny: 30 modules, 8,785 proof efforts, 0 errors; permission-tree model: 62 proof efforts
- mutation controls: 2 tests, 215 assertions, 0 failures/errors
- reflection gate, formal formatting/source closure, OpenSpec strict validation, and `git diff --check` pass
- black-box interoperability fixture verified with a version-pinned Docker image

This PR is stacked on #110; review the commits after `agent/add-safe-retraction-functions`.

Implements #111.
