### PR TITLE
Wire the physical execution layer (classified/retried reads, service-edge bulkhead, topology qualification) onto the routed engine

### DIFF
--- a/docs/reports/2026-08-15-eacl-stable-engine-audit.md
+++ b/docs/reports/2026-08-15-eacl-stable-engine-audit.md
@@ -126,13 +126,21 @@ held, and no adapter declares a capability record (task 7.7 said "per-adapter
 declarations join the 9.1 splice"; 9.1 landed without them).
 `docs/stable-discovery-engine.md` §Failure semantics and §Topology
 qualification described the routed behaviour as if wired; this branch
-rewords them (see §5). Left as a wiring decision, not repaired here: installing
-`classified-fetch-fn`/`retrying-fetch-fn` on the routed path would wrap
-every adapter exception — including the typed `:eacl/backend-contract-violation`
-thrown by the runtime guards, which today surfaces unchanged — as
-`:eacl.scan/failure` and retry it up to three times, a public error-shape
-change that the pinned error contracts do not authorize; the bulkhead needs
-a new client option. Both belong to a scoped change with their own tests.
+rewords them (see §5). Wired in the follow-up pull request (`agent/wire-physical-execution`):
+`eacl.engine.v8` installs `classified-fetch-fn`/`retrying-fetch-fn` on every
+routed read (three attempts under the request's original absolute deadline;
+typed EACL errors such as `:eacl/backend-contract-violation` pass through
+unwrapped and unretried, so the pinned public error contracts are
+unchanged; foreign failures surface as `:eacl.scan/failure` with
+`:classification` and `:cause-class`; `:adapter-attempts` joins the work
+stats), a `:service-admission` client option installs the bulkhead around
+point checks, lookups and counts and the replay ledger around checkpoint-miss
+replays, backward runs and last windows, and both clients derive the
+adapter's topology capability record from its declared execution profile
+and fail closed with `:eacl.topology/unqualified` at construction
+(`physical_route_test`: `routed-reads-are-classified-and-retried-test`,
+`service-admission-bounds-routed-enumerations-test`,
+`topology-qualification-test`; `config_test/service-admission-option-test`).
 
 ### 2.4 S3 — `with-replay-admission` never removes exhausted keys — **Fixed**
 

--- a/docs/stable-discovery-engine.md
+++ b/docs/stable-discovery-engine.md
@@ -102,32 +102,42 @@ own client options (`:security-key` / page-token keyrings).
 
 ## Failure semantics
 
-The reducer's only effectful call is the adapter scan at the canonical
-head (`eacl.engine.stable-reducer/adapter-fetch-fn`); its semantic state is
-untouched until a complete chunk is realized, so a thrown adapter failure
-leaves the state exactly where it was. Semantic limits fail typed and
-uncommitted (`:eacl.reducer/limit-exceeded`, surfaced publicly as
-`:eacl.recursive-traversal/limit-exceeded`); cancellation and the absolute
-deadline are checked cooperatively at every reducer transition
-(`eacl.engine.physical/execution-cut-point`) and never publish a partial
-page, child cursor, or checkpoint — the parent cursor stays reusable.
-Exact-basis selection classifies its failures in the Datomic and Datahike
-backends (`:eacl.basis/selection-failure` with `:retryable`/`:cancelled`;
-genuine absence maps to the contractual unavailable signal).
+Every routed adapter read has exactly three outcomes
+(`eacl.engine.physical/classified-fetch-fn`, installed on the public path by
+`eacl.engine.v8`):
 
-`eacl.engine.physical` additionally provides, as library components with
-their own tests, the three-outcome read classification
-(`classified-fetch-fn`: complete | classified failure with a cause code and
-atomic partial discard | cancelled — `nil` is never an outcome), retry of
-the exact descriptor under the original absolute deadline
-(`retrying-fetch-fn`), and a service-edge bulkhead with a replay ledger
-(`make-service-admission`, `with-admission`, `with-replay-admission`,
-`:eacl.service/admission-rejected`, `:eacl.service/replay-rejected`). The
-routed public path (`eacl.engine.v8`) currently installs only the
-execution cut-point: adapter exceptions propagate unclassified and no read
-is retried. Installing the wrappers is a `fetch-fn` option on
-`edge-page`/`check-eids`; see the 2026-08-15 audit report for the open
-decision.
+- **complete** — validated values, possibly legitimately empty;
+- **failure** — a foreign adapter exception is classified `:retryable`
+  (or `:terminal` when the adapter says so) with a cause class; the chunk is
+  realized inside the classification boundary, so partial output is
+  discarded atomically and reducer state is untouched;
+- **cancelled** — a thread interrupt inside the read.
+
+`nil` is never an outcome. Missing storage is never an empty scan. Typed
+EACL errors raised inside a read (`:eacl/backend-contract-violation` from
+the runtime guards, limits, deadlines, cooperative cancellation) are already
+verdicts: they pass through the boundary unwrapped and are never retried.
+Retries (`retrying-fetch-fn`) reuse the exact descriptor, run under the
+request's original absolute deadline, stop after three attempts, and are
+counted separately from logical commands (`:adapter-attempts` in the
+traversal work stats); the exhausted failure surfaces as
+`:eacl.scan/failure` with `:classification`, `:cause-class` and the original
+exception as its cause. Exact-basis selection follows the same discipline in
+the Datomic and Datahike backends (`:eacl.basis/selection-failure` with
+classification; genuine absence maps to the contractual unavailable signal).
+Semantic limits fail typed and uncommitted (`:eacl.reducer/limit-exceeded`,
+surfaced publicly as `:eacl.recursive-traversal/limit-exceeded`);
+cancellation and the absolute deadline are checked cooperatively at every
+reducer transition (`execution-cut-point`) and never publish a partial page,
+child cursor, or checkpoint — the parent cursor stays reusable.
+
+Service protection is a bulkhead, not a scheduler: the client option
+`:service-admission {:max-concurrent n :max-replays n :max-replays-per-key n}`
+installs bounded concurrent enumerations with slots held for the full
+synchronous call chain (`:eacl.service/admission-rejected`) and a replay
+ledger keyed by continuation identity that governs checkpoint-miss replays,
+backward runs and last windows (`:eacl.service/replay-rejected`). An
+omitted option installs no bulkhead.
 
 ## Cache artifacts and metrics
 
@@ -148,15 +158,17 @@ drops are silent by contract (the request itself is unaffected).
 
 ## Topology qualification
 
-`eacl.engine.physical/topology-capabilities` defines the closed capability
-record a topology must certify before it is considered qualified for
-stable discovery (`stable-discovery-qualified?`): immutable basis, strict
-scan order and uniqueness, replayability, strict progress, atomic
-responses, and failure-classification fidelity. Deployment width is one
-for every topology in this change; semantic concurrent-read safety is
-recorded separately as the SPI seam for the future concurrency change.
-No backend module declares a capability record yet and the routed path
-does not consult one; the adapters' scan obligations are instead stated
-by `eacl.backend.v8/adapter-obligations` and exercised by the
-certification suites. Datahike/DynamoDB remains unqualified until the
+A topology runs stable discovery only when its closed capability record
+(`eacl.engine.physical/topology-capabilities`) certifies: immutable basis,
+strict scan order and uniqueness, replayability, strict progress, atomic
+responses, and failure-classification fidelity. The record is derived from
+the adapter's declared execution profile (`eacl.backend.v8/traversal-execution`)
+plus the engine's read boundary (`adapter-topology-capabilities`), and both
+public clients check it once at construction
+(`require-qualified-topology!`, failing closed with
+`:eacl.topology/unqualified`); the three bundled adapters declare the strict
+sequential profile and qualify. Deployment width is one for every topology
+in this change; semantic concurrent-read safety and physical cancellability
+are recorded conservatively as the SPI seam for the future concurrency
+change. Datahike/DynamoDB remains unqualified operationally until the
 upstream Konserve failure-cause collapse is repaired or wrapped.

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -103,6 +103,35 @@ Exceeding a ceiling throws `:eacl.recursive-traversal/limit-exceeded`. Use
 `:count-limit` for bounded counts and raise traversal limits only after
 representative heap and load testing.
 
+Every routed adapter read runs inside the engine's three-outcome
+classification boundary: a foreign adapter failure (a storage or driver
+exception) is classified `:retryable` and retried up to three times for the
+same read-demand descriptor under the request's original absolute deadline,
+then surfaces as `:eacl.scan/failure` with `:classification` and
+`:cause-class`; typed EACL errors (contract violations, limits, deadlines,
+cancellation) pass through unwrapped and unretried. Attempts are reported as
+`:adapter-attempts` in the traversal work stats.
+
+Each client also accepts a `:service-admission` bulkhead for the routed
+enumerations (point checks, lookups, counts) and a replay ledger for cursor
+replays; slots are held for the full synchronous call chain of the work:
+
+```clojure
+(datascript/make-client
+ conn
+ {:service-admission
+  {:max-concurrent 64        ; enumerations holding a slot at once
+   :max-replays 16           ; concurrent cursor replays in total
+   :max-replays-per-key 2}}) ; concurrent replays of one continuation
+```
+
+Rejections are `:eacl.service/admission-rejected` and
+`:eacl.service/replay-rejected`; an omitted option installs no bulkhead.
+Client construction fails closed with `:eacl.topology/unqualified` when the
+backend adapter's declared execution profile does not certify the strict,
+unique, replayable, strict-progress, atomic scan contract over an immutable
+basis that stable discovery requires (the three bundled adapters do).
+
 ## Permission-tree expansion
 
 All bundled adapters implement `expand-permission-tree` through one portable

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "86efd6561fd85a72b841e4c739352e9d22e2b60561b005d67183ac12c96f486e"
+      "sha256": "7c67faf34560eca4decfcdaa66b301d60f78704179ebbe57888dc67e1690662a"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -137,7 +137,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "6219677e0342b3a2b1818ed78567a421146f9599ff5dfd54902d7d79e7bf8a60"
+      "sha256": "12e4fd4afc8eb3184ce8f1da018146bdc808f6ba454f67c07236712f31e47a17"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -157,7 +157,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/physical.cljc",
-      "sha256": "0b896e5c347b110e682c856af7b49ede6e15de00610eab1470f9988f4fb0766a"
+      "sha256": "ab00c3f5c25ed6187713bba8854bc4da563c9c6a117cbf312a98a4a7218ae3df"
     },
     {
       "path": "modules/eacl/src/eacl/engine/portable_decisions.cljc",
@@ -177,7 +177,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/stable_page.cljc",
-      "sha256": "e1916a63c1fb0ece3cdb2996fb01ff95606318e52316692f9eedd0d5bc7d0f10"
+      "sha256": "d8845631171d0d1e8997a654196e025a4c0280f99b7d4f6592f2b953eaa2526b"
     },
     {
       "path": "modules/eacl/src/eacl/engine/stable_reducer.cljc",
@@ -189,7 +189,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "f1755aed2027bf6aa97edebc3712c9e7a964804d4aba301050542ad22ea00543"
+      "sha256": "3738463ec1e15fb4ba0d4d171e769898a4f212064c1030b56ab6e15bbaa80c4f"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -329,9 +329,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1297,
-    "unionInternalDefinitionIdsSha256": "53f1b470b03e5d8064e12afd8cc33be69d53002f9da008e49ccd68aaaefc7863",
-    "unionDefinitionLocationsSha256": "10c5cc90bac7f5ea7931f7986c94fec0d3ecf26a64a5f163bf4f47378a6b94c4",
+    "unionInternalDefinitionCount": 1321,
+    "unionInternalDefinitionIdsSha256": "22425ac43297fd0b0bc0727a9a24ee65044ed017ebdc01f2e9616a438cce5484",
+    "unionDefinitionLocationsSha256": "7db687ca15259487ee987168e438eb0ca6a8d76e057fc3170cca04b8dde93022",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 15,
@@ -418,8 +418,8 @@
         "idsSha256": "6354f20b566cbf72654812e5404ad861a32ed262bf7c3ebf678b2e9f199a323b"
       },
       "modules/eacl/src/eacl/backend/v8.cljc": {
-        "count": 39,
-        "idsSha256": "865100334c8ddb320de254fb4b267959d57ca6c15e0dbcc7d5beea0a57a230f8"
+        "count": 40,
+        "idsSha256": "dca5f2e1ae7cefb3fab151b9a5d09abb2f3bac168676c13f7e96c51dbd9ea84b"
       },
       "modules/eacl/src/eacl/cache.cljc": {
         "count": 31,
@@ -450,8 +450,8 @@
         "idsSha256": "b35bffa00c76bd22c09fac6aceb428ac2dfd09691913494f8d9c6cad66f2a8a3"
       },
       "modules/eacl/src/eacl/engine/physical.cljc": {
-        "count": 1,
-        "idsSha256": "cd2573afd6c9f6e9172ca6a1ccd1d58e33e67d87504dd9873e2154d634e196bb"
+        "count": 18,
+        "idsSha256": "5fcc8cd40647145d897f5273958e6c11fe12048504bdb20ebda634b3943a7983"
       },
       "modules/eacl/src/eacl/engine/portable_decisions.cljc": {
         "count": 30,
@@ -470,8 +470,8 @@
         "idsSha256": "7ab041bdfe0d3065f838696bd3798659cd1442c47d2b9bca9edb43b4328d882d"
       },
       "modules/eacl/src/eacl/engine/stable_page.cljc": {
-        "count": 11,
-        "idsSha256": "14fef1e4ea1236c73dc2221745ebae671e7450aa85eec7bfeac5986d4147ca15"
+        "count": 12,
+        "idsSha256": "56b697f095938dc0bae040e9a1fade63b799dbcfe83af82624fe0900b1c2284c"
       },
       "modules/eacl/src/eacl/engine/stable_reducer.cljc": {
         "count": 35,
@@ -482,8 +482,8 @@
         "idsSha256": "2baa47acc019ed669bc2d286552110b2581701131dfbbe2d9496523c256e79da"
       },
       "modules/eacl/src/eacl/engine/v8.cljc": {
-        "count": 73,
-        "idsSha256": "4620efec108f176adbf91c5502423ce0da72737ed2f1cb7237e8d44092dee59d"
+        "count": 78,
+        "idsSha256": "76e77e7e4b70fedb38ec985f56914117d74d3bdda53b756c2cbd0331c180cd78"
       },
       "modules/eacl/src/eacl/execution.cljc": {
         "count": 26,
@@ -561,14 +561,15 @@
   },
   "roots": {
     "eacl.engine.v8/can?": {
-      "internalDefinitionCount": 127,
-      "internalDefinitionIdsSha256": "655e96fa628cccb361d8afba8f1fe0c71430af9aeacf0df7f2cddb3ee04c5759",
-      "externalCallCount": 8,
+      "internalDefinitionCount": 139,
+      "internalDefinitionIdsSha256": "34eece9a92eafe0cb5492304c3ba89e05d7a8b37ae654550185ca0d96aa2ceab",
+      "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "goog.crypt/stringToUtf8ByteArray",
         "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
@@ -576,14 +577,15 @@
       ]
     },
     "eacl.engine.v8/lookup-resources": {
-      "internalDefinitionCount": 277,
-      "internalDefinitionIdsSha256": "0f20fdd465f5b2a415cf5276860b39cf38a62d2ab7ddf265d5d30c676de2a8c6",
-      "externalCallCount": 8,
+      "internalDefinitionCount": 291,
+      "internalDefinitionIdsSha256": "85e94b74c060a03503de5f9db1e4cc3703f1bce2d2372cb436b1cf5f31a4ccbe",
+      "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "goog.crypt/stringToUtf8ByteArray",
         "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
@@ -591,14 +593,15 @@
       ]
     },
     "eacl.engine.v8/lookup-subjects": {
-      "internalDefinitionCount": 277,
-      "internalDefinitionIdsSha256": "20e9559184dfab5cc385f4e2244b9cf76aa5bc69f12acfcba09b5a1d1483090b",
-      "externalCallCount": 8,
+      "internalDefinitionCount": 291,
+      "internalDefinitionIdsSha256": "26c80113b1c37e1bc784e94960cad9fe6771bd45cf527ec5ca213a9a3a8c8ea0",
+      "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "goog.crypt/stringToUtf8ByteArray",
         "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
@@ -606,14 +609,15 @@
       ]
     },
     "eacl.engine.v8/count-resources": {
-      "internalDefinitionCount": 130,
-      "internalDefinitionIdsSha256": "2798673b1855cee4e80190cad493b91a064cfacea468d815132f4789e4cad7c9",
-      "externalCallCount": 8,
+      "internalDefinitionCount": 142,
+      "internalDefinitionIdsSha256": "543bf5a94a8d15c7f19836ba6932580b94a97bba86459fd536ddf2dfc18110d2",
+      "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "goog.crypt/stringToUtf8ByteArray",
         "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
@@ -621,14 +625,15 @@
       ]
     },
     "eacl.engine.v8/count-subjects": {
-      "internalDefinitionCount": 130,
-      "internalDefinitionIdsSha256": "98a75a515fcfa331c9c4f6db17db43d664ee24f5d5ddafe19034eaed97a68c0b",
-      "externalCallCount": 8,
+      "internalDefinitionCount": 142,
+      "internalDefinitionIdsSha256": "0dc5c831f626dbf50aa0d02d234e34473fc21c4f7855d3de718caf513e08f419",
+      "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "goog.crypt/stringToUtf8ByteArray",
         "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
@@ -922,8 +927,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 783,
-      "internalDefinitionIdsSha256": "1ba8a63a3451de3f7ca5d05204a3940fedc53eaaccd778232c0c620b1c7d3201",
+      "internalDefinitionCount": 797,
+      "internalDefinitionIdsSha256": "62eedec94dfb3c0115bfaff89c846b46ffda092819e03ebf0321fde03a88ec67",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1040,8 +1045,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 447,
-      "internalDefinitionIdsSha256": "ea4977e52a968db4810eed616e7a2f1dda21e769fa3443e0dbf2fbc395cab8d1",
+      "internalDefinitionCount": 459,
+      "internalDefinitionIdsSha256": "6a3473283a437a91051bab6f31d7127e9e3035c4039ddfecaf167c390ef5951e",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1070,8 +1075,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 585,
-      "internalDefinitionIdsSha256": "eef3eceac78e2caa9bcfdf8c062af907a890fa9422ef66a609dcfebde32170f4",
+      "internalDefinitionCount": 599,
+      "internalDefinitionIdsSha256": "179471fb28d670960e9f23862646112b1a11d5a1a97836a387e294658ae01396",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1100,8 +1105,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 449,
-      "internalDefinitionIdsSha256": "945d8afdf09d15a3b3a9ba904db79f55e9d9dd28562ecff07f82bd206b32da90",
+      "internalDefinitionCount": 461,
+      "internalDefinitionIdsSha256": "df864ce965e035e300f8d7bad9456210287b15751afe61230a6e2950c1a132e1",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1130,8 +1135,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 585,
-      "internalDefinitionIdsSha256": "6a7154d688c674614cf683f6694c9d3138a3569e134548768c85e14cfd6a89ca",
+      "internalDefinitionCount": 599,
+      "internalDefinitionIdsSha256": "8bd962f1702607495db0eb9fcbe5f7a24524150c17d88b945b42ba17c8967355",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1160,8 +1165,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 449,
-      "internalDefinitionIdsSha256": "fac25cc40337f10af68ba6c065585da3b5a984371281fe63f17053b32807f6e7",
+      "internalDefinitionCount": 461,
+      "internalDefinitionIdsSha256": "562b706f1c75b6cf17ed280bc1886da05f614a2529eb8776b8744430c1389e04",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1190,8 +1195,8 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 202,
-      "internalDefinitionIdsSha256": "7e69dbce454bc399b8c5d82b063ea364c4ea671dfb9c063534bff4335d0dd43a",
+      "internalDefinitionCount": 216,
+      "internalDefinitionIdsSha256": "1048e5ed17d41f749516c51a985069cadd24b3c47dd2d7b3c5d55cfbcc556bf6",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1225,8 +1230,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 784,
-      "internalDefinitionIdsSha256": "fd17c713c0daa85908a0ac5a078e15bc60d38a3e439f2b6bff92bf10492571e7",
+      "internalDefinitionCount": 798,
+      "internalDefinitionIdsSha256": "f130a63851684bc6487ef8624795cb78652baa917fd8a67e73d2d0f7c17b6b2f",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1268,8 +1273,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 786,
-      "internalDefinitionIdsSha256": "eb32625d8e3363354e379d8061f7279ec38745c8397ed511f992c5c787843323",
+      "internalDefinitionCount": 800,
+      "internalDefinitionIdsSha256": "a369b9938332f4c64634d35a36d32f25ba58f8f35896acee48d8eff0b29bf625",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1311,8 +1316,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 610,
-      "internalDefinitionIdsSha256": "93f75afcf2f7760a19ec1182cb9e88902632645406c54cbb651ea36e957b41e7",
+      "internalDefinitionCount": 624,
+      "internalDefinitionIdsSha256": "f13072bec8cd9edc17482e5680340cb015b6e835c5aa8218a0cb7187703e86fe",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1333,8 +1338,8 @@
       ]
     },
     "eacl.client.orchestration/make-client": {
-      "internalDefinitionCount": 92,
-      "internalDefinitionIdsSha256": "57f3f3542ce6a1813f6d91c66d2eeee42a11e704dd0a435b388f7885f4176834",
+      "internalDefinitionCount": 107,
+      "internalDefinitionIdsSha256": "ff1640b288c5972f5dfb0f482640ffe30222b687110275b64c09391e78bfad62",
       "externalCallCount": 8,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1450,8 +1455,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 561,
-      "internalDefinitionIdsSha256": "9916622c1b327efbd78dca257434dad62a78ad38612fa6b9a1aa8a65a4a28df5",
+      "internalDefinitionCount": 573,
+      "internalDefinitionIdsSha256": "f008bc23df4062c3b296464260264307368ee529348e8222c61d2c9d5041e70f",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1485,8 +1490,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 688,
-      "internalDefinitionIdsSha256": "4527b437d3ec219479222565167c4c8893c88d0fb061d4843da35a12954ea942",
+      "internalDefinitionCount": 702,
+      "internalDefinitionIdsSha256": "04d88f6a50f912e262d5d68c1c99b0c835a0d61ec9be313b7d8f4c4338492b2f",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1521,8 +1526,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 564,
-      "internalDefinitionIdsSha256": "aac84185b314cf64610a9145d2a46310e6ea08eecbfce2690b825e77227aed90",
+      "internalDefinitionCount": 576,
+      "internalDefinitionIdsSha256": "a3a0a40d417bd63ed3aeaf35ca2e2e6943ab853f8b285d57a1571c6f8cf846e2",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1556,8 +1561,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 688,
-      "internalDefinitionIdsSha256": "69c542f121caf981378a60bfd28d19638b595d4499cfb012bbab72179b44b174",
+      "internalDefinitionCount": 702,
+      "internalDefinitionIdsSha256": "7045106a5f6b25ad2cc6a294e9bed4059f8d1077c4fb6f6af7e1580f5e6c60b8",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1592,8 +1597,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 564,
-      "internalDefinitionIdsSha256": "7d3b0e610420536b6e568099aef105ae257c5a338aa832f7648085fcaff1b57f",
+      "internalDefinitionCount": 576,
+      "internalDefinitionIdsSha256": "16032e24c40401159f0e6c1336844f59ecf47663cae97638a9e48582534274f4",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1627,8 +1632,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 347,
-      "internalDefinitionIdsSha256": "dced7d2db3b10364e4019724bc26444650bb37648469493b80f1f5d4872943f4",
+      "internalDefinitionCount": 361,
+      "internalDefinitionIdsSha256": "95e99a5ae78836a80f5ef1c94594be61975d08cde610b508dede41371b657dec",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1757,8 +1762,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 552,
-      "internalDefinitionIdsSha256": "6e2cbff8f775fe6dfd1cc6fa001e698b1674bb6bc5e70235b941cd02b7a2e9c1",
+      "internalDefinitionCount": 564,
+      "internalDefinitionIdsSha256": "74c0278c5c191412db68178e65801cf5b0a8fb348886eb11d0e79f1fb75e5e8d",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1791,8 +1796,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 679,
-      "internalDefinitionIdsSha256": "6cb457c15b56807a8b37f73eb10a811826914dff20122fbb3bbf6ea1fe097dd2",
+      "internalDefinitionCount": 693,
+      "internalDefinitionIdsSha256": "106299fba7d483237a862cafd417079d35509c9c4e348fd1837ea09a0b80b242",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1826,8 +1831,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 555,
-      "internalDefinitionIdsSha256": "f2d3c145e08cb3685c4eeffedd11e182482e256a2ffd84bb8ec13ff6c9576ad8",
+      "internalDefinitionCount": 567,
+      "internalDefinitionIdsSha256": "a3122e1f6b7feedd0528bea67dedc0239909b5e35f835a9312f3c7d11a7edb63",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1860,8 +1865,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 679,
-      "internalDefinitionIdsSha256": "a8c9ef2b2d67016d9c422704b51744778462a78d7b361711e8b91302084323ab",
+      "internalDefinitionCount": 693,
+      "internalDefinitionIdsSha256": "1af4268e35540e9c131e4f9d5a091f2a5484c9a86c248657e0704ca38f58dea6",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1895,8 +1900,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 555,
-      "internalDefinitionIdsSha256": "af142fd9e04e2a792450697973692ff5bd1c546f3c937cc593142eaf2be5fe51",
+      "internalDefinitionCount": 567,
+      "internalDefinitionIdsSha256": "61d79381974648403e627526f0349415b205fbc134877820b7b82e6b36d345d3",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1929,8 +1934,8 @@
       ]
     },
     "eacl.datascript.core/make-client": {
-      "internalDefinitionCount": 338,
-      "internalDefinitionIdsSha256": "e300108c2b7d5aea47889fd7b35404b4167d680f45e8a941796ed3b9b99b83d9",
+      "internalDefinitionCount": 352,
+      "internalDefinitionIdsSha256": "817ff224f1a372abc2ac341dcf2a4a50014fd89ca0803186cec0704dc58e0dfc",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/modules/eacl-datascript/test/eacl/engine/physical_route_test.clj
+++ b/modules/eacl-datascript/test/eacl/engine/physical_route_test.clj
@@ -18,6 +18,7 @@
             [eacl.engine.stable-page :as page]
             [eacl.engine.stable-reducer :as reducer]
             [eacl.engine.stable-route :as route]
+            [eacl.engine.v8 :as engine]
             [eacl.execution :as execution]))
 
 (defn- seeded
@@ -420,3 +421,181 @@
                                         :target route/exhaustion-target}))]
         (is (= n (:discovered reverse-run)))
         (is (empty? (:stack reverse-run)))))))
+
+;; ---------------------------------------------------------------------------
+;; Routed wiring of the physical layer (bounded-physical-execution on the
+;; public path): classified + retried reads, the service-edge bulkhead and
+;; replay ledger, and topology qualification.
+;; ---------------------------------------------------------------------------
+
+(defn- adapter-with-scan
+  "The seeded adapter with its forward scan replaced by `scan-fn`, which
+  receives the original operation."
+  [adapter scan-fn]
+  (let [operations (:eacl.backend.v8/operations adapter)
+        original (:subject->resources operations)]
+    (backend/make-adapter
+     {:id (backend/backend-id adapter)
+      :capabilities (backend/capabilities adapter)
+      :operations (assoc operations
+                         :subject->resources (fn [& args] (apply scan-fn original args)))
+      :state (backend/state adapter)
+      :fingerprint (backend/fingerprint adapter)
+      :identity-contract (backend/identity-contract adapter)
+      :traversal-execution (backend/traversal-execution adapter)})))
+
+(defn- routed-lookup
+  [adapter env]
+  (let [principal (val (first (:principals (:fixture env))))
+        db (:db env)]
+    (mapv :id
+          (:data (engine/lookup-resources
+                  adapter
+                  {:subject {:type :user
+                             :id (ds/entid db [:eacl/id (:id principal)])}
+                   :permission (:permission (:fixture env))
+                   :resource/type (:resource-type (:fixture env))
+                   :first 50})))))
+
+(deftest routed-reads-are-classified-and-retried-test
+  (let [env (seeded :folder-chain)
+        expected (routed-lookup (:adapter env) env)
+        clean-scans (let [calls (atom 0)
+                          counting (adapter-with-scan
+                                    (:adapter env)
+                                    (fn [original & args]
+                                      (swap! calls inc)
+                                      (apply original args)))]
+                      (is (= expected (routed-lookup counting env)))
+                      @calls)]
+    (is (seq expected))
+    (is (pos? clean-scans))
+    (testing "a foreign adapter failure is retried under the deadline and the read completes"
+      (let [failures (atom 1)
+            flaky (adapter-with-scan
+                   (:adapter env)
+                   (fn [original & args]
+                     (if (pos? @failures)
+                       (do (swap! failures dec)
+                           (throw (RuntimeException. "transient storage hiccup")))
+                       (apply original args))))
+            stats (atom {})]
+        (is (= expected
+               (binding [engine/*recursive-traversal-stats* stats]
+                 (routed-lookup flaky env))))
+        (is (= (inc clean-scans) (:adapter-attempts @stats))
+            "attempts are counted separately from logical commands: the clean scans plus the one failed attempt")))
+    (testing "a persistently failing read surfaces as a classified retryable failure with its cause"
+      (let [broken (adapter-with-scan
+                    (:adapter env)
+                    (fn [_ & _] (throw (RuntimeException. "storage down"))))
+            data (try (routed-lookup broken env) nil
+                      (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= :eacl.scan/failure (:eacl/error data)))
+        (is (= :retryable (:classification data)))
+        (is (= "java.lang.RuntimeException" (:cause-class data)))
+        (is (= :subject->resources (:operation data)))))
+    (testing "typed EACL errors pass through the read boundary unwrapped and unretried"
+      (let [calls (atom 0)
+            violating (adapter-with-scan
+                       (:adapter env)
+                       (fn [_ & _]
+                         (swap! calls inc)
+                         (throw (ex-info "contract broken"
+                                         {:type :eacl/backend-contract-violation
+                                          :eacl/error :eacl/backend-contract-violation}))))
+            data (try (routed-lookup violating env) nil
+                      (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= :eacl/backend-contract-violation (:eacl/error data)))
+        (is (= 1 @calls) "no retry for a typed verdict")))))
+
+(deftest service-admission-bounds-routed-enumerations-test
+  (let [env (seeded :folder-chain)
+        gate (promise)
+        started (promise)
+        blocking (adapter-with-scan
+                  (:adapter env)
+                  (fn [original & args]
+                    (deliver started true)
+                    @gate
+                    (apply original args)))
+        admission (physical/make-service-admission {:max-concurrent 1})]
+    (testing "a second enumeration is rejected while the only slot is held"
+      (let [holder (future
+                     (binding [engine/*service-admission* admission]
+                       (routed-lookup blocking env)))]
+        (is (deref started 5000 false))
+        (let [data (try
+                     (binding [engine/*service-admission* admission]
+                       (routed-lookup (:adapter env) env))
+                     nil
+                     (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+          (is (= :eacl.service/admission-rejected (:eacl/error data)))
+          (is (= 1 (:active data))))
+        (deliver gate true)
+        (is (seq (deref holder 10000 nil)))
+        (is (zero? (:active @admission)) "the slot is released when the work returns")))
+    (testing "the replay ledger governs checkpoint-miss replays"
+      (let [page-1 (page/edge-page {:adapter (:adapter env) :plan (:plan env)
+                                    :direction :forward
+                                    :anchor-eid (ds/entid (:db env)
+                                                          [:eacl/id (:id (val (first (:principals (:fixture env)))))])
+                                    :subject-type :user :page-size 2})
+            edge {:ordinal (+ (:start-ordinal page-1) (count (:eids page-1)))
+                  :eid (peek (:eids page-1))}
+            ledger (physical/make-service-admission {:max-replays 1})
+            continue (fn []
+                       (page/edge-page {:adapter (:adapter env) :plan (:plan env)
+                                        :direction :forward
+                                        :anchor-eid (ds/entid (:db env)
+                                                              [:eacl/id (:id (val (first (:principals (:fixture env)))))])
+                                        :subject-type :user :page-size 2
+                                        :after edge
+                                        :service-admission ledger
+                                        :checkpoint-key [:test :replay]}))]
+        (is (seq (:eids (continue))) "a replay within the quota runs")
+        (is (= :eacl.service/replay-rejected
+               (physical/with-replay-admission
+                ledger [:other :key]
+                #(try (continue) nil
+                      (catch clojure.lang.ExceptionInfo e (:eacl/error (ex-data e))))))
+            "a replay beyond the total quota is rejected typed")))))
+
+(deftest topology-qualification-test
+  (let [env (seeded :folder-chain)
+        capabilities (physical/adapter-topology-capabilities (:adapter env))]
+    (testing "the DataScript adapter's declared strict profile qualifies it"
+      (is (physical/stable-discovery-qualified? capabilities))
+      (is (true? (:failure-classification? capabilities)))
+      (is (= 1 (:deployment-width capabilities)))
+      (is (= capabilities (physical/require-qualified-topology! (:adapter env)))))
+    (testing "an adapter with the conservative default profile is refused"
+      (let [conservative (backend/make-adapter
+                          {:id :synthetic
+                           :capabilities (backend/capabilities (:adapter env))
+                           :operations (:eacl.backend.v8/operations (:adapter env))
+                           :state (backend/state (:adapter env))})
+            data (try (physical/require-qualified-topology! conservative) nil
+                      (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (is (= :eacl.topology/unqualified (:eacl/error data)))
+        (is (= :eacl.topology/unqualified (:type data)))
+        (is (false? (get-in data [:capabilities :strict-scan-order?])))))
+    (testing "the client option is validated and installs the bulkhead"
+      (let [{:keys [conn]} (capture/seed-client! ((get capture/fixtures :folder-chain)))]
+        (doseq [bad [{:max-concurrent 0} {:bogus 1} 3]]
+          (is (= :eacl/invalid-config
+                 (try (datascript/make-client conn {:service-admission bad}) nil
+                      (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+              (pr-str bad)))
+        (let [client (datascript/make-client conn {:service-admission {:max-concurrent 4}})
+              admission (:service-admission (:opts client))]
+          (is (some? admission))
+          (is (= 4 (:max-concurrent @admission)))
+          (is (map? (eacl/lookup-resources
+                     client
+                     {:subject (eacl/spice-object
+                                :user (:id (val (first (:principals (:fixture env))))))
+                      :permission (:permission (:fixture env))
+                      :resource/type (:resource-type (:fixture env))
+                      :first 5}))
+              "enumerations run through the bulkhead"))))))

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -20,6 +20,7 @@
             [eacl.datomic.impl :as impl]
             [eacl.datomic.impl.indexed :as impl.indexed]
             [eacl.datomic.schema :as schema]
+            [eacl.engine.physical :as physical]
             [eacl.engine.v8 :as engine]
             [eacl.execution :as execution]
             [eacl.formal.production-kernel :as production-kernel]
@@ -83,6 +84,7 @@
               engine/*evaluation-mode* (:evaluation contract)
               engine/*recursive-traversal-limits*
               (:recursive-traversal-limits opts)
+              engine/*service-admission* (:service-admission opts)
               impl.indexed/*recursive-traversal-limits*
               (:recursive-traversal-limits opts)]
       (let [result (f opts)]
@@ -2357,6 +2359,7 @@
     :cache-attempt
     :recursive-traversal-limits
     :permission-tree-limits
+    :service-admission
     :auto-migrate-v6})
 
 (def ^:private canonical-security-opt-keys
@@ -2632,6 +2635,11 @@
     attempt bound. Cache work may remove evaluator commands but
     cannot enlarge request demand. Remote provider/decode controls are not
     exposed because caller-supplied cache providers are rejected.
+  - :service-admission — {:max-concurrent n :max-replays n :max-replays-per-key n}, the
+    service-edge bulkhead for routed enumerations (slots are held for the full
+    synchronous call chain) and the replay ledger for cursor replays; omitted
+    means no bulkhead. Rejections are :eacl.service/admission-rejected and
+    :eacl.service/replay-rejected.
   - :recursive-traversal-limits — overrides eacl.datomic.impl.indexed/default-recursive-traversal-limits
     for list calls, e.g. {:max-derived-grants 1000000 :max-advanced-datoms 1000000
     :max-queued-work 1000000}. Recursive traversal remains subject to these
@@ -2668,6 +2676,7 @@
            cache-attempt
            recursive-traversal-limits
            permission-tree-limits
+           service-admission
            auto-migrate-v6]}]
   (when-let [unknown-keys (seq (remove known-client-opt-keys (keys config-opts)))]
     (throw (ex-info (str "EACL Config Error: unknown make-client option(s) " (pr-str (vec unknown-keys))
@@ -3001,7 +3010,18 @@
                                    recursive-traversal-limits)
                             :permission-tree-limits
                             (permission-tree/normalize-limits
-                             permission-tree-limits)}]
+                             permission-tree-limits)
+                            ;; The service-edge bulkhead and replay ledger
+                            ;; (bounded-physical-execution): nil leaves the
+                            ;; routed engine unguarded, a map installs it.
+                            :service-admission
+                            (some-> (physical/normalize-service-admission
+                                     service-admission)
+                                    physical/make-service-admission)}
+        ;; The stable engine runs only on a qualified topology; the adapter's
+        ;; declared execution profile is checked once here.
+        _ (physical/require-qualified-topology!
+           ((:backend-adapter-fn opts) (d/db conn)))]
     (->Spiceomic conn opts)))
 
 (defn current-zed-token

--- a/modules/eacl-datomic/test/eacl/datomic/config_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/config_test.clj
@@ -200,3 +200,27 @@
       (testing "the other operations agree with expansion under the same codec"
         (is (true? (eacl/can? codec-client (->user "U1") :view (->server "S1"))))
         (is (contains? (leaf-subjects codec-tree) "U1"))))))
+
+(deftest service-admission-option-test
+  (with-mem-conn [conn schema/v7-schema]
+    @(d/transact conn (concat fixtures/relations+permissions fixtures/entity-fixtures))
+    @(d/transact conn (fixtures/relationship-fixtures (d/db conn)))
+    (testing "the option is validated at construction"
+      (doseq [bad [{:max-concurrent 0} {:bogus 1} :on]]
+        (is (= :eacl/invalid-config
+               (try (core/make-client conn {:service-admission bad}) nil
+                    (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+            (pr-str bad))))
+    (testing "a configured bulkhead is installed and enumerations run through it"
+      (let [client (core/make-client conn {:service-admission {:max-concurrent 8
+                                                               :max-replays 4}})
+            admission (:service-admission (:opts client))]
+        (is (= 8 (:max-concurrent @admission)))
+        (is (= 4 (:max-replays @admission)))
+        (is (= 2 (count (:data (eacl/lookup-resources client {:subject (->user "user-1")
+                                                              :permission :view
+                                                              :resource/type :server})))))
+        (is (true? (eacl/can? client (->user "user-1") :view (->server "account1-server1"))))
+        (is (zero? (:active @admission)) "slots are released when the work returns")))
+    (testing "the default client installs no bulkhead"
+      (is (nil? (:service-admission (:opts (core/make-client conn {}))))))))

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -37,6 +37,7 @@
                                         spice-object
                                         ->Relationship
                                         ->RelationshipUpdate]]
+            [eacl.engine.physical :as physical]
             [eacl.engine.v8 :as engine]
             [eacl.execution :as execution]
             [eacl.permission-tree :as permission-tree]
@@ -299,6 +300,8 @@
                            engine/*proof-frame* request-proof-frame
                            engine/*recursive-traversal-limits*
                            (:recursive-traversal-limits opts)
+                           engine/*service-admission*
+                           (:service-admission opts)
                            engine/*evaluation-mode*
                            (:evaluation contract)
                            execution/*contract* contract
@@ -1049,7 +1052,8 @@
     :adapter-deterministic?
     :consistency-sync-timeout-ms
     :execution-timeout-ms
-    :cache-attempt})
+    :cache-attempt
+    :service-admission})
 
 (defn make-client
   "Builds the shared IAuthorization client over one backend api map.
@@ -1079,7 +1083,7 @@
            consistency-sync-timeout-ms
            execution-timeout-ms
            cache-attempt
-           ]
+           service-admission]
     :or   {object-id->lookup-ref  (fn [obj-id] [:eacl/id obj-id])
            internal-cursor->spice default-internal-cursor->spice
            spice-cursor->internal default-spice-cursor->internal}}]
@@ -1270,5 +1274,16 @@
                           :spice-object->internal (fn [db obj]
                                                     (update obj :id #(object-id->entid db %)))
                           :internal-cursor->spice internal-cursor->spice
-                          :spice-cursor->internal spice-cursor->internal}]
+                          :spice-cursor->internal spice-cursor->internal
+                          ;; The service-edge bulkhead and replay ledger
+                          ;; (bounded-physical-execution): nil leaves the
+                          ;; routed engine unguarded, a map installs it.
+                          :service-admission
+                          (some-> (physical/normalize-service-admission
+                                   service-admission)
+                                  physical/make-service-admission)}
+        ;; The stable engine runs only on a qualified topology; the adapter's
+        ;; declared execution profile is checked once here.
+        _ (physical/require-qualified-topology!
+           ((:snapshot-adapter api) ((:db api) conn) opts))]
     (->ClientAuthorization conn opts api)))

--- a/modules/eacl/src/eacl/engine/physical.cljc
+++ b/modules/eacl/src/eacl/engine/physical.cljc
@@ -10,7 +10,9 @@
   any partially realized output is discarded because realization happens
   inside the classification boundary), or throws CANCELLED. Nil is never
   an outcome."
-  (:require [eacl.execution :as execution]))
+  (:require [clojure.string]
+            [eacl.backend.v8 :as backend]
+            [eacl.execution :as execution]))
 
 ;; ---------------------------------------------------------------------------
 ;; Three-outcome classification (task 7.1)
@@ -19,6 +21,20 @@
 (defn scan-failure?
   [error]
   (= :eacl.scan/failure (:eacl/error (ex-data error))))
+
+(defn typed-eacl-error?
+  "An error EACL itself raised with its typed shape (`:eacl/error`, or an
+  `:eacl…`-namespaced `:type`): a contract violation, limit, deadline,
+  cancellation, invalid configuration, or the like. These are already
+  classified verdicts and pass through the read boundary unwrapped and
+  unretried; only foreign adapter failures are classified here."
+  [error]
+  (let [data (ex-data error)]
+    (boolean
+     (and (map? data)
+          (or (keyword? (:eacl/error data))
+              (some-> (:type data) namespace
+                      (clojure.string/starts-with? "eacl")))))))
 
 (defn- classification-of
   [throwable]
@@ -41,7 +57,7 @@
     (try
       (vec (fetch-fn descriptor))
       (catch #?(:clj Throwable :cljs :default) failure
-        (if (scan-failure? failure)
+        (if (or (scan-failure? failure) (typed-eacl-error? failure))
           (throw failure)
           (throw (ex-info "Adapter read failed."
                           {:eacl/error :eacl.scan/failure
@@ -82,6 +98,34 @@
 ;; ---------------------------------------------------------------------------
 ;; Service-edge admission and the replay ledger (task 7.5)
 ;; ---------------------------------------------------------------------------
+
+(def service-admission-keys
+  #{:max-concurrent :max-replays :max-replays-per-key})
+
+(defn normalize-service-admission
+  "Validates the client's `:service-admission` option: nil disables the
+  bulkhead; otherwise a map of positive integers under
+  `service-admission-keys`."
+  [options]
+  (when (some? options)
+    (when-not (map? options)
+      (throw (ex-info ":service-admission must be a map."
+                      {:type :eacl/invalid-config
+                       :key :service-admission
+                       :value options})))
+    (when-let [unknown (seq (remove service-admission-keys (keys options)))]
+      (throw (ex-info "Unknown :service-admission option."
+                      {:type :eacl/invalid-config
+                       :key :service-admission
+                       :unknown-keys (vec unknown)
+                       :known-keys service-admission-keys})))
+    (when-not (every? (fn [[_ value]] (and (integer? value) (pos? value)))
+                      options)
+      (throw (ex-info ":service-admission limits must be positive integers."
+                      {:type :eacl/invalid-config
+                       :key :service-admission
+                       :value options})))
+    options))
 
 (defn make-service-admission
   "Bounded service-edge admission: at most `:max-concurrent` enumerations
@@ -224,6 +268,58 @@
                         :unique-scan-values? :replayable-scans?
                         :strict-progress? :atomic-response?
                         :failure-classification?]))
+
+(defn adapter-topology-capabilities
+  "The closed capability record of one adapter's topology, derived from the
+  execution profile the adapter declares (`eacl.backend.v8/traversal-execution`:
+  immutable basis reads and the strict/unique/replayable/progress/atomic scan
+  contract), its snapshot capabilities (exact selection), and the engine's
+  read boundary, which classifies every adapter failure
+  (`classified-fetch-fn`) so `:failure-classification?` holds for any adapter
+  read through it. Semantic concurrent-read safety and physical
+  cancellability stay conservative until the concurrency change certifies
+  them; deployment width is one."
+  [adapter]
+  (let [{:keys [immutable-basis-reads? scan-contract concurrent-snapshot-reads]}
+        (backend/traversal-execution adapter)]
+    (topology-capabilities
+     {:immutable-basis? (boolean immutable-basis-reads?)
+      :strict-scan-order? (boolean (:strict-order? scan-contract))
+      :unique-scan-values? (boolean (:unique? scan-contract))
+      :replayable-scans? (boolean (:replayable? scan-contract))
+      :strict-progress? (boolean (:strict-progress? scan-contract))
+      :atomic-response? (boolean (:atomic-chunk? scan-contract))
+      :failure-classification? true
+      :physically-cancellable?
+      (boolean (:physically-cancellable? concurrent-snapshot-reads))
+      :termination-on-return?
+      (if (some? concurrent-snapshot-reads)
+        (boolean (:physical-termination-on-return? concurrent-snapshot-reads))
+        true)
+      :nested-retry-exposure
+      (if-let [attempts (:maximum-nested-attempts concurrent-snapshot-reads)]
+        attempts
+        :unknown)
+      :semantic-concurrent-read-safe? false
+      :deployment-width 1
+      :exact-basis-selection?
+      (boolean (backend/supports? adapter :snapshots :exact))})))
+
+(defn require-qualified-topology!
+  "Fails closed with `:eacl.topology/unqualified` when the adapter's derived
+  capability record does not certify stable discovery. Clients call this
+  once at construction against their source adapter, so an adapter whose
+  declared execution profile is the conservative default (no strict scan
+  contract) cannot be routed through the stable engine. Returns the record."
+  [adapter]
+  (let [capabilities (adapter-topology-capabilities adapter)]
+    (when-not (stable-discovery-qualified? capabilities)
+      (throw (ex-info "This backend topology is not qualified for stable-discovery enumeration: its adapter does not declare the strict, unique, replayable, strict-progress, atomic scan contract over an immutable basis."
+                      {:type :eacl.topology/unqualified
+                       :eacl/error :eacl.topology/unqualified
+                       :backend (backend/backend-id adapter)
+                       :capabilities capabilities})))
+    capabilities))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-layer telemetry (task 7.8)

--- a/modules/eacl/src/eacl/engine/stable_page.cljc
+++ b/modules/eacl/src/eacl/engine/stable_page.cljc
@@ -22,6 +22,7 @@
     stale-cursor — when they make a page unreachable."
   (:require [clojure.string :as string]
             [eacl.backend.v8 :as backend]
+            [eacl.engine.physical :as physical]
             [eacl.engine.stable-reducer :as reducer]
             [eacl.secure-format :as secure-format]))
 
@@ -280,6 +281,17 @@
                      (dissoc (ex-data error) :eacl/error))
         (throw error)))))
 
+(defn- governed-replay
+  "A replay (a checkpoint miss, a backward run, or a last-window run) runs
+  under the service-edge replay ledger when the caller configured one
+  (`:service-admission`), keyed by the continuation identity, and always
+  under the exhaustion guard."
+  [{:keys [service-admission checkpoint-key]} thunk]
+  (physical/with-replay-admission
+   service-admission
+   (or checkpoint-key ::anonymous-replay)
+   #(guard-exhaustion thunk)))
+
 (defn- state-at-boundary
   "Reconstructs semantic state and pending lookahead at boundary `ordinal`:
   by checkpoint when the exact edge matches, else by governed deterministic
@@ -291,7 +303,8 @@
       (when-let [stats reducer/*observer-stats*]
         (swap! stats update :continuation-hits (fnil inc 0)))
       {:state (:state hit) :pending (:pending hit)})
-    (let [replayed (guard-exhaustion
+    (let [replayed (governed-replay
+                    options
                     #(run-fresh options anchor-eid ordinal))
           results (:results replayed)]
       (when (or (< (count results) ordinal)
@@ -309,7 +322,9 @@
   cursor layer against the same composite fingerprint and exact basis).
   Returns {:eids [..] :start-ordinal k :has-next? :has-previous?} in
   canonical forward order. A `:last-window?` request returns the final
-  window of the exhausted sequence."
+  window of the exhausted sequence. When `:service-admission` names a
+  service-edge admission, replays (checkpoint misses, backward runs and last
+  windows) run under its replay ledger keyed by `:checkpoint-key`."
   [{:keys [plan direction anchor-eid subject-type page-size
            after before last-window? checkpoints checkpoint-key]
     :as options}]
@@ -323,7 +338,8 @@
     before
     (let [{:keys [ordinal eid]} before
           start (max 0 (- ordinal 1 page-size))
-          replayed (guard-exhaustion
+          replayed (governed-replay
+                    options
                     #(run-fresh options anchor-eid ordinal))
           results (:results replayed)]
       (when (or (< (count results) ordinal)
@@ -337,7 +353,8 @@
        :has-previous? (pos? start)})
 
     last-window?
-    (let [run (guard-exhaustion
+    (let [run (governed-replay
+               options
                #(run-fresh options anchor-eid
                            reducer/exhaustion-target))
           results (:results run)

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -996,6 +996,48 @@
   (when-let [contract execution/*contract*]
     (physical/execution-cut-point contract)))
 
+(def ^:dynamic *service-admission*
+  "The client's service-edge admission (an atom from
+  `eacl.engine.physical/make-service-admission`), bound per request by the
+  public clients from their `:service-admission` option. nil disables the
+  bulkhead and the replay ledger."
+  nil)
+
+(def default-physical-attempts
+  "Attempts per read-demand descriptor for `:retryable` adapter failures on
+  the routed path (the original absolute deadline still bounds every retry)."
+  3)
+
+(defn- stable-fetch-fn
+  "The routed physical read path (bounded-physical-execution): the adapter
+  scan realized inside the three-outcome classification boundary (complete
+  | classified failure with a cause | cancelled — typed EACL errors pass
+  through unwrapped and unretried) and retried for `:retryable` failures
+  under the request's original absolute deadline. Returns the fetch-fn and
+  the attempt counter that feeds `:adapter-attempts` in the observer stats."
+  [db]
+  (let [attempts (atom 0)]
+    {:fetch-fn (physical/retrying-fetch-fn
+                (stable-reducer/adapter-fetch-fn db)
+                {:max-attempts default-physical-attempts
+                 :deadline-nanos (:deadline-nanos execution/*contract*)
+                 :attempts attempts})
+     :attempts attempts}))
+
+(defn- report-adapter-attempts!
+  [attempts]
+  (when-let [stats *recursive-traversal-stats*]
+    (swap! stats update :adapter-attempts (fnil + 0) @attempts))
+  nil)
+
+(defn- with-service-admission
+  "Runs `thunk` holding one enumeration slot when the client configured a
+  service-edge bulkhead; the slot is held for the full synchronous duration
+  of the routed work (at width one the enumeration is the physical call
+  chain)."
+  [thunk]
+  (physical/with-admission *service-admission* thunk))
+
 (defn- stable-checkpoints
   "Accepts a stable-page checkpoint store (raw atom) or the client's scoped
   continuation context (fn-map with its own bounds and eviction); anything
@@ -1072,28 +1114,34 @@
             anchor-eid (object-eid db (:id anchor))
             edge (when bound {:ordinal (:ordinal bound)
                               :eid (:result-eid bound)})
+            {:keys [fetch-fn attempts]} (stable-fetch-fn db)
             result (with-stale-boundary-errors
                      bound
                      (fn []
                        (with-public-limit-errors
-                        #(stable-page/edge-page
-                          (merge
-                        (stable-limits)
-                        {:adapter db
-                         :plan plan
-                         :direction traversal
-                         :anchor-eid anchor-eid
-                         :subject-type subject-type
-                         :cut-point! (stable-cut-point)
-                         :page-size size
-                         :after (when (= :asc direction) edge)
-                         :before (when (and (= :desc direction) edge) edge)
-                         :last-window? (and (= :desc direction) (nil? edge))
-                         :checkpoints (stable-checkpoints cache)
-                         :checkpoint-key [(:fingerprint plan)
-                                          (backend/invoke db :native-revision)
-                                          traversal subject-type anchor-eid
-                                          size]})))))]
+                        #(with-service-admission
+                           (fn []
+                             (stable-page/edge-page
+                              (merge
+                               (stable-limits)
+                               {:adapter db
+                                :fetch-fn fetch-fn
+                                :plan plan
+                                :direction traversal
+                                :anchor-eid anchor-eid
+                                :subject-type subject-type
+                                :cut-point! (stable-cut-point)
+                                :page-size size
+                                :after (when (= :asc direction) edge)
+                                :before (when (and (= :desc direction) edge) edge)
+                                :last-window? (and (= :desc direction) (nil? edge))
+                                :checkpoints (stable-checkpoints cache)
+                                :service-admission *service-admission*
+                                :checkpoint-key [(:fingerprint plan)
+                                                 (backend/invoke db :native-revision)
+                                                 traversal subject-type anchor-eid
+                                                 size]})))))))]
+        (report-adapter-attempts! attempts)
         (page-response
          {:items (stable-items plan traversal result-type
                                (:start-ordinal result) (:eids result))
@@ -1113,16 +1161,23 @@
               db resource-type permission))]
     (if defined-root?
       (let [root-node (permission-query-node resource-type permission)
-            plan (stable-plan db root-node)]
-        (with-public-limit-errors
-          #(stable-route/check-eids
-            (merge (stable-limits)
-                   {:adapter db
-                    :plan plan
-                    :subject-type subject-type
-                    :subject-eid subject-eid
-                    :resource-eid resource-eid
-                    :cut-point! (stable-cut-point)}))))
+            plan (stable-plan db root-node)
+            {:keys [fetch-fn attempts]} (stable-fetch-fn db)
+            allowed?
+            (with-public-limit-errors
+              #(with-service-admission
+                 (fn []
+                   (stable-route/check-eids
+                    (merge (stable-limits)
+                           {:adapter db
+                            :fetch-fn fetch-fn
+                            :plan plan
+                            :subject-type subject-type
+                            :subject-eid subject-eid
+                            :resource-eid resource-eid
+                            :cut-point! (stable-cut-point)})))))]
+        (report-adapter-attempts! attempts)
+        allowed?)
       false)))
 (defn lookup-resources
   "Stable-discovery forward pagination.
@@ -1187,18 +1242,23 @@
      (if-not (permission-root-defined? db result-type permission)
        {:count 0 :truncated? false}
        (let [plan (stable-plan
-                   db (permission-query-node result-type permission))]
-         (select-keys
-          (with-public-limit-errors
-            #(stable-route/count-resources
-              (merge (stable-limits)
-                     {:adapter db
-                      :plan plan
-                      :subject-type (:type subject)
-                      :subject-id (:id subject)
-                      :count-limit limit
-                      :cut-point! (stable-cut-point)})))
-          [:count :truncated?])))
+                   db (permission-query-node result-type permission))
+             {:keys [fetch-fn attempts]} (stable-fetch-fn db)
+             counted
+             (with-public-limit-errors
+               #(with-service-admission
+                  (fn []
+                    (stable-route/count-resources
+                     (merge (stable-limits)
+                            {:adapter db
+                             :fetch-fn fetch-fn
+                             :plan plan
+                             :subject-type (:type subject)
+                             :subject-id (:id subject)
+                             :count-limit limit
+                             :cut-point! (stable-cut-point)})))))]
+         (report-adapter-attempts! attempts)
+         (select-keys counted [:count :truncated?])))
      limit)))
 
 (defn count-subjects
@@ -1214,16 +1274,21 @@
      (if-not (permission-root-defined? db (:type resource) permission)
        {:count 0 :truncated? false}
        (let [plan (stable-plan
-                   db (permission-query-node (:type resource) permission))]
-         (select-keys
-          (with-public-limit-errors
-            #(stable-route/count-subjects
-              (merge (stable-limits)
-                     {:adapter db
-                      :plan plan
-                      :subject-type (:subject/type query)
-                      :resource-id (:id resource)
-                      :count-limit limit
-                      :cut-point! (stable-cut-point)})))
-          [:count :truncated?])))
+                   db (permission-query-node (:type resource) permission))
+             {:keys [fetch-fn attempts]} (stable-fetch-fn db)
+             counted
+             (with-public-limit-errors
+               #(with-service-admission
+                  (fn []
+                    (stable-route/count-subjects
+                     (merge (stable-limits)
+                            {:adapter db
+                             :fetch-fn fetch-fn
+                             :plan plan
+                             :subject-type (:subject/type query)
+                             :resource-id (:id resource)
+                             :count-limit limit
+                             :cut-point! (stable-cut-point)})))))]
+         (report-adapter-attempts! attempts)
+         (select-keys counted [:count :truncated?])))
      limit)))


### PR DESCRIPTION
Stacked on #118 (`agent/stable-engine-audit-cleanup`); merge that first.

## Summary

Audit item 2.3: section 7 of `adopt-stable-discovery-enumeration` (three-outcome reads, retry under the original deadline, the service-edge bulkhead and replay ledger, the topology capability record) was delivered as tested library components while the routed public path installed only the execution cut-point. This wires them in.

- **Classified, retried reads on every routed entry point** (`eacl.engine.v8/stable-fetch-fn`): a foreign adapter failure is classified `:retryable`, retried up to three times for the same descriptor under the request's original absolute deadline, and then surfaces as `:eacl.scan/failure` with `:classification`, `:cause-class` and the original exception as its cause. Typed EACL errors (`:eacl/backend-contract-violation` from the runtime guards, limits, deadlines, cancellation) pass through unwrapped and unretried — the pinned public error contracts do not change. Attempts join the traversal work stats as `:adapter-attempts`.
- **`:service-admission` client option** (`{:max-concurrent :max-replays :max-replays-per-key}`, validated): the bulkhead holds one slot per routed point check / lookup / count for the full synchronous call chain (`:eacl.service/admission-rejected`); the replay ledger governs checkpoint-miss replays, backward runs and last windows keyed by continuation identity (`:eacl.service/replay-rejected`). Omitted → no bulkhead. Both clients bind it per request.
- **Topology qualification at construction**: the adapter's closed capability record is derived from its declared execution profile plus the engine's read boundary; both clients fail closed with `:eacl.topology/unqualified` when it does not certify stable discovery. The three bundled adapters declare the strict sequential profile and qualify.

Docs: `docs/stable-discovery-engine.md` (Failure semantics, Topology qualification) and `docs/v8-backend-modules-and-upgrade.md` now describe the wired behaviour and the option; the audit report's §2.3 records the fix.

## Verification

- Fresh-JVM battery (`cognitect.test-runner`, four module test roots, `:excludes [:benchmark :formal-artifact]`): 633 tests, 26,087 assertions, 0 failures.
- DataScript CLJS suite compiled and run as CI does: 193 tests, 7,311 assertions, 0 failures.
- `formal/stable-discovery/verify-fast.sh`: 506 obligations, all mutation controls killed, 6 s.
- `node bin/public-source-closure.mjs check`: passed (61 roots, 1,321 definitions).
- New tests: `physical_route_test` `routed-reads-are-classified-and-retried-test` (retry completes the read and counts attempts; a persistent failure surfaces classified with its cause; a typed contract violation passes through with a single attempt), `service-admission-bounds-routed-enumerations-test` (a held slot rejects the second enumeration typed and is released on return; the ledger rejects a replay beyond quota), `topology-qualification-test` (strict profile qualifies; the conservative default is refused; the client option is validated and installed); `config_test/service-admission-option-test` for the Datomic client.
