### PR TITLE
Add cooperative cancellation to EACL reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,37 @@ All list APIs use the v8 Relay pagination contract:
 - `:cursor` and `:limit` are no longer supported for list pagination.
 - Acyclic lookup cursors paginate in Datomic eid order. Recursive lookup cursors paginate in deterministic traversal order.
 
+### Deadlines and cooperative cancellation
+
+Every bounded read accepts an optional per-request `:cancellation-token` in
+addition to `:timeout-ms`. Create and cancel the token through the public EACL
+API:
+
+```clojure
+(let [token (eacl/cancellation-token)]
+  ;; Give `token` to the HTTP/request owner before starting the read.
+  (future
+    (eacl/lookup-resources
+     acl
+     {:subject (eacl/spice-object :user "alice")
+      :permission :view
+      :resource/type :document
+      :first 100
+      :cancellation-token token}))
+  (eacl/cancel! token))
+```
+
+Cancellation is cooperative and best-effort. EACL checks it at the same
+orchestration, cursor, cache, traversal-quantum, and adapter-command boundaries
+as the absolute deadline and, when observed before completion, throws
+`:eacl.execution/cancelled` without returning a partial answer. A synchronous
+adapter call already in progress must return before the next check, and a
+completed result may win a race with a late cancellation. Applications must
+therefore keep the server deadline and bounded admission control; interrupting
+a worker thread is not a substitute. The token is execution-only and is
+excluded from cache, continuation, and authenticated cursor identity. One
+token belongs to one logical request.
+
 ### Schema Maintenance
 
 - `(eacl/write-schema! acl schema-string)` parses a SpiceDB schema DSL string, validates it, computes deltas against existing schema, checks for orphaned relationships, and transacts changes atomically.
@@ -231,7 +262,7 @@ the authorization schema directly, follow the recovery procedure in
 ### Permission-tree expansion
 
 Expansion accepts exactly `:resource`, `:permission`, and the optional
-`:consistency` and `:timeout-ms` keys:
+`:consistency`, `:timeout-ms`, and `:cancellation-token` keys:
 
 ```clojure
 (eacl/expand-permission-tree

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -223,6 +223,16 @@ encoded-byte, decoded-weight, and candidate-count controls are rejected. Native
 per-tier/per-entry weights remain construction-time cache limits, while the
 single request `:timeout-ms` remains the end-to-end deadline.
 
+Bounded reads also accept a per-request `:cancellation-token` created by
+`eacl.core/cancellation-token`. `eacl.core/cancel!` is idempotent; the next
+cooperative orchestration, cache, cursor, traversal-quantum, or adapter-boundary
+check throws `:eacl.execution/cancelled` and returns no partial answer.
+Tokens never participate in semantic cache, continuation, or authenticated
+cursor identity. An adapter call already executing remains synchronous and
+must return before cancellation can be observed; a completed result may also
+win a race with a late cancellation. Deadlines and bounded admission remain
+required.
+
 ## Cursor redesign
 
 Portable cursor payloads are v10 inside the compact `eacl_c4_` authenticated

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -106,7 +106,7 @@ representative heap and load testing.
 
 All bundled adapters implement `expand-permission-tree` through one portable
 CLJ/CLJS kernel. The strict request is `{:resource object :permission keyword}`
-plus optional `:consistency` and `:timeout-ms`; the response is
+plus optional `:consistency`, `:timeout-ms`, and `:cancellation-token`; the response is
 `{:expanded-at token :tree-root node}`. The token and every definition,
 relationship, and rendered ID in the tree come from one selected immutable
 adapter. Datomic can replay the exact token while history is retained;
@@ -134,6 +134,14 @@ These are construction-time ceilings; requests cannot override them. Limit,
 deadline, cycle, codec, adapter-contract, unknown-root, and consistency
 failures are typed and return no partial tree. This feature adds no schema,
 stored attribute, dependency, or database migration.
+
+Every bounded read accepts the same per-request cooperative cancellation
+token. Create it with `eacl.core/cancellation-token` and signal it with
+`eacl.core/cancel!`. Adapters do not need a new SPI operation: the shared
+orchestrator and generated traversal check the token before and after adapter
+commands. A synchronous command already in progress must return before the
+check can observe cancellation; adapter implementations with their own long
+loops should call `eacl.execution/check!` at bounded internal checkpoints.
 
 ## Backend extension boundary
 

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "3ff5e42e1b5e3b2f2b22646042a5cecb312221a08f1b5547aeaee390973025ea"
+      "sha256": "bc3ed56cd15798d964450f08ba0348aab17f87164c4ace599f8dac1ef09b9eeb"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -129,7 +129,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "75fde46c144ed9dcc0beaa8d7ea997e628b8b7c873afb9b7c502b89db048a97a"
+      "sha256": "fd0d0f9af196606983ed84db83bd7f6d65627a45f7d816f78b51c8beeabc03b4"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -137,7 +137,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "f5ed8b4ffbdbc862a033419e62e42cbe5307e02cb28290df2dacbbcf6f705554"
+      "sha256": "c0e3a0966d112288e9b146f80b50d1729e5542fbd047236db14a9ecb5065e8fc"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -149,7 +149,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/core.cljc",
-      "sha256": "daf0d89cfa16a5d4bf47ebf233b014d3e48f63424ffa0238fca8c2ffab313379"
+      "sha256": "80c91c888819fc329b541627a844f7ad1ca73b6031e3176c6b678dc528d8339e"
     },
     {
       "path": "modules/eacl/src/eacl/cursor.cljc",
@@ -169,11 +169,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "9287e7922772c7fc92c9e531a6e75abdbdbf3aa7ec7de1ec0f38947f50661474"
+      "sha256": "eb4cb1a1af7f6e01e9f0ceb0998b2ea849726e3bd3fdff430434dc2adb9cc90c"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
-      "sha256": "a04351e315546731e4767c11a58d3dd9811d96c9408fbf3b77228bfa2b98d9a6"
+      "sha256": "e16f1426ae71812b9e1adcc84d54063a2e132f7abcb74dd89ba97cfa9b26697b"
     },
     {
       "path": "modules/eacl/src/eacl/formal/generated_runtime.clj",
@@ -193,7 +193,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/permission_tree.cljc",
-      "sha256": "dd04910fac6a0c5a6c6fd9ba13b3c824fc53e46ec79a74cd8c65612f7db4f514"
+      "sha256": "7adffe10a3064ddc9cd22498ff0361e3778ac8a4cc742ed2e5bf9cb73850f0e9"
     },
     {
       "path": "modules/eacl/src/eacl/proof_frame.cljc",
@@ -205,7 +205,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/relationships/filters.cljc",
-      "sha256": "f4f8928e47ede0b312f2e071b6329d3ebc4e77ffb3fb7ca75b3e181ee0a1bd12"
+      "sha256": "015b909c400f3174b1bf0adca5ad6ee5f4d51bf355d714ae4ff0c365cf43acab"
     },
     {
       "path": "modules/eacl/src/eacl/relationships/safe_retraction.cljc",
@@ -217,7 +217,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/relay.cljc",
-      "sha256": "af7532296bdd9bde9dd7ed2d00b71025c29cee54ab732d32980781ad788ec124"
+      "sha256": "81c013bc2a44ed7cad6e98c81d6ccbb4e29dddc4586b0b78727affd7a3ee989e"
     },
     {
       "path": "modules/eacl/src/eacl/schema/errors.cljc",
@@ -315,9 +315,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 63,
-    "unionInternalDefinitionCount": 1413,
-    "unionInternalDefinitionIdsSha256": "bfe049afe03dcd297cf19f3d97e580f6a0dccf86f6794a7ebe3384fd1a872c25",
-    "unionDefinitionLocationsSha256": "fbdaa7da108209f56fd6c984893362edcf1ca325d4fcb6070fc65529add604d8",
+    "unionInternalDefinitionCount": 1418,
+    "unionInternalDefinitionIdsSha256": "1079b97cbd3c2b53e2929fa7e36318de4b12c813bd77656a9069ad6356c2aafa",
+    "unionDefinitionLocationsSha256": "ec59b839086c56648cb3c8346d7069348d68515146f9850f4df6b721b57a8cde",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 13,
@@ -452,8 +452,8 @@
         "idsSha256": "b2d44526d5a05adcbf8c3fc6e23be3ee20b0ca9dc119a173bf3f6f8d30597f4d"
       },
       "modules/eacl/src/eacl/execution.cljc": {
-        "count": 21,
-        "idsSha256": "f8b38d4b64ac440a651dd6d1868e976790ed7fc083ecb2fa8918864bac87c1a9"
+        "count": 26,
+        "idsSha256": "fa9e08b56ab45e4661cd623732c2a5afb02b959f53b46d2adaabed10f18daa3f"
       },
       "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs": {
         "count": 2,
@@ -531,8 +531,8 @@
   },
   "roots": {
     "eacl.engine.v8/can?": {
-      "internalDefinitionCount": 385,
-      "internalDefinitionIdsSha256": "820b3b8d85e04139d09e669eed720eaed4caec4bdd12f386c760b8eddb4e338f",
+      "internalDefinitionCount": 388,
+      "internalDefinitionIdsSha256": "ad064833a4329e34380868a02ab96e743028d0b9080f439af546d487d0c860a0",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -540,8 +540,8 @@
       ]
     },
     "eacl.engine.v8/lookup-resources": {
-      "internalDefinitionCount": 432,
-      "internalDefinitionIdsSha256": "9c5c413fd884b4e399915241e53a4736c0110644d0624768325f0c38c2faecbd",
+      "internalDefinitionCount": 435,
+      "internalDefinitionIdsSha256": "7241d9656cc9fcd09c3eead2b8909f143ec0e3b7339099c3bdcc9ba285ff7d4e",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -549,8 +549,8 @@
       ]
     },
     "eacl.engine.v8/lookup-subjects": {
-      "internalDefinitionCount": 432,
-      "internalDefinitionIdsSha256": "a99e2ac3197e769e76da43607f6b430690f89897c10354368267ecd0fc71a2a9",
+      "internalDefinitionCount": 435,
+      "internalDefinitionIdsSha256": "a4b799b325d1b4a5841d401fb184caa30992a5aa03dadc96214e92d6c5e7d389",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -558,8 +558,8 @@
       ]
     },
     "eacl.engine.v8/count-resources": {
-      "internalDefinitionCount": 389,
-      "internalDefinitionIdsSha256": "dc25874fd115504e2a4665d358b5f39de1eab99fa9e73539aee57fe881adac38",
+      "internalDefinitionCount": 392,
+      "internalDefinitionIdsSha256": "885b676fd6ba3f6ef172b0ff529845d869ff61ba1afc128f9cd1aa618bd995e2",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -567,8 +567,8 @@
       ]
     },
     "eacl.engine.v8/count-subjects": {
-      "internalDefinitionCount": 389,
-      "internalDefinitionIdsSha256": "413f01f2a3b9a2d96923c09c43199defcc6204bd285f5721b2d63e0bb74434d3",
+      "internalDefinitionCount": 392,
+      "internalDefinitionIdsSha256": "3535c97c0b9b165324bd60ca715bf37a9c6dfa9cd1375507797bfa95f62d9750",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -590,8 +590,8 @@
       "externalCalls": []
     },
     "eacl.relay/lookup-visited-page": {
-      "internalDefinitionCount": 60,
-      "internalDefinitionIdsSha256": "70d90dfefdc6bd12d4f56b77a8b5ae4997c15e944cf272076083aa6ee9b1b1f9",
+      "internalDefinitionCount": 63,
+      "internalDefinitionIdsSha256": "b7a6ed026aa1f7f2d0ea06cc46e9bcf370eb058b87348c9ccafd9fdc23e8e4df",
       "externalCallCount": 5,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -602,8 +602,8 @@
       ]
     },
     "eacl.relay/remember-visited-page!": {
-      "internalDefinitionCount": 78,
-      "internalDefinitionIdsSha256": "38489f128b86c94be1120a8896b0f99c3bb63f6fbd3535acb9d8068fd0681844",
+      "internalDefinitionCount": 81,
+      "internalDefinitionIdsSha256": "dd02448f9b563c32c0807551ece507bc0ef40eab21a1d80e305ca8c235630b1e",
       "externalCallCount": 8,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -617,8 +617,8 @@
       ]
     },
     "eacl.relay/select-continuation-adapter": {
-      "internalDefinitionCount": 249,
-      "internalDefinitionIdsSha256": "1a465a2a45d00592f17f9d929faf87d059ba53e01c232971e3492415b84e2f94",
+      "internalDefinitionCount": 252,
+      "internalDefinitionIdsSha256": "3a8205c930bbccc0198a18bc916c8478f564eedde3e7648bb4bcce20e53419c2",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -637,8 +637,8 @@
       ]
     },
     "eacl.relay/prepare-page-query": {
-      "internalDefinitionCount": 253,
-      "internalDefinitionIdsSha256": "561d1dbf6479f0f0f4ada06916b14cf41ede09f48a863444e36e655b92dac99b",
+      "internalDefinitionCount": 256,
+      "internalDefinitionIdsSha256": "b5dadb26d9e1df22d27141a639c18586f456fa845b2af13bfe98d241e00176cc",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -657,8 +657,8 @@
       ]
     },
     "eacl.relay/internalize-page-query": {
-      "internalDefinitionCount": 249,
-      "internalDefinitionIdsSha256": "b5a8c47fc46a13d6616523fa8d2dca495cd7447d63f5d46e6f8d540382d62fbf",
+      "internalDefinitionCount": 252,
+      "internalDefinitionIdsSha256": "52970acf239816bafdbe94559e7c1a22471b757d480a909ab6cfabdd98657c59",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -677,8 +677,8 @@
       ]
     },
     "eacl.relay/externalize-page": {
-      "internalDefinitionCount": 143,
-      "internalDefinitionIdsSha256": "ce0568a5a7ea7b97dba5880a0e3fb2dba416ca3535ba57a19ee147a296af1aac",
+      "internalDefinitionCount": 146,
+      "internalDefinitionIdsSha256": "6977cf3d3f0eb69dc31c34f59ddaf3b3ef4671c0c0f27612dff5827164fe0a7b",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -694,8 +694,8 @@
       ]
     },
     "eacl.relay/externalize-relationship-page": {
-      "internalDefinitionCount": 142,
-      "internalDefinitionIdsSha256": "62e753a8905e2b1f7a7a49dee1bc48a13d8c44b28cb1bd7a4c1c272ed65aefad",
+      "internalDefinitionCount": 145,
+      "internalDefinitionIdsSha256": "802506b02edcbc556e3b461de5ca1ee45960c8bf0da61f54e0d497a62dca44e5",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -877,8 +877,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 907,
-      "internalDefinitionIdsSha256": "4726f0408720dfec40e83c2751776f2611098517b6635528fe97a5c49a2374fa",
+      "internalDefinitionCount": 912,
+      "internalDefinitionIdsSha256": "4d07d5ab1b8201b7d373f9deb07b497cd35bc94a112ee5aadc9da69282cca4c7",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -920,8 +920,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 439,
-      "internalDefinitionIdsSha256": "48a361c2525d9152a11fccbbae8e8fe61904ae105db0f1f382b21d01a8455873",
+      "internalDefinitionCount": 442,
+      "internalDefinitionIdsSha256": "eab2afc5be5c94ba0336f050fd97925a194d06b5e32eb2f71f93a4800f4ea884",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -995,8 +995,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 554,
-      "internalDefinitionIdsSha256": "5f812227fbdebf73592660916074006cb8fed2171ea7d184111052da83fe24be",
+      "internalDefinitionCount": 557,
+      "internalDefinitionIdsSha256": "aca8ce04430a5d1e14db74a0142a4785af017926ef8d1da59108f8304fee5b44",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1025,8 +1025,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 703,
-      "internalDefinitionIdsSha256": "ec8b50d67d9208553e6c5d5cfd5df9773342efb5f4fbc924fc59c5202cc360b5",
+      "internalDefinitionCount": 706,
+      "internalDefinitionIdsSha256": "311c724e737d6a189009512982856dd8ffd3de1688aa9d7318ad6122448bfbd6",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1055,8 +1055,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 556,
-      "internalDefinitionIdsSha256": "e2d85593aefcda9db2210138bc03110355f7f24918f0b17e32326f0f7f9e7b53",
+      "internalDefinitionCount": 559,
+      "internalDefinitionIdsSha256": "f8223dcf00d614d0dfd2dc6ebfbd77e1724ec777a8820c2d4a0dc1c442809f23",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1085,8 +1085,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 703,
-      "internalDefinitionIdsSha256": "3f35c8689d4c055f92bd00b9201271bc41e8e343d97932863cf93a8482a484fb",
+      "internalDefinitionCount": 706,
+      "internalDefinitionIdsSha256": "bccf88299e701b3d8751821bf588941943e576eee160435a32e489608d0ec5b2",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1115,8 +1115,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 556,
-      "internalDefinitionIdsSha256": "d1c4e534cc7c27edb021203b3d758441d900fda7d4ac2c53a86aa782f9fc39d3",
+      "internalDefinitionCount": 559,
+      "internalDefinitionIdsSha256": "86f7e3210dd087b1390ca35d061e5997e0edef54cc8045196a6a64027d8d275b",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1180,8 +1180,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 908,
-      "internalDefinitionIdsSha256": "8d22b321211d9808f04132e6f664f6bf0517f72b950b8894f67c1d5565ac1c1f",
+      "internalDefinitionCount": 913,
+      "internalDefinitionIdsSha256": "36d563b19f43ffce0cfc03b738b9d9be357b7ab9549b9e6e8335eb428114652d",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1223,8 +1223,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 910,
-      "internalDefinitionIdsSha256": "47e85e09b07ec33c91ed455621fbe1f94549edb3d09e45c56b92aa0a71f3e2d4",
+      "internalDefinitionCount": 915,
+      "internalDefinitionIdsSha256": "787c94eeba78a783554242f9e0e240b2531c83ad65f7d404ccf43df0a8717189",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1266,8 +1266,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 737,
-      "internalDefinitionIdsSha256": "19713206187b3eb3538a9b86d32de6cf8c8e372d026c913caf3bcff959905c84",
+      "internalDefinitionCount": 742,
+      "internalDefinitionIdsSha256": "ca05197c1132f6114ef8eb6b13f3748a0ddd4e742dbda11817f64c4dbf7ea4c6",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1303,8 +1303,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 511,
-      "internalDefinitionIdsSha256": "dc13698b8b5eb4ac9d67f6a70e93f2f9a4d242c705be3818f3da52d8218de902",
+      "internalDefinitionCount": 528,
+      "internalDefinitionIdsSha256": "089fb1fe5293a5dde41812074a96fa9a8a62b61ce68ad5519d20f60ff893ff3a",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1405,8 +1405,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 660,
-      "internalDefinitionIdsSha256": "cae9c8b7f43063e1d7f50ef8d029cc9dc61ab9b817e37f5263f89b97cb924cae",
+      "internalDefinitionCount": 665,
+      "internalDefinitionIdsSha256": "173dfcd5416f331d225d9e6042d160a80260847947941fcf2d617e0098ce84bd",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1440,8 +1440,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 798,
-      "internalDefinitionIdsSha256": "8727b4cc3124dd2449a60ad852f060838d5d4e5d935f9cf3ba0abe1829ec8614",
+      "internalDefinitionCount": 803,
+      "internalDefinitionIdsSha256": "f2bef68fed56148b2d9f5bab1b8c6d43a325607cd25aab7dc073671efe961f1a",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1476,8 +1476,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 664,
-      "internalDefinitionIdsSha256": "47e2cf72c1b162f6cd000ffdb8b21cf6d3d3a1303d1a2502c3297afbcbd314fe",
+      "internalDefinitionCount": 669,
+      "internalDefinitionIdsSha256": "9d4a63a9302fffc7b5ef822308c3282568c8cfbbaa156efd25fe62c4fa7c50fa",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1511,8 +1511,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 798,
-      "internalDefinitionIdsSha256": "270b51099d35a19cd42591b2ea20fc2ca30e96ba9ca2dd35a6da294d0c1c63ad",
+      "internalDefinitionCount": 803,
+      "internalDefinitionIdsSha256": "24a6ad7d1c272ddad840557a2d37462084246b9478543b870b2dc11b14485bb5",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1547,8 +1547,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 664,
-      "internalDefinitionIdsSha256": "bb09c74c78557140de0c9ad4cefb4901093d6354dccc1fb5bb2dc07f0cc6f30a",
+      "internalDefinitionCount": 669,
+      "internalDefinitionIdsSha256": "604d097cb988462f1ed311d156f373d7d6c5925da35d8f3ae2d0788ad7c7fa39",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1613,8 +1613,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 504,
-      "internalDefinitionIdsSha256": "80502d3f04d37d16020b9d528a1fe8f70692367929135cc9e67b0e4c4efdf80d",
+      "internalDefinitionCount": 521,
+      "internalDefinitionIdsSha256": "163f1352a460337bdbabdbadaa1ccbb287efdc9bb86bf3f6fc3522dac5118570",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1712,8 +1712,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 653,
-      "internalDefinitionIdsSha256": "29acfb4ef956b8b351249bc0484854cc56718a5bbf83a196a421c51903f8150f",
+      "internalDefinitionCount": 658,
+      "internalDefinitionIdsSha256": "574eac0300594457df75bf86275012a0c3df63d089924c32e6fe2745a38b35f1",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1746,8 +1746,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 791,
-      "internalDefinitionIdsSha256": "a5f7d2250df42e46053510d4bb687bcba3386bf0ad2b9ff9007dada32754b3f8",
+      "internalDefinitionCount": 796,
+      "internalDefinitionIdsSha256": "be61f5b9935fa4a228f71b49b61343ad6ab0b92a3b867f41b2fec97bcce98a83",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1781,8 +1781,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 657,
-      "internalDefinitionIdsSha256": "20dd050a20d0f4a05424834f914e5083f066ac1177f09aa223d4f6c201010848",
+      "internalDefinitionCount": 662,
+      "internalDefinitionIdsSha256": "07e1282d016fc7f507d07b85a6251cae709e28c5b6d7ca33ffb7d4079b82491d",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1815,8 +1815,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 791,
-      "internalDefinitionIdsSha256": "b21c043a768086b01ce617d2c42bdc89d3b8566c243d274e0426d3e6a00dde02",
+      "internalDefinitionCount": 796,
+      "internalDefinitionIdsSha256": "2fd64748f3cbb3e42690739a34422a56e847dcb686f58931426126112724806d",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1850,8 +1850,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 657,
-      "internalDefinitionIdsSha256": "8f9d19a8de6fa81cd80241c9970c280258d445c3c72e73246294135712056b53",
+      "internalDefinitionCount": 662,
+      "internalDefinitionIdsSha256": "67a516217612fbbc573d224c935477b2c1c38327e451b0771ae2fdb89e1bbd2d",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/modules/eacl-datascript/test/eacl/datascript/recursive_op_count_test.clj
+++ b/modules/eacl-datascript/test/eacl/datascript/recursive_op_count_test.clj
@@ -616,3 +616,32 @@
       (is (= :eacl.execution/deadline-exceeded
              (:eacl/error render-error)))
       (is (= :rendered-identity (:stage render-error))))))
+
+(deftest cancellation-is-checked-after-a-running-adapter-command-test
+  (let [{:keys [db user-1-eid]} (seed-star!)
+        adapter (dsb/snapshot-adapter db {})
+        token (eacl/cancellation-token)
+        contract
+        (execution/normalize
+         {:execution-timeout-ms 1000}
+         :lookup-resources
+         {:first 5 :cancellation-token token})
+        query {:subject {:type :user :id user-1-eid}
+               :permission :view
+               :resource/type :account
+               :first 5}
+        data
+        (binding [execution/*contract* contract
+                  backend/*invoke-observer*
+                  (fn [{:keys [phase operation]}]
+                    (when (and (= :after phase)
+                               (= :subject->resources operation))
+                      (eacl/cancel! token)))]
+          (try
+            (engine/lookup-resources adapter query)
+            nil
+            (catch clojure.lang.ExceptionInfo error
+              (ex-data error))))]
+    (is (= :eacl.execution/cancelled (:eacl/error data)))
+    (is (= :adapter-response (:stage data)))
+    (is (not (contains? data :cancellation-token)))))

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -555,7 +555,8 @@
     :query
     (-> query
         (dissoc :first :last :after :before
-                :cursor :limit :page/basis :cache?)
+                :cursor :limit :page/basis :cache?
+                :timeout-ms :cancellation-token)
         (assoc :consistency
                (select-keys
                 (consistency/descriptor (:consistency query))
@@ -668,7 +669,8 @@
 (defn- internal-page-query
   [query page-req decoded]
   (let [edge (:edge decoded)]
-    (cond-> (dissoc query :after :before :page/basis :consistency :cache?)
+    (cond-> (dissoc query :after :before :page/basis :consistency :cache?
+                    :timeout-ms :cancellation-token)
       (and edge (= :asc (:direction page-req))) (assoc :after edge)
       (and edge (= :desc (:direction page-req))) (assoc :before edge))))
 
@@ -2130,8 +2132,11 @@
               opts))))
 
   (read-relationships [_ filters]
-    (spiceomic-read-relationships
-     conn (request-cache-opts opts (:cache? filters)) filters))
+    (execute-request
+     opts :read-relationships filters
+     #(spiceomic-read-relationships
+       conn (request-cache-opts % (:cache? filters))
+       (dissoc filters :timeout-ms :cancellation-token))))
 
   (write-relationships! [_ updates]
     (spiceomic-write-relationships! conn opts updates))
@@ -2183,28 +2188,28 @@
      opts :lookup-resources query
      #(spiceomic-lookup-resources
        conn (request-cache-opts % (:cache? query))
-       (dissoc query :evaluation :timeout-ms))))
+       (dissoc query :evaluation :timeout-ms :cancellation-token))))
 
   (count-resources [_ query]
     (execute-request
      opts :count-resources query
      #(spiceomic-count-resources
        conn (request-cache-opts % (:cache? query))
-       (dissoc query :evaluation :timeout-ms))))
+       (dissoc query :evaluation :timeout-ms :cancellation-token))))
 
   (lookup-subjects [_ query]
     (execute-request
      opts :lookup-subjects query
      #(spiceomic-lookup-subjects
        conn (request-cache-opts % (:cache? query))
-       (dissoc query :evaluation :timeout-ms))))
+       (dissoc query :evaluation :timeout-ms :cancellation-token))))
 
   (count-subjects [_ query]
     (execute-request
      opts :count-subjects query
      #(spiceomic-count-subjects
        conn (request-cache-opts % (:cache? query))
-       (dissoc query :evaluation :timeout-ms))))
+       (dissoc query :evaluation :timeout-ms :cancellation-token))))
 
   (expand-permission-tree [_ query]
     (permission-tree/validate-request! query)

--- a/modules/eacl/README.md
+++ b/modules/eacl/README.md
@@ -54,11 +54,12 @@ are test code, not selectable production engines.
 
 `eacl.permission-tree` is the portable CLJ/CLJS implementation behind
 `IAuthorization/expand-permission-tree`. A request contains `:resource` and
-`:permission`, with optional `:consistency` and `:timeout-ms`; a successful
-response is `{:expanded-at token :tree-root node}`. Nodes contain exactly one
-of `:leaf` or `:intermediate`. Expansion preserves permission/arrow boundaries,
-empty branches, duplicate paths, and typed object identity. Vector order is
-not a semantic contract.
+`:permission`, with optional `:consistency`, `:timeout-ms`, and
+`:cancellation-token`; a successful response is
+`{:expanded-at token :tree-root node}`. Nodes contain exactly one of `:leaf` or
+`:intermediate`. Expansion preserves permission/arrow boundaries, empty
+branches, duplicate paths, and typed object identity. Vector order is not a
+semantic contract.
 
 The kernel consumes definitions, relation values, and ID conversions from one
 already-selected immutable adapter, then issues the causal token from that
@@ -73,6 +74,14 @@ The Dafny file `formal/dafny/PermissionTree.dfy` is a proof-only mathematical
 model. The handwritten portable source is covered by reference-evaluator,
 CLJ/CLJS property, pinned-SpiceDB-fixture, and cross-backend tests; mechanical
 source refinement is not claimed.
+
+All bounded public reads accept an `eacl.core/cancellation-token` through the
+request `:cancellation-token` key. Calling `eacl.core/cancel!` causes the next
+deadline/traversal/adapter-boundary check to throw
+`:eacl.execution/cancelled` without returning a partial answer. Cancellation
+is best-effort: it cannot preempt a synchronous adapter call already in
+progress, and a completed result may win a race with a late signal. The token
+is excluded from semantic cache, continuation, and cursor identity.
 
 Application-facing module selection lives in the
 [backend guide](../../docs/v8-backend-modules-and-upgrade.md).

--- a/modules/eacl/src/eacl/cache.cljc
+++ b/modules/eacl/src/eacl/cache.cljc
@@ -63,9 +63,9 @@
   [public-query internal-query]
   {:public
    (dissoc public-query
-           :consistency :cache? :after :before)
+           :consistency :cache? :after :before :cancellation-token)
    :internal
-   (dissoc internal-query :consistency :cache?)})
+   (dissoc internal-query :consistency :cache? :cancellation-token)})
 
 (defrecord ExactGeneration [snapshot order subproblems])
 (defrecord ManagedGeneration

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -387,7 +387,7 @@
    dissoc
    query
    [:first :last :after :before
-    :consistency :cache? :timeout-ms]))
+    :consistency :cache? :timeout-ms :cancellation-token]))
 
 (defn- stale-cursor-anchor!
   [operation]
@@ -425,7 +425,8 @@
   ;; The unified filter contract validates the complete public query before
   ;; any snapshot selection or cursor work (backend-unification 9.1).
   (relationship-filters/validate! filters)
-  (let [{selection :selection}
+  (let [opts (ensure-execution-contract opts :read-relationships filters)
+        {selection :selection}
         (selected-context api db opts (:consistency filters))
         {adapter :adapter page-db :db cursor-opts :opts
          page-query :query}
@@ -434,8 +435,10 @@
         _ (schema-errors/validate-relationship-read!
            ((get-in api [:schema :read-schema]) page-db)
            filters)
-        base-filters (apply dissoc filters
-                            [:first :last :after :before :consistency :cache?])
+        base-filters
+        (apply dissoc filters
+               [:first :last :after :before :consistency :cache?
+                :timeout-ms :cancellation-token])
         subject-id (:subject/id base-filters)
         resource-id (:resource/id base-filters)
         subject-eid (when subject-id
@@ -444,7 +447,7 @@
                        (object-id->entid page-db resource-id))
         internal-query
         (-> page-query
-            (dissoc :consistency)
+            (dissoc :consistency :timeout-ms :cancellation-token)
             (cond->
               subject-id (assoc :subject/id subject-eid)
               resource-id (assoc :resource/id resource-eid)))]
@@ -566,7 +569,8 @@
                 :resource resource
                 :consistency consistency}
                (:execution-request opts))
-        opts (ensure-execution-contract opts :can? request)
+        opts (ensure-execution-contract
+              opts (or (:request-operation opts) :can?) request)
         {selected-db :db adapter :adapter
          completed-cache? :completed-cache?}
         (selected-context api db opts consistency)
@@ -634,7 +638,8 @@
         adapter cursor-opts :lookup-resources query)
        (let [internal-query
              (-> page-query
-                 (dissoc :consistency :evaluation :timeout-ms)
+                 (dissoc :consistency :evaluation :timeout-ms
+                         :cancellation-token)
                  (assoc :subject internal-subject))
              answer
              (cached-engine-result
@@ -687,11 +692,13 @@
       (let [internal-query
             (-> query
                 (assoc :subject internal-subject)
-                (dissoc :consistency :cache? :evaluation :timeout-ms))
+                (dissoc :consistency :cache? :evaluation :timeout-ms
+                        :cancellation-token))
             answer
             (cached-engine-result
              adapter opts :count-resources
-             {:public (dissoc query :consistency :cache?)
+             {:public (dissoc query :consistency :cache?
+                              :cancellation-token)
               :internal internal-query}
              (:resource/type internal-query)
              (:permission internal-query)
@@ -732,7 +739,8 @@
         adapter cursor-opts :lookup-subjects query)
        (let [internal-query
              (-> page-query
-                 (dissoc :consistency :evaluation :timeout-ms)
+                 (dissoc :consistency :evaluation :timeout-ms
+                         :cancellation-token)
                  (assoc :resource internal-resource))
              answer
              (cached-engine-result
@@ -786,11 +794,13 @@
       (let [internal-query
             (-> query
                 (assoc :resource internal-resource)
-                (dissoc :consistency :cache? :evaluation :timeout-ms))
+                (dissoc :consistency :cache? :evaluation :timeout-ms
+                        :cancellation-token))
             answer
             (cached-engine-result
              adapter opts :count-subjects
-             {:public (dissoc query :consistency :cache?)
+             {:public (dissoc query :consistency :cache?
+                              :cancellation-token)
               :internal internal-query}
              (:type (:resource internal-query))
              (:permission internal-query)

--- a/modules/eacl/src/eacl/core.cljc
+++ b/modules/eacl/src/eacl/core.cljc
@@ -1,5 +1,26 @@
 (ns eacl.core
-  "Defines the IAuthorization protocol, records & helpers.")
+  "Defines the IAuthorization protocol, records & helpers."
+  (:require [eacl.execution :as execution]))
+
+(defn cancellation-token
+  "Creates a caller-owned cooperative cancellation token for one request."
+  []
+  (execution/cancellation-token))
+
+(defn cancellation-token?
+  "True when `value` implements EACL cooperative cancellation."
+  [value]
+  (execution/cancellation-token? value))
+
+(defn cancel!
+  "Requests cooperative cancellation for `token`; idempotently returns true."
+  [token]
+  (execution/cancel! token))
+
+(defn cancelled?
+  "True when cancellation has been requested for `token`."
+  [token]
+  (execution/cancelled? token))
 
 (defprotocol IAuthorization
   ;; For order-dependent calls, we try to maintain the order of [subject permission resource].
@@ -90,6 +111,7 @@
   ; - :subject has {:keys [type id]}. Required.
   ; - :first with optional :after for forward pagination.
   ; - :last with optional :before for backward pagination.
+  ; - :cancellation-token optionally requests cooperative cancellation.
   ; Returns {:data [...] :page-info {:start-cursor ... :end-cursor ...
   ;                                  :has-next-page? ... :has-previous-page? ...}}.
 
@@ -111,7 +133,7 @@
 
   (expand-permission-tree [this {:as query :keys [resource permission consistency]}])
   ; expand-permission-tree accepts exactly :resource, :permission, optional
-  ; :consistency and :timeout-ms. It returns
+  ; :consistency, :timeout-ms and :cancellation-token. It returns
   ; {:expanded-at causal-token :tree-root PermissionRelationshipTree-map}.
   ; Every tree node has :expanded-object, :expanded-relation and exactly one
   ; of {:intermediate {:operation :union :children [...]}} or

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -2905,32 +2905,33 @@
 
                :need-scans
                (let [commands (:commands outcome)
-                     _ (execution/check!
-                        execution/*contract*
-                        :adapter-command
-                        (select-keys
-                         (:counters (:state outcome))
-                         dimensional-counter-keys))
-                     _ (doseq [command commands]
-                         (record-execution-trace!
-                          :generated-command
-                          {:direction direction :command command}))
+                     consumed-work
+                     (select-keys
+                      (:counters (:state outcome))
+                      dimensional-counter-keys)
                      responses
                      (mapv
-                      #(execute-generated-command db plan %)
+                      (fn [command]
+                        (execution/check!
+                         execution/*contract*
+                         :adapter-command
+                         consumed-work)
+                        (record-execution-trace!
+                         :generated-command
+                         {:direction direction :command command})
+                        (let [response
+                              (execute-generated-command db plan command)]
+                          (execution/check!
+                           execution/*contract*
+                           :adapter-response
+                           consumed-work)
+                          (record-execution-trace!
+                           :adapter-response
+                           {:direction direction
+                            :response response
+                            :fetched-values (:fetched-values response)})
+                          response))
                       commands)
-                     _ (execution/check!
-                        execution/*contract*
-                        :adapter-response
-                        (select-keys
-                         (:counters (:state outcome))
-                         dimensional-counter-keys))
-                     _ (doseq [response responses]
-                         (record-execution-trace!
-                          :adapter-response
-                          {:direction direction
-                           :response response
-                           :fetched-values (:fetched-values response)}))
                      resumed
                      (verified/resume-indexed
                       selection direction (:state outcome) responses limits)]

--- a/modules/eacl/src/eacl/execution.cljc
+++ b/modules/eacl/src/eacl/execution.cljc
@@ -1,9 +1,10 @@
 (ns eacl.execution
-  "Normalized demand, deadline, and cache-attempt contracts.
+  "Normalized demand, deadline, cancellation, and cache-attempt contracts.
 
   Public orchestration creates exactly one contract before consistency or cache
-  work. Runtime layers may observe the contract and check its absolute monotonic
-  deadline, but never replace it with a fresh relative timeout."
+  work. Runtime layers may observe the contract and cooperatively check its
+  absolute monotonic deadline and caller-owned cancellation token, but never
+  replace either control with a fresh relative timeout or token."
   (:refer-clojure :exclude [next]))
 
 (def default-execution-timeout-ms 30000)
@@ -26,6 +27,53 @@
                    (.now js/Date)))))))
 
 (def ^:dynamic *contract* nil)
+
+(defprotocol CooperativeCancellation
+  "A non-blocking, caller-owned cancellation signal.
+
+  Implementations must make `-cancelled?` safe to call repeatedly from hot
+  traversal checkpoints. EACL's `cancellation-token` is the portable default."
+  (-cancelled? [token])
+  (-cancel! [token]))
+
+(deftype CancellationToken [state]
+  CooperativeCancellation
+  (-cancelled? [_] (true? @state))
+  (-cancel! [_]
+    (reset! state true)
+    true))
+
+(defn cancellation-token
+  "Creates one portable cooperative cancellation token.
+
+  Supply the token as request `:cancellation-token`, then call `cancel!` from
+  the request owner. A token belongs to one logical request and may be shared
+  safely with the thread or callback that observes client disconnect."
+  []
+  (->CancellationToken (atom false)))
+
+(defn cancellation-token?
+  [value]
+  (satisfies? CooperativeCancellation value))
+
+(defn cancel!
+  "Requests cooperative cancellation. Returns true and is idempotent."
+  [token]
+  (when-not (cancellation-token? token)
+    (throw
+     (ex-info
+      ":cancellation-token must implement CooperativeCancellation."
+      {:type :eacl/invalid-request
+       :eacl/error :eacl.execution/invalid-contract
+       :key :cancellation-token
+       :value-type (some-> token type str)})))
+  (-cancel! token)
+  true)
+
+(defn cancelled?
+  "True when cooperative cancellation has been requested for `token`."
+  [token]
+  (boolean (and token (-cancelled? token))))
 
 (defn now-nanos []
   (*monotonic-nanos*))
@@ -163,6 +211,13 @@
              "Cache-attempt and structural safety envelopes are client configuration, not per-request demand controls."
              {:forbidden-keys (vec forbidden)}))
         evaluation (normalize-evaluation (:evaluation request))
+        cancellation-token (:cancellation-token request)
+        _ (when (and cancellation-token
+                     (not (cancellation-token? cancellation-token)))
+            (invalid-request!
+             ":cancellation-token must be created by eacl.execution/cancellation-token or implement CooperativeCancellation."
+             {:key :cancellation-token
+              :value-type (some-> cancellation-token type str)}))
         timeout-ms
         (normalize-timeout-ms
          (or (:timeout-ms request)
@@ -177,6 +232,7 @@
      :configured-timeout-ms timeout-ms
      :started-nanos started-nanos
      :deadline-nanos deadline-nanos
+     :cancellation-token cancellation-token
      :limits (:recursive-traversal-limits client-options)
      :cache-attempt (or (:cache-attempt client-options)
                         default-cache-attempt)}))
@@ -215,6 +271,18 @@
       :timeout-ms (:configured-timeout-ms contract)}
       (seq consumed-work) (assoc :consumed-work consumed-work)))))
 
+(defn cancellation-observed!
+  [contract stage consumed-work]
+  (throw
+   (ex-info
+    "EACL authorization execution was cancelled."
+    (cond->
+     {:type :eacl.execution/cancelled
+      :eacl/error :eacl.execution/cancelled
+      :operation (:operation contract)
+      :stage stage}
+      (seq consumed-work) (assoc :consumed-work consumed-work)))))
+
 (defn check!
   ([stage]
    (check! *contract* stage nil))
@@ -223,6 +291,9 @@
   ([contract stage consumed-work]
    (when (and contract (expired? contract))
      (deadline-exceeded! contract stage consumed-work))
+   (when (and contract
+              (cancelled? (:cancellation-token contract)))
+     (cancellation-observed! contract stage consumed-work))
    contract))
 
 (defn cache-stage-available?
@@ -230,5 +301,6 @@
   (let [{:keys [evaluation-reserve-ms]}
         (:cache-attempt contract)
         remaining-ms (remaining-millis contract)]
-    (and (pos? remaining-ms)
+    (and (not (cancelled? (:cancellation-token contract)))
+         (pos? remaining-ms)
          (> remaining-ms evaluation-reserve-ms))))

--- a/modules/eacl/src/eacl/permission_tree.cljc
+++ b/modules/eacl/src/eacl/permission_tree.cljc
@@ -13,7 +13,8 @@
    :max-leaf-subjects 100000})
 
 (def ^:private query-keys
-  #{:resource :permission :consistency :timeout-ms})
+  #{:resource :permission :consistency :timeout-ms
+    :cancellation-token})
 
 (defn- portable-positive-integer?
   [value]

--- a/modules/eacl/src/eacl/relationships/filters.cljc
+++ b/modules/eacl/src/eacl/relationships/filters.cljc
@@ -12,12 +12,14 @@
 (def known-filter-keys
   "Filter + pagination + execution keys read-relationships accepts. :cursor
   and :limit are named so their rejection classifies as an unsupported
-  pagination option rather than an unknown key; :consistency, :page/basis and
-  :cache? are validated and consumed by the client layer but must be listed,
-  since an unknown key is a hard error rather than something to ignore."
+  pagination option rather than an unknown key; :consistency, :page/basis,
+  :cache?, :timeout-ms, and :cancellation-token are validated and consumed by
+  the client layer but must be listed, since an unknown key is a hard error
+  rather than something to ignore."
   (into known-anchor-keys
         [:first :last :after :before :cursor :limit
-         :page/basis :consistency :cache?]))
+         :page/basis :consistency :cache? :timeout-ms
+         :cancellation-token]))
 
 (defn validate!
   [filters]

--- a/modules/eacl/src/eacl/relay.cljc
+++ b/modules/eacl/src/eacl/relay.cljc
@@ -60,14 +60,16 @@
   nil)
 
 (def ^:private relay-page-keys
-  #{:first :last :after :before :consistency :cache?})
+  #{:first :last :after :before :consistency :cache?
+    :cancellation-token})
 
 (def ^:private cursor-transport-keys
   "Relay window controls do not define the authorized result set. They remain
   caller-controlled so one boundary cursor can support forward and backward
   navigation. Consistency, principal, permission, filters, and resource type
   remain part of the authenticated semantic scope."
-  #{:first :last :after :before :cache? :timeout-ms})
+  #{:first :last :after :before :cache? :timeout-ms
+    :cancellation-token})
 
 (def cursor-emission-order-version
   "Version of the traversal emission order committed by Relay cursor digests.
@@ -157,7 +159,8 @@
 
 (defn- page-request-key
   [generation operation query]
-  [generation operation (dissoc query :consistency)])
+  [generation operation
+   (dissoc query :consistency :cancellation-token)])
 
 (defn- page-boundary-key
   [generation operation query token]

--- a/modules/eacl/test/eacl/cache_test.cljc
+++ b/modules/eacl/test/eacl/cache_test.cljc
@@ -1,7 +1,8 @@
 (ns eacl.cache-test
   (:require [#?(:clj clojure.test :cljs cljs.test)
-             :refer [deftest is testing]]
+            :refer [deftest is testing]]
             [eacl.cache :as cache]
+            [eacl.core :as eacl]
             [eacl.subproblem-cache :as subproblem]))
 
 (defn- snapshot-object
@@ -550,14 +551,21 @@
         boundary {:kind :lookup-eid :resource 42}
         original
         (cache/lookup-page-query-identity
-         (assoc base-public :after "signed-snapshot-a")
-         (assoc base-internal :after boundary))
+         (assoc base-public
+                :after "signed-snapshot-a"
+                :cancellation-token (eacl/cancellation-token))
+         (assoc base-internal
+                :after boundary
+                :cancellation-token (eacl/cancellation-token)))
         recovered
         (cache/lookup-page-query-identity
          (assoc base-public
                 :after "signed-snapshot-b"
-                :cache? true)
-         (assoc base-internal :after boundary))]
+                :cache? true
+                :cancellation-token (eacl/cancellation-token))
+         (assoc base-internal
+                :after boundary
+                :cancellation-token (eacl/cancellation-token)))]
     (is (= original recovered)
         "signed transport bytes are not page semantics")
     (is (not=

--- a/modules/eacl/test/eacl/contract_support.cljc
+++ b/modules/eacl/test/eacl/contract_support.cljc
@@ -514,6 +514,25 @@
                        :subject (->user "user-2")
                        :after cursor)))))))
 
+  (testing "cancellation tokens are execution controls, not cursor identity"
+    (let [first-token (eacl/cancellation-token)
+          next-token (eacl/cancellation-token)
+          query {:subject (->user "user-1")
+                 :permission :view
+                 :resource/type :server
+                 :first 1}
+          page-1
+          (eacl/lookup-resources
+           client (assoc query :cancellation-token first-token))
+          page-2
+          (eacl/lookup-resources
+           client
+           (assoc query
+                  :cancellation-token next-token
+                  :after (get-in page-1 [:page-info :end-cursor])))]
+      (is (= [(->server "server-1")] (:data page-1)))
+      (is (= [(->server "server-2")] (:data page-2)))))
+
   (testing "unknown anchors and bounded counts use canonical v8 shapes"
     (let [forward
           (eacl/lookup-resources
@@ -602,7 +621,75 @@
                                             :subject/type      :user
                                             :subject/id        "user-2"
                                             :first             10})))
-    (is (false? (eacl/can? client (->user "user-2") :reboot (->server "server-1"))))))
+    (is (false? (eacl/can? client (->user "user-2") :reboot (->server "server-1")))))
+
+  (testing "pre-cancelled tokens stop every bounded public read"
+    (let [token (eacl/cancellation-token)
+          _ (eacl/cancel! token)
+          subject (->user "user-1")
+          resource (->server "server-1")
+          calls
+          [[:can?
+            #(eacl/can?
+              client
+              {:subject subject
+               :permission :view
+               :resource resource
+               :cancellation-token token})]
+           [:check-permission
+            #(eacl/check-permission
+              client
+              {:subject subject
+               :permission :view
+               :resource resource
+               :cancellation-token token})]
+           [:lookup-resources
+            #(eacl/lookup-resources
+              client
+              {:subject subject
+               :permission :view
+               :resource/type :server
+               :first 1
+               :cancellation-token token})]
+           [:count-resources
+            #(eacl/count-resources
+              client
+              {:subject subject
+               :permission :view
+               :resource/type :server
+               :count-limit 1
+               :cancellation-token token})]
+           [:lookup-subjects
+            #(eacl/lookup-subjects
+              client
+              {:resource resource
+               :permission :view
+               :subject/type :user
+               :first 1
+               :cancellation-token token})]
+           [:count-subjects
+            #(eacl/count-subjects
+              client
+              {:resource resource
+               :permission :view
+               :subject/type :user
+               :count-limit 1
+               :cancellation-token token})]
+           [:read-relationships
+            #(eacl/read-relationships
+              client
+              {:resource/type :server
+               :first 1
+               :cancellation-token token})]
+           [:expand-permission-tree
+            #(eacl/expand-permission-tree
+              client
+              {:resource resource
+               :permission :view
+               :cancellation-token token})]]]
+      (doseq [[label call] calls]
+        (is (= :eacl.execution/cancelled (error-category call))
+            (name label))))))
 
 (defn assert-v8-permission-tree-contract!
   "Cross-backend shallow expansion contract over `smoke-schema`."

--- a/modules/eacl/test/eacl/execution_test.cljc
+++ b/modules/eacl/test/eacl/execution_test.cljc
@@ -48,6 +48,7 @@
            [{:timeout-ms 0} :timeout-ms]
            [{:timeout-ms -1} :timeout-ms]
            [{:timeout-ms 1.5} :timeout-ms]
+           [{:cancellation-token (atom false)} :cancellation-token]
            [{:count-limit -1} :count-limit]]]
     (testing (pr-str request)
       (let [data
@@ -79,6 +80,52 @@
         (is (= :can? (:operation data)))
         (is (= :before-command (:stage data)))
         (is (= {:backend-commands 2} (:consumed-work data)))))))
+
+(deftest cooperative-cancellation-token-test
+  (let [clock (atom 0)
+        token (execution/cancellation-token)
+        contract
+        (binding [execution/*monotonic-nanos* #(deref clock)]
+          (execution/normalize
+           {:execution-timeout-ms 100}
+           :lookup-resources
+           {:first 10 :cancellation-token token}))]
+    (is (execution/cancellation-token? token))
+    (is (false? (execution/cancelled? token)))
+    (is (identical? token (:cancellation-token contract)))
+    (binding [execution/*monotonic-nanos* #(deref clock)]
+      (is (= contract (execution/check! contract :generated-quantum)))
+      (is (true? (execution/cancel! token)))
+      (is (true? (execution/cancel! token)) "cancellation is idempotent")
+      (is (execution/cancelled? token))
+      (let [data
+            (caught-data
+             #(execution/check!
+               contract :adapter-response {:backend-commands 3}))]
+        (is (= :eacl.execution/cancelled (:type data)))
+        (is (= :eacl.execution/cancelled (:eacl/error data)))
+        (is (= :lookup-resources (:operation data)))
+        (is (= :adapter-response (:stage data)))
+        (is (= {:backend-commands 3} (:consumed-work data)))
+        (is (not (contains? data :cancellation-token))))
+      (is (false? (execution/cache-stage-available? contract))))))
+
+(deftest deadline-remains-authoritative-when-both-controls-fire-test
+  (let [clock (atom 0)
+        token (execution/cancellation-token)
+        contract
+        (binding [execution/*monotonic-nanos* #(deref clock)]
+          (execution/normalize
+           {:execution-timeout-ms 1}
+           :can?
+           {:cancellation-token token}))]
+    (execution/cancel! token)
+    (reset! clock 1000000)
+    (is (= :eacl.execution/deadline-exceeded
+           (:type
+            (binding [execution/*monotonic-nanos* #(deref clock)]
+              (caught-data
+               #(execution/check! contract :generated-quantum))))))))
 
 (deftest cache-stage-preserves-evaluation-reserve-test
   (let [clock (atom 0)


### PR DESCRIPTION
## Summary

- add an opaque, caller-owned cooperative cancellation token to every bounded EACL read
- observe cancellation at orchestration, cursor/cache, traversal-quantum, and individual adapter-command boundaries
- keep cancellation execution-only by excluding tokens from semantic cache, continuation, and authenticated cursor identity
- make Datomic relationship reads participate in the common execution contract

## API and semantics

```clojure
(let [token (eacl/cancellation-token)]
  (future
    (eacl/lookup-resources
     client
     {:subject subject
      :resource/type :document
      :permission :view
      :first 100
      :cancellation-token token}))
  (eacl/cancel! token))
```

An observed signal throws typed `:eacl.execution/cancelled` without returning a partial answer. Cancellation is cooperative and best-effort: an in-progress synchronous adapter call must return before the next checkpoint, and completion can win a race with a late signal. Deadlines and bounded admission control remain required.

## Stack

This draft targets `release/v8.0`, the head branch of #103.

## Verification

- 630 JVM tests, 25,765 assertions: 0 failures/errors
- 214 DataScript CLJS tests, 7,463 assertions: 0 failures/errors
- deterministic cancellation-after-adapter-response regression
- fresh-token cursor-resumption contract across Datomic, Datahike, and DataScript
- reflection gate clean
- four-module Maven release build/install smoke clean
