### PR TITLE
Documentation accessibility fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
+<style>
+body { color: #24292f !important; }
+a, a:visited {
+  color: #075ca8 !important;
+  text-decoration: underline !important;
+  text-underline-offset: 0.15em;
+}
+</style>
+
 # 🦅 **EACL**: Enterprise Access ControL
 
 [EACL](https://github.com/theronic/eacl) is a _situated_ [ReBAC](https://en.wikipedia.org/wiki/Relationship-based_access_control) authorization library based on [SpiceDB](https://authzed.com/spicedb), built in Clojure and backed by Datomic.


### PR DESCRIPTION
Currently, a lighthouse audit shows 2 accessibility violations.

<img width="1080" height="2340" alt="Screenshot_20260815_081151_Vivaldi" src="https://github.com/user-attachments/assets/7d4ae5f7-a2bd-4269-aff8-76a1103f0f50" />

This commit fixes them in the most minimal way possible.
