### PR TITLE
Cursors no longer expire, `at-exact-snapshot` now calls `(d/sync T)` if Peer is behind and exact queries now leverage Exact Answer cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ Situated AuthZ offers some advantages for typical use-cases:
 
 Public cursors are opaque, authenticated, and tied to the query and database
 snapshot that created them. A cursor walk stays on that snapshot even when the
-current database advances. If the backend can no longer reconstruct it, EACL
-returns a typed cursor-expired or snapshot-unavailable error.
+current database advances. Cursors have no age expiry unless
+`:cursor-ttl-seconds` is configured. If a conditionally historical backend can
+no longer reconstruct the selected value, EACL returns a typed
+snapshot-unavailable error; ordinary Datomic history and history-enabled
+Datahike do not expire a cursor merely because it is old.
 
 ## Project Status
 
@@ -536,6 +539,12 @@ dependency to your `deps.edn` file:
 ; => true
 ```
 
+EACL-created Datahike databases enable `:keep-history? true` by default so
+exact tokens and cursors survive ordinary commit-record cutoff collection.
+Pass `{:keep-history? false}` to `create-conn` only when lower write/storage
+amplification is worth making exact reconstruction conditional on retained
+commit records.
+
 ## DataScript Quickstart
 
 For server-side or browser demos, use the DataScript adapter:
@@ -758,17 +767,21 @@ The default options are to use the built-in EACL string attr `:eacl/id`, but you
 ```
 
 `make-client` rejects unknown options with `{:type :eacl/invalid-config}`.
-Datomic page tokens expire after 5 minutes by default (the shared Datahike and
-DataScript client issues non-expiring cursors unless a TTL is configured); tune with
-`:cursor-ttl-seconds`.
+All backends issue non-expiring cursors by default. Configure a positive
+`:cursor-ttl-seconds` only when the application deliberately wants a maximum
+pagination age; cache TTL and capacity remain independent of cursor age.
 
 ### Caching
 
 Caching is automatic, bounded, and private to each EACL client. Cache data is
 never written to the application database. EACL first looks for an answer from
-the exact immutable database value selected by the request. It may reuse an
-older answer only when it can establish that the relevant schema and
-relationships have not changed. If it cannot establish that safely, it runs the
+the exact immutable database value selected by the request. Authenticated
+`at-exact-snapshot` requests may reuse a completed answer only when the full
+source/lifecycle, native locator, ordinary-view, adapter/identity, engine,
+request, result-shape, demand, and limit identity matches. Exact requests never
+use managed proof-backed lifting. Ordinary current requests may reuse an older
+answer only when EACL establishes that the relevant schema and relationships
+have not changed. If it cannot establish either condition safely, it runs the
 authorization query normally.
 
 A long-running request can continue using the immutable database value it
@@ -888,9 +901,16 @@ Reads can request stronger behavior when the backend supports it:
            (consistency/at-exact-snapshot prior-token))
 ```
 
-Datomic supports synchronization and exact historical reconstruction while the
-required history remains available. Datahike advertises only the guarantees
-supported by its configured store and writer. DataScript does not provide
+Datomic exact selection treats an authentic same-source token ahead of the
+local Peer as replica lag: it performs bounded `(d/sync conn T)` when needed,
+verifies the returned basis, and always evaluates `(d/as-of db T)`. A locally
+available `T` skips synchronization. Ordinary unreplaced Datomic history has
+no EACL cursor-retention window.
+
+EACL-created Datahike databases retain temporal history by default. External
+history-enabled Datahike stores can reconstruct exact revisions after commit
+record collection; history-disabled stores advertise only conditional exact
+selection while a named commit is retained. DataScript does not provide
 general historical snapshot reconstruction. If a backend cannot satisfy the
 requested guarantee, EACL returns a typed error rather than silently selecting
 a different snapshot.
@@ -1090,9 +1110,15 @@ Now you can transact relationships. The usual way is `eacl/create-relationships!
 ## Limitations, Deficiencies & Gotchas:
 
 - *Exact snapshots require backend history:* `at-exact-snapshot` and continued
-  cursors require the backend to reconstruct the selected database value. If
-  it is unavailable, EACL returns a typed snapshot-unavailable or
-  cursor-expired error rather than silently using a newer value.
+  cursors require the backend to reconstruct the selected database value.
+  Ordinary Datomic history and history-enabled Datahike do not age-expire.
+  History-disabled Datahike can lose a conditionally retained commit and then
+  returns snapshot-unavailable rather than silently using a newer value.
+- *History destruction is a lifecycle boundary:* Datomic excision and
+  Datahike purge/cutoff, branch force, reset, restore, or equivalent destructive
+  replacement require quiescing affected traffic, completing the operation,
+  rotating the shared source lifecycle and affected clients/caches, and then
+  resuming with deliberate token/cursor key-version policy.
 - *No negation operator:* EACL only supports Union (`+`) permission operators, not `-` negation, e.g.
   - `permission admin = owner + shared_admin` is valid,
   - but `permission admin = owner - banned_member` is not (note the `-` Negation operator).

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -38,7 +38,7 @@ Caching does not alter results:
 
 | Layer | Reuse scope | Purpose |
 | --- | --- | --- |
-| Exact completed answer | Same semantic operation and immutable database value | Skips the complete operation with no proof read |
+| Exact completed answer | Same semantic operation and canonical ordinary immutable snapshot | Skips the complete operation with no proof read; retained historical generations share one bounded composite-key tier |
 | Proof-backed completed answer | Same semantic operation, lifecycle, schema generation, and dependency frontier | Survives unrelated forward transactions |
 | Identity projection | Same backend, identity contract, and internal id | Shares `internal-id->object` renderings while a page is externalized |
 | Sealed plan | Same source scope, lifecycle, basis, and permission root | Reuses the compiled stable-discovery plan across requests |
@@ -53,7 +53,7 @@ Partially processed worklists and incomplete pages are not completed answers.
 
 ## Exact-first lookup
 
-For a completed operation EACL resolves:
+For an ordinary current completed operation EACL resolves:
 
 1. an exact answer for the selected immutable database value;
 2. a proof-backed answer when complete proof is available;
@@ -63,6 +63,23 @@ For a completed operation EACL resolves:
 An exact hit performs no generation proof reads. A proof-backed hit is promoted
 into the exact store for the selected value, so the next identical request on
 that value is exact.
+
+After successful authenticated `at-exact-snapshot` selection, EACL probes only
+the snapshot-exact completed-answer tier. Its composite identity includes the
+backend/source/branch and configured lifecycle, native revision and exact
+locator, ordinary exact-view kind, adapter fingerprint and identity contract,
+engine/order ABI, normalized semantic request, result kind, demand, and every
+answer-affecting limit. Equal numeric revisions alone are insufficient. A miss
+evaluates on the already selected immutable adapter and may publish only the
+completed answer; it never probes or publishes managed proof-backed entries or
+partial traversal state.
+
+Current requests may seed the same tier only when their adapter certifies that
+the native locator is independently exact-selectable. Filtered, `since`,
+history, speculative, caller-constructed, and current-only DataScript values
+cannot acquire an ordinary snapshot-exact identity. Public tokens, cursor
+envelopes, cache basis, external IDs, and selected-snapshot metadata are rebuilt
+on every hit.
 
 ## Automatic proof-backed coherence
 
@@ -168,6 +185,10 @@ EACL cache semaphore or inherit another request's failure. Completed results
 race bounded best-effort publication. Late publication from an expired
 lifecycle is unreachable from the replacement lifecycle.
 
+Historical exact entries share the answer tier's weight/LRU/admission bounds;
+retaining more immutable generations does not make memory unbounded. Eviction
+causes exact recomputation and is never interpreted as token or cursor expiry.
+
 Typical configuration:
 
 ```clojure
@@ -243,6 +264,13 @@ Rotate lifecycle state after reset, restore, branch replacement, or any event
 that can reuse or regress native revisions. Equal revision numbers from
 different source histories are not comparable.
 
+Treat Datomic excision and Datahike purge/cutoff, branch force, reset, or other
+destructive history operations as explicit lifecycle replacement. Quiesce
+affected authorization traffic, complete the destructive operation, rotate
+the shared lifecycle and all clients/caches, deliberately retire or retain the
+appropriate signing keys and wire versions, then resume. An unchanged
+lifecycle provides no safety across concurrent history destruction.
+
 ## Cursors and time travel
 
 Cursors are authenticated and scoped to operation, normalized query, adapter,
@@ -251,6 +279,12 @@ current value may continue a walk. Otherwise, a history-capable backend may
 reconstruct the authenticated exact snapshot; if it cannot, the cursor fails
 closed. DataScript does not emulate history with hidden retained database
 values.
+
+Cursors carry no expiry unless a positive `:cursor-ttl-seconds` is configured.
+Cache TTL, answer eviction, page-navigation eviction, and checkpoint eviction
+do not limit cursor age; they only cause deterministic replay. An old cursor
+continues the original historical enumeration. Consumers that require current
+authorization at object-consumption time must make a separate current check.
 
 EACL does not promise proof-backed cache availability for `as-of`, `since`,
 filtered, speculative, or caller-constructed database values. Exact historical
@@ -266,7 +300,10 @@ also expose `:cached?` and `:cache-basis`; `can?` returns only a Boolean.
 
 The cache-free evaluator is the behavioral oracle. Differential and randomized
 tests compare cached and bypassed results across all bundled backends. Dafny
-proves the scalar-frontier theorem and cache refinements under the documented
-adapter obligations; backend certification tests establish the executable
-trusted boundary. See [formal verification](formal-verification.md) and the
+proves the scalar-frontier theorem and distinguishes current-exact,
+snapshot-exact, and managed cache decisions under the documented adapter
+obligations. Backend I/O effects, temporal-history retention, future
+cancellation, and canonical-key truthfulness are certified adapter assumptions,
+not kernel theorems. Backend certification and real-store regressions establish
+the executable trusted boundary. See [formal verification](formal-verification.md) and the
 [scalar-frontier measurements](benchmarks/results/2026-08-11-scalar-frontier-coherence.md).

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -113,7 +113,7 @@ starts no test JVM and only evaluates a supplied form in an existing server.
 | `IndexedBatching.dfy` | **retired** bounded ordered scan waves and crossing law of the generated indexed traversal; same disposition |
 | `IndexedBatchCompleteness.dfy` | **retired** proof-only pending-scan ghost views; same disposition |
 | `CacheKernel.dfy` | dependency-scope completeness, forward cache acceptance, recomputation equivalence, and telemetry noninterference |
-| `CurrentCache.dfy` | exact/current admission, lifecycle isolation, scalar stamps, least-fixed-point dependency frame, selected-snapshot rendering |
+| `CurrentCache.dfy` | distinct current-exact/snapshot-exact/managed admission, canonical exact identity and lifecycle isolation, scalar stamps, least-fixed-point dependency frame, selected-snapshot rendering |
 | `NativeGenerationCoherence.dfy` | forward native-generation frame, empty dependencies, stale endpoint exclusion, component cleanup/stamping, and lifecycle isolation |
 | `ScalarFrontierCoherence.dfy` | globally ordered native generations, scalar-frontier soundness, complete proof frames, demand identity, and completed-only publication |
 | `SchemaPlanCost.dfy` | one recursive-plan compilation per permission root/schema generation and bounded page-sensitive stream batches |

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -93,9 +93,12 @@ schemas, relationships, caches, and tokens require no rewrite.
 - `:fully-consistent` explicitly requests a backend synchronization barrier.
 - `:at-least-as-fresh` performs targeted selection and validates the
   authenticated native revision floor within one source lifecycle.
-- `:at-exact-snapshot` performs exact selection and bypasses completed-answer
-  caching on backends that advertise it. DataScript rejects it before cache
-  access because DataScript has no EACL time-travel registry.
+- `:at-exact-snapshot` performs exact selection and may reuse only a completed
+  answer bound to the identical canonical snapshot and semantic request. It
+  never uses managed proof-backed lifting. Datomic catches a lagging Peer up
+  to authenticated `T` with bounded two-argument `d/sync` before exact
+  `d/as-of T`; DataScript rejects exact mode before cache access because it has
+  no EACL time-travel registry.
 - Low-level operations accepting an arbitrary `db`, including caller-created
   `d/as-of`, `d/with`, prospective, or filtered views, bypass completed-answer
   caching.
@@ -134,15 +137,20 @@ permission check.
 ## Completed-answer cache
 
 Each Datomic, Datahike, and DataScript client owns a bounded native cache. It
-has two sound reuse rules:
+has three sound reuse rules:
 
 1. **Exact-current:** accept an entry only for the identical immutable selected
    DB generation.
 2. **Managed-current:** under an explicit stamped-writer contract, accept an
    entry when its schema generation and relevant dependency stamp still match.
+3. **Snapshot-exact:** after authenticated exact selection, accept only the
+   complete answer with the identical source/lifecycle, native locator,
+   ordinary-view, adapter/identity, engine, request, result, demand, and limit
+   identity.
 
 The cache is an optimization over the cache-free evaluator. It does not define
-authorization and does not support time travel.
+authorization; snapshot-exact retention accelerates, but never creates,
+backend time travel.
 
 ### Exact-current tier
 
@@ -154,6 +162,9 @@ authorization and does not support time travel.
   calculation occurs on an exact hit.
 - Publication captures the generation/lifecycle. A delayed computation cannot
   repopulate a newer or explicitly expired lifecycle.
+- Retained historical exact answers share one bounded weighted/LRU composite
+  store. Exact requests never bind this as a partial traversal store and never
+  consult managed relation/schema proof.
 
 ### Managed-current tier
 
@@ -200,7 +211,10 @@ projections) under one relation-stamp framing:
 
 These rotate source/token scope and replace the entire client lifecycle. Use them after reset,
 restore, branch force, manual history manipulation, or unstamped bulk repair.
-Async Datomic excision is outside this v8 contract.
+Datomic excision and Datahike purge/cutoff or branch replacement are outside
+the unchanged-lifecycle contract: quiesce traffic, complete the operation,
+rotate the shared lifecycle and every client/cache, apply deliberate key/wire
+retirement policy, and then resume.
 
 The corresponding `cache-stats` functions report native exact/managed hits,
 misses, bypasses, stamp failures, publications, expirations, and entry counts.
@@ -234,12 +248,19 @@ required.
 
 ## Cursor redesign
 
-Portable cursor payloads are v11 inside the compact `eacl_c4_` authenticated
+Portable cursor payloads are v12 inside the compact `eacl_c4_` authenticated
 frame. Cursors bind the backend/source, operation, complete semantic query
 (including principal and consistency), result kind, semantic/configuration
 identity, source lifecycle, native revision, and exact snapshot locator. Relay window size and
 direction remain caller-controlled so the same boundary supports forward and
 backward navigation.
+
+Cursor expiry is off by default on every backend. A positive
+`:cursor-ttl-seconds` adds explicit policy expiry; answer, navigation, and
+checkpoint eviction only trigger deterministic replay. The v12 query-scope
+digest excludes mutable current schema proof so a changed schema can reach
+proof comparison and exact fallback. v11 decoding remains supported for
+compatible existing envelopes.
 
 - Every permission lookup page uses one `:stable-edge` boundary containing
   traversal direction, the boundary result's one-based ordinal, its identity,
@@ -495,8 +516,9 @@ as replayed counterexamples against the stable engine.
 
 `formal/dafny/CurrentCache.dfy` proves:
 
-- exact/historical/arbitrary-DB completed-cache bypass;
-- exact-hit same-snapshot equality;
+- arbitrary-DB completed-cache bypass and canonical exact-snapshot admission;
+- distinct current-exact, snapshot-exact, and managed hit/miss decisions;
+- snapshot-exact identity equality rather than numeric-revision equality;
 - late publication cannot repopulate an expired lifecycle;
 - forward scalar-stamp invalidation;
 - relevant relationship projection framing for direct, self, arrow-relation,
@@ -504,7 +526,12 @@ as replayed counterexamples against the stable engine.
 - equality of least fixed points for complete compiled dependencies;
 - selected-snapshot internal-to-public result rendering.
 
-The locked Dafny run completes 8,785 proof efforts across 30 source-project
+The model does not prove Datomic I/O effects or future cancellation, Datahike
+temporal-history retention, or the truthfulness of adapter-provided canonical
+cache-key fields. Those are explicit certified adapter assumptions exercised
+by deterministic effect and real-backend tests.
+
+The locked Dafny run completes 8,793 proof efforts across 30 source-project
 invocations with zero errors, admissions, warnings, or timeouts. The count
 includes dependency obligations repeated by multiple top-level invocations; it
 is pipeline work, not a count of unique theorems. Since 2026-08-14 the

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -9,8 +9,8 @@ depend on one adapter module; backend authors depend on core.
 
 | Module | Runtime | Consistency and snapshots | Cursors |
 | --- | --- | --- | --- |
-| `eacl-datomic` | Clojure/JVM | current Peer DB, explicit sync barrier, causal floor, exact `d/as-of` | authenticated; proof-equivalent current continuation or exact reconstruction |
-| `eacl-datahike` | Clojure/JVM | current connection DB; configured head barrier and retained exact selection when supported | authenticated; proof-equivalent current continuation or supported exact reconstruction |
+| `eacl-datomic` | Clojure/JVM | current Peer DB, explicit sync barrier, causal floor, targeted catch-up plus exact `d/as-of T` | authenticated; proof-equivalent current continuation or full-history exact reconstruction |
+| `eacl-datahike` | Clojure/JVM | current connection DB; durable temporal history when enabled, otherwise conditional retained-commit selection | authenticated; proof-equivalent current continuation or configuration-honest exact reconstruction |
 | `eacl-datascript` | Clojure and ClojureScript | current connection DB; no arbitrary exact selection | authenticated proof-equivalent current continuation |
 | `eacl` | Clojure and ClojureScript | supplied by an adapter | shared protocol, engine, proof, and cache implementation |
 
@@ -43,6 +43,13 @@ generations. The retained identity contains the source lifecycle, schema
 generation, and scalar maximum generation over the complete relation
 dependency closure.
 
+Authenticated `at-exact-snapshot` requests use a separate bounded
+snapshot-exact answer tier after selection. Its key binds the complete
+source/lifecycle, native locator, ordinary-view, adapter/identity, engine,
+semantic request, result-shape, demand, and limit identity. Exact requests do
+not use managed proof lifting; public IDs, basis, tokens, cursors, and metadata
+are rebuilt from the selected adapter on every hit.
+
 All authorization-relevant schema, relationship, identity/liveness, repair,
 and safe-deletion mutations must use EACL APIs or documented EACL transaction
 data/functions transacted intact. Unsupported raw mutation can leave stale
@@ -61,6 +68,27 @@ The exact lifecycle functions are:
 
 See [cache operations](v8-consistency-cache-operations.md) for proof
 availability, custom-codec, time-travel, and multi-process lifecycle rules.
+
+## Exact history and cursor lifetime
+
+Datomic treats a valid same-source exact `T` ahead of the local Peer as lag.
+It waits boundedly on `(d/sync conn T)`, cancels the future on timeout or
+interruption, verifies `basis >= T`, and evaluates only `(d/as-of db T)`. If
+`T` is already local it skips synchronization. Ordinary Datomic history has no
+EACL age-based exact/cursor expiry.
+
+`eacl.datahike/create-conn` enables `:keep-history? true` by default. This
+costs additional storage and write amplification but permits temporal exact
+reconstruction after named commit records are collected. Explicit
+`{:keep-history? false}` opts out: exact selection is then conditional on a
+retained commit graph, and collected commits may become unavailable.
+
+Cursors have no default TTL on any backend. A positive
+`:cursor-ttl-seconds` is an application policy; cache/checkpoint eviction only
+causes replay. Datomic excision and Datahike purge/cutoff, reset, branch force,
+or history replacement require quiescence, completion, shared source-lifecycle
+rotation, complete client/cache detachment, and deliberate signing-key/wire
+version policy before traffic resumes.
 
 ## Optional atomic entity retraction
 
@@ -139,8 +167,9 @@ CLJ/CLJS kernel. The strict request is `{:resource object :permission keyword}`
 plus optional `:consistency`, `:timeout-ms`, and `:cancellation-token`; the response is
 `{:expanded-at token :tree-root node}`. The token and every definition,
 relationship, and rendered ID in the tree come from one selected immutable
-adapter. Datomic can replay the exact token while history is retained;
-Datahike can do so only in configurations with retained exact selection;
+adapter. Datomic can replay the exact token throughout ordinary unreplaced
+history. Datahike can do so durably with temporal history, or conditionally
+while a named commit remains retained when temporal history is disabled;
 DataScript supplies current/causal selection but no arbitrary historical
 reconstruction.
 

--- a/docs/v8-consistency-cache-operations.md
+++ b/docs/v8-consistency-cache-operations.md
@@ -11,12 +11,24 @@ result rendering, and cursor construction all use that value.
 | omitted / `:minimize-latency` | current DB visible to the Peer | current connection DB | current connection DB | exact-first, then automatic proof-backed reuse |
 | `:fully-consistent` | bounded zero-argument `d/sync` | authoritative head barrier when supported | serialized connection head | enabled for the selected current DB |
 | `:at-least-as-fresh` | targeted `d/sync conn t` and revision validation | selects/waits for a sufficient native revision | selects a sufficient connection-local revision | enabled only when selection is an ordinary current DB |
-| `:at-exact-snapshot` | authenticated `d/as-of` | retained exact/temporal selection when supported | unsupported | proof-backed completed answers bypassed |
+| `:at-exact-snapshot` | authenticated targeted catch-up when behind, then exact `d/as-of T` | retained commit or durable temporal selection, configuration-specific | unsupported | matching snapshot-exact answers only; managed proof reuse prohibited |
 
 The default performs no synchronization or historical selection. Low-level
 engine functions that accept caller-supplied historical, filtered, or
 prospective database values do not have a managed-cache availability
 guarantee.
+
+For Datomic, an authenticated same-source exact token ahead of the local Peer
+is a freshness barrier, not an out-of-range snapshot. EACL compares `T` with
+one local database, skips synchronization when already local, otherwise waits
+boundedly on `(d/sync conn T)` and cancels that future on timeout or
+interruption. It verifies the caught-up basis and evaluates only
+`(d/as-of caught-up-db T)`, never the possibly newer synchronized head.
+
+EACL-created Datahike databases default to `:keep-history? true`. That durable
+temporal path survives ordinary commit-record cutoff collection. A
+history-disabled store with a commit graph has only conditional exact support:
+collection of the named commit can make that snapshot unavailable.
 
 ## Automatic current cache
 
@@ -31,6 +43,14 @@ Missing, malformed, partial, oversized, unsupported, or exceptional proof
 evidence falls back to evaluation
 and exact caching for the selected value. It never becomes an authorization
 error and never permits partial-proof reuse.
+
+Authenticated exact requests use a separate bounded completed-answer tier
+keyed by the complete ordinary snapshot identity and semantic request. That
+key includes source/lifecycle, native revision and locator, exact view kind,
+adapter and identity contracts, engine/order ABI, result shape, demand, and
+answer-affecting limits. Exact requests never probe the managed tier and never
+bind partial traversal stores. Public IDs, tokens, cursors, cache basis, and
+other metadata are rebuilt from the selected adapter on every hit.
 
 Disable caching:
 
@@ -71,6 +91,13 @@ Pass one shared new lifecycle as the optional second argument when processes
 exchange tokens. Also rotate after reset, restore, branch replacement, or
 another change that can reuse or regress native revision identities.
 
+Datomic excision and Datahike purge/cutoff or branch-force operations are
+destructive history boundaries. Quiesce all affected traffic, let the
+operation complete, rotate the shared source lifecycle and every client/cache,
+apply the intended token/cursor key and format retirement policy, and only then
+resume. EACL does not support concurrent history destruction and authorization
+under one unchanged lifecycle.
+
 ## Custom identity
 
 Custom ID codecs are client-local and exact-only by default. Cross-snapshot
@@ -92,11 +119,23 @@ Continuation state is a private performance optimization. Eviction replays the
 authenticated prefix on the already selected snapshot and does not select a
 different lifecycle. DataScript has no arbitrary time-travel path.
 
+Cursor expiry is disabled by default and cache retention never determines
+cursor lifetime. A positive `:cursor-ttl-seconds` adds an explicit application
+policy expiry. Without it, elapsed wall-clock age is irrelevant; key
+retirement, incompatible wire/ABI versions, lifecycle rotation, genuine
+conditional-history loss, or bounded replay failure remain explicit outcomes.
+An old cursor enumerates its original historical result set. Applications that
+need current entitlement while consuming it must perform a current permission
+check for each consumed object.
+
 ## Assurance boundary
 
-Dafny proves exact-first selection, lifecycle isolation, proof completeness,
-and the scalar-frontier preservation theorem under globally ordered atomic
-relation stamps and deterministic complete dependencies. Adapter certification
-tests establish those obligations for Datomic, Datahike, and DataScript. The
-database engines, adapter conversion, cryptography, and production routing
-remain explicit trusted and empirically tested layers.
+Dafny proves the finite cache decision distinguishes current exact, managed,
+and snapshot-exact hit/miss actions; it also proves lifecycle isolation, proof
+completeness, and scalar-frontier preservation under globally ordered atomic
+relation stamps and deterministic complete dependencies. It does not prove
+Datomic I/O effects or future cancellation, Datahike history retention, or the
+truthfulness of a canonical cache key. Those are explicit adapter assumptions
+covered by deterministic effect tests and real-backend evidence. Database
+engines, adapter conversion, cryptography, and production routing remain
+trusted or empirically certified layers.

--- a/formal/dafny/CurrentCache.dfy
+++ b/formal/dafny/CurrentCache.dfy
@@ -43,6 +43,7 @@ module CurrentCache {
     | EligibilityStage
     | GenerationStage
     | ExactEntryStage
+    | SnapshotExactEntryStage
     | ManagedEntryStage
 
   datatype CurrentCacheAction =
@@ -52,6 +53,8 @@ module CurrentCache {
     | ProbeManagedEntry
     | UseManagedEntry
     | ComputeCurrentValue
+    | UseSnapshotExactEntry
+    | ComputeSnapshotExactValue
 
   function DecideCurrentCache(
     stage: CurrentCacheStage,
@@ -64,6 +67,8 @@ module CurrentCache {
       if available then ProbeExactEntry else BypassCurrentCache
     case ExactEntryStage =>
       if available then UseExactEntry else ProbeManagedEntry
+    case SnapshotExactEntryStage =>
+      if available then UseSnapshotExactEntry else ComputeSnapshotExactValue
     case ManagedEntryStage =>
       if available then UseManagedEntry else ComputeCurrentValue
   }
@@ -76,6 +81,8 @@ module CurrentCache {
               stage.ExactEntryStage? && available
     ensures DecideCurrentCache(stage, available).UseManagedEntry? ==>
               stage.ManagedEntryStage? && available
+    ensures DecideCurrentCache(stage, available).UseSnapshotExactEntry? ==>
+              stage.SnapshotExactEntryStage? && available
   {
   }
 
@@ -95,6 +102,8 @@ module CurrentCache {
   )
     ensures DecideCurrentCache(stage, available).ComputeCurrentValue? ==>
               stage.ManagedEntryStage? && !available
+    ensures DecideCurrentCache(stage, available).ComputeSnapshotExactValue? ==>
+              stage.SnapshotExactEntryStage? && !available
   {
   }
 
@@ -103,16 +112,31 @@ module CurrentCache {
     | ExactCurrentHit(value: T)
     | ManagedCurrentHit(value: T)
 
-  predicate CompletedAnswerCacheable(requestClass: RequestClass) {
-    requestClass.CurrentSnapshot?
+  predicate CompletedAnswerCacheable(
+    requestClass: RequestClass,
+    canonicalExactSnapshotSelected: bool
+  ) {
+    requestClass.CurrentSnapshot? ||
+    (requestClass.ExactSnapshot? && canonicalExactSnapshotSelected)
   }
 
-  lemma HistoricalRequestsBypassCompletedAnswers(
-    requestClass: RequestClass
+  lemma ArbitraryDatabaseValuesBypassCompletedAnswers(
+    canonicalExactSnapshotSelected: bool
   )
-    requires requestClass.ExactSnapshot? ||
-             requestClass.ArbitraryDatabaseValue?
-    ensures !CompletedAnswerCacheable(requestClass)
+    ensures !CompletedAnswerCacheable(
+              ArbitraryDatabaseValue,
+              canonicalExactSnapshotSelected
+            )
+  {
+  }
+
+  lemma ExactRequestsRequireCanonicalSnapshotIdentity(
+    canonicalExactSnapshotSelected: bool
+  )
+    ensures CompletedAnswerCacheable(
+              ExactSnapshot,
+              canonicalExactSnapshotSelected
+            ) == canonicalExactSnapshotSelected
   {
   }
 
@@ -193,22 +217,47 @@ module CurrentCache {
   {
   }
 
+  datatype SnapshotExactIdentity =
+    | SnapshotExactIdentity(
+        sourceScope: string,
+        sourceLifecycle: string,
+        nativeRevision: string,
+        exactLocator: string,
+        viewKind: string,
+        adapterFingerprint: string,
+        identityContract: string
+      )
+
   predicate ExactGenerationMatches(
-    selectedSnapshot: int,
-    generationSnapshot: int
+    selectedSnapshot: SnapshotExactIdentity,
+    generationSnapshot: SnapshotExactIdentity
   ) {
     selectedSnapshot == generationSnapshot
   }
 
   lemma ExactGenerationHitIsSameSnapshot(
-    selectedSnapshot: int,
-    generationSnapshot: int
+    selectedSnapshot: SnapshotExactIdentity,
+    generationSnapshot: SnapshotExactIdentity
   )
     requires ExactGenerationMatches(
                selectedSnapshot,
                generationSnapshot
              )
     ensures selectedSnapshot == generationSnapshot
+  {
+  }
+
+  lemma NumericRevisionAloneCannotEstablishExactIdentity(
+    selectedSnapshot: SnapshotExactIdentity,
+    generationSnapshot: SnapshotExactIdentity
+  )
+    requires selectedSnapshot.nativeRevision ==
+             generationSnapshot.nativeRevision
+    requires selectedSnapshot != generationSnapshot
+    ensures !ExactGenerationMatches(
+              selectedSnapshot,
+              generationSnapshot
+            )
   {
   }
 

--- a/formal/mutations/registry.edn
+++ b/formal/mutations/registry.edn
@@ -73,6 +73,12 @@
    :killed-by
    {:proof :current-cache-hit-requires-available-entry
     :test :current-cache-stage-boundary-control}}
+  {:id :snapshot-exact-key-omits-lifecycle
+   :mechanism :identify-two-replacement-histories-by-equal-numeric-revision
+   :control {:kind :clojure}
+   :killed-by
+   {:proof :numeric-revision-alone-cannot-establish-exact-identity
+    :test :snapshot-exact-completed-answer-cache-test}}
   {:id :mismatched-indexed-request-scope-response
    :mechanism :accept-scan-response-with-matching-local-id-but-different-traversal-scope
    :control {:kind :clojure}

--- a/formal/smoke/clj/eacl/formal/production_kernel_test.clj
+++ b/formal/smoke/clj/eacl/formal/production_kernel_test.clj
@@ -837,6 +837,10 @@
             :probe-exact-entry]
            [{:stage :exact-entry :available? false}
             :probe-managed-entry]
+           [{:stage :snapshot-exact-entry :available? true}
+            :use-snapshot-exact-entry]
+           [{:stage :snapshot-exact-entry :available? false}
+            :compute-snapshot-exact-value]
            [{:stage :managed-entry :available? true}
             :use-managed-entry]]]
     (is (= expected

--- a/formal/smoke/clj/eacl/formal/state_trace_differential_test.clj
+++ b/formal/smoke/clj/eacl/formal/state_trace_differential_test.clj
@@ -696,7 +696,7 @@
     (is (= 1 @calls)
         "generated can? must not repeat the public permission-root lookup")))
 
-(deftest generated-current-cursor-rejects-removed-permission-generation
+(deftest generated-current-cursor-reaches-proof-rejection-after-permission-removal
   (let [conn (datascript/create-conn)
         calls (atom {})
         client
@@ -747,9 +747,9 @@
               (catch clojure.lang.ExceptionInfo thrown
                 thrown))]
         (is (some? error))
-        (is (= :eacl.pagination/invalid-cursor
+        (is (= :eacl.pagination/stale-cursor
                (:type (ex-data error))))
-        (is (= :query-mismatch (:reason (ex-data error))))
+        (is (= :dependency-proof-changed (:reason (ex-data error))))
         (let [fresh-error
               (try
                 (eacl/lookup-resources client query)

--- a/formal/smoke/cljs/eacl/formal/generated_runtime.ext.js
+++ b/formal/smoke/cljs/eacl/formal/generated_runtime.ext.js
@@ -27,6 +27,8 @@ Object.prototype.ContinueForwardPage;
 Object.prototype.CountForward;
 Object.prototype.CurrentCache;
 Object.prototype.CurrentCacheStage;
+Object.prototype.is_UseSnapshotExactEntry;
+Object.prototype.is_ComputeSnapshotExactValue;
 Object.prototype.DecideAcyclicContinuation;
 Object.prototype.DecideAcyclicCount;
 Object.prototype.DecideAcyclicPage;

--- a/formal/smoke/cljs/eacl/formal/production_kernel_js.cljs
+++ b/formal/smoke/cljs/eacl/formal/production_kernel_js.cljs
@@ -872,6 +872,9 @@
       :exact-entry
       (js-invoke stages "create_ExactEntryStage")
 
+      :snapshot-exact-entry
+      (js-invoke stages "create_SnapshotExactEntryStage")
+
       :managed-entry
       (js-invoke stages "create_ManagedEntryStage"))))
 
@@ -890,6 +893,8 @@
       (.-is_UseExactEntry action) :use-exact-entry
       (.-is_ProbeManagedEntry action) :probe-managed-entry
       (.-is_UseManagedEntry action) :use-managed-entry
+      (.-is_UseSnapshotExactEntry action) :use-snapshot-exact-entry
+      (.-is_ComputeSnapshotExactValue action) :compute-snapshot-exact-value
       :else :compute-current-value)))
 
 (defn- ordered-merge-head

--- a/formal/smoke/cljs/eacl/formal/production_kernel_test.cljs
+++ b/formal/smoke/cljs/eacl/formal/production_kernel_test.cljs
@@ -906,6 +906,10 @@
             :probe-exact-entry]
            [{:stage :exact-entry :available? false}
             :probe-managed-entry]
+           [{:stage :snapshot-exact-entry :available? true}
+            :use-snapshot-exact-entry]
+           [{:stage :snapshot-exact-entry :available? false}
+            :compute-snapshot-exact-value]
            [{:stage :managed-entry :available? true}
             :use-managed-entry]]]
     (is (= expected

--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -519,12 +519,15 @@
    :entry-points ['eacl.cache
                   'eacl.subproblem-cache]
    :theorems [:exact-current-same-snapshot
+              :snapshot-exact-hit-requires-available-entry
+              :snapshot-exact-miss-computes-without-managed-fallback
+              :numeric-revision-alone-cannot-establish-exact-identity
               :managed-atomic-relation-projection-frame
               :managed-source-schema-scalar-frontier-key-separation
               :changed-relation-slice-requires-changed-stamp
               :forward-scalar-stamp-invalidation
               :late-publication-unreachable
-              :exact-and-arbitrary-db-bypass
+              :arbitrary-db-bypass-and-canonical-exact-admission
               :projection-chunk-concatenation
               :equal-root-rule-bodies-have-equal-semantic-denotations
               :acyclic-subproblem-call-stack-independence
@@ -543,6 +546,10 @@
            "formal/dafny/SubproblemCache.dfy"
            "formal/dafny/TemporalSafety.dfy"]
    :adapter-obligations [:immutable-snapshot
+                         :truthful-canonical-snapshot-exact-key
+                         :durable-history-when-advertised
+                         :targeted-sync-and-exact-as-of-effects
+                         :provider-future-cancellation
                          :complete-compiled-dependencies
                          :atomic-relation-stamped-writer-contract
                          :selected-snapshot-rendering

--- a/formal/verification/backend-dispatch.edn
+++ b/formal/verification/backend-dispatch.edn
@@ -8,7 +8,7 @@
   "modules/eacl-datascript/src"]
  :runtime-passes
  {:clj
-  {:invoke-call-count 57
+  {:invoke-call-count 59
    :operations
    #{:snapshot-id
      :source-scope
@@ -30,7 +30,7 @@
      :all-permission-nodes
      :proof-frame}}
   :cljs
-  {:invoke-call-count 57
+  {:invoke-call-count 59
    :operations
    #{:snapshot-id
      :source-scope

--- a/formal/verification/cache-kernel.edn
+++ b/formal/verification/cache-kernel.edn
@@ -20,14 +20,17 @@
    :compare-and-set-race-preserves-chosen-value]}
  :current-generation-proof
  {:source "formal/dafny/CurrentCache.dfy"
-  :verified-obligations 30
+  :verified-obligations 32
   :claims
   [:cache-eligibility-does-not-select-engine-authority
    :generated-current-cache-stage-selection
    :current-cache-hit-requires-available-entry
+   :snapshot-exact-hit-requires-available-entry
+   :snapshot-exact-miss-computes-without-managed-fallback
+   :numeric-revision-alone-cannot-establish-exact-identity
    :current-cache-bypass-requires-ineligible-or-inactive-generation
    :current-cache-computation-requires-managed-miss
-   :exact-and-arbitrary-db-bypass
+   :arbitrary-db-bypass-and-canonical-exact-admission
    :exact-current-hit-is-same-selected-snapshot
    :late-publication-is-unreachable-after-lifecycle-expiry
    :forward-relevant-write-raises-scalar-dependency-stamp

--- a/formal/verification/cljs-production.edn
+++ b/formal/verification/cljs-production.edn
@@ -82,7 +82,7 @@
   {:tests 172 :assertions 4682 :failures 0 :errors 0
    :all-required-indexed-operations-observed true}
   :mutation-registry
-  {:mutants 95 :killed 95 :survived 0}}
+  {:mutants 96 :killed 96 :survived 0}}
  :trust-posture
  {:browser-authorization :advisory
   :server-recheck-required true

--- a/formal/verification/generated-boundary.edn
+++ b/formal/verification/generated-boundary.edn
@@ -347,7 +347,8 @@
     [:source-scope :snapshot-id :native-revision :exact-locator]
     :client-local-exact-locator-included true}
    :current-cache-generated-selection true
-   :tests 7 :assertions 187 :status :passed}
+   :snapshot-exact-generated-selection true
+   :tests 7 :assertions 192 :status :passed}
   :cljs-public-state-trace
   {:namespace eacl.formal.production-kernel-test
    :backend :datascript

--- a/formal/verification/manifest.edn
+++ b/formal/verification/manifest.edn
@@ -100,7 +100,7 @@
    :production-assurance-contribution :none}
   :current-generation-cache
   {:status :passed
-   :verified-obligations 30
+   :verified-obligations 32
    :source "formal/dafny/CurrentCache.dfy"
    :report "formal/verification/cache-kernel.edn"
    :integration-status
@@ -146,7 +146,7 @@
    :conditional-least-fixed-point-and-traversal-order-refinement}
   :complete-public-engine
   {:status :passed
-   :verified-obligations 8791
+   :verified-obligations 8793
    :report "formal/verification/final-assurance-audit.md"
    :integration-status
    :recursive-generated-authority-and-acyclic-generated-decisions-with-source-specializations-routed

--- a/formal/verification/mutation-control.edn
+++ b/formal/verification/mutation-control.edn
@@ -1,15 +1,15 @@
 {:schema-version 2
  :registry "formal/mutations/registry.edn"
- :mutants 95
- :killed 95
+ :mutants 96
+ :killed 96
  :survived 0
  :score 1.0
  :status :passed
  :controls
  {:clojure
-  {:mutants 91
+  {:mutants 92
    :tests 2
-   :assertions 217
+   :assertions 219
    :command "EACL_NREPL_PORT=<dev-port> bin/formal mutation-control"}
   :apalache
   {:mutants 4

--- a/formal/verification/production-decision-inventory.md
+++ b/formal/verification/production-decision-inventory.md
@@ -18,7 +18,7 @@ reused.
 | Relationship pagination | `eacl.engine.relationships` scan planning, physical keyset edges, bounded lookahead, and generated page-window decision | relationship list APIs |
 | Authenticated token scope and continuation decision | cursor decode/validate and current/exact graph selection in `eacl.relay` | lookup/count/relationship continuation |
 | Consistency plan and selected-snapshot postconditions | `eacl.consistency/selection-plan`, `captured-current-selection`, `select` | snapshot chosen for every Datomic, Datahike, and DataScript authorization request |
-| Semantic cache key and entry eligibility | exact generated command/snapshot/ABI keys and completed typed artifact validation | `can?`, lookup, count cache-enabled responses; eligibility has zero backend-command authority |
+| Semantic cache key and entry eligibility | canonical source/lifecycle/native-locator/view/adapter identity plus generated current-exact, snapshot-exact, and managed entry decisions and completed typed artifact validation | `can?`, lookup, count, relationship-read, and permission-tree cache-enabled responses; eligibility has zero backend-command authority |
 | Cache miss ownership and publication | `eacl.subproblem-cache/resolve-independent!`, generation-qualified bounded `publish!` | misses compute independently; compatible winners are retained and losing/late candidates are discarded without changing authorization |
 | Local cache failure and invalid-entry handling | `eacl.cache` current-generation decisions plus `eacl.subproblem-cache` lookup/validation/publication | whether a client-private cached authorization result may be returned |
 | Backend snapshot and scan contract | `eacl.backend.v8` protocol operations | every engine result, through adapter-provided facts and identities |
@@ -57,6 +57,17 @@ This verifies the finite decision over observed facts. It does not prove that
 an adapter's source scope, native revision, exact reconstruction, or
 authoritative barrier is truthful, and it does not prove token cryptography.
 Those remain explicit adapter and cryptographic refinement obligations.
+
+The generated cache decision now has a separate snapshot-exact entry stage:
+availability selects `UseSnapshotExactEntry`; absence selects
+`ComputeSnapshotExactValue` and can never fall through to managed proof reuse.
+The finite decision proves only that a declared available entry controls the
+corresponding hit. It does not prove that the host's composite key truthfully
+identifies an ordinary immutable snapshot. Backend I/O effects (including
+Datomic targeted sync and `d/as-of`), cancellation of provider futures,
+Datahike full-history retention, and canonical cache-key fields remain named
+adapter/host assumptions covered by deterministic effect tests and real-store
+integration evidence.
 
 The acyclic ordered-EID merge now has an exact production control model rather
 than only a canonical sorted-union oracle. `OrderedMerge.dfy` represents the

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,7 +13,7 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "00ae2c1ee9c2c0885b84f3a487bccdfa02bea05d8c573a3ea097091b47338305"
+      "sha256": "524d44438e2911fab49535c141d2284998f9e61965eeb6f3d49b631fe13a7100"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
@@ -69,7 +69,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/backend.clj",
-      "sha256": "09f8d649a291e4e06ca307e1e0d163a0eef6800519656320a8c5b63860ae6ec8"
+      "sha256": "e1dc1f75a1b7258eeb8c3ce3d7d8703324514f63884333d8c1b68c5d3367d696"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/cache.clj",
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "77ca2bc16f1323175fa7559480b1e80fe3ca2c522a60b6c6f5519a8a31ccc622"
+      "sha256": "d43a5609b20230d82ef883a68e50aa0088f0b8672f6611d26a6b86be9ceb41e6"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -129,7 +129,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "449d27e460680dcd1a012f00437caf7c7363b7a3394fa736a3b1370900ef465c"
+      "sha256": "972b86cdcd30fc3858f55fa20466085eb90c9c775b28988bc6cfa6690096dbcf"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -189,7 +189,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "3738463ec1e15fb4ba0d4d171e769898a4f212064c1030b56ab6e15bbaa80c4f"
+      "sha256": "0621c12643a8b0ebb1d04f7efcf060e3e9e933e43015f009b1ebb58dbcc3a3e2"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -333,9 +333,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1344,
-    "unionInternalDefinitionIdsSha256": "3be08f87d89c46dfca922d35b2a6641d48b727c89de9cf3ef6b590d3ef67053e",
-    "unionDefinitionLocationsSha256": "00313d2bef3d64e1f37c65526e5cffa4d14ceb570029623bd003da8932dd0ba4",
+    "unionInternalDefinitionCount": 1350,
+    "unionInternalDefinitionIdsSha256": "919126752eba9d9978cc740cd1e1a93afb0385d463d1ce31ffa7dec06d3822a0",
+    "unionDefinitionLocationsSha256": "9c1885a646be472571b3b634c286b6e00d256f630e6c5cca82bfb5097f99c39e",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,
@@ -378,8 +378,8 @@
         "idsSha256": "7ffedf1948fac06fa42a2f7976c664f9a1cc9a537f315169f974c4cddd0cb68f"
       },
       "modules/eacl-datomic/src/eacl/datomic/backend.clj": {
-        "count": 12,
-        "idsSha256": "a7761318eeaf44358f14ff732f9efb98189701eaea2c5dc9b722fd2cd44f2adc"
+        "count": 13,
+        "idsSha256": "898b12609377bb4c6294d34c53abeb4a44bbf2228a0f5f14974068978f997b0b"
       },
       "modules/eacl-datomic/src/eacl/datomic/cache.clj": {
         "count": 4,
@@ -394,8 +394,8 @@
         "idsSha256": "41564ae9195b19dd851d20e77ec6d32379244f26211d5a815622b45fb2df2592"
       },
       "modules/eacl-datomic/src/eacl/datomic/core.clj": {
-        "count": 121,
-        "idsSha256": "18faeb96e23d6817cf7c2a02bd6d2c0f9ecb02d103d9fa96ad408f59f632efee"
+        "count": 122,
+        "idsSha256": "e63dd0f06bde510f85f3360eb8cc515591d7f917927b1c4e880d693e3fdc3c53"
       },
       "modules/eacl-datomic/src/eacl/datomic/db.clj": {
         "count": 9,
@@ -426,8 +426,8 @@
         "idsSha256": "1ef9aaa3526b5cd6d8664568a8ff02a76252eb777f563d32789ba574e576d072"
       },
       "modules/eacl/src/eacl/cache.cljc": {
-        "count": 36,
-        "idsSha256": "1334f67606da887bf62d3e9c44b2b4f1750ac270a242f4954505ee55fc633f38"
+        "count": 39,
+        "idsSha256": "b42be3a4a8ce0e1554cb06bdf07f1b804103ec863e9e3364303f9e32c7ec524f"
       },
       "modules/eacl/src/eacl/causal_token.cljc": {
         "count": 17,
@@ -486,8 +486,8 @@
         "idsSha256": "2baa47acc019ed669bc2d286552110b2581701131dfbbe2d9496523c256e79da"
       },
       "modules/eacl/src/eacl/engine/v8.cljc": {
-        "count": 78,
-        "idsSha256": "76e77e7e4b70fedb38ec985f56914117d74d3bdda53b756c2cbd0331c180cd78"
+        "count": 79,
+        "idsSha256": "478429a13246b4fe561e6ecd49a53fd494303523669fac4c659e4a60438e0814"
       },
       "modules/eacl/src/eacl/execution.cljc": {
         "count": 26,
@@ -816,8 +816,8 @@
       ]
     },
     "eacl.cache/resolve-current!": {
-      "internalDefinitionCount": 171,
-      "internalDefinitionIdsSha256": "4af9f182c08dc33b4265c7d5dafe1099e31e412ed6a35b7718577a26617ee6e6",
+      "internalDefinitionCount": 174,
+      "internalDefinitionIdsSha256": "777975cbcd6c98e189a8508315d1209ef129c402d7d797a6af7a7dcd98103b85",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -935,8 +935,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 808,
-      "internalDefinitionIdsSha256": "74430e67ea8af61b74d68755eced7c6b797312b9c168324709e1712a2b6e682e",
+      "internalDefinitionCount": 814,
+      "internalDefinitionIdsSha256": "9565da92a3fc925ebc4f256990ba48c4e22c3a58e0e90d375bfc360c5c99d7f0",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -978,8 +978,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 515,
-      "internalDefinitionIdsSha256": "7936c5f71abd2ffa38f73c014e8f32385e677a2ee85499ae6d070e5d562d233b",
+      "internalDefinitionCount": 520,
+      "internalDefinitionIdsSha256": "891f1c76a3bb46bd7613a3558139c31086ef70d022fcd991cf875b8c7a9721de",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1053,8 +1053,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 472,
-      "internalDefinitionIdsSha256": "ee26adb9498f2a8e4a0d49fceb05575dfde8a6a53cdc7b25c387729aefb77c47",
+      "internalDefinitionCount": 477,
+      "internalDefinitionIdsSha256": "5fefe20acff7c6f7d974f98ce5c7ac25746004fab693ee9d15feae520a1d6d20",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1083,8 +1083,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 607,
-      "internalDefinitionIdsSha256": "b39b112001e09b2a2084cfa62cccf43c0ea6ec2822a38ab73a5b5d4a42a81d68",
+      "internalDefinitionCount": 613,
+      "internalDefinitionIdsSha256": "518b81fe109964d5bc4b6a7750727d365dab97a3278244315e97e6455cb9ea5d",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1113,8 +1113,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 474,
-      "internalDefinitionIdsSha256": "5d1a2eb86aa8f4883b4fb09b567b1e9905e71b3ec866ad1f10fe9d30d4cf49b1",
+      "internalDefinitionCount": 479,
+      "internalDefinitionIdsSha256": "ac315e55bb65b79390c2cb73702a453e44cbd1bc88a308c6fe325c75e9f3013d",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1143,8 +1143,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 607,
-      "internalDefinitionIdsSha256": "338a001ab297efa7e5d1ed58ba7586db19a7b6fa457c8a50664b0e39db26b5d3",
+      "internalDefinitionCount": 613,
+      "internalDefinitionIdsSha256": "d6422f130e4921146116bd964e18ba79e860ac5b827b6299a74a871cb210936a",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1173,8 +1173,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 474,
-      "internalDefinitionIdsSha256": "4b2dbdd2ae2f6dfd7e1bc18a18b051493910c78cc7a5889f9048d0667d392edb",
+      "internalDefinitionCount": 479,
+      "internalDefinitionIdsSha256": "599b39af031b41b546ed708bea2c158759daaa80947ca242681dd8e15f6a7074",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1203,8 +1203,8 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 221,
-      "internalDefinitionIdsSha256": "751b682d6f54478ced948e20b4187d3b2d397dfe2e8f2ba4cc278a32c8457829",
+      "internalDefinitionCount": 222,
+      "internalDefinitionIdsSha256": "d4aeab5d5d70521b2663620c71fbb0f88a85f76eeefa7229156f9fc5303bff6a",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1238,8 +1238,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 809,
-      "internalDefinitionIdsSha256": "d8c575a77a5d113f6c474eb802e7d61153ca7d3c523ab70bfd50300863a5d43a",
+      "internalDefinitionCount": 815,
+      "internalDefinitionIdsSha256": "84d50a553dc3e9840e28867322580addb767db1d6f6203f16c32e997a8faf9a0",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1281,8 +1281,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 811,
-      "internalDefinitionIdsSha256": "383455e3b7a9bcc589e758a4c72f02a2fade24ee5a32f67f8082d8c9e4a932e2",
+      "internalDefinitionCount": 817,
+      "internalDefinitionIdsSha256": "e4f9acc0148a82cbf751d922794bf05af3065df841e8caa417e5084d1d259e1b",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1324,8 +1324,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 634,
-      "internalDefinitionIdsSha256": "bae3df59ee94044709b71fa9d2ac18298a011dc4af37a5d977b1934bfccdc3c2",
+      "internalDefinitionCount": 638,
+      "internalDefinitionIdsSha256": "ae6775d04cb735de0b34f747074de5e047cc85fc0bd69042a18123eb0108c910",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1361,8 +1361,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 590,
-      "internalDefinitionIdsSha256": "14975d841a05f94a1dd2b26939669b10bb200cbb4c28f225106ecc39b0c1580e",
+      "internalDefinitionCount": 594,
+      "internalDefinitionIdsSha256": "9c397c7311b2215b562d1f974e52cbd451dee26608e85b017cdc0b4712d076be",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1463,8 +1463,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 588,
-      "internalDefinitionIdsSha256": "1273544599930eed825377e8f92bf4e35c66e771c3b06c2094384949e2383992",
+      "internalDefinitionCount": 592,
+      "internalDefinitionIdsSha256": "106c72c3242fafaf00971f29f10c33fbab8014063db7abd9cb43efd827672ddd",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1498,8 +1498,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 717,
-      "internalDefinitionIdsSha256": "18534a081ad2375f99997aa5299cd432fb6b2a5fbbb3d32c263d9e62c271f1ec",
+      "internalDefinitionCount": 721,
+      "internalDefinitionIdsSha256": "a93b818688928b981525b80d20daaea207a899eb33288ba94140386a78b46981",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1534,8 +1534,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 591,
-      "internalDefinitionIdsSha256": "5994bc060e86be34195a5de4cc67293045c6764c1929b41325b0e8a56db5136b",
+      "internalDefinitionCount": 595,
+      "internalDefinitionIdsSha256": "df5fb92946b29e3fa10c97f390f468cdce7344e877c81b559b071e78b94437ed",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1569,8 +1569,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 717,
-      "internalDefinitionIdsSha256": "5f9f1c3d78bf722ec14d624dadbb50f69854efb398927bc89906d2498a7da60c",
+      "internalDefinitionCount": 721,
+      "internalDefinitionIdsSha256": "921caac9e6d35dcd30082bde3075fb72aacc726508f8d24707a93284a42d9fcc",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1605,8 +1605,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 591,
-      "internalDefinitionIdsSha256": "f756a4ac9ddfb69bc372d09d3a44bb6b5525c6f765ae654d6ce3fa369e1fcce5",
+      "internalDefinitionCount": 595,
+      "internalDefinitionIdsSha256": "63742aa9319d568b26881c50b17286d6a284317e60388003f411089f671b768c",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1671,8 +1671,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 575,
-      "internalDefinitionIdsSha256": "8109bcbc26956d58304699cb0016278d2b0f16c4feabca4515c2c8f4d8b0cc89",
+      "internalDefinitionCount": 579,
+      "internalDefinitionIdsSha256": "1fdec765d29c5a9c3c1f65b8b58c46c21f539aab1f8e86123b7b0f3ba4c21004",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1770,8 +1770,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 573,
-      "internalDefinitionIdsSha256": "f17bd9060c4eec88493203121ae873b84e05397b34c76981614e425b330d131f",
+      "internalDefinitionCount": 577,
+      "internalDefinitionIdsSha256": "edec8bba2927e2f01859df1e5ccd6386e552ae32265a64731442f67f1e2f0b23",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1804,8 +1804,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 702,
-      "internalDefinitionIdsSha256": "6b595e17ff216cd632061fc2ab5eb2b10a753764ff5aff336cd595a2ea4896ff",
+      "internalDefinitionCount": 706,
+      "internalDefinitionIdsSha256": "3681d1a3de9205b6ea69cbc71330578f8e25e96dc718ca41ac93a85020805313",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1839,8 +1839,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 576,
-      "internalDefinitionIdsSha256": "0cb5fc7a3c775f574549f6c2b53fc7da47fa47feb932a7e988280c2b91514162",
+      "internalDefinitionCount": 580,
+      "internalDefinitionIdsSha256": "6cc32b83963b9c43f1671120ff1b9f29e857c206b77e4e9a7c62205c0b36bb4e",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1873,8 +1873,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 702,
-      "internalDefinitionIdsSha256": "760b1971d4320afd32c157e60391ea09ab3c0a4fcaa6c07fa5044e3ab5f9b943",
+      "internalDefinitionCount": 706,
+      "internalDefinitionIdsSha256": "a9e32fdea895eb301f0827fcecd6f63c2a15ae6c4c435ca4861f9715c7e18762",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1908,8 +1908,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 576,
-      "internalDefinitionIdsSha256": "a5e365da6639970681e7afa331a4db5d4d6be0a3e92f617c2167994d6e9e59c3",
+      "internalDefinitionCount": 580,
+      "internalDefinitionIdsSha256": "ed1b43979596e772391a3dd2dd0892a77edcd56a4e965b1663955bfe38003281",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,7 +13,7 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "524d44438e2911fab49535c141d2284998f9e61965eeb6f3d49b631fe13a7100"
+      "sha256": "d086ae44132d18ce75edb3f9aabd0c969bfc1429c9f535a045578e8840055a67"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
@@ -129,7 +129,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "972b86cdcd30fc3858f55fa20466085eb90c9c775b28988bc6cfa6690096dbcf"
+      "sha256": "5f32f85e47c86391e780a0d0d17f1cee0a6e56af204b27a676a319a2eb932aa8"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -335,7 +335,7 @@
     "rootCount": 61,
     "unionInternalDefinitionCount": 1350,
     "unionInternalDefinitionIdsSha256": "919126752eba9d9978cc740cd1e1a93afb0385d463d1ce31ffa7dec06d3822a0",
-    "unionDefinitionLocationsSha256": "9c1885a646be472571b3b634c286b6e00d256f630e6c5cca82bfb5097f99c39e",
+    "unionDefinitionLocationsSha256": "09b485656f24a7bcdb1b7779356a0261e0b93ce398c7b298fdc54c49f6fd22d3",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,7 +13,7 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "e9174670726b426bbcb89b6b7b4431090aee18b656cf868d38cc6ca95956066f"
+      "sha256": "00ae2c1ee9c2c0885b84f3a487bccdfa02bea05d8c573a3ea097091b47338305"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
@@ -37,7 +37,7 @@
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/schema.clj",
-      "sha256": "0fc7d3087ed65027a4748402dcb3e55d341ca92480132ebd94e39abdc61afdbd"
+      "sha256": "6407122c005ae40e280bfc35c72b2b4706b1cf4df25e851cf45a46ce9556c496"
     },
     {
       "path": "modules/eacl-datascript/src/eacl/datascript/backend.cljc",
@@ -69,7 +69,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/backend.clj",
-      "sha256": "7bc21e64d2062c5876a5f53503ca0c1fcd539ca412c704d4c9029142c50bbf69"
+      "sha256": "09f8d649a291e4e06ca307e1e0d163a0eef6800519656320a8c5b63860ae6ec8"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/cache.clj",
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "30a4adc3377f60a2a259e2d1afcb9a9acbd4522e06a6589aa9421318c779fc57"
+      "sha256": "77ca2bc16f1323175fa7559480b1e80fe3ca2c522a60b6c6f5519a8a31ccc622"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -129,7 +129,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "fd0d0f9af196606983ed84db83bd7f6d65627a45f7d816f78b51c8beeabc03b4"
+      "sha256": "449d27e460680dcd1a012f00437caf7c7363b7a3394fa736a3b1370900ef465c"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -137,7 +137,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "7e52713e791da01bb29c09acee36bac60cc8cfebe02623420f10a3ee0c6af733"
+      "sha256": "ba061df40a22732f5c27c3ddf4c67cd39ad61363093f14f684217bedc30ffca5"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -161,7 +161,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/portable_decisions.cljc",
-      "sha256": "1094fb1b4a585e5f5e8cf63bce2c5745ad918f98ab54f70f50518864301d7164"
+      "sha256": "80f5798f93f736dc861319b607c1ce4760d16b75ede71c648bd84f73ba99b2c0"
     },
     {
       "path": "modules/eacl/src/eacl/engine/portable_indexed.cljc",
@@ -201,7 +201,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "06a10b02cd6420fa516a101cbfbe7c2a4a1eb6d57fbc6a27ea302e5e40d6209d"
+      "sha256": "3cf57b5b50ddc2cebf46e035b7703b1d855d72ea5b7b3acbfd1c7269117a7187"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -237,7 +237,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/relay.cljc",
-      "sha256": "d57ac37d9b71939be82ea71fc92375ac7c91d980a3c9493bb2cab33619a17e33"
+      "sha256": "ce64198288cf80033d979c15ca906a38b8d42de392b2964364c53fae532af329"
     },
     {
       "path": "modules/eacl/src/eacl/schema/errors.cljc",
@@ -265,7 +265,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/verified_kernel.cljc",
-      "sha256": "8ec729628f0f9a1886e84ba6dd8a53e8a9cd949ef2948c68003f9903300e19c4"
+      "sha256": "1288b39341cac10f233169bb07cfd1c70c3492a3cd018134f1da7471680b266b"
     }
   ],
   "scope": {
@@ -333,13 +333,13 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1331,
-    "unionInternalDefinitionIdsSha256": "a6333f28b0b8201ea165d6781c1066590279d477fffbbcc79dd4f243705453f5",
-    "unionDefinitionLocationsSha256": "6d79d742afec036e9caa6bf8a5c7bae0e49564aeac128e88dcf9510dad5af712",
+    "unionInternalDefinitionCount": 1344,
+    "unionInternalDefinitionIdsSha256": "3be08f87d89c46dfca922d35b2a6641d48b727c89de9cf3ef6b590d3ef67053e",
+    "unionDefinitionLocationsSha256": "00313d2bef3d64e1f37c65526e5cffa4d14ceb570029623bd003da8932dd0ba4",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
-        "count": 15,
-        "idsSha256": "7c5dff39653fdbc9e956bc1759cae145538b675a7ac65e3a6b4bc6fd43e2a450"
+        "count": 18,
+        "idsSha256": "68a9242fa3ee650da550e530db88f9be79e8a233dd1410402279e9aa65e87a2e"
       },
       "modules/eacl-datahike/src/eacl/datahike/core.clj": {
         "count": 13,
@@ -378,8 +378,8 @@
         "idsSha256": "7ffedf1948fac06fa42a2f7976c664f9a1cc9a537f315169f974c4cddd0cb68f"
       },
       "modules/eacl-datomic/src/eacl/datomic/backend.clj": {
-        "count": 6,
-        "idsSha256": "1f56667f78d1f142fd672199148c14a8e53f717e615270cf82c8b6560c7b85ee"
+        "count": 12,
+        "idsSha256": "a7761318eeaf44358f14ff732f9efb98189701eaea2c5dc9b722fd2cd44f2adc"
       },
       "modules/eacl-datomic/src/eacl/datomic/cache.clj": {
         "count": 4,
@@ -394,8 +394,8 @@
         "idsSha256": "41564ae9195b19dd851d20e77ec6d32379244f26211d5a815622b45fb2df2592"
       },
       "modules/eacl-datomic/src/eacl/datomic/core.clj": {
-        "count": 124,
-        "idsSha256": "2f25c9b03b2a5a66cf4cc4305530d12385ea6332923c97d95010a2163e114884"
+        "count": 121,
+        "idsSha256": "18faeb96e23d6817cf7c2a02bd6d2c0f9ecb02d103d9fa96ad408f59f632efee"
       },
       "modules/eacl-datomic/src/eacl/datomic/db.clj": {
         "count": 9,
@@ -422,12 +422,12 @@
         "idsSha256": "6354f20b566cbf72654812e5404ad861a32ed262bf7c3ebf678b2e9f199a323b"
       },
       "modules/eacl/src/eacl/backend/v8.cljc": {
-        "count": 40,
-        "idsSha256": "dca5f2e1ae7cefb3fab151b9a5d09abb2f3bac168676c13f7e96c51dbd9ea84b"
+        "count": 41,
+        "idsSha256": "1ef9aaa3526b5cd6d8664568a8ff02a76252eb777f563d32789ba574e576d072"
       },
       "modules/eacl/src/eacl/cache.cljc": {
-        "count": 31,
-        "idsSha256": "80d784eeca3e4303e408fb00dab62647231ec8deff1354e6c0c2063161371537"
+        "count": 36,
+        "idsSha256": "1334f67606da887bf62d3e9c44b2b4f1750ac270a242f4954505ee55fc633f38"
       },
       "modules/eacl/src/eacl/causal_token.cljc": {
         "count": 17,
@@ -526,8 +526,8 @@
         "idsSha256": "fb4e5788ec3bdcef44e445bbeaf59b2a34727116072b77ddfd4f0f6747e11894"
       },
       "modules/eacl/src/eacl/relay.cljc": {
-        "count": 56,
-        "idsSha256": "cb9c3b05aee2c4e7c05f72ae8a56cccf95768e6c51a8e8a7345393e941ed8efb"
+        "count": 57,
+        "idsSha256": "d33504b8bf1a0d5e39182dcb72cb8c51e304a13288b401ab5592c6f2e130ec75"
       },
       "modules/eacl/src/eacl/schema/errors.cljc": {
         "count": 10,
@@ -690,8 +690,8 @@
       ]
     },
     "eacl.relay/select-continuation-adapter": {
-      "internalDefinitionCount": 252,
-      "internalDefinitionIdsSha256": "3a8205c930bbccc0198a18bc916c8478f564eedde3e7648bb4bcce20e53419c2",
+      "internalDefinitionCount": 253,
+      "internalDefinitionIdsSha256": "115c8d8d9647b76cb3af421c1c2db749c64076a090bba364ca44a7ce2fb8821c",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -710,8 +710,8 @@
       ]
     },
     "eacl.relay/prepare-page-query": {
-      "internalDefinitionCount": 256,
-      "internalDefinitionIdsSha256": "b5dadb26d9e1df22d27141a639c18586f456fa845b2af13bfe98d241e00176cc",
+      "internalDefinitionCount": 257,
+      "internalDefinitionIdsSha256": "61eac97c513a6529cd35e48d1b0b3c1ee9d1a7b96003d37df38aa9b9f1657a93",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -730,8 +730,8 @@
       ]
     },
     "eacl.relay/internalize-page-query": {
-      "internalDefinitionCount": 252,
-      "internalDefinitionIdsSha256": "52970acf239816bafdbe94559e7c1a22471b757d480a909ab6cfabdd98657c59",
+      "internalDefinitionCount": 253,
+      "internalDefinitionIdsSha256": "a1ce7577d954e7596d7308b40fe6d26be6b4cd917fb09be8cde8d4763a40ae51",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -750,8 +750,8 @@
       ]
     },
     "eacl.relay/externalize-page": {
-      "internalDefinitionCount": 146,
-      "internalDefinitionIdsSha256": "6977cf3d3f0eb69dc31c34f59ddaf3b3ef4671c0c0f27612dff5827164fe0a7b",
+      "internalDefinitionCount": 145,
+      "internalDefinitionIdsSha256": "ebed123414ca6688dc60fc4eef901ff2100db569eb5551a96776732172c8402a",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -767,8 +767,8 @@
       ]
     },
     "eacl.relay/externalize-relationship-page": {
-      "internalDefinitionCount": 145,
-      "internalDefinitionIdsSha256": "802506b02edcbc556e3b461de5ca1ee45960c8bf0da61f54e0d497a62dca44e5",
+      "internalDefinitionCount": 144,
+      "internalDefinitionIdsSha256": "9312f0ab8610e4a2eddc40346656d0c43a369f722a6bb4748c92bc5f2eb978e7",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -816,8 +816,8 @@
       ]
     },
     "eacl.cache/resolve-current!": {
-      "internalDefinitionCount": 169,
-      "internalDefinitionIdsSha256": "294bd1354c80c7f121bfbda05faaaed713cd47c072de4e08f894dacc5917f7ca",
+      "internalDefinitionCount": 171,
+      "internalDefinitionIdsSha256": "4af9f182c08dc33b4265c7d5dafe1099e31e412ed6a35b7718577a26617ee6e6",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -935,8 +935,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 799,
-      "internalDefinitionIdsSha256": "db6ac709f988a2ce425762afd6e1bf3510ecf6032678e9142241c9e12f6ce8e9",
+      "internalDefinitionCount": 808,
+      "internalDefinitionIdsSha256": "74430e67ea8af61b74d68755eced7c6b797312b9c168324709e1712a2b6e682e",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -978,8 +978,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 446,
-      "internalDefinitionIdsSha256": "860dca4a9c2d2efc169cde11bdf03452f62ecb08895a6437404ac51791d7b8ee",
+      "internalDefinitionCount": 515,
+      "internalDefinitionIdsSha256": "7936c5f71abd2ffa38f73c014e8f32385e677a2ee85499ae6d070e5d562d233b",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1053,8 +1053,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 459,
-      "internalDefinitionIdsSha256": "6a3473283a437a91051bab6f31d7127e9e3035c4039ddfecaf167c390ef5951e",
+      "internalDefinitionCount": 472,
+      "internalDefinitionIdsSha256": "ee26adb9498f2a8e4a0d49fceb05575dfde8a6a53cdc7b25c387729aefb77c47",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1083,8 +1083,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 599,
-      "internalDefinitionIdsSha256": "179471fb28d670960e9f23862646112b1a11d5a1a97836a387e294658ae01396",
+      "internalDefinitionCount": 607,
+      "internalDefinitionIdsSha256": "b39b112001e09b2a2084cfa62cccf43c0ea6ec2822a38ab73a5b5d4a42a81d68",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1113,8 +1113,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 461,
-      "internalDefinitionIdsSha256": "df864ce965e035e300f8d7bad9456210287b15751afe61230a6e2950c1a132e1",
+      "internalDefinitionCount": 474,
+      "internalDefinitionIdsSha256": "5d1a2eb86aa8f4883b4fb09b567b1e9905e71b3ec866ad1f10fe9d30d4cf49b1",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1143,8 +1143,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 599,
-      "internalDefinitionIdsSha256": "8bd962f1702607495db0eb9fcbe5f7a24524150c17d88b945b42ba17c8967355",
+      "internalDefinitionCount": 607,
+      "internalDefinitionIdsSha256": "338a001ab297efa7e5d1ed58ba7586db19a7b6fa457c8a50664b0e39db26b5d3",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1173,8 +1173,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 461,
-      "internalDefinitionIdsSha256": "562b706f1c75b6cf17ed280bc1886da05f614a2529eb8776b8744430c1389e04",
+      "internalDefinitionCount": 474,
+      "internalDefinitionIdsSha256": "4b2dbdd2ae2f6dfd7e1bc18a18b051493910c78cc7a5889f9048d0667d392edb",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1203,8 +1203,8 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 216,
-      "internalDefinitionIdsSha256": "1048e5ed17d41f749516c51a985069cadd24b3c47dd2d7b3c5d55cfbcc556bf6",
+      "internalDefinitionCount": 221,
+      "internalDefinitionIdsSha256": "751b682d6f54478ced948e20b4187d3b2d397dfe2e8f2ba4cc278a32c8457829",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1238,8 +1238,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 800,
-      "internalDefinitionIdsSha256": "1c8ee0d9d2f29a7ad20a0265acf80b31e3c57ffb77b5a4f6099199271b1f3e8d",
+      "internalDefinitionCount": 809,
+      "internalDefinitionIdsSha256": "d8c575a77a5d113f6c474eb802e7d61153ca7d3c523ab70bfd50300863a5d43a",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1281,8 +1281,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 802,
-      "internalDefinitionIdsSha256": "fa16d7af6ad98b57dbafd7906e34ec4e104626c5484c520db4fbcd42dd3606c2",
+      "internalDefinitionCount": 811,
+      "internalDefinitionIdsSha256": "383455e3b7a9bcc589e758a4c72f02a2fade24ee5a32f67f8082d8c9e4a932e2",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1324,8 +1324,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 627,
-      "internalDefinitionIdsSha256": "27339ce19840fd2b0fcc512e8c915d716aea6ad5f395ba109cf039573d372073",
+      "internalDefinitionCount": 634,
+      "internalDefinitionIdsSha256": "bae3df59ee94044709b71fa9d2ac18298a011dc4af37a5d977b1934bfccdc3c2",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1361,8 +1361,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 540,
-      "internalDefinitionIdsSha256": "f5ae37fb5b2a41e59fc63f56eb650ef2e25aa7d21a6003c8a8f6d24f9d1820bc",
+      "internalDefinitionCount": 590,
+      "internalDefinitionIdsSha256": "14975d841a05f94a1dd2b26939669b10bb200cbb4c28f225106ecc39b0c1580e",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1397,8 +1397,8 @@
       ]
     },
     "eacl.datahike.core/datahike-write-relationships!": {
-      "internalDefinitionCount": 347,
-      "internalDefinitionIdsSha256": "db260629963df96f57ec452b8f394ef8c697ddb253e4a9cb115b26882e2de3f3",
+      "internalDefinitionCount": 350,
+      "internalDefinitionIdsSha256": "12b7204e2cb4442aaa288e02d165702458fbbd9fa1bc5361065def48f0e5340f",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1431,8 +1431,8 @@
       ]
     },
     "eacl.datahike.core/datahike-delete-object!": {
-      "internalDefinitionCount": 338,
-      "internalDefinitionIdsSha256": "c04e3978d3d64cf94d1749df2f1755fc2d59c49328421041fbab4b9e44e42c7f",
+      "internalDefinitionCount": 341,
+      "internalDefinitionIdsSha256": "ba18df53ad039cab73d007a76392d3025e54b862d4a761631178e6aab7713b54",
       "externalCallCount": 25,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1463,8 +1463,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 578,
-      "internalDefinitionIdsSha256": "9b761142481047397840a242961ed9966f321e31a234c94c5f6d7d286e6add14",
+      "internalDefinitionCount": 588,
+      "internalDefinitionIdsSha256": "1273544599930eed825377e8f92bf4e35c66e771c3b06c2094384949e2383992",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1498,8 +1498,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 707,
-      "internalDefinitionIdsSha256": "5df61001e0df8b74e8c0ee71e3ee6372f5a6f93ac2fbcd76fc8546bf1366f016",
+      "internalDefinitionCount": 717,
+      "internalDefinitionIdsSha256": "18534a081ad2375f99997aa5299cd432fb6b2a5fbbb3d32c263d9e62c271f1ec",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1534,8 +1534,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 581,
-      "internalDefinitionIdsSha256": "f7afa0bcec24e6eaf9005c2755b9c33ad5825945ee15d126e4fc94a18700fb7d",
+      "internalDefinitionCount": 591,
+      "internalDefinitionIdsSha256": "5994bc060e86be34195a5de4cc67293045c6764c1929b41325b0e8a56db5136b",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1569,8 +1569,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 707,
-      "internalDefinitionIdsSha256": "250243ceb1cb781e742ef914f24ffbe27a8123cc7bb4e376cffdb8cc9df5d0b9",
+      "internalDefinitionCount": 717,
+      "internalDefinitionIdsSha256": "5f9f1c3d78bf722ec14d624dadbb50f69854efb398927bc89906d2498a7da60c",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1605,8 +1605,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 581,
-      "internalDefinitionIdsSha256": "a01c0276fc0bfec675f5b78c3063ace769ba9cd038f1091e28bfe44fadb29803",
+      "internalDefinitionCount": 591,
+      "internalDefinitionIdsSha256": "f756a4ac9ddfb69bc372d09d3a44bb6b5525c6f765ae654d6ce3fa369e1fcce5",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1640,8 +1640,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 366,
-      "internalDefinitionIdsSha256": "63e153b6fffc7f15a6ff623a99f62d1d0ecfab2fbeedc701fce2c38483b74f15",
+      "internalDefinitionCount": 369,
+      "internalDefinitionIdsSha256": "b6064fc38e4b18ef37cf117cd5eeeb5df33390046cea52bef5b217eb71f8e69d",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1671,8 +1671,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 528,
-      "internalDefinitionIdsSha256": "7e59e2edc186c56471d8fb768460309ec3ffa9d897540d0fe7bfe3d3b99596a5",
+      "internalDefinitionCount": 575,
+      "internalDefinitionIdsSha256": "8109bcbc26956d58304699cb0016278d2b0f16c4feabca4515c2c8f4d8b0cc89",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1770,8 +1770,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 566,
-      "internalDefinitionIdsSha256": "a07b2a790bb4f38e2f1ce164bec20f5de983b8266f2bd6d04ef99b68532d8ec6",
+      "internalDefinitionCount": 573,
+      "internalDefinitionIdsSha256": "f17bd9060c4eec88493203121ae873b84e05397b34c76981614e425b330d131f",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1804,8 +1804,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 695,
-      "internalDefinitionIdsSha256": "21b883e3fe38adc9b61f38766321812027f930a48f579b78e2b6d9cd183cfac6",
+      "internalDefinitionCount": 702,
+      "internalDefinitionIdsSha256": "6b595e17ff216cd632061fc2ab5eb2b10a753764ff5aff336cd595a2ea4896ff",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1839,8 +1839,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 569,
-      "internalDefinitionIdsSha256": "5bd9a9203c8744f078cd16228f2dafe2f833fb178fbfb696473b73e9f3116cec",
+      "internalDefinitionCount": 576,
+      "internalDefinitionIdsSha256": "0cb5fc7a3c775f574549f6c2b53fc7da47fa47feb932a7e988280c2b91514162",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1873,8 +1873,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 695,
-      "internalDefinitionIdsSha256": "5c6e0a18988114faca1a11f29180af4653f1f8ed4aabb8c8f65c3bb13ce5447f",
+      "internalDefinitionCount": 702,
+      "internalDefinitionIdsSha256": "760b1971d4320afd32c157e60391ea09ab3c0a4fcaa6c07fa5044e3ab5f9b943",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1908,8 +1908,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 569,
-      "internalDefinitionIdsSha256": "8408eed3c552a3cf2a1dc3c139b9925cd951ef5b70fc75f2ff0ff1a798466eeb",
+      "internalDefinitionCount": 576,
+      "internalDefinitionIdsSha256": "a5e365da6639970681e7afa331a4db5d4d6be0a3e92f617c2167994d6e9e59c3",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -268,7 +268,7 @@
        (fn [] (or (commit-locator db) selected-exact-locator))
 
        :select-exact
-       (fn [token-data timeout-ms]
+       (fn [token-data _timeout-ms]
          (when (and conn
                     (or (:exact-locator token-data)
                         (and (temporal-history? db)
@@ -282,14 +282,18 @@
                             (temporal-history? db)
                             (integer? (:revision token-data)))
                    (try
-                     ;; A reader connection may simply not have observed the
-                     ;; writer's revision yet. Await it exactly as
-                     ;; :select-at-least does, so replica lag is reported as
-                     ;; bounded lag instead of as durable history that is
-                     ;; missing. Retained history older than the local head
-                     ;; still resolves without waiting.
-                     (d/as-of (await-revision-db conn db token-data timeout-ms)
-                              (:revision token-data))
+                     ;; A revision above the local head is reported unavailable
+                     ;; immediately rather than waited for. Datahike has no
+                     ;; `d/sync` (replikativ/datahike#958), so the only ways to
+                     ;; wait are unbounded polling or a fixed N-second timeout,
+                     ;; and neither can distinguish a revision that is merely
+                     ;; late from one that will never arrive. Failing closed
+                     ;; keeps the caller's deadline theirs to spend. Datahike
+                     ;; also caches connections per store config in-process, so
+                     ;; for a direct writer this local head is authoritative.
+                     (let [current (d/db conn)]
+                       (when (<= (:revision token-data) (:max-tx current))
+                         (d/as-of current (:revision token-data))))
                      (catch InterruptedException interrupt
                        (.interrupt (Thread/currentThread))
                        (throw
@@ -301,17 +305,6 @@
                           :phase :exact-temporal
                           :requested-revision (:revision token-data)}
                          interrupt)))
-                     (catch clojure.lang.ExceptionInfo info
-                       ;; A classified freshness or selection failure is the
-                       ;; answer, not a provider fault to re-wrap.
-                       (if (contains?
-                            #{:eacl.consistency/freshness-unavailable
-                              :eacl.basis/selection-failure}
-                            (:type (ex-data info)))
-                         (throw info)
-                         (selection-failure!
-                          "Datahike temporal reconstruction failed."
-                          :exact-temporal token-data info)))
                      (catch Exception failure
                        (selection-failure!
                         "Datahike temporal reconstruction failed."

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -12,7 +12,7 @@
                   :fully-consistent
                   :at-least-as-fresh
                   :at-exact-snapshot}
-   :snapshots #{:current :authoritative :causal :exact}
+   :snapshots #{:current :authoritative :causal}
    :source #{:stable-scope :source-lifecycle :native-revision :order-hint}
    :cursor #{:forward :reverse :opaque}
    :transactions #{:schema :relationships :object-deletion}
@@ -43,6 +43,56 @@
   [db]
   (or (exact-commits? db)
       (temporal-history? db)))
+
+(defn- selection-failure!
+  [message phase token-data cause]
+  (throw
+   (ex-info
+    message
+    {:type :eacl.basis/selection-failure
+     :eacl/error :eacl.basis/selection-failure
+     :classification :retryable
+     :phase phase
+     :requested-revision (:revision token-data)
+     :requested-exact-locator (:exact-locator token-data)}
+    cause)))
+
+(defn- missing-commit-error?
+  [error]
+  (some #{:not-found :missing-node}
+        [(:type (ex-data error)) (:error (ex-data error))]))
+
+(defn- load-exact-commit
+  [conn locator token-data]
+  (when locator
+    (try
+      (d/commit-as-db conn (UUID/fromString locator))
+      ;; A locator from another backend format is absence for the conditional
+      ;; commit path. Temporal history may still reconstruct by revision.
+      (catch IllegalArgumentException _
+        nil)
+      (catch InterruptedException interrupt
+        (.interrupt (Thread/currentThread))
+        (throw
+         (ex-info
+          "Datahike exact commit selection was interrupted."
+          {:type :eacl.basis/selection-failure
+           :eacl/error :eacl.basis/selection-failure
+           :classification :cancelled
+           :phase :exact-commit
+           :requested-revision (:revision token-data)
+           :requested-exact-locator locator}
+          interrupt)))
+      (catch clojure.lang.ExceptionInfo info
+        (if (missing-commit-error? info)
+          nil
+          (selection-failure!
+           "Datahike exact commit selection failed."
+           :exact-commit token-data info)))
+      (catch Exception failure
+        (selection-failure!
+         "Datahike exact commit selection failed."
+         :exact-commit token-data failure)))))
 
 (defn- commit-locator
   [db]
@@ -147,6 +197,15 @@
                           :selected-internal/current-external-injective-v2)
       :capabilities
       (cond-> capabilities
+        (exact-reconstruction? db)
+        (update :snapshots conj :exact)
+
+        (temporal-history? db)
+        (update :snapshots conj :durable-history)
+
+        (exact-commits? db)
+        (update :snapshots conj :conditional-exact)
+
         (or (nil? conn)
             (not (direct-writer? db)))
         (update :consistency disj :fully-consistent)
@@ -214,62 +273,40 @@
                     (or (:exact-locator token-data)
                         (and (temporal-history? db)
                              (integer? (:revision token-data)))))
-           (try
-             (let [commit-db
-                   (when (and (exact-commits? db)
-                              (:exact-locator token-data))
-                     (d/commit-as-db
-                      conn
-                      (UUID/fromString
-                       (:exact-locator token-data))))
-                   temporal-db
-                   (when (and (nil? commit-db)
-                              (temporal-history? db)
-                              (integer? (:revision token-data))
-                              (<= (:revision token-data)
-                                  (:max-tx (d/db conn))))
-                     (d/as-of (d/db conn)
-                              (:revision token-data)))]
-               (when-let [selected-db (or commit-db temporal-db)]
-                 (snapshot-adapter
-                  selected-db
-                  (assoc opts'
-                         :selected-order-hint (:revision token-data)
-                         :selected-exact-locator
-                         (:exact-locator token-data)))))
-             ;; Genuine absence maps to the contractual unavailable nil: a
-             ;; foreign locator format fails UUID parsing, and a GC'd
-             ;; commit makes commit-as-db return nil (handled above by the
-             ;; when-let). A store that reports absence through a typed
-             ;; not-found / missing-node error is treated the same. A
-             ;; failed READ is not absence: it stays a classified retryable
-             ;; failure so a transient store outage never expires a valid
-             ;; cursor. Every other Throwable is a classified failure.
-             (catch IllegalArgumentException _
-               nil)
-             (catch clojure.lang.ExceptionInfo info
-               (if (some #{:not-found :missing-node}
-                         [(:type (ex-data info)) (:error (ex-data info))])
-                 nil
-                 (throw (ex-info "Exact-basis selection failed."
-                                 {:type :eacl.basis/selection-failure
-                                  :eacl/error :eacl.basis/selection-failure
-                                  :classification :retryable
-                                  :cause (ex-data info)}
-                                 info))))
-             (catch InterruptedException interrupt
-               (throw (ex-info "Exact-basis selection was interrupted."
-                               {:type :eacl.basis/selection-failure
-                                :eacl/error :eacl.basis/selection-failure
-                                :classification :cancelled}
-                               interrupt)))
-             (catch Throwable failure
-               (throw (ex-info "Exact-basis selection failed."
-                               {:type :eacl.basis/selection-failure
-                                :eacl/error :eacl.basis/selection-failure
-                                :classification :retryable
-                                :cause-class (.getName (class failure))}
-                               failure))))))
+           (let [commit-db
+                 (when (exact-commits? db)
+                   (load-exact-commit
+                    conn (:exact-locator token-data) token-data))
+                 temporal-db
+                 (when (and (nil? commit-db)
+                            (temporal-history? db)
+                            (integer? (:revision token-data)))
+                   (try
+                     (let [current (d/db conn)]
+                       (when (<= (:revision token-data) (:max-tx current))
+                         (d/as-of current (:revision token-data))))
+                     (catch InterruptedException interrupt
+                       (.interrupt (Thread/currentThread))
+                       (throw
+                        (ex-info
+                         "Datahike temporal reconstruction was interrupted."
+                         {:type :eacl.basis/selection-failure
+                          :eacl/error :eacl.basis/selection-failure
+                          :classification :cancelled
+                          :phase :exact-temporal
+                          :requested-revision (:revision token-data)}
+                         interrupt)))
+                     (catch Exception failure
+                       (selection-failure!
+                        "Datahike temporal reconstruction failed."
+                        :exact-temporal token-data failure))))]
+             (when-let [selected-db (or commit-db temporal-db)]
+               (snapshot-adapter
+                selected-db
+                (assoc opts'
+                       :selected-order-hint (:revision token-data)
+                       :selected-exact-locator
+                       (:exact-locator token-data)))))))
 
        :object-id->internal
        (fn [object-id]

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -268,7 +268,7 @@
        (fn [] (or (commit-locator db) selected-exact-locator))
 
        :select-exact
-       (fn [token-data _timeout-ms]
+       (fn [token-data timeout-ms]
          (when (and conn
                     (or (:exact-locator token-data)
                         (and (temporal-history? db)
@@ -282,9 +282,14 @@
                             (temporal-history? db)
                             (integer? (:revision token-data)))
                    (try
-                     (let [current (d/db conn)]
-                       (when (<= (:revision token-data) (:max-tx current))
-                         (d/as-of current (:revision token-data))))
+                     ;; A reader connection may simply not have observed the
+                     ;; writer's revision yet. Await it exactly as
+                     ;; :select-at-least does, so replica lag is reported as
+                     ;; bounded lag instead of as durable history that is
+                     ;; missing. Retained history older than the local head
+                     ;; still resolves without waiting.
+                     (d/as-of (await-revision-db conn db token-data timeout-ms)
+                              (:revision token-data))
                      (catch InterruptedException interrupt
                        (.interrupt (Thread/currentThread))
                        (throw
@@ -296,6 +301,17 @@
                           :phase :exact-temporal
                           :requested-revision (:revision token-data)}
                          interrupt)))
+                     (catch clojure.lang.ExceptionInfo info
+                       ;; A classified freshness or selection failure is the
+                       ;; answer, not a provider fault to re-wrap.
+                       (if (contains?
+                            #{:eacl.consistency/freshness-unavailable
+                              :eacl.basis/selection-failure}
+                            (:type (ex-data info)))
+                         (throw info)
+                         (selection-failure!
+                          "Datahike temporal reconstruction failed."
+                          :exact-temporal token-data info)))
                      (catch Exception failure
                        (selection-failure!
                         "Datahike temporal reconstruction failed."

--- a/modules/eacl-datahike/src/eacl/datahike/schema.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/schema.clj
@@ -135,7 +135,11 @@
 (def default-config
   {:store              {:backend :memory}
    :schema-flexibility :write
-   :keep-history?      false
+   ;; EACL-created stores retain temporal values so exact tokens and cursors
+   ;; survive ordinary commit-record cutoff GC. Applications may explicitly
+   ;; opt out with {:keep-history? false} to trade this guarantee for lower
+   ;; storage and write amplification.
+   :keep-history?      true
    ;; EACL object ids come from the caller, so no cap is imposed here; stating 0
    ;; declares that as intentional rather than leaving datahike to warn about it.
    :max-string-length  0})
@@ -143,9 +147,11 @@
 (defn create-conn
   "A datahike connection carrying EACL's schema.
 
-  `config` is merged over `default-config`; pass `{:attribute-refs? true}` to get
-  Datomic's numeric attribute representation. A memory store gets a fresh id per
-  connection unless one is supplied, so two calls do not collide."
+  `config` is merged over `default-config`; temporal history is enabled unless
+  the caller explicitly passes `{:keep-history? false}`. Pass
+  `{:attribute-refs? true}` to get Datomic's numeric attribute representation.
+  A memory store gets a fresh id per connection unless one is supplied, so two
+  calls do not collide."
   ([] (create-conn nil nil))
   ([extra-schema] (create-conn extra-schema nil))
   ([extra-schema config]

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -148,9 +148,10 @@
         (is (= [(second documents)] (:data historical-1)))
         (is (= (:data historical-1) (:data historical-2)))
         (is (nil? (get-in historical-1 [:page-info :cursor-recovery])))
-        (is (false? (:cached? historical-1)))
-        (is (false? (:cached? historical-2)))
-        (is (= (+ 2 (:bypasses before)) (:bypasses after)))))))
+        (is (true? (:cached? historical-1)))
+        (is (true? (:cached? historical-2)))
+        (is (= (:bypasses before) (:bypasses after))
+            "exact replay uses only the matching immutable page/answer tier")))))
 
 (deftest repeated-relationship-page-uses-client-private-navigation-cache-test
   (let [conn (datahike/create-conn)
@@ -241,7 +242,8 @@
                           :resource document
                           :cache? :invalid})))))
     (let [after (datahike/cache-stats authorization)]
-      (is (= (+ 10 (:bypasses before)) (:bypasses after)))
+      (is (= (+ 11 (:bypasses before)) (:bypasses after))
+          "five permission shapes twice plus one relationship page bypass")
       (doseq [metric [:exact-hits :managed-hits :misses :puts]]
         (is (= (metric before) (metric after))
             (str metric " must not change during request bypass"))))))
@@ -270,11 +272,10 @@
               authorization user :view document
               (consistency/at-exact-snapshot token))))
         (let [after (datahike/cache-stats authorization)]
-          (is (= (+ 2 (:bypasses before))
-                 (:bypasses after)))
-          (is (= (:exact-hits before)
+          (is (= (:bypasses before) (:bypasses after)))
+          (is (= (+ 2 (:exact-hits before))
                  (:exact-hits after))
-              "exact requests never consult the completed-answer cache"))))
+              "exact requests reuse only the identical retained snapshot"))))
     (testing "force-moving the branch to a predecessor cannot pass by max-tx"
       (d/force-branch!
        pre-write
@@ -310,6 +311,9 @@
          adapter :consistency :fully-consistent))
     (is (backend/supports?
          adapter :consistency :at-exact-snapshot))
+    (is (true? (get-in (d/db conn) [:config :keep-history?])))
+    (is (backend/supports? adapter :snapshots :durable-history))
+    (is (backend/supports? adapter :snapshots :conditional-exact))
     (let [streaming-db
           (assoc-in (d/db conn)
                     [:config :writer]
@@ -331,7 +335,10 @@
          (:opts authorization))]
     (is (not
          (backend/supports?
-          adapter :consistency :at-exact-snapshot)))))
+          adapter :consistency :at-exact-snapshot)))
+    (is (not (backend/supports? adapter :snapshots :exact)))
+    (is (not (backend/supports? adapter :snapshots :durable-history)))
+    (is (not (backend/supports? adapter :snapshots :conditional-exact)))))
 
 (deftest low-level-db-entry-point-bypasses-completed-cache-test
   (let [conn (datahike/create-conn)
@@ -474,7 +481,7 @@
             authorization user :view document
             (consistency/at-exact-snapshot token))))
       (d/release conn)))
-  (testing "collected commit history expires exact, not causal anchor membership"
+  (testing "temporal history reconstructs exact state after commit cutoff GC"
     ;; Datahike 0.8.1759's in-memory konserve backend cannot mark its
     ;; persistent-set roots (`:flush-before-marking`). Exercise the public GC
     ;; contract on the file backend, where the persisted roots are flushable.
@@ -486,9 +493,10 @@
           (datahike/create-conn
            nil
            {:store {:backend :file
-                    :path (str temp-dir "/db")}})
+                    :path (str temp-dir "/db")}
+            :keep-history? true})
           config (:config (d/db conn))
-          authorization (client conn)
+          authorization (client conn {:cache cache/no-cache})
           _ (seed! conn authorization)
           token
           (:zed/token
@@ -500,16 +508,44 @@
               authorization user :view document
               (consistency/at-exact-snapshot token))))
         @(d/gc-storage conn (Date. (+ 1000 (System/currentTimeMillis))))
+        (is (true?
+             (eacl/can?
+              authorization user :view document
+              (consistency/at-exact-snapshot token)))
+            "temporal d/as-of is durable even when the named commit is gone")
+        (is (false?
+             (eacl/can?
+              authorization user :view document
+              (consistency/at-least-as-fresh token))))
+        (finally
+          (d/release conn)
+          (d/delete-database config)))))
+  (testing "history-disabled collected commits are genuinely unavailable"
+    (let [temp-dir
+          (Files/createTempDirectory
+           "eacl-datahike-gc-no-history-"
+           (make-array FileAttribute 0))
+          conn
+          (datahike/create-conn
+           nil
+           {:store {:backend :file
+                    :path (str temp-dir "/db")}
+            :keep-history? false})
+          config (:config (d/db conn))
+          authorization (client conn {:cache cache/no-cache})
+          _ (seed! conn authorization)
+          token
+          (:zed/token
+           (eacl/create-relationship! authorization relationship))]
+      (try
+        (eacl/delete-relationship! authorization relationship)
+        @(d/gc-storage conn (Date. (+ 1000 (System/currentTimeMillis))))
         (is (= :eacl.consistency/exact-snapshot-unavailable
                (:type
                 (error-data
                  #(eacl/can?
                    authorization user :view document
                    (consistency/at-exact-snapshot token))))))
-        (is (false?
-             (eacl/can?
-              authorization user :view document
-              (consistency/at-least-as-fresh token))))
         (finally
           (d/release conn)
           (d/delete-database config))))))

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -697,11 +697,12 @@
            (eacl/->Relationship second-reader :reader document))))
       (finally (d/release conn)))))
 
-(deftest lagging-datahike-reader-awaits-the-exact-revision-test
-  ;; Datahike used to report a locally future revision as missing history while
-  ;; :select-at-least waited for the same revision on the same adapter. Exact
-  ;; selection now awaits it under the caller's bound, so replica lag is
-  ;; reported as bounded lag rather than as durable history that is gone.
+(deftest future-datahike-revision-is-unavailable-without-blocking-test
+  ;; Datahike has no `d/sync` (replikativ/datahike#958), so the only ways to
+  ;; wait for an unobserved revision are unbounded polling or a fixed N-second
+  ;; timeout, and neither distinguishes a revision that is late from one that
+  ;; will never arrive. Exact selection therefore reports a locally future
+  ;; revision as unavailable immediately and leaves the deadline to the caller.
   (let [conn (datahike/create-conn nil {:keep-history? true})
         authorization (client conn)]
     (try
@@ -710,16 +711,21 @@
       (let [db (d/db conn)
             adapter (datahike-backend/snapshot-adapter db {:conn conn})
             future-revision (+ 1000 (:max-tx db))
-            data (try
-                   (backend/invoke
-                    adapter :select-exact
-                    {:revision future-revision :exact-locator nil}
-                    25)
-                   nil
-                   (catch clojure.lang.ExceptionInfo error
-                     (ex-data error)))]
-        (is (= :eacl.consistency/freshness-unavailable (:type data))
-            "an unobserved revision is bounded lag, not missing history")
-        (is (= :freshness-timeout (:reason data)))
-        (is (= future-revision (:requested-order-hint data))))
+            started (System/nanoTime)
+            selected (backend/invoke
+                      adapter :select-exact
+                      {:revision future-revision :exact-locator nil}
+                      30000)
+            elapsed-ms (quot (- (System/nanoTime) started) 1000000)]
+        (is (nil? selected)
+            "a revision the local value has not observed is unavailable")
+        (is (< elapsed-ms 1000)
+            "selection must not spend the caller's timeout waiting for it"))
+      (testing "retained history at or below the local head still resolves"
+        (let [db (d/db conn)
+              adapter (datahike-backend/snapshot-adapter db {:conn conn})]
+          (is (some? (backend/invoke
+                      adapter :select-exact
+                      {:revision (:max-tx db) :exact-locator nil}
+                      30000)))))
       (finally (d/release conn)))))

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -1,5 +1,6 @@
 (ns eacl.datahike.consistency-v3-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk]
             [datahike.api :as d]
             [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
@@ -649,3 +650,76 @@
                                               [:database-id :store]))))
         "the store identity carries only backend and id, never connection configuration")
     (d/release conn)))
+
+;; --- 2026-08-16 exact-cache review ------------------------------------------
+
+(deftest relation-root-tree-expansion-observes-relationship-writes-test
+  ;; A relation root reads that relation's relationships, but no permission
+  ;; path names it. When the dependency closure missed it, the managed
+  ;; cross-snapshot tier proved a stale tree equal at every later snapshot.
+  (let [conn (datahike/create-conn)
+        authorization (client conn)
+        second-reader (eacl/spice-object :user "second-reader")
+        leaf-subject-ids
+        (fn [tree]
+          (let [ids (atom #{})]
+            (clojure.walk/postwalk
+             (fn [node]
+               (when (and (map? node) (contains? node :subjects))
+                 (swap! ids into (map :id (:subjects node))))
+               node)
+             tree)
+            @ids))]
+    (try
+      (seed! conn authorization)
+      (d/transact conn [{:eacl/id "second-reader"}])
+      (eacl/create-relationship! authorization relationship)
+      (doseq [root [:reader :view]]
+        (testing (str "root " root)
+          (is (= #{"user"}
+                 (leaf-subject-ids
+                  (:tree-root
+                   (eacl/expand-permission-tree
+                    authorization
+                    {:resource document :permission root})))))
+          (eacl/create-relationship!
+           authorization
+           (eacl/->Relationship second-reader :reader document))
+          (is (= #{"user" "second-reader"}
+                 (leaf-subject-ids
+                  (:tree-root
+                   (eacl/expand-permission-tree
+                    authorization
+                    {:resource document :permission root}))))
+              "a cached tree must not survive a write it reports")
+          (eacl/delete-relationship!
+           authorization
+           (eacl/->Relationship second-reader :reader document))))
+      (finally (d/release conn)))))
+
+(deftest lagging-datahike-reader-awaits-the-exact-revision-test
+  ;; Datahike used to report a locally future revision as missing history while
+  ;; :select-at-least waited for the same revision on the same adapter. Exact
+  ;; selection now awaits it under the caller's bound, so replica lag is
+  ;; reported as bounded lag rather than as durable history that is gone.
+  (let [conn (datahike/create-conn nil {:keep-history? true})
+        authorization (client conn)]
+    (try
+      (seed! conn authorization)
+      (eacl/create-relationship! authorization relationship)
+      (let [db (d/db conn)
+            adapter (datahike-backend/snapshot-adapter db {:conn conn})
+            future-revision (+ 1000 (:max-tx db))
+            data (try
+                   (backend/invoke
+                    adapter :select-exact
+                    {:revision future-revision :exact-locator nil}
+                    25)
+                   nil
+                   (catch clojure.lang.ExceptionInfo error
+                     (ex-data error)))]
+        (is (= :eacl.consistency/freshness-unavailable (:type data))
+            "an unobserved revision is bounded lag, not missing history")
+        (is (= :freshness-timeout (:reason data)))
+        (is (= future-revision (:requested-order-hint data))))
+      (finally (d/release conn)))))

--- a/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
@@ -122,14 +122,21 @@
       (contract/assert-pinned-permission-tree-golden! client)
       (let [request {:resource (eacl/spice-object :document "testdoc")
                      :permission :view}
-            first-response (eacl/expand-permission-tree client request)]
+            first-response (eacl/expand-permission-tree client request)
+            exact-request
+            (assoc request :consistency
+                   (consistency/at-exact-snapshot
+                    (:expanded-at first-response)))
+            before (datahike/cache-stats client)
+            exact-response (eacl/expand-permission-tree client exact-request)
+            repeated-exact (eacl/expand-permission-tree client exact-request)
+            after (datahike/cache-stats client)]
         (is (= (:tree-root first-response)
-               (:tree-root
-                (eacl/expand-permission-tree
-                 client
-                 (assoc request :consistency
-                        (consistency/at-exact-snapshot
-                         (:expanded-at first-response)))))))))))
+               (:tree-root exact-response)
+               (:tree-root repeated-exact)))
+        (is (= (+ 2 (:snapshot-exact-hits before))
+               (:snapshot-exact-hits after))
+            "tree roots are reusable, while expanded-at is rebuilt per exact request")))))
 
 (deftest datahike-permission-tree-schema-mutation-snapshot-test
   (let [conn (datahike/create-conn)

--- a/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
@@ -296,7 +296,8 @@
                           :resource document
                           :cache? :invalid})))))
     (let [after (datascript/cache-stats client)]
-      (is (= (+ 10 (:bypasses before)) (:bypasses after)))
+      (is (= (+ 11 (:bypasses before)) (:bypasses after))
+          "five permission shapes twice plus one relationship page bypass")
       (doseq [metric [:exact-hits :managed-hits :misses :puts]]
         (is (= (metric before) (metric after))
             (str metric " must not change during request bypass"))))))

--- a/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/contract_test.cljc
@@ -556,8 +556,8 @@
                 thrown))]
         (is (some? error)
             "a cursor from another schema generation must not resume the walk")
-        (is (= :eacl.pagination/invalid-cursor (:type (ex-data error))))
-        (is (= :query-mismatch (:reason (ex-data error))))
+        (is (= :eacl.pagination/stale-cursor (:type (ex-data error))))
+        (is (= :dependency-proof-changed (:reason (ex-data error))))
         (let [fresh-error
               (try
                 (eacl/lookup-resources client query)
@@ -923,7 +923,7 @@
       (is (= [(contract/->server "server-1")] (:data page-1)))
       (is (= [(contract/->server "server-2")] (:data page-2)))
       (is (empty? (:data page-3)))
-      (is (= 11 (:v envelope)))
+      (is (= 12 (:v envelope)))
       (is (= :stable-edge
              (get-in envelope [:edge :kind])))
       (is (= "server-1"

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -25,6 +25,21 @@
   [^datomic.Database db]
   (or (.asOfT db) (d/basis-t db)))
 
+(defn- ordinary-view?
+  "True when `db` is an ordinary current or as-of database value.
+
+  `d/filter`, `d/since` and `d/history` views report the same database id and
+  basis as the plain value they wrap, so nothing downstream can tell them apart
+  by revision: they would mint the identical snapshot identity while answering
+  different questions. Exact-snapshot consistency is therefore refused for
+  them, which is also what keeps them out of the snapshot-exact cache tier. An
+  as-of value is ordinary — it is precisely the exact view this backend
+  selects."
+  [^datomic.Database db]
+  (and (not (.isFiltered db))
+       (not (.isHistory db))
+       (nil? (.sinceT db))))
+
 (def ^:private sync-timeout-marker (Object.))
 
 (defn- freshness-unavailable!
@@ -251,7 +266,10 @@
          (nil? conn)
          (update :consistency disj
                  :fully-consistent :at-least-as-fresh
-                 :at-exact-snapshot))
+                 :at-exact-snapshot)
+
+         (not (ordinary-view? db))
+         (update :consistency disj :at-exact-snapshot))
        :state {:db db
                :opts opts}
        :operations
@@ -281,83 +299,124 @@
 
         :select-authoritative
         (fn [timeout-ms]
-          (try
-            (let [selected
-                  (if conn
-                    (deref (d/sync conn)
-                           (or timeout-ms 30000)
-                           ::timeout)
-                    db)]
-              (when (= ::timeout selected)
-                (throw
-                 (ex-info
-                  "Timed out establishing the Datomic authoritative head."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :freshness-timeout
-                   :timeout-ms (or timeout-ms 30000)})))
-              (snapshot-adapter selected opts'))
-            (catch clojure.lang.ExceptionInfo error
-              (if (= :eacl.consistency/freshness-unavailable
-                     (:type (ex-data error)))
-                (throw error)
-                (throw
-                 (ex-info
-                  "Failed establishing the Datomic authoritative head."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :sync-failed
-                   :timeout-ms (or timeout-ms 30000)}
-                  error))))))
+          ;; The waiter is held outside the body so every exit path can cancel
+          ;; it, while `d/sync` itself stays inside the try and keeps its
+          ;; existing failure classification.
+          (let [waiter (volatile! nil)]
+            (try
+              (let [selected
+                    (if conn
+                      (do (vreset! waiter (d/sync conn))
+                          (deref @waiter (or timeout-ms 30000) ::timeout))
+                      db)]
+                (when (= ::timeout selected)
+                  ;; EACL owns the future once it stops waiting: an abandoned
+                  ;; sync stays registered on the connection until its basis
+                  ;; arrives, which under retry traffic is unbounded.
+                  (cancel-waiter! @waiter)
+                  (throw
+                   (ex-info
+                    "Timed out establishing the Datomic authoritative head."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :freshness-timeout
+                     :timeout-ms (or timeout-ms 30000)})))
+                (snapshot-adapter selected opts'))
+              (catch InterruptedException interrupt
+                (cancel-waiter! @waiter)
+                (let [classified
+                      (ex-info
+                       "Establishing the Datomic authoritative head was interrupted."
+                       {:type :eacl.basis/selection-failure
+                        :eacl/error :eacl.basis/selection-failure
+                        :classification :cancelled
+                        :phase :authoritative-sync
+                        :timeout-ms (or timeout-ms 30000)}
+                       interrupt)]
+                  (.interrupt (Thread/currentThread))
+                  (throw classified)))
+              (catch clojure.lang.ExceptionInfo error
+                (if (= :eacl.consistency/freshness-unavailable
+                       (:type (ex-data error)))
+                  (throw error)
+                  (throw
+                   (ex-info
+                    "Failed establishing the Datomic authoritative head."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :sync-failed
+                     :timeout-ms (or timeout-ms 30000)}
+                    error)))))))
 
         :select-at-least
         (fn [token-data timeout-ms]
-          (try
-            (let [selected
-                  (if conn
-                    (deref (d/sync conn (:revision token-data))
-                           (or timeout-ms 30000)
-                           ::timeout)
-                    db)
-                  requested-order-hint (:revision token-data)]
-              (when (= ::timeout selected)
-                (throw
-                 (ex-info
-                  "Timed out waiting for the Datomic causal floor."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :freshness-timeout
-                   :requested-order-hint (:revision token-data)
-                   :timeout-ms (or timeout-ms 30000)})))
-              ;; d/sync is specified to return a DB at least as new as the
-              ;; requested basis. Check the postcondition anyway: adapters and
-              ;; test doubles are not allowed to turn an order hint into an
-              ;; unverified freshness claim.
-              (when (and requested-order-hint
-                         (< (d/basis-t selected) requested-order-hint))
-                (throw
-                 (ex-info
-                  "The selected Datomic snapshot did not reach the causal floor."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :head-behind
-                   :requested-order-hint requested-order-hint
-                   :observed-order-hint (d/basis-t selected)
-                   :timeout-ms (or timeout-ms 30000)})))
-              (snapshot-adapter selected opts'))
-            (catch clojure.lang.ExceptionInfo error
-              (if (= :eacl.consistency/freshness-unavailable
-                     (:type (ex-data error)))
-                (throw error)
-                (throw
-                 (ex-info
-                  "Failed waiting for the Datomic causal floor."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :sync-failed
-                   :requested-order-hint (:revision token-data)
-                   :timeout-ms (or timeout-ms 30000)}
-                  error))))))
+          ;; The waiter is held outside the body so every exit path can cancel
+          ;; it, while `d/sync` itself stays inside the try and keeps its
+          ;; existing failure classification.
+          (let [waiter (volatile! nil)]
+            (try
+              (let [selected
+                    (if conn
+                      (do (vreset! waiter (d/sync conn (:revision token-data)))
+                          (deref @waiter (or timeout-ms 30000) ::timeout))
+                      db)
+                    requested-order-hint (:revision token-data)]
+                (when (= ::timeout selected)
+                  ;; EACL owns the future once it stops waiting: an abandoned
+                  ;; sync stays registered on the connection until its basis
+                  ;; arrives, which under retry traffic is unbounded.
+                  (cancel-waiter! @waiter)
+                  (throw
+                   (ex-info
+                    "Timed out waiting for the Datomic causal floor."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :freshness-timeout
+                     :requested-order-hint (:revision token-data)
+                     :timeout-ms (or timeout-ms 30000)})))
+                ;; d/sync is specified to return a DB at least as new as the
+                ;; requested basis. Check the postcondition anyway: adapters and
+                ;; test doubles are not allowed to turn an order hint into an
+                ;; unverified freshness claim.
+                (when (and requested-order-hint
+                           (< (d/basis-t selected) requested-order-hint))
+                  (throw
+                   (ex-info
+                    "The selected Datomic snapshot did not reach the causal floor."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :head-behind
+                     :requested-order-hint requested-order-hint
+                     :observed-order-hint (d/basis-t selected)
+                     :timeout-ms (or timeout-ms 30000)})))
+                (snapshot-adapter selected opts'))
+              (catch InterruptedException interrupt
+                (cancel-waiter! @waiter)
+                (let [classified
+                      (ex-info
+                       "Waiting for the Datomic causal floor was interrupted."
+                       {:type :eacl.basis/selection-failure
+                        :eacl/error :eacl.basis/selection-failure
+                        :classification :cancelled
+                        :phase :at-least-sync
+                        :requested-order-hint (:revision token-data)
+                        :timeout-ms (or timeout-ms 30000)}
+                       interrupt)]
+                  (.interrupt (Thread/currentThread))
+                  (throw classified)))
+              (catch clojure.lang.ExceptionInfo error
+                (if (= :eacl.consistency/freshness-unavailable
+                       (:type (ex-data error)))
+                  (throw error)
+                  (throw
+                   (ex-info
+                    "Failed waiting for the Datomic causal floor."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :sync-failed
+                     :requested-order-hint (:revision token-data)
+                     :timeout-ms (or timeout-ms 30000)}
+                    error)))))))
 
         :exact-locator
         (fn []

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -4,7 +4,8 @@
   (:require [datomic.api :as d]
             [eacl.backend.v8 :as backend]
             [eacl.datomic.db :as ddb])
-  (:import [java.util UUID]))
+  (:import [java.util UUID]
+           [java.util.concurrent Future]))
 
 (def capabilities
   {:consistency #{:minimize-latency
@@ -23,6 +24,152 @@
   "Returns the actual selected Datomic revision, including an as-of bound."
   [^datomic.Database db]
   (or (.asOfT db) (d/basis-t db)))
+
+(def ^:private sync-timeout-marker (Object.))
+
+(defn- freshness-unavailable!
+  [message data]
+  (throw
+   (ex-info
+    message
+    (assoc data
+           :type :eacl.consistency/freshness-unavailable
+           :eacl/error :eacl.consistency/freshness-unavailable))))
+
+(defn- selection-failure!
+  [message classification phase data cause]
+  (throw
+   (ex-info
+    message
+    (merge
+     {:type :eacl.basis/selection-failure
+      :eacl/error :eacl.basis/selection-failure
+      :classification classification
+      :phase phase}
+     data)
+    cause)))
+
+(defn- cancel-waiter!
+  [waiter]
+  (when (instance? Future waiter)
+    (.cancel ^Future waiter true))
+  nil)
+
+(defn await-basis-db
+  "Returns one Datomic DB whose observed basis is at least `requested-t`.
+
+  `local-db` is the request's single captured local observation. Synchronizes
+  only when that value is behind, bounds the wait, verifies Datomic's promised
+  postcondition, and owns cancellation of the returned future on timeout or
+  interruption. Provider failures retain their cause and selection phase."
+  [conn local-db requested-t timeout-ms phase]
+  (let [timeout-ms (or timeout-ms 30000)
+        local-t
+        (try
+          (d/basis-t local-db)
+          (catch Exception failure
+            (selection-failure!
+             "Failed reading the local Datomic basis."
+             :retryable phase
+             {:requested-t requested-t
+              :requested-order-hint requested-t
+              :timeout-ms timeout-ms}
+             failure)))]
+    (if (<= requested-t local-t)
+      local-db
+      (let [waiter
+            (try
+              (d/sync conn requested-t)
+              (catch Exception failure
+                (selection-failure!
+                 "Failed starting targeted Datomic synchronization."
+                 :retryable phase
+                 {:requested-t requested-t
+                  :observed-t local-t
+                  :requested-order-hint requested-t
+                  :observed-order-hint local-t
+                  :timeout-ms timeout-ms}
+                 failure)))]
+        (try
+          (let [selected (deref waiter timeout-ms sync-timeout-marker)]
+            (when (identical? sync-timeout-marker selected)
+              (cancel-waiter! waiter)
+              (freshness-unavailable!
+               "Timed out waiting for the requested Datomic basis."
+               {:reason :freshness-timeout
+                :phase phase
+                :requested-t requested-t
+                :observed-t local-t
+                :requested-order-hint requested-t
+                :observed-order-hint local-t
+                :timeout-ms timeout-ms}))
+            (let [selected-t (d/basis-t selected)]
+              (when (< selected-t requested-t)
+                (freshness-unavailable!
+                 "Targeted Datomic synchronization returned below the requested basis."
+                 {:reason :head-behind
+                  :phase phase
+                  :requested-t requested-t
+                  :observed-t selected-t
+                  :requested-order-hint requested-t
+                  :observed-order-hint selected-t
+                  :timeout-ms timeout-ms}))
+              selected))
+          (catch InterruptedException interrupt
+            (cancel-waiter! waiter)
+            (let [classified
+                  (ex-info
+                   "Targeted Datomic synchronization was interrupted."
+                   {:type :eacl.basis/selection-failure
+                    :eacl/error :eacl.basis/selection-failure
+                    :classification :cancelled
+                    :phase phase
+                    :requested-t requested-t
+                    :observed-t local-t
+                    :requested-order-hint requested-t
+                    :observed-order-hint local-t
+                    :timeout-ms timeout-ms}
+                   interrupt)]
+              ;; Set the flag after constructing the classified error so no
+              ;; intervening provider/runtime work can consume it.
+              (.interrupt (Thread/currentThread))
+              (throw classified)))
+          (catch clojure.lang.ExceptionInfo error
+            (throw error))
+          (catch Exception failure
+            (selection-failure!
+             "Targeted Datomic synchronization failed."
+             :retryable phase
+             {:requested-t requested-t
+              :observed-t local-t
+              :requested-order-hint requested-t
+              :observed-order-hint local-t
+              :timeout-ms timeout-ms}
+             failure)))))))
+
+(defn- validate-exact-token!
+  [{:keys [revision exact-locator] :as token-data}]
+  (when-not (and (integer? revision)
+                 (not (neg? revision))
+                 (integer? exact-locator)
+                 (not (neg? exact-locator)))
+    (throw
+     (ex-info
+      "Datomic exact selection requires a non-negative integer locator."
+      {:type :eacl/invalid-zed-token
+       :eacl/error :eacl/invalid-zed-token
+       :reason :malformed
+       :token-data token-data})))
+  (when-not (= revision exact-locator)
+    (throw
+     (ex-info
+      "Datomic token revision and exact locator contradict one another."
+      {:type :eacl/invalid-zed-token
+       :eacl/error :eacl/invalid-zed-token
+       :reason :contradictory-native-revision
+       :revision revision
+       :exact-locator exact-locator})))
+  token-data)
 
 (defn- relation-defs
   [db resource-type relation-name]
@@ -217,35 +364,55 @@
           (db-revision db))
 
         :select-exact
-        (fn [token-data _timeout-ms]
+        (fn [token-data timeout-ms]
+          (validate-exact-token! token-data)
           (let [locator (:exact-locator token-data)
-                current (if conn (d/db conn) db)]
-            (when (and (integer? locator)
-                       (<= locator (d/basis-t current)))
-              ;; Genuine unavailability (a future locator) is handled by the
-              ;; guard above; nothing in this body legitimately throws for
-              ;; trimmed history, so every Throwable here is a classified
-              ;; failure — never a silent nil that would misreport a
-              ;; transient fault as an expired snapshot.
-              (try
-                (snapshot-adapter
-                 (d/as-of current locator)
-                 (assoc opts'
-                        :selected-order-hint locator
-                        :selected-exact-locator locator))
-                (catch InterruptedException interrupt
-                  (throw (ex-info "Exact-basis selection was interrupted."
-                                  {:type :eacl.basis/selection-failure
-                                   :eacl/error :eacl.basis/selection-failure
-                                   :classification :cancelled}
-                                  interrupt)))
-                (catch Throwable failure
-                  (throw (ex-info "Exact-basis selection failed."
-                                  {:type :eacl.basis/selection-failure
-                                   :eacl/error :eacl.basis/selection-failure
-                                   :classification :retryable
-                                   :cause-class (.getName (class failure))}
-                                  failure)))))))
+                current
+                (try
+                  (if conn (d/db conn) db)
+                  (catch Exception failure
+                    (selection-failure!
+                     "Failed reading the local Datomic database."
+                     :retryable :exact-local-read
+                     {:requested-t locator
+                      :requested-order-hint locator
+                      :timeout-ms (or timeout-ms 30000)}
+                     failure)))
+                caught-up
+                (await-basis-db
+                 conn current locator timeout-ms :exact-sync)
+                exact-db
+                (try
+                  (d/as-of caught-up locator)
+                  (catch InterruptedException interrupt
+                    (let [classified
+                          (ex-info
+                           "Exact Datomic reconstruction was interrupted."
+                           {:type :eacl.basis/selection-failure
+                            :eacl/error :eacl.basis/selection-failure
+                            :classification :cancelled
+                            :phase :exact-as-of
+                            :requested-t locator
+                            :requested-order-hint locator
+                            :timeout-ms (or timeout-ms 30000)}
+                           interrupt)]
+                      (.interrupt (Thread/currentThread))
+                      (throw classified)))
+                  (catch Exception failure
+                    (selection-failure!
+                     "Exact Datomic reconstruction failed."
+                     :retryable :exact-as-of
+                     {:requested-t locator
+                      :requested-order-hint locator
+                      :observed-t (d/basis-t caught-up)
+                      :observed-order-hint (d/basis-t caught-up)
+                      :timeout-ms (or timeout-ms 30000)}
+                     failure)))]
+            (snapshot-adapter
+             exact-db
+             (assoc opts'
+                    :selected-order-hint locator
+                    :selected-exact-locator locator))))
 
         :object-id->internal
         (fn [object-id]

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -46,9 +46,9 @@
            [javax.crypto.spec GCMParameterSpec SecretKeySpec]))
 
 ;; eacl4_ tokens carry a binary envelope; the eacl3_ EDN format they replace is
-;; not read. Cursors are short-lived (300s by default) and every caller already
-;; handles :eacl.pagination/invalid-cursor on expiry, so a rolling deploy
-;; fails the affected continuation closed instead of producing wrong answers.
+;; not read. Cursor expiry is optional policy: without an explicitly configured
+;; TTL, authenticated cursors remain age-valid and exact history supplies their
+;; snapshot semantics.
 (def ^:private page-token-prefix "eacl4_")
 (def ^:private page-token-version 7)
 (def ^:private maximum-page-token-length
@@ -57,10 +57,9 @@
   permission graph; mirrors the cap eacl.datomic.consistency puts on Zed
   tokens."
   16384)
-(def ^:private default-page-token-ttl-seconds 300)
 (def ^:private maximum-page-token-ttl-seconds
-  ;; Keep both the cache's millisecond lifetime and the cursor's second-based
-  ;; expiry representable as signed longs. This is intentionally enormous
+  ;; Keep the cursor's second-based expiry representable as a signed long.
+  ;; This is intentionally enormous
   ;; (about 292 million years); it is a numeric-safety bound, not policy.
   (quot Long/MAX_VALUE 1000))
 (def ^:private default-consistency-sync-timeout-ms 30000)
@@ -404,16 +403,16 @@
   ttl-seconds)
 
 (defn page-token
-  [opts {:keys [ttl-seconds]
-         :or {ttl-seconds default-page-token-ttl-seconds}
-         :as payload}]
-  (let [ttl-seconds (validate-cursor-ttl! ttl-seconds)]
-    (encrypt-page-token opts
-                        (-> payload
-                            (dissoc :ttl-seconds)
-                            (assoc :v page-token-version
-                                   :exp (+ (now-seconds)
-                                           (long ttl-seconds)))))))
+  [opts {:keys [ttl-seconds] :as payload}]
+  (let [ttl-seconds (when (some? ttl-seconds)
+                      (validate-cursor-ttl! ttl-seconds))]
+    (encrypt-page-token
+     opts
+     (cond-> (-> payload
+                 (dissoc :ttl-seconds)
+                 (assoc :v page-token-version))
+       ttl-seconds
+       (assoc :exp (+ (now-seconds) (long ttl-seconds)))))))
 
 (defn token->page-bound
   [opts token]
@@ -449,105 +448,67 @@
   (some->> (:bound page-req)
            (decrypt-authenticated-page-token opts)))
 
-(def ^:private sync-timeout-marker (Object.))
-
-(declare snapshot-unavailable!)
-
-(defn- freshness-unavailable!
-  [message data]
+(defn- historical-selection-failure!
+  [message phase requested-t timeout-ms cause]
   (throw
-   (ex-info message
-            (assoc data
-                   :type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable))))
-
-(defn- observed-connection-revision
-  [conn]
-  (try
-    (d/basis-t (d/db conn))
-    (catch Exception _
-      nil)))
+   (ex-info
+    message
+    {:type :eacl.basis/selection-failure
+     :eacl/error :eacl.basis/selection-failure
+     :classification :retryable
+     :phase phase
+     :requested-t requested-t
+     :requested-order-hint requested-t
+     :timeout-ms timeout-ms}
+    cause)))
 
 (defn- await-revision-db
   "Returns a local DB that has observed `requested-t`, waiting only when needed."
   [conn opts requested-t]
-  (let [local-db (d/db conn)
-        local-t (d/basis-t local-db)]
-    (if (or (nil? requested-t)
-            (<= requested-t local-t))
-      local-db
-      (let [timeout-ms (:consistency-sync-timeout-ms opts)]
+  (let [timeout-ms (:consistency-sync-timeout-ms opts)
+        local-db
         (try
-          (let [synced-db (deref (d/sync conn requested-t)
-                                 timeout-ms
-                                 sync-timeout-marker)]
-            (when (identical? sync-timeout-marker synced-db)
-              (freshness-unavailable!
-               "Timed out waiting for the requested EACL revision."
-               {:reason :freshness-timeout
-                :requested-t requested-t
-                :observed-t (observed-connection-revision conn)
-                ;; The shared adapters' key names for the same facts.
-                :requested-order-hint requested-t
-                :observed-order-hint (observed-connection-revision conn)
-                :timeout-ms timeout-ms}))
-            (let [observed-t (d/basis-t synced-db)]
-              (when (< observed-t requested-t)
-                (freshness-unavailable!
-                 "The local Peer did not reach the requested EACL revision."
-                 {:reason :head-behind
-                  :requested-t requested-t
-                  :observed-t observed-t
-                  :requested-order-hint requested-t
-                  :observed-order-hint observed-t
-                  :timeout-ms timeout-ms}))
-              synced-db))
-          (catch clojure.lang.ExceptionInfo e
-            (if (= :eacl.consistency/freshness-unavailable
-                   (:type (ex-data e)))
-              (throw e)
-              (freshness-unavailable!
-               "Failed while waiting for the requested EACL revision."
-               {:reason :sync-failed
-                :requested-t requested-t
-                :observed-t (observed-connection-revision conn)
-                :requested-order-hint requested-t
-                :observed-order-hint (observed-connection-revision conn)
-                :timeout-ms timeout-ms})))
-          (catch Exception _
-            (freshness-unavailable!
-             "Failed while waiting for the requested EACL revision."
-             {:reason :sync-failed
-              :requested-t requested-t
-              :observed-t (observed-connection-revision conn)
-              :requested-order-hint requested-t
-              :observed-order-hint (observed-connection-revision conn)
-              :timeout-ms timeout-ms})))))))
+          (d/db conn)
+          (catch Exception failure
+            (historical-selection-failure!
+             "Failed reading the local Datomic database."
+             :cursor-exact-local-read requested-t timeout-ms failure)))]
+    (if (nil? requested-t)
+      local-db
+      (datomic-backend/await-basis-db
+       conn local-db requested-t timeout-ms :cursor-exact-sync))))
 
 (defn- historical-db
   [conn opts requested-t operation]
   (try
     (d/as-of (await-revision-db conn opts requested-t) requested-t)
     (catch clojure.lang.ExceptionInfo e
-      (if (= :eacl.consistency/freshness-unavailable
-             (:type (ex-data e)))
+      (if (contains? #{:eacl.consistency/freshness-unavailable
+                       :eacl.basis/selection-failure}
+                     (:type (ex-data e)))
         (throw e)
-        (snapshot-unavailable!
-         {:operation operation
-          :revision requested-t
-          :reason :historical-database-unavailable})))
-    (catch Exception _
-      (snapshot-unavailable!
-       {:operation operation
-        :revision requested-t
-        :reason :historical-database-unavailable}))))
-
-(defn- snapshot-unavailable!
-  [data]
-  (throw (ex-info "The requested EACL cache snapshot is unavailable."
-                  (assoc data
-                         :type :eacl.consistency/snapshot-unavailable
-                         :eacl/error :eacl.consistency/snapshot-unavailable))))
+        (historical-selection-failure!
+         "Failed reconstructing the Datomic cursor snapshot."
+         :cursor-exact-as-of requested-t
+         (:consistency-sync-timeout-ms opts) e)))
+    (catch InterruptedException interrupt
+      (.interrupt (Thread/currentThread))
+      (throw
+       (ex-info
+        "Datomic cursor reconstruction was interrupted."
+        {:type :eacl.basis/selection-failure
+         :eacl/error :eacl.basis/selection-failure
+         :classification :cancelled
+         :phase :cursor-exact-as-of
+         :operation operation
+         :requested-t requested-t
+         :requested-order-hint requested-t}
+        interrupt)))
+    (catch Exception failure
+      (historical-selection-failure!
+       "Failed reconstructing the Datomic cursor snapshot."
+       :cursor-exact-as-of requested-t
+       (:consistency-sync-timeout-ms opts) failure))))
 
 (defn- list-query-identity
   [op query]
@@ -793,7 +754,7 @@
   these three. (The vestigial :latest-result kind was deleted by
   trusted-surface-hygiene 11.1 — nothing has minted it since the v8 cursor
   redesign.)"
-  #{:can? :lookup-page :count})
+  #{:can? :lookup-page :relationship-page :count :permission-tree})
 
 (defn- internal-page-weight
   [page]
@@ -856,6 +817,27 @@
                      (or (nil? (:type end-result))
                          (= (:type (peek data)) (:type end-result)))))))))
 
+(defn- internal-relationship-page?
+  [page]
+  (and (map? page)
+       (vector? (:data page))
+       (every?
+        (fn [{:keys [subject relation resource]}]
+          (and (keyword? relation)
+               (keyword? (:type subject))
+               (positive-eid? (:id subject))
+               (keyword? (:type resource))
+               (positive-eid? (:id resource))))
+        (:data page))
+       (let [{:keys [start-cursor end-cursor
+                     has-next-page? has-previous-page?]}
+             (:page-info page)]
+         (and (map? (:page-info page))
+              (or (nil? start-cursor) (map? start-cursor))
+              (or (nil? end-cursor) (map? end-cursor))
+              (boolean? has-next-page?)
+              (boolean? has-previous-page?)))))
+
 (defn- count-response?
   [response]
   (let [limit (:limit response)]
@@ -903,9 +885,12 @@
                    (portable-result kind (compute)))]
              (execution/check! contract :semantic-evaluation)
              value))
+        snapshot-exact? (:snapshot-exact? consistency-context)
         cacheable?
         (and (:current-cache-store opts)
              completed-cache?
+             (or (not snapshot-exact?)
+                 (backend/deterministic? adapter))
              (or (nil? contract)
                  (execution/cache-stage-available? contract)))]
     (if-not cacheable?
@@ -927,44 +912,58 @@
               (proof-frame/resolve!
                request-proof-frame (relation-ids)))
             _ (execution/check! contract :cache-lookup)
+            semantic-key
+            {:operation op
+             :query query-identity
+             :evaluation (:evaluation contract)
+             :demand (:demand contract)
+             :engine-version engine/engine-version
+             ;; The public order ABI is part of an answer's identity: a page
+             ;; cached under one order must never be served under another.
+             :order-abi engine/stable-order-abi
+             :source-lifecycle
+             (proof-frame/source-lifecycle request-proof-frame)
+             :adapter-fingerprint (backend/fingerprint adapter)
+             :recursive-traversal-limits
+             (:recursive-traversal-limits opts)
+             :permission-tree-limits
+             (:permission-tree-limits opts)}
             answer
-            (shared-cache/resolve-current!
-             (:current-cache-store opts)
-             {:snapshot basis-t
-              :cache-lifecycle (:cache-lifecycle opts)
-              :snapshot-order basis-t
-              :same-snapshot? =
-              :cache-basis basis-t
-              :decision-kernel (:decision-kernel opts)
-              :managed-key-fn
-              (when (:managed-cache-enabled? opts)
-                #(proof-frame/descriptor @complete-proof))
-              :managed-subproblem-key-fn
-              (when (:managed-cache-enabled? opts)
-                (fn [dependency]
-                  (proof-frame/subset-descriptor
-                   @complete-proof dependency)))
-              :managed-subproblem-scope
-              (consistency-v3/source-scope adapter)
-              :answer-weight-fn weight-fn
-              :remember-answer?
-              (:cache-remember-answers? opts)}
-             {:operation op
-              :query query-identity
-              :evaluation (:evaluation contract)
-              :demand (:demand contract)
-              :engine-version engine/engine-version
-              ;; The public order ABI is part of an answer's identity: a page
-              ;; cached under one order must never be served under another.
-              :order-abi engine/stable-order-abi
-              :source-lifecycle
-              (proof-frame/source-lifecycle request-proof-frame)
-              :adapter-fingerprint (backend/fingerprint adapter)
-              :recursive-traversal-limits
-              (:recursive-traversal-limits opts)}
-             kind
-             valid-result?
-             evaluate)
+            (if snapshot-exact?
+              (shared-cache/resolve-exact!
+               (:current-cache-store opts)
+               {:snapshot-exact-key
+                (shared-cache/snapshot-exact-key adapter)
+                :cache-lifecycle (:cache-lifecycle opts)
+                :cache-basis basis-t
+                :decision-kernel (:decision-kernel opts)
+                :answer-weight-fn weight-fn
+                :remember-answer? (:cache-remember-answers? opts)}
+               semantic-key kind valid-result? evaluate)
+              (shared-cache/resolve-current!
+               (:current-cache-store opts)
+               {:snapshot basis-t
+                :cache-lifecycle (:cache-lifecycle opts)
+                :snapshot-order basis-t
+                :same-snapshot? =
+                :snapshot-exact-key
+                (shared-cache/snapshot-exact-key adapter)
+                :cache-basis basis-t
+                :decision-kernel (:decision-kernel opts)
+                :managed-key-fn
+                (when (:managed-cache-enabled? opts)
+                  #(proof-frame/descriptor @complete-proof))
+                :managed-subproblem-key-fn
+                (when (:managed-cache-enabled? opts)
+                  (fn [dependency]
+                    (proof-frame/subset-descriptor
+                     @complete-proof dependency)))
+                :managed-subproblem-scope
+                (consistency-v3/source-scope adapter)
+                :answer-weight-fn weight-fn
+                :remember-answer?
+                (:cache-remember-answers? opts)}
+               semantic-key kind valid-result? evaluate))
             _ (execution/check! contract :cache-result)]
         (assoc consistency-context
                :result (:value answer)
@@ -1027,7 +1026,7 @@
                :has-next-page? false
                :has-previous-page? false}})
 
-(declare capture-result-context)
+(declare capture-result-context with-cache-info)
 
 (defn spiceomic-read-relationships
   [conn
@@ -1042,7 +1041,8 @@
         page-req (impl.indexed/normalize-page-request filters)
         decoded (authenticate-page-bound
                  opts :read-relationships query-shape page-req)
-        {:keys [db basis-t schema-version cursor-context]}
+        {:keys [db basis-t schema-version cursor-context]
+         :as result-context}
         (capture-result-context
          conn opts (:consistency filters)
          (fn [db _decoded]
@@ -1081,10 +1081,19 @@
       (let [filters'     (cond-> filters
                            subject-id (assoc :subject/id subject-eid)
                            resource-id (assoc :resource/id resource-eid))
-            internal-query (internal-page-query filters' page-req decoded)]
-        (coerce-relationship-page
-         db selected-opts :read-relationships query-shape basis-t
-         (impl/read-relationships db internal-query))))))
+            internal-query (internal-page-query filters' page-req decoded)
+            answer
+            (cached-authorization-result
+             selected-opts result-context :read-relationships
+             (shared-cache/lookup-page-query-identity filters internal-query)
+             :relationship-page internal-relationship-page?
+             internal-page-weight
+             #(impl/read-relationships db internal-query))]
+        (with-cache-info
+         (coerce-relationship-page
+          db selected-opts :read-relationships query-shape basis-t
+          (:result answer))
+         answer)))))
 
 (defn- resolve-existing-object
   "Resolves an external spice object to its internal eid, verifying the entity
@@ -1591,20 +1600,22 @@
     (when (:revision-checkpoints opts)
       (revision/observe! (:revision-checkpoints opts)
                          (d/basis-t (d/db conn))))
-    (merge
+    (let [snapshot-exact?
+          (or (= :at-exact-snapshot
+                 (or (:mode selected-context) mode))
+              (not= selected-current-basis (:basis-t selected-context)))]
+      (merge
      selected-context
      {:mode (or (:mode selected-context) mode)
-      ;; A cursor is authenticated before snapshot selection. It is cacheable
-      ;; only when that selection retained the request's current immutable
-      ;; basis. Historical reconstruction necessarily changes the basis and
-      ;; must never publish into or read from the current completed cache.
+      :snapshot-exact? snapshot-exact?
+      ;; A cursor is authenticated before snapshot selection. Historical
+      ;; reconstruction may use only the separately keyed snapshot-exact tier;
+      ;; current requests retain exact-current plus managed-proof behavior.
       :completed-cache?
-      (and (not= :at-exact-snapshot
-                 (or (:mode selected-context) mode))
-           (= selected-current-basis (:basis-t selected-context)))
+      true
       :requested-t requested-t
       :selection selection
-      :response-token nil})))
+      :response-token nil}))))
 
 (defn- capture-basic-result-context
   "Selects one immutable snapshot without constructing schema or relation
@@ -1626,6 +1637,7 @@
      :basis-t basis-t
      :request-proof-frame (new-request-proof-frame opts adapter)
      :mode mode
+     :snapshot-exact? (= :at-exact-snapshot mode)
      :requested-t (:revision request-token)
      :selection selection
      :response-token nil}))
@@ -1649,10 +1661,12 @@
                    (portable-result kind (compute)))]
              (execution/check! contract :semantic-evaluation)
              value))
+        snapshot-exact? (= :at-exact-snapshot mode)
         cacheable?
         (and (:current-cache-store opts)
              (:cache-remember-answers? opts)
-             (not= :at-exact-snapshot mode)
+             (or (not snapshot-exact?)
+                 (backend/deterministic? adapter))
              (or (nil? contract)
                  (execution/cache-stage-available? contract)))]
     (if-not cacheable?
@@ -1675,41 +1689,53 @@
                request-proof-frame
                (:relationship-dependencies @dependencies)))
             _ (execution/check! contract :cache-lookup)
+            semantic-key
+            {:operation op
+             :query query-identity
+             :evaluation (:evaluation contract)
+             :demand (:demand contract)
+             :engine-version engine/engine-version
+             ;; The public order ABI is part of an answer's identity: a page
+             ;; cached under one order must never be served under another.
+             :order-abi engine/stable-order-abi
+             :source-lifecycle
+             (proof-frame/source-lifecycle request-proof-frame)
+             :adapter-fingerprint (backend/fingerprint adapter)
+             :recursive-traversal-limits
+             (:recursive-traversal-limits opts)
+             :permission-tree-limits
+             (:permission-tree-limits opts)}
             answer
-            (shared-cache/resolve-current!
-             (:current-cache-store opts)
-             {:snapshot basis-t
-              :cache-lifecycle (:cache-lifecycle opts)
-              :snapshot-order basis-t
-              :same-snapshot? =
-              :cache-basis basis-t
-              :decision-kernel (:decision-kernel opts)
-              :managed-key-fn
-              (when (:managed-cache-enabled? opts)
-                #(proof-frame/descriptor @complete-proof))
-              :managed-subproblem-key-fn
-              (when (:managed-cache-enabled? opts)
-                (fn [dependency]
-                  (proof-frame/subset-descriptor
-                   @complete-proof dependency)))
-              :managed-subproblem-scope
-              (consistency-v3/source-scope adapter)}
-             {:operation op
-              :query query-identity
-              :evaluation (:evaluation contract)
-              :demand (:demand contract)
-              :engine-version engine/engine-version
-              ;; The public order ABI is part of an answer's identity: a page
-              ;; cached under one order must never be served under another.
-              :order-abi engine/stable-order-abi
-              :source-lifecycle
-              (proof-frame/source-lifecycle request-proof-frame)
-              :adapter-fingerprint (backend/fingerprint adapter)
-              :recursive-traversal-limits
-              (:recursive-traversal-limits opts)}
-             kind
-             valid-result?
-             evaluate)
+            (if snapshot-exact?
+              (shared-cache/resolve-exact!
+               (:current-cache-store opts)
+               {:snapshot-exact-key
+                (shared-cache/snapshot-exact-key adapter)
+                :cache-lifecycle (:cache-lifecycle opts)
+                :cache-basis basis-t
+                :decision-kernel (:decision-kernel opts)}
+               semantic-key kind valid-result? evaluate)
+              (shared-cache/resolve-current!
+               (:current-cache-store opts)
+               {:snapshot basis-t
+                :cache-lifecycle (:cache-lifecycle opts)
+                :snapshot-order basis-t
+                :same-snapshot? =
+                :snapshot-exact-key
+                (shared-cache/snapshot-exact-key adapter)
+                :cache-basis basis-t
+                :decision-kernel (:decision-kernel opts)
+                :managed-key-fn
+                (when (:managed-cache-enabled? opts)
+                  #(proof-frame/descriptor @complete-proof))
+                :managed-subproblem-key-fn
+                (when (:managed-cache-enabled? opts)
+                  (fn [dependency]
+                    (proof-frame/subset-descriptor
+                     @complete-proof dependency)))
+                :managed-subproblem-scope
+                (consistency-v3/source-scope adapter)}
+               semantic-key kind valid-result? evaluate))
             _ (execution/check! contract :cache-result)]
         (assoc context
                :result (:value answer)
@@ -2131,7 +2157,7 @@
 
 (defn spiceomic-expand-permission-tree
   [conn opts query]
-  (let [{:keys [adapter db]}
+  (let [{:keys [adapter db] :as context}
         (capture-basic-result-context
          conn opts (:consistency query))
         _ (schema-errors/validate-expansion-request!
@@ -2140,13 +2166,19 @@
            (:type (:resource query))
            (:permission query))
         contract (:execution-contract opts)
-        tree
-        (permission-tree/expand
-         adapter
-         {:limits (:permission-tree-limits opts)
-          :execution-contract contract}
-         (:resource query)
-         (:permission query))]
+        answer
+        (cached-basic-authorization-result
+         opts context :expand-permission-tree
+         (dissoc query :consistency :cache? :timeout-ms :cancellation-token)
+         :permission-tree map?
+         (:type (:resource query)) (:permission query)
+         #(permission-tree/expand
+           adapter
+           {:limits (:permission-tree-limits opts)
+            :execution-contract contract}
+           (:resource query)
+           (:permission query)))
+        tree (:result answer)]
     (execution/check! contract :permission-tree-token-issuance)
     (let [token
           (permission-tree/selected-adapter-token adapter opts)]
@@ -2410,7 +2442,7 @@
   Datomic's completed-answer and continuation stores are client-private.
   Caller-supplied CacheStore adapters used to be accepted but never controlled
   either live store, so they are now rejected instead of being decorative."
-  [cache-option cursor-ttl-seconds]
+  [cache-option]
   (when (boolean? cache-option)
     (throw (ex-info (str "EACL Config Error: :cache takes a configuration map, not"
                          " a boolean. Use eacl.cache/no-cache to"
@@ -2494,8 +2526,6 @@
                      (when enabled? (:remember-answers config))
                      (when enabled? true))
           remember-answers? (boolean remember)
-          token-ttl-ms (* 1000 (or cursor-ttl-seconds
-                                   default-page-token-ttl-seconds))
           ;; No expiry by default. A ttl was originally a staleness bound;
           ;; relation stamps are that bound now, and they are exact rather than
           ;; approximate. What remains is capacity, which :max-weight and
@@ -2542,7 +2572,7 @@
           (if (map? (:checkpoints config))
             (:checkpoints config)
             {})))
-       :ttl-ms (when ttl-ms (min ttl-ms token-ttl-ms))
+       :ttl-ms ttl-ms
        :native-max-entries
        (or (:max-entries config) 1024)
        :native-admit-on-repeat?
@@ -2623,7 +2653,8 @@
     page tokens do not survive restarts and are not portable across clients;
     supply stable key material in production. The :page-token-* names are
     accepted as non-mixable aliases.
-  - :cursor-ttl-seconds — overrides the default page-token expiry.
+  - :cursor-ttl-seconds — optional positive page-token expiry. Omitted means
+    cursors do not expire by age.
     :page-token-ttl-seconds is a non-mixable alias.
   - :zed-token-key / :zed-token-keyring / :zed-token-kid — HMAC key material
     for authenticated Zed tokens. When omitted, purpose-specific signing keys
@@ -2838,7 +2869,7 @@
         database-id       (impl.indexed/database-id initial-db)
         diagnostic-schema-version
         (atom (impl.indexed/schema-version initial-db))
-        cache-config       (normalize-cache-config cache page-token-ttl-seconds)
+        cache-config       (normalize-cache-config cache)
         timeout-ms         (if (contains? config-opts
                                           :consistency-sync-timeout-ms)
                              consistency-sync-timeout-ms

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -462,10 +462,22 @@
      :timeout-ms timeout-ms}
     cause)))
 
+(defn- cursor-selection-timeout-ms
+  "The catch-up bound for cursor reconstruction.
+
+  Every other selection path bounds its wait by the request's remaining
+  execution time as well as the configured sync timeout; a cursor replay that
+  ignored the deadline could outlive the request that asked for it."
+  [opts]
+  (if-let [contract (:execution-contract opts)]
+    (min (:consistency-sync-timeout-ms opts)
+         (execution/remaining-millis contract))
+    (:consistency-sync-timeout-ms opts)))
+
 (defn- await-revision-db
   "Returns a local DB that has observed `requested-t`, waiting only when needed."
   [conn opts requested-t]
-  (let [timeout-ms (:consistency-sync-timeout-ms opts)
+  (let [timeout-ms (cursor-selection-timeout-ms opts)
         local-db
         (try
           (d/db conn)
@@ -490,7 +502,7 @@
         (historical-selection-failure!
          "Failed reconstructing the Datomic cursor snapshot."
          :cursor-exact-as-of requested-t
-         (:consistency-sync-timeout-ms opts) e)))
+         (cursor-selection-timeout-ms opts) e)))
     (catch InterruptedException interrupt
       (.interrupt (Thread/currentThread))
       (throw
@@ -508,7 +520,7 @@
       (historical-selection-failure!
        "Failed reconstructing the Datomic cursor snapshot."
        :cursor-exact-as-of requested-t
-       (:consistency-sync-timeout-ms opts) failure))))
+       (cursor-selection-timeout-ms opts) failure))))
 
 (defn- list-query-identity
   [op query]
@@ -873,7 +885,7 @@
   [opts consistency-context op query-identity kind valid-result? weight-fn compute]
   (let [contract (:execution-contract opts)
         {:keys [adapter db relationship-dependencies
-                permission-dependencies basis-t completed-cache?
+                permission-dependencies basis-t snapshot-exact?
                 request-proof-frame]}
         consistency-context
         evaluate
@@ -885,10 +897,8 @@
                    (portable-result kind (compute)))]
              (execution/check! contract :semantic-evaluation)
              value))
-        snapshot-exact? (:snapshot-exact? consistency-context)
         cacheable?
         (and (:current-cache-store opts)
-             completed-cache?
              (or (not snapshot-exact?)
                  (backend/deterministic? adapter))
              (or (nil? contract)
@@ -1605,17 +1615,16 @@
                  (or (:mode selected-context) mode))
               (not= selected-current-basis (:basis-t selected-context)))]
       (merge
-     selected-context
-     {:mode (or (:mode selected-context) mode)
-      :snapshot-exact? snapshot-exact?
-      ;; A cursor is authenticated before snapshot selection. Historical
-      ;; reconstruction may use only the separately keyed snapshot-exact tier;
-      ;; current requests retain exact-current plus managed-proof behavior.
-      :completed-cache?
-      true
-      :requested-t requested-t
-      :selection selection
-      :response-token nil}))))
+       selected-context
+       {:mode (or (:mode selected-context) mode)
+        ;; A cursor is authenticated before snapshot selection. Historical
+        ;; reconstruction may use only the separately keyed snapshot-exact
+        ;; tier; current requests retain exact-current plus managed-proof
+        ;; behavior.
+        :snapshot-exact? snapshot-exact?
+        :requested-t requested-t
+        :selection selection
+        :response-token nil}))))
 
 (defn- capture-basic-result-context
   "Selects one immutable snapshot without constructing schema or relation
@@ -1646,7 +1655,8 @@
   [opts context op query-identity kind valid-result?
    resource-type permission compute]
   (let [contract (:execution-contract opts)
-        {:keys [adapter db basis-t mode request-proof-frame]} context
+        {:keys [adapter db basis-t snapshot-exact? request-proof-frame]}
+        context
         schema-cache
         (delay
           (selected-schema-cache!
@@ -1661,7 +1671,6 @@
                    (portable-result kind (compute)))]
              (execution/check! contract :semantic-evaluation)
              value))
-        snapshot-exact? (= :at-exact-snapshot mode)
         cacheable?
         (and (:current-cache-store opts)
              (:cache-remember-answers? opts)

--- a/modules/eacl-datomic/test/eacl/datomic/backend_exact_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/backend_exact_test.clj
@@ -210,3 +210,43 @@
           (is (= :retryable (:classification data)))
           (is (= :exact-sync (:phase data)))
           (is (identical? provider (:cause data))))))))
+
+(deftest bounded-waits-cancel-their-datomic-future-test
+  ;; Cancellation is a property of every bounded EACL wait, not only of exact
+  ;; selection: an abandoned sync stays registered on the connection until its
+  ;; basis arrives, which under retry traffic is unbounded.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [local (d/db conn)
+          local-t (d/basis-t local)
+          target (inc local-t)
+          adapter (datomic-backend/snapshot-adapter
+                   local {:conn conn :source-lifecycle "bounded-waits"})]
+      (testing "a causal-floor timeout cancels the waiter"
+        (let [cancelled? (atom false)
+              data (with-redefs [d/sync (fn [_ _] (waiter ::timeout cancelled?))]
+                     (error-data
+                      #(backend/invoke
+                        adapter :select-at-least {:revision target} 1)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :freshness-timeout (:reason data)))
+          (is @cancelled?
+              "the abandoned causal-floor sync must not stay registered")))
+
+      (testing "an authoritative-head timeout cancels the waiter"
+        (let [cancelled? (atom false)
+              data (with-redefs [d/sync (fn [_] (waiter ::timeout cancelled?))]
+                     (error-data
+                      #(backend/invoke adapter :select-authoritative 1)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :freshness-timeout (:reason data)))
+          (is @cancelled?)))
+
+      (testing "a failing provider keeps its established classification"
+        (let [data (with-redefs [d/sync (fn [_ _]
+                                          (throw (ex-info "peer down" {})))]
+                     (error-data
+                      #(backend/invoke
+                        adapter :select-at-least {:revision target} 50)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :sync-failed (:reason data))
+              "hoisting the waiter must not change the failure taxonomy"))))))

--- a/modules/eacl-datomic/test/eacl/datomic/backend_exact_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/backend_exact_test.clj
@@ -1,0 +1,212 @@
+(ns eacl.datomic.backend-exact-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datomic.api :as d]
+            [eacl.backend.v8 :as backend]
+            [eacl.datomic.backend :as datomic-backend]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
+            [eacl.datomic.schema :as schema]))
+
+(defn- waiter
+  [blocking-value cancelled?]
+  (reify
+    clojure.lang.IDeref
+    (deref [_]
+      (if (fn? blocking-value)
+        (blocking-value)
+        blocking-value))
+
+    clojure.lang.IBlockingDeref
+    (deref [_ _timeout-ms timeout-value]
+      (if (= ::timeout blocking-value)
+        timeout-value
+        (if (fn? blocking-value)
+          (blocking-value)
+          blocking-value)))
+
+    java.util.concurrent.Future
+    (cancel [_ _may-interrupt?]
+      (reset! cancelled? true)
+      true)
+    (isCancelled [_] @cancelled?)
+    (isDone [_] false)
+    (get [_]
+      (if (fn? blocking-value)
+        (blocking-value)
+        blocking-value))
+    (get [_ _timeout _unit]
+      (if (fn? blocking-value)
+        (blocking-value)
+        blocking-value))))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (assoc (ex-data error)
+             :cause (ex-cause error)
+             :caller-thread-interrupted?
+             (.isInterrupted (Thread/currentThread))))))
+
+(deftest exact-selection-skips-or-targets-sync-test
+  (with-mem-conn [conn schema/v7-schema]
+    @(d/transact conn [{:db/ident :eacl.test/exact-selection}])
+    (let [head (d/db conn)
+          head-t (d/basis-t head)
+          adapter (datomic-backend/snapshot-adapter
+                   head {:conn conn :source-lifecycle "exact-effects"})
+          original-as-of d/as-of]
+      (testing "an already-local basis skips synchronization and applies as-of once"
+        (let [as-of-calls (atom [])]
+          (with-redefs [d/sync (fn [& _]
+                                (throw (ex-info "must not synchronize" {})))
+                        d/as-of (fn [db t]
+                                  (swap! as-of-calls conj [db t])
+                                  (original-as-of db t))]
+            (let [selected (backend/invoke
+                            adapter :select-exact
+                            {:revision head-t :exact-locator head-t}
+                            50)]
+              (is (= [[head head-t]] @as-of-calls))
+              (is (= {:revision head-t :exact-locator head-t}
+                     (backend/invoke selected :native-revision)))))))
+
+      (testing "a locally future basis performs bounded targeted sync then as-of"
+        (let [local-t (dec head-t)
+              sync-calls (atom [])
+              as-of-calls (atom [])
+              cancelled? (atom false)
+              original-basis-t d/basis-t]
+          (with-redefs [d/db (constantly head)
+                        d/basis-t (fn [db]
+                                    (if (identical? db head)
+                                      local-t
+                                      (original-basis-t db)))
+                        d/sync (fn [actual-conn t]
+                                 (swap! sync-calls conj [actual-conn t])
+                                 (waiter (original-as-of head head-t)
+                                         cancelled?))
+                        d/as-of (fn [db t]
+                                  (swap! as-of-calls conj [db t])
+                                  (original-as-of head t))]
+            (let [selected (backend/invoke
+                            adapter :select-exact
+                            {:revision head-t :exact-locator head-t}
+                            50)]
+              (is (= [[conn head-t]] @sync-calls))
+              (is (= 1 (count @as-of-calls)))
+              (is (= head-t (second (first @as-of-calls))))
+              (is (false? @cancelled?))
+              (is (= {:revision head-t :exact-locator head-t}
+                     (backend/invoke selected :native-revision))))))))))
+
+(deftest exact-selection-cancels-bounded-waits-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [local (d/db conn)
+          local-t (d/basis-t local)
+          target (inc local-t)
+          adapter (datomic-backend/snapshot-adapter
+                   local {:conn conn :source-lifecycle "exact-cancellation"})]
+      (testing "timeout cancels the Datomic future and never applies as-of"
+        (let [cancelled? (atom false)
+              as-of-calls (atom 0)
+              data
+              (with-redefs [d/sync (fn [_ _]
+                                     (waiter ::timeout cancelled?))
+                            d/as-of (fn [& _]
+                                      (swap! as-of-calls inc)
+                                      local)]
+                (error-data
+                 #(backend/invoke
+                   adapter :select-exact
+                   {:revision target :exact-locator target}
+                   1)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :freshness-timeout (:reason data)))
+          (is (= target (:requested-order-hint data)))
+          (is (= local-t (:observed-order-hint data)))
+          (is (= 1 (:timeout-ms data)))
+          (is @cancelled?)
+          (is (zero? @as-of-calls))))
+
+      (testing "interruption cancels, remains classified, and restores the flag"
+        (let [cancelled? (atom false)
+              data
+              (with-redefs [d/sync
+                            (fn [_ _]
+                              (waiter
+                               #(throw (InterruptedException. "stop"))
+                               cancelled?))]
+                (error-data
+                 #(backend/invoke
+                   adapter :select-exact
+                   {:revision target :exact-locator target}
+                   50)))]
+          (is (= :eacl.basis/selection-failure (:type data)))
+          (is (= :cancelled (:classification data)))
+          (is (= :exact-sync (:phase data)))
+          (is @cancelled?)
+          (is (:caller-thread-interrupted? data)
+              "the caller observes the restored flag at the catch boundary")
+          ;; Do not leak the deliberate test interruption into later tests.
+          (Thread/interrupted))))))
+
+(deftest exact-selection-rejects-invalid-or-failing-providers-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [local (d/db conn)
+          local-t (d/basis-t local)
+          target (inc local-t)
+          adapter (datomic-backend/snapshot-adapter
+                   local {:conn conn :source-lifecycle "exact-errors"})]
+      (testing "malformed and contradictory locators fail before storage work"
+        (let [storage-calls (atom 0)]
+          (with-redefs [d/db (fn [_]
+                               (swap! storage-calls inc)
+                               local)
+                        d/sync (fn [& _]
+                                 (swap! storage-calls inc)
+                                 (promise))]
+            (doseq [[payload reason]
+                    [[{:revision local-t :exact-locator "not-a-t"} :malformed]
+                     [{:revision local-t :exact-locator (inc local-t)}
+                      :contradictory-native-revision]]]
+              (let [data (error-data
+                          #(backend/invoke
+                            adapter :select-exact payload 10))]
+                (is (= :eacl/invalid-zed-token (:type data)))
+                (is (= reason (:reason data)))))
+            (is (zero? @storage-calls)))))
+
+      (testing "a below-floor sync result is freshness failure, never as-of"
+        (let [cancelled? (atom false)
+              as-of-calls (atom 0)
+              data
+              (with-redefs [d/sync (fn [_ _] (waiter local cancelled?))
+                            d/as-of (fn [& _]
+                                      (swap! as-of-calls inc)
+                                      local)]
+                (error-data
+                 #(backend/invoke
+                   adapter :select-exact
+                   {:revision target :exact-locator target}
+                   50)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :head-behind (:reason data)))
+          (is (= target (:requested-order-hint data)))
+          (is (= local-t (:observed-order-hint data)))
+          (is (zero? @as-of-calls))))
+
+      (testing "unexpected provider failure retains phase and cause"
+        (let [provider (ex-info "peer down" {:provider :datomic})
+              data
+              (with-redefs [d/sync (fn [_ _] (throw provider))]
+                (error-data
+                 #(backend/invoke
+                   adapter :select-exact
+                   {:revision target :exact-locator target}
+                   50)))]
+          (is (= :eacl.basis/selection-failure (:type data)))
+          (is (= :retryable (:classification data)))
+          (is (= :exact-sync (:phase data)))
+          (is (identical? provider (:cause data))))))))

--- a/modules/eacl-datomic/test/eacl/datomic/cache_review_regressions_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/cache_review_regressions_test.clj
@@ -383,12 +383,13 @@
         (is (= (:data recovered-1) (:data recovered-2)))
         (is (nil? (get-in recovered-1
                           [:page-info :cursor-recovery])))
-        (is (false? (:cached? recovered-1)))
-        (is (false? (:cached? recovered-2)))
-        (is (= (+ 2 (:bypasses before-recovery))
+        (is (true? (:cached? recovered-1)))
+        (is (true? (:cached? recovered-2)))
+        (is (= (:bypasses before-recovery)
                (:bypasses after-recovery)))
-        (is (= (:exact-hits before-recovery)
-               (:exact-hits after-recovery)))))))
+        (is (= (+ 2 (:exact-hits before-recovery))
+               (:exact-hits after-recovery))
+            "exact cursor recovery reuses only the matching historical page")))))
 
 ;; --- L2 ---------------------------------------------------------------------
 

--- a/modules/eacl-datomic/test/eacl/datomic/config_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/config_test.clj
@@ -63,6 +63,32 @@
         (is (= :eacl/invalid-config (:type data)) (pr-str value))
         (is (= :cursor-ttl-seconds (:key data)) (pr-str value))))))
 
+(deftest cursor-expiry-is-optional-and-independent-from-cache-ttl-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (core/make-client conn {:security-key "non-expiring-cursor"})
+          opts (:opts client)
+          token (core/page-token opts {:op :test})
+          decoded (core/token->page-bound opts token)]
+      (is (nil? (:page-token-ttl-seconds opts)))
+      (is (not (contains? decoded :exp))
+          "an omitted cursor TTL mints no age-expiry field"))
+
+    (let [client (core/make-client
+                  conn
+                  {:security-key "expiring-cursor"
+                   :cursor-ttl-seconds 60})
+          opts (:opts client)
+          token (core/page-token opts {:op :test :ttl-seconds 60})]
+      (is (integer? (:exp (core/token->page-bound opts token)))
+          "an explicit positive cursor TTL remains authenticated and enforced"))
+
+    (let [client (core/make-client
+                  conn
+                  {:cursor-ttl-seconds 1
+                   :cache {:ttl-ms 5000}})]
+      (is (= 5000 (get-in client [:opts :lookup-cache-ttl-ms]))
+          "cursor policy no longer caps an independently configured cache TTL"))))
+
 (deftest uniform-construction-option-family-test
   (with-mem-conn [conn schema/v7-schema]
     (let [lookup-ref (fn [object-id] [:eacl/id object-id])

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
@@ -1,9 +1,12 @@
 (ns eacl.datomic.consistency-cache-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk]
             [datomic.api :as d]
+            [eacl.backend.v8 :as backend]
             [eacl.cache :as shared-cache]
             [eacl.causal-token :as causal-token]
             [eacl.core :as eacl :refer [->Relationship spice-object]]
+            [eacl.datomic.backend :as datomic-backend]
             [eacl.datomic.cache :as cache]
             [eacl.datomic.core :as core]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
@@ -800,3 +803,100 @@
         (is (true? (:allowed? second-result)))
         (is (true? (:cached? second-result))
             "exact selection reuses the answer computed at the identical basis")))))
+
+;; --- 2026-08-16 exact-cache review ------------------------------------------
+
+(def ^:private relation-root-schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     permission view = viewer
+   }")
+
+(defn- leaf-subject-ids
+  [tree]
+  (let [ids (atom #{})]
+    (clojure.walk/postwalk
+     (fn [node]
+       (when (and (map? node) (contains? node :subjects))
+         (swap! ids into (map :id (:subjects node))))
+       node)
+     tree)
+    @ids))
+
+(deftest relation-root-tree-expansion-observes-relationship-writes-test
+  ;; A relation root reads that relation's relationships, but no permission
+  ;; path names it. When the dependency closure missed it, the managed
+  ;; cross-snapshot tier proved a stale tree equal at every later snapshot.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (cached-client conn)
+          alice (spice-object :user "alice")
+          bob (spice-object :user "bob")
+          document (spice-object :document "doc1")]
+      (eacl/write-schema! client relation-root-schema)
+      @(d/transact conn [{:eacl/id "alice"}
+                         {:eacl/id "bob"}
+                         {:eacl/id "doc1"}])
+      (eacl/create-relationship! client (->Relationship alice :viewer document))
+      (doseq [root [:viewer :view]]
+        (testing (str "root " root)
+          (let [before (eacl/expand-permission-tree
+                        client {:resource document :permission root})]
+            (is (= #{"alice"} (leaf-subject-ids (:tree-root before))))
+            (eacl/create-relationship!
+             client (->Relationship bob :viewer document))
+            (let [after (eacl/expand-permission-tree
+                         client {:resource document :permission root})]
+              (is (= #{"alice" "bob"} (leaf-subject-ids (:tree-root after)))
+                  "a cached tree must not survive a write it reports")
+              (eacl/delete-relationship!
+               client (->Relationship bob :viewer document)))))))))
+
+(deftest non-deterministic-clients-do-not-seed-the-snapshot-exact-tier-test
+  ;; Readers refuse a non-deterministic adapter, so minting its snapshot
+  ;; identity would only fill a bounded tier with unreadable entries.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (core/make-client
+                  conn
+                  {:zed-token-key "consistency-cache-test-key"
+                   :source-lifecycle source-lifecycle
+                   :object-id->lookup-ref (fn [id] [:eacl/id id])
+                   :cache {:remember-answers true}})
+          alice (spice-object :user "alice")
+          account (spice-object :account "account")]
+      (eacl/write-schema! client direct-schema)
+      @(d/transact conn [{:eacl/id "alice"} {:eacl/id "account"}])
+      (eacl/create-relationship! client (->Relationship alice :owner account))
+      (is (false? (backend/deterministic?
+                   ((get-in client [:opts :backend-adapter-fn]) (d/db conn))))
+          "a custom id codec without a fingerprint is not deterministic")
+      (eacl/can? client alice :admin account)
+      (eacl/can? client alice :admin account)
+      (is (zero? (:snapshot-exact-entries (core/cache-stats client)))
+          "current answers must not seed a tier no exact request can read"))))
+
+(deftest filtered-datomic-views-cannot-claim-exact-consistency-test
+  ;; d/filter, d/since and d/history report their origin's database id and
+  ;; basis, so an exact identity minted from one is indistinguishable from the
+  ;; plain value at the same basis while answering a different question.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [db (d/db conn)
+          adapter-for (fn [value]
+                        (datomic-backend/snapshot-adapter
+                         value {:conn conn
+                                :source-lifecycle source-lifecycle
+                                :adapter-fingerprint {:test :fingerprint}
+                                :adapter-deterministic? true}))
+          exact? (fn [value]
+                   (backend/supports?
+                    (adapter-for value) :consistency :at-exact-snapshot))]
+      (is (true? (exact? db))
+          "an ordinary current value selects exact snapshots")
+      (is (true? (exact? (d/as-of db (d/basis-t db))))
+          "an as-of value is the exact view this backend selects")
+      (is (false? (exact? (d/since db 0))))
+      (is (false? (exact? (d/history db))))
+      (is (false? (exact? (d/filter db (fn [_ _] true)))))
+      (is (nil? (shared-cache/snapshot-exact-key (adapter-for (d/since db 0))))
+          "a non-ordinary view mints no snapshot-exact identity")
+      (is (some? (shared-cache/snapshot-exact-key (adapter-for db)))))))

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
@@ -148,25 +148,26 @@
             (is (true? (eacl/can? client alice :admin account
                                   (consistency/at-exact-snapshot
                                    created-token))))
-            (is (= 3 @calls)))
+            (is (= 2 @calls)
+                "the answer computed at that exact immutable basis is reused"))
 
           (testing "fully-consistent observes the relationship deletion"
             (is (false? (eacl/can? client alice :admin account)))
-            (is (= 3 @calls)
+            (is (= 2 @calls)
                 "the exact-current deletion result is reused"))
 
           (testing "at-least-as-fresh accepts the current cached revision"
             (is (false? (eacl/can? client alice :admin account
                                    (consistency/at-least-as-fresh
                                     deleted-token))))
-            (is (= 3 @calls)))
+            (is (= 2 @calls)))
 
           (testing "and repeated exact selection remains snapshot-correct"
             (is (true? (eacl/can? client alice :admin account
                                   (consistency/at-exact-snapshot
                                    created-token))))
-            (is (= 4 @calls)
-                "exact requests bypass completed-answer caching")))))))
+            (is (= 2 @calls)
+                "repeated exact requests hit only the matching snapshot tier")))))))
 
 (deftest missing-external-ids-never-enter-the-result-cache-test
   (with-mem-conn [conn schema/v7-schema]
@@ -283,8 +284,8 @@
                       (consistency/at-exact-snapshot created-token))))
       (is (false? (eacl/can? client alice :admin account)))))
 
-  ;; Native current answers are client-private and admitted immediately.
-  ;; Exact replay remains cache-free.
+  ;; Native current answers are client-private and admitted immediately. The
+  ;; same completed semantic answer is also addressable by its exact snapshot.
   (with-mem-conn [conn schema/v7-schema]
     (let [client (core/make-client
                   conn
@@ -777,7 +778,7 @@
             (is (= future-t
                    (:requested-order-hint (ex-data e))))))))))
 
-(deftest exact-request-bypasses-completed-cache-test
+(deftest exact-request-reuses-only-the-matching-snapshot-cache-test
   (with-mem-conn [conn schema/v7-schema]
     (let [client (core/make-client
                   conn
@@ -789,12 +790,13 @@
                   :permission :admin
                   :resource account}]
       (is (true? (eacl/can? client alice :admin account)))
-      (let [result
-            (eacl/check-permission
-             client
-             (assoc demand
-                    :consistency
-                    (consistency/at-exact-snapshot token)))]
-        (is (true? (:allowed? result)))
-        (is (false? (:cached? result))
-            "exact selection bypasses the completed-answer cache")))))
+      (let [exact-demand
+            (assoc demand
+                   :consistency
+                   (consistency/at-exact-snapshot token))
+            first-result (eacl/check-permission client exact-demand)
+            second-result (eacl/check-permission client exact-demand)]
+        (is (true? (:allowed? first-result)))
+        (is (true? (:allowed? second-result)))
+        (is (true? (:cached? second-result))
+            "exact selection reuses the answer computed at the identical basis")))))

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_v3_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_v3_test.clj
@@ -1,6 +1,7 @@
 (ns eacl.datomic.consistency-v3-test
   (:require [clojure.test :refer [deftest is testing]]
             [datomic.api :as d]
+            [eacl.causal-token :as causal-token]
             [eacl.core :as eacl]
             [eacl.datomic.core :as datomic]
             [eacl.datomic.datomic-helpers
@@ -43,6 +44,12 @@
     nil
     (catch clojure.lang.ExceptionInfo error
       (ex-data error))))
+
+(defn- token-data
+  [authorization token]
+  (causal-token/token-data
+   (get-in authorization [:opts :format-options])
+   token))
 
 (deftest map-can-rejects-malformed-consistency-test
   (with-mem-conn [conn schema/v7-schema]
@@ -120,6 +127,91 @@
                    #(eacl/can?
                      reader user :view document
                      (consistency/at-exact-snapshot token)))))))))))
+
+(deftest lagging-real-peer-exact-selection-targets-token-basis-test
+  (with-mem-conns [writer-conn reader-conn schema/v7-schema]
+    (let [client-opts {:security-key security-key
+                       :zed-token-key security-key
+                       :source-lifecycle source-lifecycle
+                       :consistency-sync-timeout-ms 5000}
+          writer (datomic/make-client writer-conn client-opts)
+          reader (datomic/make-client reader-conn client-opts)
+          _ (seed! writer-conn writer)
+          stale-reader-db @(d/sync reader-conn)
+          token (:zed/token
+                 (eacl/create-relationship! writer relationship))
+          requested-t (:exact-locator (token-data reader token))
+          original-db d/db
+          original-sync d/sync
+          sync-calls (atom [])]
+      (is (< (d/basis-t stale-reader-db) requested-t)
+          "the controlled reader snapshot genuinely predates the writer token")
+      (with-redefs [d/db
+                    (fn [connection]
+                      (if (identical? connection reader-conn)
+                        stale-reader-db
+                        (original-db connection)))
+                    d/sync
+                    (fn
+                      ([connection]
+                       (original-sync connection))
+                      ([connection basis]
+                       (swap! sync-calls conj [connection basis])
+                       (original-sync connection basis)))]
+        (is (true?
+             (eacl/can?
+              reader user :view document
+              (consistency/at-exact-snapshot token))))
+        (is (= [[reader-conn requested-t]] @sync-calls)
+            "real Datomic targeted sync catches the lagging Peer up exactly to T")))))
+
+(deftest lagging-real-peer-resumes-historical-cursor-test
+  (with-mem-conns [writer-conn reader-conn schema/v7-schema]
+    (let [client-opts {:security-key security-key
+                       :zed-token-key security-key
+                       :source-lifecycle source-lifecycle
+                       :consistency-sync-timeout-ms 5000}
+          writer (datomic/make-client writer-conn client-opts)
+          reader (datomic/make-client reader-conn client-opts)
+          second-document (eacl/spice-object :document "document-2")
+          _ (seed! writer-conn writer)
+          _ @(d/transact writer-conn [{:eacl/id "document-2"}])
+          stale-reader-db @(d/sync reader-conn)
+          _ (eacl/create-relationships!
+             writer
+             [relationship
+              (eacl/->Relationship user :reader second-document)])
+          query {:subject user
+                 :permission :view
+                 :resource/type :document
+                 :first 1}
+          first-page (eacl/lookup-resources writer query)
+          cursor (get-in first-page [:page-info :end-cursor])
+          expected-page (eacl/lookup-resources writer (assoc query :after cursor))
+          original-db d/db
+          original-sync d/sync
+          sync-calls (atom [])]
+      (is (some? cursor))
+      (with-redefs [d/db
+                    (fn [connection]
+                      (if (identical? connection reader-conn)
+                        stale-reader-db
+                        (original-db connection)))
+                    d/sync
+                    (fn
+                      ([connection]
+                       (original-sync connection))
+                      ([connection basis]
+                       (swap! sync-calls conj [connection basis])
+                       (original-sync connection basis)))]
+        (is (= (:data expected-page)
+               (:data
+                (eacl/lookup-resources reader (assoc query :after cursor))))
+            "a lagging Peer deterministically replays the cursor at its historical basis")
+        (is (= 1 (count @sync-calls)))
+        (is (identical? reader-conn (ffirst @sync-calls)))
+        (is (< (d/basis-t stale-reader-db) (second (first @sync-calls)))
+            "cursor replay catches the lagging Peer up to the authenticated basis")))))
 
 (deftest missing-anchor-and-bounded-wait-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl-datomic/test/eacl/datomic/contract_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/contract_test.clj
@@ -57,14 +57,21 @@
       (contract/assert-pinned-permission-tree-golden! client)
       (let [request {:resource (eacl/spice-object :document "testdoc")
                      :permission :view}
-            first-response (eacl/expand-permission-tree client request)]
+            first-response (eacl/expand-permission-tree client request)
+            exact-request
+            (assoc request :consistency
+                   (consistency/at-exact-snapshot
+                    (:expanded-at first-response)))
+            before (datomic/cache-stats client)
+            exact-response (eacl/expand-permission-tree client exact-request)
+            repeated-exact (eacl/expand-permission-tree client exact-request)
+            after (datomic/cache-stats client)]
         (is (= (:tree-root first-response)
-               (:tree-root
-                (eacl/expand-permission-tree
-                 client
-                 (assoc request :consistency
-                        (consistency/at-exact-snapshot
-                         (:expanded-at first-response)))))))))))
+               (:tree-root exact-response)
+               (:tree-root repeated-exact)))
+        (is (= (+ 2 (:snapshot-exact-hits before))
+               (:snapshot-exact-hits after))
+            "tree roots are reusable, while expanded-at is rebuilt per exact request")))))
 
 (deftest datomic-permission-tree-schema-mutation-snapshot-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl-datomic/test/eacl/datomic/trusted_surface_audit_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/trusted_surface_audit_test.clj
@@ -61,7 +61,8 @@
                         source))
           (str resource " must stay free of EACL-owned blocking coordination"))))
   (testing "the vestigial :latest-result answer kind is gone"
-    (is (= #{:can? :lookup-page :count}
+    (is (= #{:can? :lookup-page :count
+             :relationship-page :permission-tree}
            @(resolve 'eacl.datomic.core/answer-cache-kinds))))
   (testing "the write-only provider options are gone from client opts"
     (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl/src/eacl/cache.cljc
+++ b/modules/eacl/src/eacl/cache.cljc
@@ -103,8 +103,14 @@
     ;; certifies that the same native locator is independently selectable.
     ;; In particular, immutable DataScript values and arbitrary caller-owned
     ;; views cannot acquire an "exact" cache identity from revision equality.
+    ;;
+    ;; Determinism is required to MINT the identity, not merely to read it.
+    ;; Readers already refuse a non-deterministic adapter, so minting one here
+    ;; would let current requests fill a bounded tier with entries no exact
+    ;; request on that client can ever consult, evicting answers that could be.
     (when (and (backend/supports?
                 adapter :consistency :at-exact-snapshot)
+               (backend/deterministic? adapter)
                (some? exact-locator))
       {:key-version 1
        :backend (backend/backend-id adapter)
@@ -190,17 +196,62 @@
                  next-state)))
       @admitted?)))
 
+(def ^:private answer-weight-floor 512)
+(def ^:private answer-weight-per-unit 128)
+
+(defn- structural-answer-units
+  "Counts the collection entries an answer retains, walking with an explicit
+  stack so a deep tree cannot exhaust the runtime stack.
+
+  Permission trees carry their payload in nested `:intermediate`/`:leaf` nodes
+  rather than a flat `:data` vector, so a shape-specific rule would weigh a
+  100k-subject tree the same as a boolean. The traversal is bounded by the
+  expansion limits that produced the value and runs only when an answer is
+  published."
+  [value]
+  (loop [stack (list value)
+         units 0]
+    ;; Test the stack, not the element: a nil or false value inside the answer
+    ;; must not end the walk and silently drop everything still queued.
+    (if (seq stack)
+      (let [current (first stack)
+            remaining (rest stack)]
+        (cond
+          (map? current)
+          (recur (into remaining (vals current))
+                 (+ units (count current)))
+
+          (coll? current)
+          (recur (into remaining current)
+                 (+ units (count current)))
+
+          :else
+          (recur remaining units)))
+      units)))
+
 (defn- default-answer-weight
   "Conservative retained-size estimate for one completed answer.
 
   Mirrors the page-weight family the Datomic backend supplies explicitly:
-  paged results weigh in by row count; scalar decisions and counts pay a
-  flat floor. Callers with better knowledge pass `:answer-weight-fn`."
+  paged results weigh in by row count, nested results by retained collection
+  entries, and scalar decisions and counts pay a flat floor. Callers with
+  better knowledge pass `:answer-weight-fn`."
   [value]
   (let [data (when (map? value) (:data value))]
-    (if (counted? data)
-      (+ 512 (* 128 (count data)))
-      512)))
+    (cond
+      ;; `some?` before `counted?`: ClojureScript answers true for
+      ;; `(counted? nil)` while Clojure answers false, so testing countedness
+      ;; alone would silently route every non-page answer down the page branch
+      ;; on one runtime only.
+      (and (some? data) (counted? data))
+      (+ answer-weight-floor (* answer-weight-per-unit (count data)))
+
+      (coll? value)
+      (+ answer-weight-floor
+         (* answer-weight-per-unit (structural-answer-units value)))
+
+      :else
+      answer-weight-floor)))
 
 (defn- answer-entry-options
   "Store options validating and weighing `{:value v :cache-basis b}` wrappers."
@@ -498,6 +549,15 @@
   selected immutable adapter and may publish the completed semantic answer
   under the complete canonical snapshot plus request key.
 
+  An adapter that cannot mint a canonical snapshot identity bypasses this tier
+  instead of failing the request: `snapshot-exact-key` documents nil as the
+  contractual outcome for views that must not acquire an exact identity, and a
+  cache that cannot key an answer is a caching limit, not a request error.
+
+  The reported `:cache-basis` is the caller's selected snapshot, rebuilt per
+  request rather than copied from the entry, which may have been retained from
+  a proof-lifted answer computed at an earlier basis.
+
   Returns `{:value v :cached? b :cache-tier tier :cache-basis basis}`."
   [store
    {:keys [snapshot-exact-key cache-basis cache-lifecycle decision-kernel
@@ -507,73 +567,82 @@
   (when-not (fn? compute)
     (throw (ex-info "Snapshot-exact cache computation must be a function."
                     {:type :eacl/invalid-config})))
-  (when-not (and (current-cache? store)
-                 (valid-snapshot-exact-key? snapshot-exact-key))
-    (throw (ex-info "Invalid snapshot-exact cache context."
+  (when-not (current-cache? store)
+    (throw (ex-info "Expected an EACL current-generation cache."
                     {:type :eacl/invalid-config
-                     :snapshot-exact-key snapshot-exact-key})))
-  (let [lifecycle (or cache-lifecycle @(:lifecycle store))
-        answer-store (:snapshot-exact lifecycle)
-        entry-key
-        (snapshot-answer-entry-key snapshot-exact-key semantic-key kind)
-        answer-options (answer-entry-options valid-value? answer-weight-fn)
-        exact-entry
-        (when remember-answer?
-          (:value
-           (subproblem/lookup!
-            answer-store :answer entry-key answer-options)))
-        exact-action
-        (current-cache-action
-         decision-kernel :snapshot-exact-entry (some? exact-entry))
-        evaluate-entry
+                     :cache store})))
+  (let [isolated-compute
         (fn []
-          {:value
-           (binding [subproblem/*store* nil
-                     subproblem/*managed-store* nil
-                     subproblem/*managed-key-fn* nil
-                     subproblem/*managed-scope* nil
-                     subproblem/*decision-kernel*
-                     (or decision-kernel subproblem/*decision-kernel*)]
-             (subproblem/with-decision-memo compute))
-           :cache-basis cache-basis})]
-    (if (= :use-snapshot-exact-entry exact-action)
+          (binding [subproblem/*store* nil
+                    subproblem/*managed-store* nil
+                    subproblem/*managed-key-fn* nil
+                    subproblem/*managed-scope* nil
+                    subproblem/*decision-kernel*
+                    (or decision-kernel subproblem/*decision-kernel*)]
+            (subproblem/with-decision-memo compute)))]
+    (if-not (valid-snapshot-exact-key? snapshot-exact-key)
       (do
-        (swap! (:metrics store) update :exact-hits inc)
-        (swap! (:metrics store) update :snapshot-exact-hits inc)
-        {:value (:value exact-entry)
-         :cached? true
-         :cache-tier :snapshot-exact
-         :cache-basis (:cache-basis exact-entry)})
-      (if (and remember-answer?
-               (admit-answer? store entry-key))
-      (let [resolved
-            (subproblem/resolve-independent!
-             answer-store :answer entry-key answer-options evaluate-entry)
-            entry (:value resolved)]
-        (if (:cached? resolved)
-          (do
-            (swap! (:metrics store) update :exact-hits inc)
-            (swap! (:metrics store) update :snapshot-exact-hits inc)
-            {:value (:value entry)
-             :cached? true
-             :cache-tier :snapshot-exact
-             :cache-basis (:cache-basis entry)})
-          (do
-            (swap! (:metrics store) update :misses inc)
-            (swap! (:metrics store) update :puts inc)
-            {:value (:value entry)
-             :cached? false
-             :cache-tier nil
-             :cache-basis (:cache-basis entry)})))
-        (let [entry (evaluate-entry)]
-          (swap! (:metrics store)
-                 update
-                 (if remember-answer? :misses :bypasses)
-                 inc)
-          {:value (:value entry)
-           :cached? false
-           :cache-tier nil
-           :cache-basis (:cache-basis entry)})))))
+        (swap! (:metrics store) update :bypasses inc)
+        {:value (isolated-compute)
+         :cached? false
+         :cache-tier nil
+         :cache-basis nil})
+      (let [lifecycle (or cache-lifecycle @(:lifecycle store))
+            answer-store (:snapshot-exact lifecycle)
+            entry-key
+            (snapshot-answer-entry-key snapshot-exact-key semantic-key kind)
+            answer-options (answer-entry-options valid-value? answer-weight-fn)
+            exact-entry
+            (when remember-answer?
+              (:value
+               (subproblem/lookup!
+                answer-store :answer entry-key answer-options)))
+            exact-action
+            (current-cache-action
+             decision-kernel :snapshot-exact-entry (some? exact-entry))
+            evaluate-entry
+            (fn []
+              {:value (isolated-compute)
+               :cache-basis cache-basis})
+            hit
+            (fn [entry]
+              (swap! (:metrics store)
+                     #(-> %
+                          (update :exact-hits inc)
+                          (update :snapshot-exact-hits inc)))
+              {:value (:value entry)
+               :cached? true
+               :cache-tier :snapshot-exact
+               :cache-basis cache-basis})]
+        (if (= :use-snapshot-exact-entry exact-action)
+          (hit exact-entry)
+          (if (and remember-answer?
+                   (admit-answer? store entry-key))
+            (let [resolved
+                  (subproblem/resolve-independent!
+                   answer-store :answer entry-key answer-options
+                   evaluate-entry)
+                  entry (:value resolved)]
+              (if (:cached? resolved)
+                (hit entry)
+                (do
+                  (swap! (:metrics store)
+                         #(-> %
+                              (update :misses inc)
+                              (update :puts inc)))
+                  {:value (:value entry)
+                   :cached? false
+                   :cache-tier nil
+                   :cache-basis cache-basis})))
+            (let [entry (evaluate-entry)]
+              (swap! (:metrics store)
+                     update
+                     (if remember-answer? :misses :bypasses)
+                     inc)
+              {:value (:value entry)
+               :cached? false
+               :cache-tier nil
+               :cache-basis cache-basis})))))))
 
 (defn resolve-current!
   "Resolves one completed semantic answer against a captured current snapshot.
@@ -675,9 +744,11 @@
                  decision-kernel :exact-entry (some? exact-entry))]
             (if (= :use-exact-entry exact-action)
               (do
-                (retain-snapshot-answer!
-                 store lifecycle snapshot-exact-key semantic-key kind
-                 answer-options exact-entry)
+                ;; Deliberately no snapshot-exact retention here. This answer
+                ;; was already offered to that tier when it was computed or
+                ;; promoted; republishing on every hit re-runs the answer
+                ;; validator and weight function on the hot path and records a
+                ;; publication race against the entry it just found.
                 (swap! (:metrics store) update :exact-hits inc)
                 {:value (:value exact-entry)
                  :cached? true

--- a/modules/eacl/src/eacl/cache.cljc
+++ b/modules/eacl/src/eacl/cache.cljc
@@ -6,7 +6,9 @@
   path that once lived here was deleted by trusted-surface-hygiene 11.1
   (native completed answers are client-private and never flow through
   portable providers)."
-  (:require [eacl.subproblem-cache :as subproblem]
+  (:require [eacl.backend.v8 :as backend]
+            [eacl.consistency :as consistency]
+            [eacl.subproblem-cache :as subproblem]
             [eacl.verified-kernel :as verified]))
 
 (defprotocol CacheStore
@@ -69,14 +71,66 @@
 
 (defrecord ExactGeneration [snapshot order subproblems])
 (defrecord ManagedGeneration
-  [schema-stamp installed-order subproblems])
-(defrecord CacheLifecycle [exact managed])
+           [schema-stamp installed-order subproblems])
+(defrecord CacheLifecycle [exact managed snapshot-exact])
 (defrecord CurrentGenerationCache [lifecycle metrics max-entries admissions
                                    admit-on-repeat? subproblem-options])
 
 (defn- new-lifecycle
-  []
-  (->CacheLifecycle (atom nil) (atom nil)))
+  [subproblem-options]
+  (->CacheLifecycle
+   (atom nil)
+   (atom nil)
+   ;; One composite-key store retains completed answers from multiple exact
+   ;; snapshots under one weight/LRU budget. It deliberately is not bound as
+   ;; a traversal subproblem store: partial traversal keys do not carry the
+   ;; complete snapshot identity required for historical reuse.
+   (subproblem/store (dissoc subproblem-options :enabled?))))
+
+(defn snapshot-exact-key
+  "Returns the canonical identity of an ordinary selected immutable snapshot.
+
+  Callers must invoke this only after current or authenticated exact selection
+  through a certified backend adapter. Arbitrary filtered/since/history/
+  speculative DB views must bypass snapshot-exact caching rather than infer
+  identity from a numeric revision. The semantic request, result shape,
+  evaluation demand, engine/order ABI, and answer-affecting limits are added
+  separately by `resolve-current!`/`resolve-exact!`."
+  [adapter]
+  (let [native-revision (consistency/native-revision adapter)
+        exact-locator (:exact-locator native-revision)]
+    ;; A captured current adapter may seed this tier only when the backend
+    ;; certifies that the same native locator is independently selectable.
+    ;; In particular, immutable DataScript values and arbitrary caller-owned
+    ;; views cannot acquire an "exact" cache identity from revision equality.
+    (when (and (backend/supports?
+                adapter :consistency :at-exact-snapshot)
+               (some? exact-locator))
+      {:key-version 1
+       :backend (backend/backend-id adapter)
+       :source-scope (consistency/source-scope adapter)
+       :native-revision native-revision
+       :exact-locator exact-locator
+       :view-kind :ordinary-exact
+       :snapshot-id (backend/invoke adapter :snapshot-id)
+       :adapter-fingerprint (backend/fingerprint adapter)
+       :identity-contract (backend/identity-contract adapter)})))
+
+(defn- valid-snapshot-exact-key?
+  [snapshot-key]
+  (and (map? snapshot-key)
+       (= 1 (:key-version snapshot-key))
+       (keyword? (:backend snapshot-key))
+       (map? (:source-scope snapshot-key))
+       (= :ordinary-exact (:view-kind snapshot-key))
+       (some? (:snapshot-id snapshot-key))
+       (some? (:adapter-fingerprint snapshot-key))
+       (keyword? (:identity-contract snapshot-key))
+       (let [{:keys [revision exact-locator]}
+             (:native-revision snapshot-key)]
+         (and (some? revision)
+              (some? exact-locator)
+              (= exact-locator (:exact-locator snapshot-key))))))
 
 (def ^:private empty-answer-sightings
   {:tick 0
@@ -198,8 +252,9 @@
    ;; Validate budgets before a request attempts to install a generation.
    (subproblem/store (dissoc subproblem-cache :enabled?))
    (->CurrentGenerationCache
-    (atom (new-lifecycle))
+    (atom (new-lifecycle subproblem-cache))
     (atom {:exact-hits 0
+           :snapshot-exact-hits 0
            :managed-hits 0
            :misses 0
            :bypasses 0
@@ -250,17 +305,21 @@
   (let [lifecycle @(:lifecycle store)
         exact @(:exact lifecycle)
         managed @(:managed lifecycle)
+        snapshot-exact (:snapshot-exact lifecycle)
         exact-stats
         (when-let [subproblems (:subproblems exact)]
           (subproblem/stats subproblems))
         managed-stats
         (when-let [subproblems (:subproblems managed)]
-          (subproblem/stats subproblems))]
+          (subproblem/stats subproblems))
+        snapshot-exact-stats (subproblem/stats snapshot-exact)]
     (assoc @(:metrics store)
            :exact-entries
            (get-in exact-stats [:tiers :answer :entries] 0)
            :managed-entries
            (get-in managed-stats [:tiers :answer :entries] 0)
+           :snapshot-exact-entries
+           (get-in snapshot-exact-stats [:tiers :answer :entries] 0)
            :admission-entries
            (count (:seen @(:admissions store)))
            :subproblems
@@ -269,7 +328,9 @@
                 (subproblem/store
                  (dissoc (:subproblem-options store) :enabled?))))
            :managed-subproblems
-           managed-stats)))
+           managed-stats
+           :snapshot-exact
+           snapshot-exact-stats)))
 
 (defn record-current-bypass!
   "Records that a configured native cache was deliberately skipped without
@@ -326,7 +387,7 @@
     (throw (ex-info "Expected an EACL current-generation cache."
                     {:type :eacl/invalid-config
                      :cache store})))
-  (reset! (:lifecycle store) (new-lifecycle))
+  (reset! (:lifecycle store) (new-lifecycle (:subproblem-options store)))
   (reset! (:admissions store) empty-answer-sightings)
   (swap! (:metrics store) update :expirations inc)
   nil)
@@ -411,6 +472,109 @@
    :current-cache-decision
    {:stage stage :available? available?}))
 
+(defn- snapshot-answer-entry-key
+  [snapshot-key semantic-key kind]
+  [snapshot-key semantic-key kind])
+
+(defn- retain-snapshot-answer!
+  [store lifecycle snapshot-key semantic-key kind answer-options entry]
+  (when snapshot-key
+    (subproblem/publish!
+     (:snapshot-exact lifecycle)
+     :answer
+     (snapshot-answer-entry-key snapshot-key semantic-key kind)
+     answer-options
+     entry
+     subproblem/*publication-attempt-limit*))
+  nil)
+
+(defn resolve-exact!
+  "Resolves one completed answer for an already selected authenticated exact
+  snapshot.
+
+  This path consults only the lifecycle-owned snapshot-exact answer store. It
+  never probes managed proof-backed entries and never binds historical data as
+  a traversal subproblem store. A miss evaluates on the caller's already
+  selected immutable adapter and may publish the completed semantic answer
+  under the complete canonical snapshot plus request key.
+
+  Returns `{:value v :cached? b :cache-tier tier :cache-basis basis}`."
+  [store
+   {:keys [snapshot-exact-key cache-basis cache-lifecycle decision-kernel
+           remember-answer? answer-weight-fn]
+    :or {remember-answer? true}}
+   semantic-key kind valid-value? compute]
+  (when-not (fn? compute)
+    (throw (ex-info "Snapshot-exact cache computation must be a function."
+                    {:type :eacl/invalid-config})))
+  (when-not (and (current-cache? store)
+                 (valid-snapshot-exact-key? snapshot-exact-key))
+    (throw (ex-info "Invalid snapshot-exact cache context."
+                    {:type :eacl/invalid-config
+                     :snapshot-exact-key snapshot-exact-key})))
+  (let [lifecycle (or cache-lifecycle @(:lifecycle store))
+        answer-store (:snapshot-exact lifecycle)
+        entry-key
+        (snapshot-answer-entry-key snapshot-exact-key semantic-key kind)
+        answer-options (answer-entry-options valid-value? answer-weight-fn)
+        exact-entry
+        (when remember-answer?
+          (:value
+           (subproblem/lookup!
+            answer-store :answer entry-key answer-options)))
+        exact-action
+        (current-cache-action
+         decision-kernel :snapshot-exact-entry (some? exact-entry))
+        evaluate-entry
+        (fn []
+          {:value
+           (binding [subproblem/*store* nil
+                     subproblem/*managed-store* nil
+                     subproblem/*managed-key-fn* nil
+                     subproblem/*managed-scope* nil
+                     subproblem/*decision-kernel*
+                     (or decision-kernel subproblem/*decision-kernel*)]
+             (subproblem/with-decision-memo compute))
+           :cache-basis cache-basis})]
+    (if (= :use-snapshot-exact-entry exact-action)
+      (do
+        (swap! (:metrics store) update :exact-hits inc)
+        (swap! (:metrics store) update :snapshot-exact-hits inc)
+        {:value (:value exact-entry)
+         :cached? true
+         :cache-tier :snapshot-exact
+         :cache-basis (:cache-basis exact-entry)})
+      (if (and remember-answer?
+               (admit-answer? store entry-key))
+      (let [resolved
+            (subproblem/resolve-independent!
+             answer-store :answer entry-key answer-options evaluate-entry)
+            entry (:value resolved)]
+        (if (:cached? resolved)
+          (do
+            (swap! (:metrics store) update :exact-hits inc)
+            (swap! (:metrics store) update :snapshot-exact-hits inc)
+            {:value (:value entry)
+             :cached? true
+             :cache-tier :snapshot-exact
+             :cache-basis (:cache-basis entry)})
+          (do
+            (swap! (:metrics store) update :misses inc)
+            (swap! (:metrics store) update :puts inc)
+            {:value (:value entry)
+             :cached? false
+             :cache-tier nil
+             :cache-basis (:cache-basis entry)})))
+        (let [entry (evaluate-entry)]
+          (swap! (:metrics store)
+                 update
+                 (if remember-answer? :misses :bypasses)
+                 inc)
+          {:value (:value entry)
+           :cached? false
+           :cache-tier nil
+           :cache-basis (:cache-basis entry)})))))
+
 (defn resolve-current!
   "Resolves one completed semantic answer against a captured current snapshot.
 
@@ -432,7 +596,8 @@
 
   Returns `{:value v :cached? b :cache-tier tier :cache-basis basis}`."
   [store
-   {:keys [snapshot snapshot-order same-snapshot? cache-basis cacheable?
+   {:keys [snapshot snapshot-order same-snapshot? snapshot-exact-key
+           cache-basis cacheable?
            cache-lifecycle
            managed-key-fn
            managed-subproblem-key-fn managed-subproblem-scope
@@ -477,7 +642,7 @@
       (let [lifecycle (or cache-lifecycle @(:lifecycle store))
             {:keys [generation active?]}
             (install-exact-generation!
-            (:exact lifecycle)
+             (:exact lifecycle)
              snapshot snapshot-order same-snapshot?
              (:subproblem-options store))
             entry-key [semantic-key kind]]
@@ -509,110 +674,122 @@
                 (current-cache-action
                  decision-kernel :exact-entry (some? exact-entry))]
             (if (= :use-exact-entry exact-action)
-            (do
-              (swap! (:metrics store) update :exact-hits inc)
-              {:value (:value exact-entry)
-               :cached? true
-               :cache-tier :exact-current
-               :cache-basis (:cache-basis exact-entry)
-               :subproblem-store answer-store})
-            (let [{:keys [schema-stamp dependency-stamp]}
-                  (managed-descriptor
-                   store managed-key-fn)
-                  managed-generation
-                  (when (some? schema-stamp)
-                    (install-managed-generation!
-                     (:managed lifecycle)
-                     schema-stamp snapshot-order
-                     (:subproblem-options store)))
-                  managed-store (:subproblems managed-generation)
-                  managed-entry-key
-                  (when managed-generation
-                    [semantic-key kind dependency-stamp])
-                  managed-entry
-                  (when (and remember-answer? managed-entry-key)
-                    (:value
-                     (subproblem/lookup!
-                      managed-store :answer managed-entry-key
-                      answer-options)))
-                  managed-action
-                  (current-cache-action
-                   decision-kernel :managed-entry (some? managed-entry))]
-              (if (= :use-managed-entry managed-action)
-                (do
+              (do
+                (retain-snapshot-answer!
+                 store lifecycle snapshot-exact-key semantic-key kind
+                 answer-options exact-entry)
+                (swap! (:metrics store) update :exact-hits inc)
+                {:value (:value exact-entry)
+                 :cached? true
+                 :cache-tier :exact-current
+                 :cache-basis (:cache-basis exact-entry)
+                 :subproblem-store answer-store})
+              (let [{:keys [schema-stamp dependency-stamp]}
+                    (managed-descriptor
+                     store managed-key-fn)
+                    managed-generation
+                    (when (some? schema-stamp)
+                      (install-managed-generation!
+                       (:managed lifecycle)
+                       schema-stamp snapshot-order
+                       (:subproblem-options store)))
+                    managed-store (:subproblems managed-generation)
+                    managed-entry-key
+                    (when managed-generation
+                      [semantic-key kind dependency-stamp])
+                    managed-entry
+                    (when (and remember-answer? managed-entry-key)
+                      (:value
+                       (subproblem/lookup!
+                        managed-store :answer managed-entry-key
+                        answer-options)))
+                    managed-action
+                    (current-cache-action
+                     decision-kernel :managed-entry (some? managed-entry))]
+                (if (= :use-managed-entry managed-action)
+                  (do
                   ;; Promote the still-valid managed answer into the selected
                   ;; exact generation so the next identical request hits
                   ;; without dependency-stamp extraction.
-                  (subproblem/resolve-independent!
-                   answer-store :answer entry-key answer-options
-                   (fn [] managed-entry))
-                  (swap! (:metrics store) update :puts inc)
-                  (swap! (:metrics store) update :managed-hits inc)
-                  {:value (:value managed-entry)
-                   :cached? true
-                   :cache-tier :managed-current
-                   :cache-basis (:cache-basis managed-entry)
-                   :subproblem-store answer-store})
-                (let [subproblems-enabled?
-                      (get (:subproblem-options store) :enabled? true)
-                      compute-entry
-                      (fn []
-                        {:value
-                         (binding [subproblem/*store*
-                                   (when subproblems-enabled?
-                                     answer-store)
-                                   subproblem/*managed-store*
-                                   (when subproblems-enabled?
-                                     managed-store)
-                                   subproblem/*managed-key-fn*
-                                   managed-subproblem-key-fn
-                                   subproblem/*managed-scope*
-                                   managed-subproblem-scope
-                                   subproblem/*decision-kernel*
-                                   (or decision-kernel
-                                       subproblem/*decision-kernel*)]
-                           (subproblem/with-decision-memo compute))
-                         :cache-basis cache-basis})
-                      layered-compute
-                      (fn []
-                        (if managed-entry-key
-                          (:value
-                           (subproblem/resolve-independent!
-                            managed-store :answer managed-entry-key
-                            answer-options compute-entry))
-                          (compute-entry)))]
-                  (if (and remember-answer?
-                           (admit-answer? store entry-key))
-                    (let [resolved
-                          (subproblem/resolve-independent!
-                           answer-store :answer entry-key
-                           answer-options layered-compute)
-                          entry (:value resolved)]
-                      (if (:cached? resolved)
+                    (subproblem/resolve-independent!
+                     answer-store :answer entry-key answer-options
+                     (fn [] managed-entry))
+                    (retain-snapshot-answer!
+                     store lifecycle snapshot-exact-key semantic-key kind
+                     answer-options managed-entry)
+                    (swap! (:metrics store) update :puts inc)
+                    (swap! (:metrics store) update :managed-hits inc)
+                    {:value (:value managed-entry)
+                     :cached? true
+                     :cache-tier :managed-current
+                     :cache-basis (:cache-basis managed-entry)
+                     :subproblem-store answer-store})
+                  (let [subproblems-enabled?
+                        (get (:subproblem-options store) :enabled? true)
+                        compute-entry
+                        (fn []
+                          {:value
+                           (binding [subproblem/*store*
+                                     (when subproblems-enabled?
+                                       answer-store)
+                                     subproblem/*managed-store*
+                                     (when subproblems-enabled?
+                                       managed-store)
+                                     subproblem/*managed-key-fn*
+                                     managed-subproblem-key-fn
+                                     subproblem/*managed-scope*
+                                     managed-subproblem-scope
+                                     subproblem/*decision-kernel*
+                                     (or decision-kernel
+                                         subproblem/*decision-kernel*)]
+                             (subproblem/with-decision-memo compute))
+                           :cache-basis cache-basis})
+                        layered-compute
+                        (fn []
+                          (if managed-entry-key
+                            (:value
+                             (subproblem/resolve-independent!
+                              managed-store :answer managed-entry-key
+                              answer-options compute-entry))
+                            (compute-entry)))]
+                    (if (and remember-answer?
+                             (admit-answer? store entry-key))
+                      (let [resolved
+                            (subproblem/resolve-independent!
+                             answer-store :answer entry-key
+                             answer-options layered-compute)
+                            entry (:value resolved)]
+                        (if (:cached? resolved)
                         ;; A compatible completed value was already visible
                         ;; at lookup time; serve it as the exact hit it is.
-                        (do
-                          (swap! (:metrics store) update :exact-hits inc)
-                          {:value (:value entry)
-                           :cached? true
-                           :cache-tier :exact-current
-                           :cache-basis (:cache-basis entry)
-                           :subproblem-store answer-store})
-                        (do
-                          (swap! (:metrics store) update :misses inc)
-                          (swap! (:metrics store) update :puts inc)
-                          {:value (:value entry)
-                           :cached? false
-                           :cache-tier nil
-                           :cache-basis (:cache-basis entry)
-                           :subproblem-store answer-store})))
-                    (let [entry (compute-entry)]
-                      (swap! (:metrics store)
-                             update
-                             (if remember-answer? :misses :bypasses)
-                             inc)
-                      {:value (:value entry)
-                       :cached? false
-                       :cache-tier nil
-                       :cache-basis cache-basis
-                       :subproblem-store answer-store}))))))))))))
+                          (do
+                            (retain-snapshot-answer!
+                             store lifecycle snapshot-exact-key semantic-key kind
+                             answer-options entry)
+                            (swap! (:metrics store) update :exact-hits inc)
+                            {:value (:value entry)
+                             :cached? true
+                             :cache-tier :exact-current
+                             :cache-basis (:cache-basis entry)
+                             :subproblem-store answer-store})
+                          (do
+                            (retain-snapshot-answer!
+                             store lifecycle snapshot-exact-key semantic-key kind
+                             answer-options entry)
+                            (swap! (:metrics store) update :misses inc)
+                            (swap! (:metrics store) update :puts inc)
+                            {:value (:value entry)
+                             :cached? false
+                             :cache-tier nil
+                             :cache-basis (:cache-basis entry)
+                             :subproblem-store answer-store})))
+                      (let [entry (compute-entry)]
+                        (swap! (:metrics store)
+                               update
+                               (if remember-answer? :misses :bypasses)
+                               inc)
+                        {:value (:value entry)
+                         :cached? false
+                         :cache-tier nil
+                         :cache-basis cache-basis
+                         :subproblem-store answer-store}))))))))))))

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -165,10 +165,14 @@
     {:adapter adapter
      :db (:db (backend/state adapter))
      :selection selection
+     :snapshot-exact?
+     (= :at-exact-snapshot
+        (get-in selection [:descriptor :mode]))
      :completed-cache?
      (and (:completed-cache-request? opts)
-          (not= :at-exact-snapshot
-                (get-in selection [:descriptor :mode])))}))
+          (or (not= :at-exact-snapshot
+                    (get-in selection [:descriptor :mode]))
+              (backend/deterministic? adapter)))}))
 
 (defn- permission-dependencies
   [adapter resource-type permission]
@@ -255,22 +259,26 @@
          adapter current-opts operation query)
         page-adapter
         (:adapter prepared)
+        snapshot-exact?
+        (or (= :at-exact-snapshot
+               (get-in selection [:descriptor :mode]))
+            (not
+             (identical?
+              (:db (backend/state adapter))
+              (:db (backend/state page-adapter)))))
         page-opts
         (assoc
          (cursor-options
           page-adapter opts selection resource-type permission)
+         :snapshot-exact? snapshot-exact?
          :completed-cache?
          (and
           (:completed-cache-request? opts)
-          (not= :at-exact-snapshot
-                (get-in selection [:descriptor :mode]))
-          ;; Cursor authentication and snapshot selection happen before this
-          ;; decision. A continuation that still resolves to the selected
-          ;; current DB is therefore safe to cache; a historical continuation
-          ;; selects another immutable DB and continues to bypass this cache.
-          (identical?
-           (:db (backend/state adapter))
-           (:db (backend/state page-adapter)))))]
+          ;; Historical completed-answer reuse additionally requires a stable
+          ;; adapter/identity contract. Cursor authentication and exact
+          ;; selection have already happened before this decision.
+          (or (not snapshot-exact?)
+              (backend/deterministic? page-adapter))))]
     {:adapter page-adapter
      :db (:db (backend/state page-adapter))
      :opts page-opts
@@ -349,7 +357,9 @@
              (proof-frame/source-lifecycle request-proof-frame)
              :adapter-fingerprint (:adapter-fingerprint opts)
              :recursive-traversal-limits
-             (:recursive-traversal-limits opts)}]
+             (:recursive-traversal-limits opts)
+             :permission-tree-limits
+             (:permission-tree-limits opts)}]
         (execution/check! contract :cache-lookup)
         (let [answer
               (binding
@@ -357,28 +367,36 @@
                    (get-in contract
                            [:cache-attempt :maximum-atomic-attempts]
                            4)]
-                (cache/resolve-current!
-                 (:current-cache-store opts)
-                 {:snapshot db
-          :cache-lifecycle (:cache-lifecycle opts)
-          :snapshot-order (:max-tx db)
-          :same-snapshot? identical?
-          :cache-basis (backend/invoke adapter :snapshot-id)
-          :decision-kernel (:decision-kernel opts)
-          :managed-key-fn
-          (when (:managed-cache-enabled? opts)
-            #(proof-frame/descriptor @complete-proof))
-          :managed-subproblem-key-fn
-          (when (:managed-cache-enabled? opts)
-            (fn [dependency]
-              (proof-frame/subset-descriptor
-               @complete-proof dependency)))
-                :managed-subproblem-scope
-                (consistency-v3/source-scope adapter)}
-               semantic-key
-               operation
-                 valid-value?
-                 evaluate))]
+                (if (:snapshot-exact? opts)
+                  (cache/resolve-exact!
+                   (:current-cache-store opts)
+                   {:snapshot-exact-key (cache/snapshot-exact-key adapter)
+                    :cache-lifecycle (:cache-lifecycle opts)
+                    :cache-basis (backend/invoke adapter :snapshot-id)
+                    :decision-kernel (:decision-kernel opts)}
+                   semantic-key operation valid-value? evaluate)
+                  (cache/resolve-current!
+                   (:current-cache-store opts)
+                   {:snapshot db
+                    :cache-lifecycle (:cache-lifecycle opts)
+                    :snapshot-order (:max-tx db)
+                    :same-snapshot? identical?
+                    :snapshot-exact-key (cache/snapshot-exact-key adapter)
+                    :cache-basis (backend/invoke adapter :snapshot-id)
+                    :decision-kernel (:decision-kernel opts)
+                    :managed-key-fn
+                    (when (and (:managed-cache-enabled? opts)
+                               resource-type permission)
+                      #(proof-frame/descriptor @complete-proof))
+                    :managed-subproblem-key-fn
+                    (when (and (:managed-cache-enabled? opts)
+                               resource-type permission)
+                      (fn [dependency]
+                        (proof-frame/subset-descriptor
+                         @complete-proof dependency)))
+                    :managed-subproblem-scope
+                    (consistency-v3/source-scope adapter)}
+                   semantic-key operation valid-value? evaluate)))]
           (execution/check! contract :cache-publication)
           answer)))))
 
@@ -466,21 +484,22 @@
       (or
        (relay/lookup-visited-page
         adapter cursor-opts :read-relationships filters)
-       (relay/remember-visited-page!
-        adapter
-        cursor-opts
-        :read-relationships
-        filters
-        (assoc
-         (relay/externalize-relationship-page
-          adapter
-          cursor-opts
-          :read-relationships
-          filters
-          ((get-in api [:impl :read-relationships])
-           page-db internal-query (:decision-kernel cursor-opts)))
-         :cached? false
-         :cache-basis nil))))))
+       (let [answer
+             (cached-engine-result
+              adapter cursor-opts :read-relationships
+              (cache/lookup-page-query-identity filters internal-query)
+              nil nil
+              #(and (map? %) (vector? (:data %)) (map? (:page-info %)))
+              #((get-in api [:impl :read-relationships])
+                page-db internal-query (:decision-kernel cursor-opts)))
+             page
+             (with-cache-info
+               (relay/externalize-relationship-page
+                adapter cursor-opts :read-relationships filters
+                (:value answer))
+               answer)]
+         (relay/remember-visited-page!
+          adapter cursor-opts :read-relationships filters page))))))
 
 (defn spice-relationship->internal
   [db {:keys [spice-object->internal object-id->lookup-ref]}
@@ -609,9 +628,12 @@
         opts (ensure-execution-contract
               opts (or (:request-operation opts) :can?) request)
         {selected-db :db adapter :adapter
-         completed-cache? :completed-cache?}
+         completed-cache? :completed-cache?
+         snapshot-exact? :snapshot-exact?}
         (selected-context api db opts consistency)
-        opts (assoc opts :completed-cache? completed-cache?)
+        opts (assoc opts
+                    :completed-cache? completed-cache?
+                    :snapshot-exact? snapshot-exact?)
         _ (schema-errors/validate-permission-request!
            ((get-in api [:schema :read-schema]) selected-db)
            (or (:request-operation opts) :can?)
@@ -711,9 +733,12 @@
    {:as query :keys [subject]}]
   (let [opts (ensure-execution-contract opts :count-resources query)
         {selected-db :db adapter :adapter
-         completed-cache? :completed-cache?}
+         completed-cache? :completed-cache?
+         snapshot-exact? :snapshot-exact?}
         (selected-context api db opts (:consistency query))
-        opts (assoc opts :completed-cache? completed-cache?)
+        opts (assoc opts
+                    :completed-cache? completed-cache?
+                    :snapshot-exact? snapshot-exact?)
         _ (schema-errors/validate-permission-request!
            ((get-in api [:schema :read-schema]) selected-db)
            :count-resources
@@ -812,9 +837,12 @@
    query]
   (let [opts (ensure-execution-contract opts :count-subjects query)
         {selected-db :db adapter :adapter
-         completed-cache? :completed-cache?}
+         completed-cache? :completed-cache?
+         snapshot-exact? :snapshot-exact?}
         (selected-context api db opts (:consistency query))
-        opts (assoc opts :completed-cache? completed-cache?)
+        opts (assoc opts
+                    :completed-cache? completed-cache?
+                    :snapshot-exact? snapshot-exact?)
         _ (schema-errors/validate-permission-request!
            ((get-in api [:schema :read-schema]) selected-db)
            :count-subjects
@@ -851,19 +879,32 @@
   (let [opts (ensure-execution-contract
               opts :expand-permission-tree query)
         contract (:execution-contract opts)
-        {:keys [adapter db]}
+        {adapter :adapter db :db
+         completed-cache? :completed-cache?
+         snapshot-exact? :snapshot-exact?}
         (selected-context api db opts (:consistency query))
+        opts (assoc opts
+                    :completed-cache? completed-cache?
+                    :snapshot-exact? snapshot-exact?)
         _ (schema-errors/validate-expansion-request!
            ((get-in api [:schema :read-schema]) db)
            :expand-permission-tree
            (:type (:resource query))
            (:permission query))
-        tree (permission-tree/expand
-              adapter
-              {:limits (:permission-tree-limits opts)
-               :execution-contract contract}
-              (:resource query)
-              (:permission query))]
+        answer
+        (cached-engine-result
+         adapter opts :expand-permission-tree
+         (dissoc query :consistency :cache? :timeout-ms :cancellation-token)
+         (:type (:resource query))
+         (:permission query)
+         map?
+         #(permission-tree/expand
+           adapter
+           {:limits (:permission-tree-limits opts)
+            :execution-contract contract}
+           (:resource query)
+           (:permission query)))
+        tree (:value answer)]
     (execution/check! contract :permission-tree-token-issuance)
     (let [token
           (permission-tree/selected-adapter-token adapter opts)]
@@ -993,7 +1034,10 @@
 
   (expand-permission-tree [_ query]
     (expand-permission-tree
-     api ((:db api) conn) opts query))
+     api
+     ((:db api) conn)
+     (assoc opts :completed-cache-request? true)
+     query))
 
   IDetailedAuthorization
   (-check-permission

--- a/modules/eacl/src/eacl/engine/portable_decisions.cljc
+++ b/modules/eacl/src/eacl/engine/portable_decisions.cljc
@@ -125,6 +125,10 @@
     (if available? :probe-exact-entry :bypass-current-cache)
     :exact-entry
     (if available? :use-exact-entry :probe-managed-entry)
+    :snapshot-exact-entry
+    (if available?
+      :use-snapshot-exact-entry
+      :compute-snapshot-exact-value)
     :managed-entry
     (if available? :use-managed-entry :compute-current-value)))
 

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -676,6 +676,20 @@
   [resource-type permission-name]
   [resource-type permission-name])
 
+(defn- node-relation-eids
+  "Relation-definition eids for a node name that is a relation, not a
+  permission.
+
+  Permission-tree expansion accepts a relation as its root and then reads that
+  relation's relationships directly, so those definitions belong in the
+  dependency closure even though no permission path names them. Without this,
+  a relation root closes over nothing, its answer is proof-equal at every later
+  snapshot, and a cached tree survives the relationship writes it reports."
+  [db resource-type relation-name]
+  (into #{}
+        (map :e)
+        (relation-datoms db resource-type relation-name)))
+
 (defn- calc-permission-relationship-eids
   [db resource-type permission-name]
   (loop [stack [(permission-query-node resource-type permission-name)]
@@ -685,6 +699,14 @@
       (if (contains? seen node)
         (recur (pop stack) seen relationship-eids)
         (let [paths (get-permission-paths db node-resource-type node-permission)
+              ;; Only a name with no permission paths can be a relation, so
+              ;; ordinary permission roots never pay this lookup.
+              relationship-eids
+              (if (seq paths)
+                relationship-eids
+                (into relationship-eids
+                      (node-relation-eids
+                       db node-resource-type node-permission)))
               next-nodes
               (keep (fn [path]
                       (case (:type path)

--- a/modules/eacl/src/eacl/formal/production_kernel.clj
+++ b/modules/eacl/src/eacl/formal/production_kernel.clj
@@ -854,6 +854,9 @@
     :exact-entry
     (CurrentCacheStage/create_ExactEntryStage)
 
+    :snapshot-exact-entry
+    (CurrentCacheStage/create_SnapshotExactEntryStage)
+
     :managed-entry
     (CurrentCacheStage/create_ManagedEntryStage)))
 
@@ -869,6 +872,8 @@
       (.is_UseExactEntry action) :use-exact-entry
       (.is_ProbeManagedEntry action) :probe-managed-entry
       (.is_UseManagedEntry action) :use-managed-entry
+      (.is_UseSnapshotExactEntry action) :use-snapshot-exact-entry
+      (.is_ComputeSnapshotExactValue action) :compute-snapshot-exact-value
       :else :compute-current-value)))
 
 (defn- ordered-merge-head

--- a/modules/eacl/src/eacl/relay.cljc
+++ b/modules/eacl/src/eacl/relay.cljc
@@ -122,11 +122,10 @@
     (:subject query) (update :subject plain-scope-object)
     (:resource query) (update :resource plain-scope-object)))
 
-(defn- cursor-scope
-  "Digest of the complete authenticated query scope, including the selected
-  snapshot's schema generation. A cursor minted under another schema
-  generation therefore fails scope validation unconditionally — recovery
-  mode included."
+(defn- legacy-cursor-scope
+  "Version-11 query scope retained so existing cursors continue while their
+  current schema generation remains unchanged. Version 12 moves the schema
+  proof out of query identity so exact historical recovery can run."
   [adapter opts operation query]
   (secure/canonical-digest
    "eacl/cursor/query-scope/v7"
@@ -134,6 +133,21 @@
     operation
     {:schema-stamp (request-schema-stamp adapter opts)
      :recursive-traversal-limits (:recursive-traversal-limits opts)}
+    (scoped-query-form query)]))
+
+(defn- cursor-scope
+  "Digest of immutable operation/query/principal/configuration identity.
+
+  Snapshot schema and relationship proof live in the separately authenticated
+  dependency context. Keeping them out of this pre-recovery scope allows a
+  changed current schema to reach proof comparison and exact fallback without
+  weakening rejection of an actually changed query."
+  [_adapter opts operation query]
+  (secure/canonical-digest
+   "eacl/cursor/query-scope/v8"
+   [cursor-emission-order-version
+    operation
+    {:recursive-traversal-limits (:recursive-traversal-limits opts)}
     (scoped-query-form query)]))
 
 (defn- navigation-boundary-scope
@@ -422,7 +436,7 @@
     (let [token
           (cursor/cursor->token
            (merge
-            {:v 11
+            {:v 12
              :scope scope
              :edge (transform-edge-ids
                     #(backend/invoke adapter :internal-id->object %)
@@ -462,7 +476,7 @@
                error)))
           envelope (:cursor decoded)
           _ (execution/check! (:execution-contract opts) :cursor-decoded)]
-      (when-not (and (= 11 (:v envelope))
+      (when-not (and (contains? #{11 12} (:v envelope))
                      (map? (:edge envelope)))
         (invalid-cursor! "Invalid Relay cursor envelope."
                          {:reason :invalid-envelope}
@@ -472,7 +486,10 @@
              :cursor/expired? (boolean (:expired? decoded))
              :cursor/expired-at (:expired-at decoded)
              :cursor/scope-matches?
-             (= (cursor-scope adapter opts operation query)
+             (= ((if (= 11 (:v envelope))
+                   legacy-cursor-scope
+                   cursor-scope)
+                 adapter opts operation query)
                 (:scope envelope))))))
 
 (def ^:private execution-identity-fields

--- a/modules/eacl/src/eacl/verified_kernel.cljc
+++ b/modules/eacl/src/eacl/verified_kernel.cljc
@@ -314,7 +314,8 @@
     input))
 
 (def ^:private current-cache-stages
-  #{:eligibility :generation :exact-entry :managed-entry})
+  #{:eligibility :generation :exact-entry :snapshot-exact-entry
+    :managed-entry})
 
 (def ^:private current-cache-actions
   #{:bypass-current-cache
@@ -322,7 +323,9 @@
     :use-exact-entry
     :probe-managed-entry
     :use-managed-entry
-    :compute-current-value})
+    :compute-current-value
+    :use-snapshot-exact-entry
+    :compute-snapshot-exact-value})
 
 (defn- validate-current-cache-input!
   [input]
@@ -1863,6 +1866,11 @@
     (if available?
       :use-exact-entry
       :probe-managed-entry)
+
+    :snapshot-exact-entry
+    (if available?
+      :use-snapshot-exact-entry
+      :compute-snapshot-exact-value)
 
     :managed-entry
     (if available?

--- a/modules/eacl/test/eacl/cache_test.cljc
+++ b/modules/eacl/test/eacl/cache_test.cljc
@@ -162,6 +162,68 @@
              key :decision boolean?
              (constantly true)))))))
 
+(deftest snapshot-exact-completed-answer-cache-test
+  (let [store (cache/current-cache)
+        current-snapshot (snapshot-object)
+        semantic-key {:operation :can? :query [:alice :read :document]}
+        snapshot-key
+        (fn [lifecycle revision]
+          {:key-version 1
+           :backend :test
+           :source-scope {:source-id :source
+                          :branch nil
+                          :source-lifecycle lifecycle
+                          :backend :test}
+           :native-revision {:revision revision :exact-locator revision}
+           :exact-locator revision
+           :view-kind :ordinary-exact
+           :snapshot-id {:basis-t revision}
+           :adapter-fingerprint :adapter-v1
+           :identity-contract :identity-v1})
+        key-1 (snapshot-key :lifecycle-a 1)
+        key-2 (snapshot-key :lifecycle-a 2)
+        key-1-replaced (snapshot-key :lifecycle-b 1)
+        computations (atom 0)
+        exact
+        (fn [snapshot-key value]
+          (cache/resolve-exact!
+           store
+           {:snapshot-exact-key snapshot-key
+            :cache-basis (:snapshot-id snapshot-key)}
+           semantic-key :decision boolean?
+           (fn []
+             (swap! computations inc)
+             value)))]
+    (testing "a current answer seeds the matching authenticated exact tier"
+      (cache/resolve-current!
+       store
+       {:snapshot current-snapshot
+        :snapshot-order 1
+        :same-snapshot? identical?
+        :snapshot-exact-key key-1
+        :cache-basis {:basis-t 1}}
+       semantic-key :decision boolean? (constantly true))
+      (let [answer (exact key-1 false)]
+        (is (true? (:value answer)))
+        (is (true? (:cached? answer)))
+        (is (= :snapshot-exact (:cache-tier answer)))
+        (is (zero? @computations))))
+
+    (testing "different revisions and repeated numbers after lifecycle rotation cannot collide"
+      (is (false? (:value (exact key-2 false))))
+      (is (false? (:cached? (exact key-1-replaced false))))
+      (is (= 2 @computations))
+      (is (true? (:value (exact key-1 false)))
+          "the older retained snapshot remains independently addressable")
+      (is (false? (:value (exact key-2 true)))
+          "the newer retained snapshot keeps its own completed answer"))
+
+    (testing "explicit cache lifecycle expiry detaches every historical answer"
+      (cache/expire-current! store)
+      (is (false? (:cached? (exact key-1 false))))
+      (is (false? (:value (exact key-1 false))))
+      (is (= 3 @computations)))))
+
 (deftest current-generation-expiry-test
   (let [store (cache/current-cache)
         snapshot (snapshot-object)

--- a/modules/eacl/test/eacl/cache_test.cljc
+++ b/modules/eacl/test/eacl/cache_test.cljc
@@ -224,6 +224,117 @@
       (is (false? (:value (exact key-1 false))))
       (is (= 3 @computations)))))
 
+(defn- ordinary-exact-key
+  [revision]
+  {:key-version 1
+   :backend :test
+   :source-scope {:source-id :source
+                  :branch nil
+                  :source-lifecycle :lifecycle-a
+                  :backend :test}
+   :native-revision {:revision revision :exact-locator revision}
+   :exact-locator revision
+   :view-kind :ordinary-exact
+   :snapshot-id {:basis-t revision}
+   :adapter-fingerprint :adapter-v1
+   :identity-contract :identity-v1})
+
+(deftest snapshot-exact-retention-does-not-republish-on-every-hit-test
+  (let [store (cache/current-cache)
+        snapshot (snapshot-object)
+        semantic-key {:operation :can? :query [:alice :read :document]}
+        current
+        (fn []
+          (cache/resolve-current!
+           store
+           {:snapshot snapshot
+            :snapshot-order 1
+            :same-snapshot? identical?
+            :snapshot-exact-key (ordinary-exact-key 1)
+            :cache-basis {:basis-t 1}}
+           semantic-key :decision boolean? (constantly true)))]
+    (dotimes [_ 8] (current))
+    (let [stats (get-in (cache/current-cache-stats store)
+                        [:snapshot-exact :tiers :answer])
+          races (:publication-races
+                 (get (cache/current-cache-stats store) :snapshot-exact))]
+      (is (= 1 (:entries stats))
+          "the first computation still seeds the snapshot-exact tier")
+      (is (zero? (or races 0))
+          "a cache hit must not republish an answer the tier already holds"))))
+
+(deftest snapshot-exact-bypasses-an-unkeyable-adapter-test
+  (let [store (cache/current-cache)
+        computations (atom 0)
+        resolve-with
+        (fn [snapshot-key]
+          (cache/resolve-exact!
+           store
+           {:snapshot-exact-key snapshot-key :cache-basis {:basis-t 1}}
+           {:operation :can?} :decision boolean?
+           (fn [] (swap! computations inc) true)))]
+    (testing "a view that cannot mint a canonical identity computes uncached"
+      (doseq [unkeyable [nil
+                         (dissoc (ordinary-exact-key 1) :adapter-fingerprint)
+                         (assoc (ordinary-exact-key 1)
+                                :view-kind :filtered-view)]]
+        (let [answer (resolve-with unkeyable)]
+          (is (true? (:value answer)))
+          (is (false? (:cached? answer)))
+          (is (nil? (:cache-tier answer))
+              "an unkeyable snapshot bypasses the tier instead of failing"))))
+    (is (= 3 @computations))
+    (is (= 3 (:bypasses (cache/current-cache-stats store))))))
+
+(deftest snapshot-exact-hit-reports-the-selected-basis-test
+  (let [store (cache/current-cache)
+        snapshot (snapshot-object)
+        semantic-key {:operation :can? :query [:alice :read :document]}
+        key-1 (ordinary-exact-key 1)]
+    ;; Seed the tier from a current answer whose recorded basis is deliberately
+    ;; older than the basis a later exact request selects, as a proof-lifted
+    ;; managed answer would be.
+    (cache/resolve-current!
+     store
+     {:snapshot snapshot
+      :snapshot-order 1
+      :same-snapshot? identical?
+      :snapshot-exact-key key-1
+      :cache-basis {:basis-t :stale-origin}}
+     semantic-key :decision boolean? (constantly true))
+    (let [answer
+          (cache/resolve-exact!
+           store
+           {:snapshot-exact-key key-1 :cache-basis {:basis-t 1}}
+           semantic-key :decision boolean? (constantly false))]
+      (is (true? (:cached? answer)))
+      (is (= {:basis-t 1} (:cache-basis answer))
+          "cache basis is rebuilt from the selected snapshot, not copied"))))
+
+(deftest nested-answers-weigh-more-than-scalar-answers-test
+  (let [snapshot (snapshot-object)
+        tree {:expanded-object {:type :document :id "doc"}
+              :leaf {:subjects (mapv (fn [i]
+                                       {:type :user :id (str "u" i)})
+                                     (range 200))}}
+        weight-of
+        (fn [value]
+          (let [store (cache/current-cache)]
+            (cache/resolve-current!
+             store
+             {:snapshot snapshot
+              :snapshot-order 1
+              :same-snapshot? identical?
+              :cache-basis {:basis-t 1}}
+             {:operation :expand-permission-tree} :permission-tree
+             map? (constantly value))
+            (get-in (cache/current-cache-stats store)
+                    [:subproblems :tiers :answer :weight])))]
+    (is (> (weight-of tree) (weight-of {:leaf {:subjects []}}))
+        "a large nested answer must not weigh the same as an empty one")
+    (is (> (weight-of tree) (* 100 128))
+        "weight scales with the retained subjects, not a flat floor")))
+
 (deftest current-generation-expiry-test
   (let [store (cache/current-cache)
         snapshot (snapshot-object)

--- a/modules/eacl/test/eacl/formal/cache_strategy_adversarial_test.cljc
+++ b/modules/eacl/test/eacl/formal/cache_strategy_adversarial_test.cljc
@@ -478,37 +478,50 @@
          (stale-envelope-mutant selected-snapshot entry))
         "copying computation-snapshot metadata retains a mismatch")))
 
-(deftest completed-cache-is-current-snapshot-only-test
-  (let [current-cache
-        {:mode :current
-         :generation 100
-         :entries {[:can? :q] true}}
-        exact-request
-        {:mode :at-exact-snapshot
-         :generation 90
-         :query [:can? :q]}
+(deftest completed-cache-requires-canonical-snapshot-identity-test
+  (let [identity
+        (fn [lifecycle revision view-kind]
+          {:source-scope :source-a
+           :source-lifecycle lifecycle
+           :native-revision revision
+           :exact-locator revision
+           :view-kind view-kind
+           :adapter-fingerprint :adapter-v1
+           :identity-contract :identity-v1})
+        identity-100 (identity :lifecycle-a 100 :ordinary-exact)
+        exact-cache
+        {:current-generation identity-100
+         :entries {[identity-100 [:can? :q]] true}}
         completed-cache-lookup
         (fn [cache request]
-          (when (and (= :current (:mode request))
-                     (= (:generation cache)
-                        (:generation request)))
-            (get-in cache [:entries (:query request)])))]
+          (let [request-identity (:snapshot-identity request)]
+            (when (and (#{:current :at-exact-snapshot} (:mode request))
+                       (= :ordinary-exact (:view-kind request-identity)))
+              (get-in cache [:entries [request-identity (:query request)]]))))]
+    (is (true? (completed-cache-lookup
+                exact-cache
+                {:mode :at-exact-snapshot
+                 :snapshot-identity identity-100
+                 :query [:can? :q]}))
+        "an authenticated exact request may reuse its identical snapshot")
     (is (nil? (completed-cache-lookup
-               current-cache
-               exact-request))
-        "at-exact-snapshot always bypasses the completed-answer cache")
-    (is (nil? (completed-cache-lookup
-               current-cache
+               exact-cache
                {:mode :current
-                :generation 101
+                :snapshot-identity
+                (identity :lifecycle-a 101 :ordinary-exact)
                 :query [:can? :q]}))
         "a newer current snapshot cannot read the old exact generation")
-    (is (true? (completed-cache-lookup
-                current-cache
-                {:mode :current
-                 :generation 100
-                 :query [:can? :q]}))
-        "the current generation remains a hot cache")
-    (is (= [:can? :q]
-           (first (keys (:entries current-cache))))
-        "database identity is bound by the client cache instance, not every key")))
+    (is (nil? (completed-cache-lookup
+               exact-cache
+               {:mode :at-exact-snapshot
+                :snapshot-identity
+                (identity :lifecycle-b 100 :ordinary-exact)
+                :query [:can? :q]}))
+        "numeric revision equality cannot cross lifecycle replacement")
+    (is (nil? (completed-cache-lookup
+               exact-cache
+               {:mode :at-exact-snapshot
+                :snapshot-identity
+                (identity :lifecycle-a 100 :filtered-view)
+                :query [:can? :q]}))
+        "an arbitrary view cannot masquerade as an ordinary exact snapshot")))

--- a/modules/eacl/test/eacl/formal/mutation_control_test.clj
+++ b/modules/eacl/test/eacl/formal/mutation_control_test.clj
@@ -140,6 +140,19 @@
     (and (= :probe-managed-entry correct)
          (not= correct mutant))))
 
+(defn- snapshot-exact-key-omits-lifecycle-killed?
+  []
+  (let [base {:backend :datomic
+              :source :database-a
+              :native-revision 100
+              :exact-locator 100
+              :view-kind :ordinary-exact}
+        before (assoc base :source-lifecycle :lifecycle-a)
+        after (assoc base :source-lifecycle :lifecycle-b)
+        mutant-key #(dissoc % :source-lifecycle)]
+    (and (not= before after)
+         (= (mutant-key before) (mutant-key after)))))
+
 (defn- mismatched-indexed-request-scope-response-killed?
   []
   (let [pending
@@ -1255,6 +1268,8 @@
    immediate-reverse-consumer-registration-killed?
    :current-cache-missing-entry-hit
    current-cache-missing-entry-hit-killed?
+   :snapshot-exact-key-omits-lifecycle
+   snapshot-exact-key-omits-lifecycle-killed?
    :mismatched-indexed-request-scope-response
    mismatched-indexed-request-scope-response-killed?
    :ordered-merge-wrong-comparator

--- a/modules/eacl/test/eacl/relay_test.cljc
+++ b/modules/eacl/test/eacl/relay_test.cljc
@@ -2,6 +2,7 @@
   (:require [#?(:clj clojure.test :cljs cljs.test)
              :refer [deftest is testing]]
             [eacl.backend.v8 :as backend]
+            [eacl.cache :as cache]
             [eacl.core :as eacl]
             [eacl.cursor :as cursor]
             [eacl.relay :as relay]
@@ -40,13 +41,23 @@
   [snapshot-id exact]
   (backend/make-adapter
    {:id :relay-test
-    :capabilities {:snapshots #{:historical}}
+    :capabilities {:consistency #{:at-exact-snapshot}
+                   :snapshots #{:historical}}
     :fingerprint {:adapter :relay-test}
     :deterministic? true
     :operations
     (assoc
      (operation-map snapshot-id nil)
      :select-exact (fn [& _] exact))}))
+
+(deftest snapshot-exact-key-requires-certified-exact-selection-test
+  (let [current-only (adapter 1 nil true)
+        exact-capable (adapter-with-exact 1 current-only)]
+    (is (nil? (cache/snapshot-exact-key current-only))
+        "a current-only or arbitrary immutable view cannot infer exact identity from revision equality")
+    (is (= :ordinary-exact
+           (:view-kind (cache/snapshot-exact-key exact-capable))))
+    (is (= 1 (:exact-locator (cache/snapshot-exact-key exact-capable))))))
 
 (deftest cursor-proof-identity-test
   (testing "even equal dependency proofs cannot lift across revisions"
@@ -270,6 +281,28 @@
     (is (pos? (get @crossings :cursor-continuation 0))
         "the expired token was rejected by a :cursor-continuation kernel decision")))
 
+(deftest cursor-without-configured-ttl-remains-age-valid-test
+  (let [snapshot (adapter 1 nil true)
+        page
+        (relay/externalize-page
+         snapshot {:now-seconds 1000}
+         :lookup-resources lookup-query lookup-page)
+        token (get-in page [:page-info :end-cursor])
+        prepared
+        (relay/prepare-page-query
+         snapshot
+         {:now-seconds 1000000}
+         :lookup-resources
+         (assoc lookup-query :after token))]
+    (is (identical? snapshot (:adapter prepared)))
+    (is (= {:frontier-direction :asc
+            :kind :lookup-eid
+            :result-eid "document-1"}
+           (get-in prepared [:query :after]))
+        "the old authenticated transport is internalized to its exact boundary")
+    (is (not (contains? (:cursor-context (:opts prepared)) :exp))
+        "elapsed age far beyond five minutes is irrelevant without an explicit TTL")))
+
 (deftest exact-snapshot-continuation-never-rebases-test
   (let [exact (adapter 1 nil true)
         current (adapter-with-exact 2 exact)
@@ -294,6 +327,25 @@
                 (get-in page [:page-info :end-cursor])))]
     (is (identical? exact (:adapter prepared)))
     (is (not (contains? prepared :recovery)))))
+
+(deftest changed-current-schema-reaches-exact-cursor-fallback-test
+  (let [exact (adapter 1 nil true)
+        current (adapter-with-exact 2 exact)
+        page
+        (relay/externalize-page
+         exact
+         {:cursor-schema-stamp {:adapter exact :stamp (delay 10)}}
+         :lookup-resources lookup-query lookup-page)
+        prepared
+        (relay/prepare-page-query
+         current
+         {:cursor-consistency-mode :minimize-latency
+          :cursor-schema-stamp {:adapter current :stamp (delay 20)}}
+         :lookup-resources
+         (assoc lookup-query
+                :after (get-in page [:page-info :end-cursor])))]
+    (is (identical? exact (:adapter prepared))
+        "schema proof changes must not masquerade as query-scope changes")))
 
 (deftest one-page-builds-one-snapshot-context-test
   (let [native-revision-calls (atom 0)

--- a/openspec/changes/sync-datomic-exact-snapshots/.openspec.yaml
+++ b/openspec/changes/sync-datomic-exact-snapshots/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/sync-datomic-exact-snapshots/design.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/design.md
@@ -1,0 +1,130 @@
+## Context
+
+EACL authenticates and scope-checks an exact-snapshot token before invoking a backend adapter's `:select-exact` operation. Datomic currently reads `(d/db conn)` and calls `d/as-of` only when the token locator is no greater than that local database's basis. A same-source token produced through another Peer can therefore name a committed basis that exists in Datomic but is still ahead of this Peer; the adapter returns `nil` and shared validation misreports replica lag as exact-snapshot unavailability.
+
+Datomic documents two-argument `d/sync` and `d/as-of` as complementary operations: sync ensures a local connection has reached at least `T`, while as-of filters an observed database to no later than `T`. Numeric `d/as-of` does not validate that the backing database has reached `T`; EACL must establish that postcondition first. The returned Datomic `ListenableFuture` is a `java.util.concurrent.Future` and must be cancelled when EACL stops waiting.
+
+Ordinary Datomic history has no SpiceDB-style GC window. Datahike can likewise reconstruct arbitrary historical revisions when `:keep-history? true`; when history is disabled it may instead rely on commit records that cutoff garbage collection can remove. Cursor lifetime and exact-answer cache eligibility must follow these actual backend facts rather than SpiceDB's retention policy.
+
+The current completed cache has an exact tier, but orchestration marks every `:at-exact-snapshot` request uncacheable because the tier is implemented as one current generation. That protects against arbitrary historical views and current-only managed proofs, but it also discards a safe hit when the selected authenticated snapshot and semantic request exactly match a retained answer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make valid same-source Datomic exact tokens portable between Peers at different locally observed bases.
+- Evaluate exactly at the authenticated basis after bounded, cancellable catch-up.
+- Give full-history Datomic and Datahike cursors no default age limit.
+- Preserve explicit invalidation through key retirement, format/ABI incompatibility, source-lifecycle rotation, and genuine history unavailability.
+- Reuse completed answers only when their canonical snapshot identity and complete semantic request equal the selected exact request.
+- Preserve bounded memory and execution: cache/checkpoint eviction causes recomputation or replay, and deadlines/resource ceilings remain enforceable.
+
+**Non-Goals:**
+
+- Removing causal-token TTL or changing its authenticated wire format.
+- Making a cursor represent current authorization after it has deliberately pinned an older enumeration.
+- Adding arbitrary historical support to DataScript.
+- Reusing managed proof-backed answers across snapshots for `:at-exact-snapshot`.
+- Supporting concurrent Datomic excision, Datahike purge, restore, reset, or history replacement without quiescence and source-lifecycle rotation.
+- Making an arbitrary unauthenticated transaction number a valid exact locator.
+
+## Decisions
+
+### 1. Catch up to an authenticated Datomic basis before applying `d/as-of`
+
+For a Datomic exact locator `T`:
+
+1. Authentication, TTL, backend/source scope, and source lifecycle are validated before the adapter is invoked.
+2. The Datomic adapter requires an integer locator and the Datomic invariant `revision == exact-locator`; malformed or contradictory payloads fail before synchronization.
+3. Read one current local database.
+4. If `T <= basis(local-db)`, use that database without synchronization.
+5. If `T > basis(local-db)`, retain the future returned by `(d/sync conn T)`, dereference it using the remaining consistency/request deadline, and cancel it on timeout or interruption.
+6. Verify `basis(caught-up-db) >= T`.
+7. Construct the selected adapter from `(d/as-of caught-up-db T)` and report both native revision and exact locator as `T`.
+8. Shared consistency validation independently verifies exact equality and source identity.
+
+Targeted sync is preferred to zero-argument sync because the authenticated token already supplies the required causal point. The selected caught-up head is never evaluated directly when it is newer than `T`.
+
+### 2. Model real errors, not a Datomic retention window
+
+| Condition | Public classification |
+| --- | --- |
+| Authenticated causal-token TTL elapsed | Existing `:eacl.consistency/token-expired` |
+| Malformed, negative, contradictory, or non-Datomic locator | Existing invalid-token family |
+| Targeted synchronization exceeds its bound | `:eacl.consistency/freshness-unavailable`, reason `:freshness-timeout` |
+| Synchronization returns below `T` | `:eacl.consistency/freshness-unavailable`, reason `:head-behind` |
+| Wait is interrupted | Cancel waiter, preserve thread interruption, and throw classified cancellation |
+| Unexpected synchronization, storage, or selection failure | Classified retryable selection/provider failure with cause and phase |
+| Restore, reset, excision, purge, branch replacement, or destructive history rewrite | Reject through rotated source lifecycle; operation is outside the unchanged-lifecycle contract |
+| Datahike history-disabled configuration loses a retained commit | Exact-snapshot unavailable; cursor boundary may expose its established unavailable/stale form |
+
+Within an unreplaced ordinary Datomic history, an authentic same-source EACL token names a committed `T`; a locally future `T` is lag, not out of range. Datomic `:select-exact` therefore does not return `nil` merely because `T` is ahead locally and does not manufacture storage-expiry errors.
+
+An authoritative check could distinguish a signer defect that names a transaction beyond the transactor head, but it would add a transactor round trip to an otherwise targeted synchronization path. Authenticated EACL issuance makes that state impossible under the supported lifecycle, so bounded freshness failure is the safe operational outcome unless a future design introduces an explicit signer-diagnostics mode.
+
+### 3. Cursor TTL is optional policy, not history availability
+
+Cursor envelopes remain authenticated, query-bound tokens. Without `:cursor-ttl-seconds`, minting omits expiry and decoding imposes no age check. With a configured positive TTL, the existing expired-cursor error remains unchanged.
+
+A full-history cursor binds the operation, complete normalized query/principal, ordering ABI, adapter/identity contract, source lifecycle, exact native revision/locator, dependency or exact-snapshot proof, and stable boundary. It may continue on a proof-equivalent current snapshot or reconstruct the original exact snapshot. Ordinary forward schema or relationship changes may force exact reconstruction but do not invalidate the original cursor.
+
+Schema generation belongs to dependency/exact-snapshot identity, not to the immutable query-scope digest used before recovery. Otherwise comparing a cursor against the current schema rejects it before EACL can select and validate the cursor's original historical schema.
+
+Private checkpoints are acceleration only. A miss or eviction deterministically replays the authenticated prefix against the selected exact snapshot and validates ordinal plus boundary identity before publishing a page. Replay deadline/resource failures remain typed deadline/resource outcomes, not expiry.
+
+An old cursor intentionally returns the remainder of its original enumeration. Applications that require current authorization when consuming each object must perform a current permission check; an optional cursor TTL is an application policy for limiting historical enumeration, not a storage correctness mechanism.
+
+### 4. Make Datahike's durable-history contract configuration-honest
+
+EACL-created Datahike databases will enable `:keep-history? true` by default so their ordinary contract matches durable exact replay. Temporal `d/as-of` is the durable fallback even when a named commit record is absent or the commit graph is disabled.
+
+Externally supplied Datahike databases remain configuration-specific:
+
+- `:keep-history? true`: exact revisions and cursors are durable across ordinary forward history and commit-record GC.
+- history disabled with retained commit graph: exact reconstruction is available only while the named commit remains retained.
+- neither temporal history nor retained exact commits: do not advertise exact-snapshot capability.
+
+Cutoff GC, purge, branch force, and source replacement must rotate EACL's source lifecycle when they can invalidate or reinterpret prior exact locators.
+
+### 5. Allow snapshot-exact answer reuse without managed lifting
+
+An exact request may probe and populate a bounded snapshot-exact completed-answer tier after exact selection succeeds. Eligibility requires equality of a canonical snapshot key containing at least:
+
+- backend and stable source/branch identity;
+- configured source lifecycle;
+- native revision and exact locator;
+- ordinary exact-view kind;
+- adapter fingerprint and identity contract;
+- engine/order ABI, normalized semantic request, result kind/shape, evaluation demand, and answer-affecting limits.
+
+The exact entry stores only the completed semantic answer. Response tokens, cursor envelopes, cache basis, external rendering context, and other public metadata are rebuilt from the selected adapter on every request.
+
+`at-exact-snapshot` never probes or publishes to the managed cross-snapshot tier and never validates an old answer using current-only relation/schema stamps. A miss evaluates on the already selected immutable exact adapter and may publish to the snapshot-exact tier. The tier is bounded by weight/LRU/admission policy; eviction is a miss, not snapshot unavailability.
+
+The current one-generation exact store may be replaced by a bounded map of snapshot-exact generations or by an equivalently safe composite-key answer store. The representation is not normative. A newer current request must not see an older exact entry, while an explicit request selecting that older canonical snapshot may see it if retained.
+
+### 6. Preserve verification boundaries and state the unproved effect
+
+The generated exact-selection decision already verifies presence, adapter validity, source equality, and exact revision/locator equality. It does not prove Datomic I/O effects, future cancellation, temporal-history retention, or cache-key truthfulness. Those remain adapter/certification obligations covered by deterministic effect tests, real backend integration tests, and the assurance matrix.
+
+Formal cache decisions must distinguish snapshot-exact equality from managed proof equality. No proof artifact may imply that an equal numeric revision alone identifies an exact snapshot across lifecycle replacement or arbitrary DB views.
+
+## Risks / Trade-offs
+
+- [A far-future authenticated basis can hold a waiter] -> Bound it by the existing deadline and cancel the Datomic future on every timeout/interruption path.
+- [Full Datahike temporal history increases write/storage cost] -> Make the durable-history benefit explicit; externally configured history-off stores retain their lower-cost conditional capability.
+- [Non-expiring cursors require old keys and format support] -> Key retirement and unsupported versions remain explicit invalidation events; operators choose their compatibility window independently of database history.
+- [Historical exact answers increase cache cardinality] -> Use one bounded weighted/LRU tier; retention is an optimization and never part of correctness.
+- [Excision or purge can change the meaning of the same locator] -> Require quiescence, completion, and source-lifecycle rotation before traffic resumes.
+- [Custom identity conversion may depend on non-historical data] -> Exact reuse requires the adapter identity contract/fingerprint; unsupported history-discarding dependencies fail certification or bypass cache/replay.
+- [Very deep cursor replay may be expensive after checkpoint eviction] -> Preserve request deadlines and replay admission; return resource/deadline errors without expiring or rebasing the cursor.
+
+## Migration Plan
+
+Implement adapter/cache/cursor changes behind existing public options. Datomic clients that omitted `:cursor-ttl-seconds` change from five-minute expiry to no expiry; deployments wanting the old policy set `{:cursor-ttl-seconds 300}` explicitly. EACL-created Datahike databases enable temporal history by default; existing databases retain their stored configuration and capability-specific behavior.
+
+Regenerate the public-source closure ledger after source/assurance edits, run targeted Datomic/Datahike/shared suites through nREPL, run the CI-equivalent non-benchmark battery, then run the ClojureScript build last if shared CLJC changed. Validate the OpenSpec change strictly and record the real-backend multi-Peer/history-GC evidence.
+
+## Open Questions
+
+None for semantics. The implementation may choose the simplest bounded representation for multiple snapshot-exact answer generations, provided the canonical key and no-managed-lifting requirements are preserved.

--- a/openspec/changes/sync-datomic-exact-snapshots/proposal.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+A valid same-source Datomic exact-snapshot token can name a committed basis that a lagging Peer has not observed yet. EACL currently treats that locally future basis as unavailable instead of first catching the Peer up.
+
+The audit also found two unnecessary losses of the stronger semantics available from immutable full-history backends:
+
+- Datomic cursors expire after five minutes by default even though ordinary Datomic history remains exactly reconstructible; Datahike and the shared cursor specification already default to no cursor expiry.
+- `:at-exact-snapshot` bypasses the completed-answer cache even when it contains an answer computed for the same authenticated immutable snapshot and semantic request.
+
+These are implementation restrictions, not requirements of snapshot-stable authorization. Within one unreplaced full-history source lifecycle, EACL can catch a lagging reader up, evaluate exactly at `T`, replay query-bound cursors without an age limit, and reuse only answers proven to belong to that exact snapshot.
+
+## What Changes
+
+- Make Datomic `:at-exact-snapshot` selection compare the authenticated token basis with the current local Peer basis.
+- When the token basis is newer, perform bounded targeted `d/sync` to that basis, cancel the returned future on timeout or interruption, verify the reached basis, and then apply `d/as-of` exactly at the token basis.
+- Remove speculative Datomic storage-expiry/out-of-range classification. Token expiry remains a distinct authenticated-envelope rule; malformed locators are invalid tokens; catch-up failures remain typed freshness or selection failures.
+- Make cursor expiry optional and off by default for every backend. Datomic and full-history Datahike cursors remain replayable across ordinary forward transactions for as long as their key, source lifecycle, format/ABI, and exact history remain valid.
+- Make EACL-created Datahike databases retain temporal history by default. History-disabled or cutoff-GC configurations may advertise only their actual retained-commit behavior and may report exact snapshot unavailability when a named commit is genuinely gone.
+- Permit `:at-exact-snapshot` to probe and populate a bounded snapshot-exact completed-answer tier keyed by authenticated canonical snapshot identity plus the complete semantic request. It must never use the managed cross-snapshot tier.
+- Keep checkpoint and completed-answer retention as bounded optimizations: eviction causes deterministic exact replay or recomputation, never cursor expiry or a fall-forward to another snapshot.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `backend-native-revision-consistency`: Datomic exact selection catches up to a locally newer authenticated basis and distinguishes token invalidity/expiry, freshness failure, provider failure, and lifecycle replacement without inventing a Datomic retention window. Datahike durable exact-history claims depend on temporal-history configuration.
+- `cursor-token-handling`: Cursor TTL remains configurable but defaults to no expiry uniformly, including Datomic.
+- `snapshot-stable-pagination`: A query-bound cursor on a full-history backend can reconstruct its original schema, graph, and position without age-based invalidation; query scope must not reject exact fallback merely because the current schema generation changed.
+- `forward-history-cache-coherence`: Authenticated exact requests may use only completed answers bound to the identical canonical snapshot and semantic request; managed cross-snapshot reuse remains current-only.
+
+## Impact
+
+- Datomic selection and cursor encoding in `modules/eacl-datomic/src/eacl/datomic/backend.clj` and `modules/eacl-datomic/src/eacl/datomic/core.clj`.
+- Datahike default history configuration and exact capability behavior in `modules/eacl-datahike`.
+- Shared cursor scope/recovery and completed-answer cache orchestration in `modules/eacl`.
+- Datomic/Datahike integration tests, shared cursor/cache contract tests, and formal/assurance fixtures that classify selection, continuation, or cache outcomes.
+- README, backend, cursor, consistency, cache, and operational lifecycle documentation.
+
+The public request shapes and cursor/token formats remain compatible: cursor expiry fields stay optional, configured TTLs remain enforced, and old authenticated cursor versions continue according to their existing version/key policy.

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/backend-native-revision-consistency/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/backend-native-revision-consistency/spec.md
@@ -1,0 +1,87 @@
+## MODIFIED Requirements
+
+### Requirement: Datomic forward-history selection
+Within one unreplaced Datomic database history, EACL SHALL use authenticated database scope and transaction `t` as the native causal floor, targeted synchronization for at-least selection and for an exact token basis ahead of the local Peer, and `d/as-of` selection only for explicit exact-snapshot behavior. An authentic same-source exact basis that is ahead of one Peer SHALL be treated as propagation lag, not as an expired or out-of-range snapshot.
+
+#### Scenario: Peer is behind requested floor
+- **WHEN** a Datomic Peer receives an at-least token whose `t` is ahead of its locally observed database
+- **THEN** EACL performs bounded targeted synchronization and selects a database with basis at least that `t` or returns a typed freshness failure
+
+#### Scenario: Peer is behind requested exact basis
+- **WHEN** a Datomic Peer receives an authenticated same-source exact token whose `t` is ahead of its locally observed database
+- **THEN** EACL performs bounded two-argument `d/sync` to `t`
+- **AND** verifies that the synchronized database has basis at least `t`
+- **AND** applies `d/as-of` so authorization evaluates exactly at `t`
+
+#### Scenario: Exact basis is already local
+- **WHEN** an authenticated same-source exact token names `t` at or below the locally observed Datomic basis
+- **THEN** EACL does not invoke `d/sync`
+- **AND** selects the exact `d/as-of` database at `t`
+
+#### Scenario: Exact catch-up times out
+- **WHEN** a Datomic Peer does not observe an authenticated exact token basis before the bounded consistency deadline
+- **THEN** EACL cancels the targeted-sync future
+- **AND** throws `:eacl.consistency/freshness-unavailable` with reason `:freshness-timeout`
+- **AND** does not report the exact snapshot as expired or evaluate a different basis
+
+#### Scenario: Exact catch-up is interrupted
+- **WHEN** the request thread is interrupted while waiting for an exact basis
+- **THEN** EACL cancels the targeted-sync future and preserves interruption
+- **AND** throws a classified cancellation rather than snapshot expiry
+
+#### Scenario: Exact synchronization returns behind the token
+- **WHEN** targeted synchronization completes with a database whose basis is below the authenticated exact token basis
+- **THEN** EACL throws `:eacl.consistency/freshness-unavailable` with reason `:head-behind` and the requested and observed bases
+- **AND** does not call `d/as-of` on the insufficient database
+
+#### Scenario: Datomic token fields contradict one another
+- **WHEN** an authenticated payload supplied to Datomic has a non-integer locator or its native revision differs from its exact locator
+- **THEN** EACL rejects it as an invalid or contradictory token before synchronization
+
+#### Scenario: Exact selection provider fails
+- **WHEN** synchronization, storage access, or exact reconstruction fails unexpectedly
+- **THEN** EACL preserves a typed freshness or retryable selection failure with its phase and cause
+- **AND** does not return `nil` or misreport the failure as snapshot expiry
+
+#### Scenario: Ordinary Datomic history grows older
+- **WHEN** an authenticated unexpired token names an older `t` in the same unreplaced ordinary Datomic history
+- **THEN** age alone does not make the exact snapshot unavailable
+- **AND** EACL selects `d/as-of` at that `t`
+
+#### Scenario: Datomic history is destructively rewritten
+- **WHEN** restore, reset, excision, or another operation can change the meaning of an old exact locator
+- **THEN** operators quiesce affected traffic and rotate the configured source lifecycle before resuming
+- **AND** old tokens/cursors fail lifecycle comparison rather than being reinterpreted or reported as age-expired
+
+#### Scenario: Ordinary current request
+- **WHEN** a caller requests minimize-latency or fully-consistent current behavior
+- **THEN** EACL does not call `d/as-of` merely to validate or reuse an answer
+
+### Requirement: Backend capability honesty
+Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, durable-history, and ordered-generation proof operations supported by its configured backend. Exact selection from conditionally retained commits SHALL remain distinguishable from durable temporal-history reconstruction. Unsupported consistency modes SHALL be rejected before cache access.
+
+#### Scenario: Datahike temporal history is enabled
+- **WHEN** a Datahike source has `:keep-history? true`
+- **THEN** EACL may advertise durable exact reconstruction by native revision even when a named commit record is absent
+- **AND** cutoff collection of commit records does not expire an exact cursor whose temporal history remains available
+
+#### Scenario: Datahike relies only on retained commits
+- **WHEN** Datahike temporal history is disabled but its commit graph supports exact commit loading
+- **THEN** EACL may advertise conditional exact selection
+- **AND** a genuinely collected named commit returns exact-snapshot unavailable rather than a provider-failure or substituted snapshot
+
+#### Scenario: Datahike cannot reconstruct exact history
+- **WHEN** neither temporal history nor retained exact commits are available
+- **THEN** the adapter does not advertise `:at-exact-snapshot`
+
+#### Scenario: DataScript current-only source
+- **WHEN** a DataScript connection cannot reconstruct arbitrary prior immutable values
+- **THEN** its adapter does not advertise `:at-exact-snapshot` and never retains hidden historical values to emulate it
+
+#### Scenario: Ordered-generation proof is not certified
+- **WHEN** an adapter cannot certify complete dependency reads and globally ordered native relation generations
+- **THEN** native revision and snapshot-exact operations may remain available while cross-snapshot managed answer reuse fails closed
+
+#### Scenario: Completed-answer cache is disabled
+- **WHEN** a client disables completed-answer caching but its adapter and lifecycle support native revision operations
+- **THEN** EACL may still issue and select authenticated native revision tokens and reconstruct exact cursors

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/backend-native-revision-consistency/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/backend-native-revision-consistency/spec.md
@@ -5,7 +5,7 @@ Within one unreplaced Datomic database history, EACL SHALL use authenticated dat
 
 #### Scenario: Peer is behind requested floor
 - **WHEN** a Datomic Peer receives an at-least token whose `t` is ahead of its locally observed database
-- **THEN** EACL performs bounded targeted synchronization and selects a database with basis at least that `t` or returns a typed freshness failure
+- **THEN** EACL performs a bounded targeted synchronization and selects a database with basis at least that `t` or returns a typed timeout or unavailable error
 
 #### Scenario: Peer is behind requested exact basis
 - **WHEN** a Datomic Peer receives an authenticated same-source exact token whose `t` is ahead of its locally observed database
@@ -18,70 +18,53 @@ Within one unreplaced Datomic database history, EACL SHALL use authenticated dat
 - **THEN** EACL does not invoke `d/sync`
 - **AND** selects the exact `d/as-of` database at `t`
 
-#### Scenario: Exact catch-up times out
-- **WHEN** a Datomic Peer does not observe an authenticated exact token basis before the bounded consistency deadline
+#### Scenario: Exact catch-up times out or is interrupted
+- **WHEN** the local Peer does not observe `t` before the consistency bound, or the wait is interrupted
 - **THEN** EACL cancels the targeted-sync future
-- **AND** throws `:eacl.consistency/freshness-unavailable` with reason `:freshness-timeout`
-- **AND** does not report the exact snapshot as expired or evaluate a different basis
-
-#### Scenario: Exact catch-up is interrupted
-- **WHEN** the request thread is interrupted while waiting for an exact basis
-- **THEN** EACL cancels the targeted-sync future and preserves interruption
-- **AND** throws a classified cancellation rather than snapshot expiry
+- **AND** returns typed freshness timeout or cancellation without calling `d/as-of`
 
 #### Scenario: Exact synchronization returns behind the token
-- **WHEN** targeted synchronization completes with a database whose basis is below the authenticated exact token basis
-- **THEN** EACL throws `:eacl.consistency/freshness-unavailable` with reason `:head-behind` and the requested and observed bases
-- **AND** does not call `d/as-of` on the insufficient database
+- **WHEN** targeted synchronization returns a database whose basis is below `t`
+- **THEN** EACL returns `:eacl.consistency/freshness-unavailable` with reason `:head-behind`, requested and observed bases
+- **AND** performs no authorization evaluation
 
 #### Scenario: Datomic token fields contradict one another
-- **WHEN** an authenticated payload supplied to Datomic has a non-integer locator or its native revision differs from its exact locator
-- **THEN** EACL rejects it as an invalid or contradictory token before synchronization
-
-#### Scenario: Exact selection provider fails
-- **WHEN** synchronization, storage access, or exact reconstruction fails unexpectedly
-- **THEN** EACL preserves a typed freshness or retryable selection failure with its phase and cause
-- **AND** does not return `nil` or misreport the failure as snapshot expiry
+- **WHEN** the locator is not a non-negative integer or native revision differs from exact locator
+- **THEN** EACL rejects the token before storage or synchronization
 
 #### Scenario: Ordinary Datomic history grows older
 - **WHEN** an authenticated unexpired token names an older `t` in the same unreplaced ordinary Datomic history
 - **THEN** age alone does not make the exact snapshot unavailable
-- **AND** EACL selects `d/as-of` at that `t`
-
-#### Scenario: Datomic history is destructively rewritten
-- **WHEN** restore, reset, excision, or another operation can change the meaning of an old exact locator
-- **THEN** operators quiesce affected traffic and rotate the configured source lifecycle before resuming
-- **AND** old tokens/cursors fail lifecycle comparison rather than being reinterpreted or reported as age-expired
 
 #### Scenario: Ordinary current request
 - **WHEN** a caller requests minimize-latency or fully-consistent current behavior
-- **THEN** EACL does not call `d/as-of` merely to validate or reuse an answer
+- **THEN** EACL does not call `d/as-of` merely to validate or reuse a completed answer
 
 ### Requirement: Backend capability honesty
-Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, durable-history, and ordered-generation proof operations supported by its configured backend. Exact selection from conditionally retained commits SHALL remain distinguishable from durable temporal-history reconstruction. Unsupported consistency modes SHALL be rejected before cache access.
+Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, durable-history, and ordered-generation proof operations supported by its configured backend and SHALL reject unsupported consistency modes before cache access. Exact selection from conditionally retained commits SHALL remain distinguishable from durable temporal-history reconstruction. Native revision capability SHALL remain independent of completed-answer caching and SHALL NOT depend on a cache-authority or proof-mode option.
 
 #### Scenario: Datahike temporal history is enabled
 - **WHEN** a Datahike source has `:keep-history? true`
-- **THEN** EACL may advertise durable exact reconstruction by native revision even when a named commit record is absent
-- **AND** cutoff collection of commit records does not expire an exact cursor whose temporal history remains available
+- **THEN** EACL advertises durable exact reconstruction by native revision even when a named commit record is absent
+- **AND** cutoff collection of commit records does not expire an exact cursor
 
 #### Scenario: Datahike relies only on retained commits
 - **WHEN** Datahike temporal history is disabled but its commit graph supports exact commit loading
-- **THEN** EACL may advertise conditional exact selection
-- **AND** a genuinely collected named commit returns exact-snapshot unavailable rather than a provider-failure or substituted snapshot
+- **THEN** EACL advertises conditional exact selection
+- **AND** a genuinely collected named commit returns exact-snapshot unavailable rather than provider failure or a substituted snapshot
 
-#### Scenario: Datahike cannot reconstruct exact history
-- **WHEN** neither temporal history nor retained exact commits are available
-- **THEN** the adapter does not advertise `:at-exact-snapshot`
+#### Scenario: Datahike capability is not certified for a configuration
+- **WHEN** EACL cannot prove stable commit acquisition and branch selection for the active Datahike store configuration
+- **THEN** the adapter advertises the smaller current-only capability instead of inferring support from implementation details
 
 #### Scenario: DataScript current-only source
-- **WHEN** a DataScript connection cannot reconstruct arbitrary prior immutable values
-- **THEN** its adapter does not advertise `:at-exact-snapshot` and never retains hidden historical values to emulate it
+- **WHEN** a DataScript connection has no retained historical selection mechanism
+- **THEN** its adapter does not advertise arbitrary exact-snapshot selection and never retains hidden historical database values to emulate it
 
 #### Scenario: Ordered-generation proof is not certified
 - **WHEN** an adapter cannot certify complete dependency reads and globally ordered native relation generations
-- **THEN** native revision and snapshot-exact operations may remain available while cross-snapshot managed answer reuse fails closed
+- **THEN** native revision operations may remain available while cross-snapshot managed answer reuse fails closed to exact evaluation
 
 #### Scenario: Completed-answer cache is disabled
-- **WHEN** a client disables completed-answer caching but its adapter and lifecycle support native revision operations
-- **THEN** EACL may still issue and select authenticated native revision tokens and reconstruct exact cursors
+- **WHEN** a client disables completed-answer caching but its adapter and lifecycle support a native revision operation
+- **THEN** EACL may still issue and select authenticated native revision tokens

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/cursor-token-handling/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/cursor-token-handling/spec.md
@@ -1,29 +1,23 @@
 ## MODIFIED Requirements
 
 ### Requirement: Cursor TTL is configurable and defaults to no expiry
-Cursor expiry SHALL be off by default for every backend. Tokens minted without `:cursor-ttl-seconds` SHALL carry no expiry and SHALL remain age-valid. When a positive TTL is configured, minted tokens SHALL embed an expiry and decoding after that instant SHALL throw the established typed expired-cursor error without restarting pagination.
+Cursor expiry SHALL be off by default for every backend. Tokens minted without `:cursor-ttl-seconds` SHALL carry no expiry and SHALL remain age-valid. When a positive TTL is configured, minted tokens SHALL embed an expiry and decoding at or after that instant SHALL throw `ex-info` with `:type :eacl.pagination/expired-cursor` and `:reason :expired` without restarting pagination. Cache and checkpoint retention SHALL NOT determine cursor lifetime.
 
-#### Scenario: Datomic cursor exceeds the former five-minute default
-- **WHEN** a Datomic client without `:cursor-ttl-seconds` resumes an authenticated cursor more than five minutes after minting
-- **THEN** age alone does not reject the cursor
-- **AND** EACL continues on a proof-equivalent snapshot or reconstructs its exact historical basis
+#### Scenario: Slow batch pagination does not restart
+- **WHEN** a client without `:cursor-ttl-seconds` resumes pagination with a token minted more than 5 minutes ago
+- **THEN** the next page is returned normally
 
-#### Scenario: Datahike cursor has no configured TTL
-- **WHEN** a full-history Datahike client resumes an authenticated cursor of arbitrary age within the same source lifecycle
-- **THEN** age alone does not reject the cursor
-
-#### Scenario: Configured TTL is enforced
-- **WHEN** a client configured with `{:cursor-ttl-seconds 60}` decodes a cursor at or after its expiry
-- **THEN** EACL throws `:eacl.pagination/expired-cursor` with reason `:expired`
-- **AND** does not silently return page one or classify storage as unavailable
+#### Scenario: Configured TTL is enforced loudly
+- **WHEN** a client configured with `{:cursor-ttl-seconds 60}` decodes a token older than 60 seconds
+- **THEN** an `:eacl.pagination/expired-cursor` error with `:reason :expired` is thrown — not a silent first page
 
 #### Scenario: Key is deliberately retired
-- **WHEN** a non-expiring cursor names a key id no longer present in the configured keyring
+- **WHEN** a non-expiring cursor names a key id absent from the configured keyring
 - **THEN** EACL rejects it as an invalid authenticated cursor rather than age expiry
 
 #### Scenario: Source lifecycle changes
 - **WHEN** restore, reset, excision, purge, branch replacement, or destructive history replacement rotates the source lifecycle
-- **THEN** a prior non-expiring cursor is rejected for lifecycle mismatch and is never interpreted against the replacement history
+- **THEN** a prior non-expiring cursor is rejected for lifecycle mismatch and never interpreted against replacement history
 
 ## ADDED Requirements
 
@@ -31,20 +25,18 @@ Cursor expiry SHALL be off by default for every backend. Tokens minted without `
 Cursor authentication SHALL bind the complete normalized operation/query/principal and answer-affecting configuration independently from the selected snapshot's schema/dependency proof. A change to the current schema or relationship graph SHALL be allowed to reach proof comparison and exact fallback rather than being rejected prematurely as a different query.
 
 #### Scenario: Relevant schema changes after page one
-- **WHEN** the current schema generation differs from the cursor's generation but the operation, normalized query, principal, and configuration are unchanged
-- **THEN** EACL does not reject the cursor merely because current schema generation participates in query scope
-- **AND** a history-capable backend reconstructs and validates the cursor's original exact schema and graph
+- **WHEN** current schema generation differs from the cursor's generation but operation, normalized query, principal, and configuration are unchanged
+- **THEN** EACL does not reject the cursor merely because current schema generation differs
+- **AND** a history-capable backend may reconstruct and validate the original exact schema and graph
 
 #### Scenario: Query actually changes
-- **WHEN** operation, principal, permission, resource/subject filter, direction, page shape, ordering ABI, or answer-affecting configuration differs from the authenticated cursor
+- **WHEN** operation, principal, permission, resource/subject filter, direction, page shape, ordering ABI, or answer-affecting configuration differs
 - **THEN** EACL rejects it as an invalid cursor before authorization traversal
 
 #### Scenario: Checkpoint was evicted
-- **WHEN** a non-expiring cursor's client-private continuation checkpoint is missing or evicted
-- **THEN** EACL deterministically replays and validates the authenticated boundary on the selected exact snapshot
-- **AND** checkpoint retention does not become cursor lifetime
+- **WHEN** a non-expiring cursor's private continuation checkpoint is missing or evicted
+- **THEN** EACL deterministically replays and validates its authenticated boundary on the selected exact snapshot
 
-#### Scenario: Exact replay exceeds an execution bound
-- **WHEN** exact replay cannot reach the authenticated boundary within the configured request deadline or resource limit
-- **THEN** EACL returns the typed deadline/resource outcome
-- **AND** does not expire, rebase, or silently restart the cursor
+#### Scenario: Exact replay exceeds a bound
+- **WHEN** exact replay cannot reach the authenticated boundary within the request deadline or resource limit
+- **THEN** EACL returns the typed deadline/resource outcome rather than expiring, rebasing, or restarting the cursor

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/cursor-token-handling/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/cursor-token-handling/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Cursor TTL is configurable and defaults to no expiry
+Cursor expiry SHALL be off by default for every backend. Tokens minted without `:cursor-ttl-seconds` SHALL carry no expiry and SHALL remain age-valid. When a positive TTL is configured, minted tokens SHALL embed an expiry and decoding after that instant SHALL throw the established typed expired-cursor error without restarting pagination.
+
+#### Scenario: Datomic cursor exceeds the former five-minute default
+- **WHEN** a Datomic client without `:cursor-ttl-seconds` resumes an authenticated cursor more than five minutes after minting
+- **THEN** age alone does not reject the cursor
+- **AND** EACL continues on a proof-equivalent snapshot or reconstructs its exact historical basis
+
+#### Scenario: Datahike cursor has no configured TTL
+- **WHEN** a full-history Datahike client resumes an authenticated cursor of arbitrary age within the same source lifecycle
+- **THEN** age alone does not reject the cursor
+
+#### Scenario: Configured TTL is enforced
+- **WHEN** a client configured with `{:cursor-ttl-seconds 60}` decodes a cursor at or after its expiry
+- **THEN** EACL throws `:eacl.pagination/expired-cursor` with reason `:expired`
+- **AND** does not silently return page one or classify storage as unavailable
+
+#### Scenario: Key is deliberately retired
+- **WHEN** a non-expiring cursor names a key id no longer present in the configured keyring
+- **THEN** EACL rejects it as an invalid authenticated cursor rather than age expiry
+
+#### Scenario: Source lifecycle changes
+- **WHEN** restore, reset, excision, purge, branch replacement, or destructive history replacement rotates the source lifecycle
+- **THEN** a prior non-expiring cursor is rejected for lifecycle mismatch and is never interpreted against the replacement history
+
+## ADDED Requirements
+
+### Requirement: Cursor query scope permits exact historical recovery
+Cursor authentication SHALL bind the complete normalized operation/query/principal and answer-affecting configuration independently from the selected snapshot's schema/dependency proof. A change to the current schema or relationship graph SHALL be allowed to reach proof comparison and exact fallback rather than being rejected prematurely as a different query.
+
+#### Scenario: Relevant schema changes after page one
+- **WHEN** the current schema generation differs from the cursor's generation but the operation, normalized query, principal, and configuration are unchanged
+- **THEN** EACL does not reject the cursor merely because current schema generation participates in query scope
+- **AND** a history-capable backend reconstructs and validates the cursor's original exact schema and graph
+
+#### Scenario: Query actually changes
+- **WHEN** operation, principal, permission, resource/subject filter, direction, page shape, ordering ABI, or answer-affecting configuration differs from the authenticated cursor
+- **THEN** EACL rejects it as an invalid cursor before authorization traversal
+
+#### Scenario: Checkpoint was evicted
+- **WHEN** a non-expiring cursor's client-private continuation checkpoint is missing or evicted
+- **THEN** EACL deterministically replays and validates the authenticated boundary on the selected exact snapshot
+- **AND** checkpoint retention does not become cursor lifetime
+
+#### Scenario: Exact replay exceeds an execution bound
+- **WHEN** exact replay cannot reach the authenticated boundary within the configured request deadline or resource limit
+- **THEN** EACL returns the typed deadline/resource outcome
+- **AND** does not expire, rebase, or silently restart the cursor

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/forward-history-cache-coherence/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/forward-history-cache-coherence/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Exact-current generation isolation
+The exact-current completed-answer tier SHALL admit and return an entry only for the canonical immutable snapshot generation, source lifecycle, and complete semantic request for which it was computed. A newer current request MUST NOT observe an older exact entry, while an explicit exact request selecting that older snapshot MAY use the entry through the separately bounded snapshot-exact retention path if it remains retained.
+
+#### Scenario: Same authenticated exact snapshot
+- **WHEN** `:at-exact-snapshot` selects canonical snapshot `T` and the exact tier contains a completed answer for the identical semantic request at `T`
+- **THEN** EACL returns that answer without authorization traversal or managed-proof reads
+- **AND** rebuilds public snapshot metadata and tokens from the selected adapter at `T`
+
+#### Scenario: Different exact snapshot
+- **WHEN** an exact-tier entry belongs to revision/locator `T1` and the request selects `T2`
+- **THEN** the entry is ineligible even if its semantic answer would coincidentally be equal
+
+#### Scenario: New current snapshot is selected
+- **WHEN** a current request selects `T2` after an answer was computed at `T1`
+- **THEN** it cannot use the `T1` snapshot-exact entry as an exact hit
+- **AND** may use only separately certified managed proof-backed reuse
+
+#### Scenario: Late historical publication
+- **WHEN** computation at older snapshot `T1` finishes after current snapshot `T2` is installed
+- **THEN** publication remains keyed to `T1` and cannot populate, replace, or masquerade as `T2`
+
+#### Scenario: Snapshot-exact retention is bounded
+- **WHEN** weight, entry, or admission bounds evict an exact answer or generation
+- **THEN** a later exact request recomputes on its selected immutable snapshot
+- **AND** eviction does not imply snapshot or cursor expiry
+
+## ADDED Requirements
+
+### Requirement: Exact requests never use managed cross-snapshot lifting
+An `:at-exact-snapshot` request SHALL probe only completed answers bound to its identical canonical snapshot. It SHALL NOT use relation/schema proof equality to lift a managed answer computed at another revision, and SHALL NOT validate historical answers using current-only or no-history stamps.
+
+#### Scenario: Managed answer has equal dependency proof
+- **WHEN** a managed answer computed at `T2` has a proof equal to the exact request's proof at `T1`
+- **THEN** the exact request does not use that managed entry unless a separate snapshot-exact entry exists for `T1`
+
+#### Scenario: Exact cache miss
+- **WHEN** no retained completed answer matches the selected exact snapshot and semantic request
+- **THEN** EACL evaluates against the already selected exact adapter
+- **AND** may publish the completed semantic answer into the snapshot-exact tier at that exact key
+
+#### Scenario: Public response metadata
+- **WHEN** a snapshot-exact completed answer is reused
+- **THEN** response tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the request's selected exact adapter rather than copied from the cache entry
+
+### Requirement: Exact cache identity is complete and lifecycle-scoped
+The canonical snapshot-exact key SHALL include stable backend/source/branch identity, configured source lifecycle, native revision and exact locator, exact view kind, adapter fingerprint and identity contract, engine/order ABI, normalized semantic request, result kind/shape, normalized demand, and answer-affecting limits. Numeric revision equality alone SHALL NOT establish snapshot identity.
+
+#### Scenario: Source lifecycle rotates
+- **WHEN** cache expiry or history replacement installs a new source lifecycle
+- **THEN** every old snapshot-exact entry becomes unreachable from new requests even when native revision numbers repeat
+
+#### Scenario: Adapter semantics change
+- **WHEN** adapter fingerprint, identity contract, engine ABI, order ABI, or an answer-affecting limit changes
+- **THEN** an entry computed under the prior semantic identity is ineligible
+
+#### Scenario: Arbitrary historical view
+- **WHEN** a caller supplies a filtered, since, history, speculative, or otherwise uncertified database view
+- **THEN** EACL does not identify it with an ordinary current/as-of exact generation merely because database id and numeric revision match

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/forward-history-cache-coherence/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/forward-history-cache-coherence/spec.md
@@ -1,28 +1,23 @@
 ## MODIFIED Requirements
 
 ### Requirement: Exact-current generation isolation
-The exact-current completed-answer tier SHALL admit and return an entry only for the canonical immutable snapshot generation, source lifecycle, and complete semantic request for which it was computed. A newer current request MUST NOT observe an older exact entry, while an explicit exact request selecting that older snapshot MAY use the entry through the separately bounded snapshot-exact retention path if it remains retained.
+The exact-current completed-answer tier SHALL admit and return an entry only for the canonical immutable snapshot generation, source lifecycle, and complete semantic request for which it was computed. A newer current request MUST NOT observe an older exact entry, while an explicit exact request selecting that older snapshot MAY use the separately bounded snapshot-exact retention path if it remains retained.
+
+#### Scenario: Any forward transaction advances the snapshot
+- **WHEN** the selected current snapshot changes after any committed transaction
+- **THEN** the previous exact-current generation is unreachable from requests selecting the new snapshot
+
+#### Scenario: Late old-generation publication
+- **WHEN** computation against an old snapshot finishes after a newer exact generation is installed
+- **THEN** its result remains keyed to the old canonical snapshot and cannot populate, replace, or masquerade as the newer generation
 
 #### Scenario: Same authenticated exact snapshot
-- **WHEN** `:at-exact-snapshot` selects canonical snapshot `T` and the exact tier contains a completed answer for the identical semantic request at `T`
-- **THEN** EACL returns that answer without authorization traversal or managed-proof reads
+- **WHEN** `:at-exact-snapshot` selects canonical snapshot `T` and a completed answer for the identical semantic request at `T` remains retained
+- **THEN** EACL may return it without traversal or managed-proof reads
 - **AND** rebuilds public snapshot metadata and tokens from the selected adapter at `T`
 
-#### Scenario: Different exact snapshot
-- **WHEN** an exact-tier entry belongs to revision/locator `T1` and the request selects `T2`
-- **THEN** the entry is ineligible even if its semantic answer would coincidentally be equal
-
-#### Scenario: New current snapshot is selected
-- **WHEN** a current request selects `T2` after an answer was computed at `T1`
-- **THEN** it cannot use the `T1` snapshot-exact entry as an exact hit
-- **AND** may use only separately certified managed proof-backed reuse
-
-#### Scenario: Late historical publication
-- **WHEN** computation at older snapshot `T1` finishes after current snapshot `T2` is installed
-- **THEN** publication remains keyed to `T1` and cannot populate, replace, or masquerade as `T2`
-
 #### Scenario: Snapshot-exact retention is bounded
-- **WHEN** weight, entry, or admission bounds evict an exact answer or generation
+- **WHEN** weight, entry, or admission bounds evict an exact answer
 - **THEN** a later exact request recomputes on its selected immutable snapshot
 - **AND** eviction does not imply snapshot or cursor expiry
 
@@ -32,29 +27,29 @@ The exact-current completed-answer tier SHALL admit and return an entry only for
 An `:at-exact-snapshot` request SHALL probe only completed answers bound to its identical canonical snapshot. It SHALL NOT use relation/schema proof equality to lift a managed answer computed at another revision, and SHALL NOT validate historical answers using current-only or no-history stamps.
 
 #### Scenario: Managed answer has equal dependency proof
-- **WHEN** a managed answer computed at `T2` has a proof equal to the exact request's proof at `T1`
-- **THEN** the exact request does not use that managed entry unless a separate snapshot-exact entry exists for `T1`
+- **WHEN** a managed answer computed at `T2` has proof equal to the exact request's proof at `T1`
+- **THEN** the request does not use that answer unless a separate snapshot-exact entry exists for `T1`
 
 #### Scenario: Exact cache miss
 - **WHEN** no retained completed answer matches the selected exact snapshot and semantic request
 - **THEN** EACL evaluates against the already selected exact adapter
-- **AND** may publish the completed semantic answer into the snapshot-exact tier at that exact key
+- **AND** may publish only the completed semantic answer at that exact key
 
 #### Scenario: Public response metadata
 - **WHEN** a snapshot-exact completed answer is reused
-- **THEN** response tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the request's selected exact adapter rather than copied from the cache entry
+- **THEN** response tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the selected exact adapter
 
 ### Requirement: Exact cache identity is complete and lifecycle-scoped
-The canonical snapshot-exact key SHALL include stable backend/source/branch identity, configured source lifecycle, native revision and exact locator, exact view kind, adapter fingerprint and identity contract, engine/order ABI, normalized semantic request, result kind/shape, normalized demand, and answer-affecting limits. Numeric revision equality alone SHALL NOT establish snapshot identity.
+The canonical snapshot-exact key SHALL include stable backend/source/branch identity, configured source lifecycle, native revision and exact locator, ordinary exact view kind, adapter fingerprint and identity contract, engine/order ABI, normalized semantic request, result kind/shape, normalized demand, and answer-affecting limits. Numeric revision equality alone SHALL NOT establish snapshot identity.
 
 #### Scenario: Source lifecycle rotates
 - **WHEN** cache expiry or history replacement installs a new source lifecycle
-- **THEN** every old snapshot-exact entry becomes unreachable from new requests even when native revision numbers repeat
+- **THEN** every old snapshot-exact entry becomes unreachable even if native revision numbers repeat
 
 #### Scenario: Adapter semantics change
-- **WHEN** adapter fingerprint, identity contract, engine ABI, order ABI, or an answer-affecting limit changes
-- **THEN** an entry computed under the prior semantic identity is ineligible
+- **WHEN** adapter fingerprint, identity contract, engine/order ABI, or an answer-affecting limit changes
+- **THEN** entries computed under the prior semantic identity are ineligible
 
 #### Scenario: Arbitrary historical view
 - **WHEN** a caller supplies a filtered, since, history, speculative, or otherwise uncertified database view
-- **THEN** EACL does not identify it with an ordinary current/as-of exact generation merely because database id and numeric revision match
+- **THEN** EACL does not identify it with an ordinary current/as-of exact generation merely because source and numeric revision match

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/snapshot-stable-pagination/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/snapshot-stable-pagination/spec.md
@@ -9,74 +9,106 @@ Every paginated lookup SHALL select one immutable snapshot before scanning. Each
 
 #### Scenario: Cursor is exposed to the caller
 - **WHEN** a portable cursor is serialized
-- **THEN** its complete query scope, stable external/opaque position, snapshot identity, and proof metadata are authenticated
+- **THEN** its scope, stable external/opaque position, and proof metadata are authenticated
 - **AND** base64 encoding alone is not considered protection
 
+#### Scenario: Cursor confidentiality is advertised
+- **WHEN** an adapter/runtime advertises confidential cursors
+- **THEN** the cursor uses authenticated encryption and exposes no plaintext proof or position
+
+#### Scenario: Query or configuration changes
+- **WHEN** a cursor is presented with a different operation, query scope, direction, engine version, codec, or answer-affecting configuration
+- **THEN** EACL rejects it as an invalid cursor
+
 #### Scenario: Dependency proof is too large
-- **WHEN** complete dependency evidence would exceed the cursor size bound
+- **WHEN** a complete dependency proof map would exceed the cursor size bound
 - **THEN** the cursor carries a domain-separated digest and rederives the complete closure on continuation
-- **AND** does not truncate the dependency set
+- **AND** MUST NOT truncate the dependency set
+
+#### Scenario: Complete proof cannot be recomputed
+- **WHEN** continuation cannot recompute the full proof within configured resource bounds
+- **THEN** graph-equivalent continuation is unavailable
+- **AND** EACL uses exact fallback or returns a typed stale/resource error
 
 ### Requirement: Exact reconstruction is a fallback
-When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator if the request does not require a causally newer floor. On an unreplaced full-history source, cursor age and ordinary forward mutations SHALL NOT make that locator unavailable. If the configured backend cannot reconstruct the exact value, continuation MUST fail rather than use a changed graph.
+When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator only if the request does not require a causally newer floor. On an unreplaced full-history source, cursor age and ordinary forward mutations SHALL NOT make that locator unavailable. If the configured backend cannot reconstruct the exact value, continuation MUST fail rather than use a changed graph.
 
 #### Scenario: Datomic exact fallback after arbitrary forward history
 - **WHEN** a cursor proof changed and its original Datomic basis belongs to the same unreplaced source lifecycle
-- **THEN** EACL reconstructs the verified `d/as-of` value, synchronizing to the basis first when the local Peer is behind
+- **THEN** EACL catches the Peer up to that basis when necessary and continues on the verified `d/as-of` value
 - **AND** cursor age alone does not reject it
 
 #### Scenario: Datahike temporal-history fallback
 - **WHEN** a cursor proof changed and the Datahike source has `:keep-history? true`
-- **THEN** EACL reconstructs the verified temporal snapshot by native revision even if a commit record was collected
+- **THEN** EACL reconstructs the verified temporal snapshot even if the named commit record was collected
 
 #### Scenario: Datahike retained-commit fallback
-- **WHEN** temporal history is disabled and the cursor's exact commit remains retained
+- **WHEN** temporal history is disabled and the cursor's named commit remains retained
 - **THEN** EACL may continue on that exact commit
 
-#### Scenario: Conditionally retained snapshot is unavailable
-- **WHEN** a history-disabled backend configuration no longer retains the cursor's exact handle
-- **THEN** EACL returns typed exact-snapshot unavailable/stale-cursor behavior
-- **AND** does not silently restart or continue on current data
+#### Scenario: DataScript current-only source
+- **WHEN** a DataScript cursor proof changes after the current basis advances
+- **THEN** EACL returns a typed stale-cursor result and does not consult a hidden historical registry
+
+#### Scenario: Original snapshot is unavailable
+- **WHEN** the proof changed and a history-disabled conditional backend no longer retains the exact handle
+- **THEN** EACL returns typed stale-cursor or exact-snapshot-unavailable
+- **AND** MUST NOT silently restart or continue on current data
 
 #### Scenario: History replacement invalidates old locators
 - **WHEN** source lifecycle rotation records restore, reset, excision, purge, branch replacement, or destructive history replacement
 - **THEN** old cursors are rejected for lifecycle mismatch before exact reconstruction
 
 ### Requirement: Cursor failures are distinguishable
-EACL SHALL distinguish authentication/query-scope failure, configured envelope expiry, source-lifecycle replacement, conditionally retained exact-snapshot absence, changed dependency proof, incompatible newer freshness, and replay resource/deadline failure.
+EACL SHALL distinguish authentication/query-scope failure, configured envelope expiry, source-lifecycle replacement, conditional exact-snapshot absence, changed dependency proof, incompatible newer freshness, and replay deadline/resource failure.
 
 #### Scenario: Cursor authentication fails
-- **WHEN** encrypted cursor contents, key id, or authentication tag are invalid
+- **WHEN** encrypted cursor contents, key id, or tag are invalid
 - **THEN** EACL returns `:eacl.pagination/invalid-cursor`
 
 #### Scenario: Configured cursor lifetime expires
-- **WHEN** a cursor carrying an explicit expiry is resumed at or after that expiry
+- **WHEN** the authenticated cursor expiry has elapsed
 - **THEN** EACL returns `:eacl.pagination/expired-cursor`
 
 #### Scenario: Non-expiring cursor grows older
 - **WHEN** a cursor carries no expiry and its exact full-history source remains in the same lifecycle
 - **THEN** elapsed wall-clock time is not a rejection condition
 
-#### Scenario: Exact storage is conditionally unavailable
-- **WHEN** a valid changed-proof cursor depends on a retained handle that its history-disabled backend has genuinely collected
-- **THEN** EACL returns the typed exact-snapshot unavailable/stale-cursor outcome
+#### Scenario: Conditional exact storage is unavailable
+- **WHEN** a valid changed-proof cursor needs a history-disabled commit that has genuinely been collected
+- **THEN** EACL returns the typed exact-snapshot-unavailable/stale-cursor outcome
+
+#### Scenario: Proof changed without exact fallback
+- **WHEN** a valid cursor's current proof differs and the backend never supported exact history
+- **THEN** EACL returns a typed stale-cursor error
 
 #### Scenario: Replay is bounded
-- **WHEN** checkpoint-free exact replay exceeds the configured deadline or resource ceiling
+- **WHEN** checkpoint-free exact replay exceeds its deadline or resource ceiling
 - **THEN** EACL returns the corresponding deadline/resource error rather than cursor expiry
 
 ### Requirement: Pagination is differential-tested against an oracle
-The shared suite SHALL compare concatenated cursor pages with deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof, including recovery after wall-clock delay, process-local checkpoint eviction, schema/relationship mutation, and backend catch-up.
+The shared suite SHALL compare concatenated cursor pages with a deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof, including recovery after wall-clock delay, checkpoint eviction, forward mutation, and backend catch-up.
 
-#### Scenario: Authorization revocation after page one
+#### Scenario: Insert before cursor boundary
+- **WHEN** a relevant result is inserted before continuation
+- **THEN** current-proof continuation is rejected or exact fallback preserves the original enumeration
+
+#### Scenario: Delete after cursor boundary
+- **WHEN** a relevant result is deleted after page one
+- **THEN** current-proof continuation is rejected or exact fallback preserves the original enumeration
+
+#### Scenario: Unrelated mutation
+- **WHEN** arbitrary unrelated schema-external or relation-external data changes
+- **THEN** proof-equivalent continuation yields neither duplicates nor omissions
+
+#### Scenario: Authorization revocation
 - **WHEN** a recursive dependency revokes a result after page one
-- **THEN** current-proof continuation is rejected
-- **AND** a full-history exact fallback preserves the original enumeration without combining old and new results
+- **THEN** EACL never emits a hybrid enumeration spanning the old and new proofs
 
 #### Scenario: Client-local checkpoint is lost
-- **WHEN** page continuation runs after client restart or checkpoint eviction with stable key and source lifecycle configuration
-- **THEN** exact replay yields the same remaining sequence and boundary validation as the uninterrupted enumeration
+- **WHEN** continuation runs after client restart or checkpoint eviction with stable key and source lifecycle configuration
+- **THEN** exact replay yields the same remaining sequence and boundary validation as uninterrupted enumeration
 
 #### Scenario: Lagging Datomic Peer receives cursor
 - **WHEN** a cursor minted on one Peer names a committed basis ahead of the receiving Peer
-- **THEN** bounded exact catch-up followed by `d/as-of` yields the same original enumeration
+- **THEN** bounded catch-up followed by exact `d/as-of` yields the original enumeration

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/snapshot-stable-pagination/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/snapshot-stable-pagination/spec.md
@@ -1,0 +1,82 @@
+## MODIFIED Requirements
+
+### Requirement: First page binds graph and execution identity
+Every paginated lookup SHALL select one immutable snapshot before scanning. Each cursor SHALL bind under mandatory authentication, and optional advertised encryption, the backend source/branch scope and lifecycle, native revision and exact locator, canonical query scope, engine/adapter/identity/configuration fingerprints, complete schema/relation dependency scope and proof, deterministic direction/position, format version, and optional configured expiry.
+
+#### Scenario: First page uses at-least freshness
+- **WHEN** a first-page request selects a snapshot satisfying an at-least token
+- **THEN** every emitted cursor identifies that selected snapshot, proof, and stable position
+
+#### Scenario: Cursor is exposed to the caller
+- **WHEN** a portable cursor is serialized
+- **THEN** its complete query scope, stable external/opaque position, snapshot identity, and proof metadata are authenticated
+- **AND** base64 encoding alone is not considered protection
+
+#### Scenario: Dependency proof is too large
+- **WHEN** complete dependency evidence would exceed the cursor size bound
+- **THEN** the cursor carries a domain-separated digest and rederives the complete closure on continuation
+- **AND** does not truncate the dependency set
+
+### Requirement: Exact reconstruction is a fallback
+When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator if the request does not require a causally newer floor. On an unreplaced full-history source, cursor age and ordinary forward mutations SHALL NOT make that locator unavailable. If the configured backend cannot reconstruct the exact value, continuation MUST fail rather than use a changed graph.
+
+#### Scenario: Datomic exact fallback after arbitrary forward history
+- **WHEN** a cursor proof changed and its original Datomic basis belongs to the same unreplaced source lifecycle
+- **THEN** EACL reconstructs the verified `d/as-of` value, synchronizing to the basis first when the local Peer is behind
+- **AND** cursor age alone does not reject it
+
+#### Scenario: Datahike temporal-history fallback
+- **WHEN** a cursor proof changed and the Datahike source has `:keep-history? true`
+- **THEN** EACL reconstructs the verified temporal snapshot by native revision even if a commit record was collected
+
+#### Scenario: Datahike retained-commit fallback
+- **WHEN** temporal history is disabled and the cursor's exact commit remains retained
+- **THEN** EACL may continue on that exact commit
+
+#### Scenario: Conditionally retained snapshot is unavailable
+- **WHEN** a history-disabled backend configuration no longer retains the cursor's exact handle
+- **THEN** EACL returns typed exact-snapshot unavailable/stale-cursor behavior
+- **AND** does not silently restart or continue on current data
+
+#### Scenario: History replacement invalidates old locators
+- **WHEN** source lifecycle rotation records restore, reset, excision, purge, branch replacement, or destructive history replacement
+- **THEN** old cursors are rejected for lifecycle mismatch before exact reconstruction
+
+### Requirement: Cursor failures are distinguishable
+EACL SHALL distinguish authentication/query-scope failure, configured envelope expiry, source-lifecycle replacement, conditionally retained exact-snapshot absence, changed dependency proof, incompatible newer freshness, and replay resource/deadline failure.
+
+#### Scenario: Cursor authentication fails
+- **WHEN** encrypted cursor contents, key id, or authentication tag are invalid
+- **THEN** EACL returns `:eacl.pagination/invalid-cursor`
+
+#### Scenario: Configured cursor lifetime expires
+- **WHEN** a cursor carrying an explicit expiry is resumed at or after that expiry
+- **THEN** EACL returns `:eacl.pagination/expired-cursor`
+
+#### Scenario: Non-expiring cursor grows older
+- **WHEN** a cursor carries no expiry and its exact full-history source remains in the same lifecycle
+- **THEN** elapsed wall-clock time is not a rejection condition
+
+#### Scenario: Exact storage is conditionally unavailable
+- **WHEN** a valid changed-proof cursor depends on a retained handle that its history-disabled backend has genuinely collected
+- **THEN** EACL returns the typed exact-snapshot unavailable/stale-cursor outcome
+
+#### Scenario: Replay is bounded
+- **WHEN** checkpoint-free exact replay exceeds the configured deadline or resource ceiling
+- **THEN** EACL returns the corresponding deadline/resource error rather than cursor expiry
+
+### Requirement: Pagination is differential-tested against an oracle
+The shared suite SHALL compare concatenated cursor pages with deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof, including recovery after wall-clock delay, process-local checkpoint eviction, schema/relationship mutation, and backend catch-up.
+
+#### Scenario: Authorization revocation after page one
+- **WHEN** a recursive dependency revokes a result after page one
+- **THEN** current-proof continuation is rejected
+- **AND** a full-history exact fallback preserves the original enumeration without combining old and new results
+
+#### Scenario: Client-local checkpoint is lost
+- **WHEN** page continuation runs after client restart or checkpoint eviction with stable key and source lifecycle configuration
+- **THEN** exact replay yields the same remaining sequence and boundary validation as the uninterrupted enumeration
+
+#### Scenario: Lagging Datomic Peer receives cursor
+- **WHEN** a cursor minted on one Peer names a committed basis ahead of the receiving Peer
+- **THEN** bounded exact catch-up followed by `d/as-of` yields the same original enumeration

--- a/openspec/changes/sync-datomic-exact-snapshots/tasks.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/tasks.md
@@ -1,0 +1,61 @@
+## 1. Pin Datomic Exact-Selection Effects
+
+- [x] 1.1 Add adapter regressions proving an already-local exact basis skips `d/sync`, calls `d/as-of` once, and reports native revision and exact locator equal to the token basis.
+- [x] 1.2 Add a lagging-Peer regression proving a token basis ahead of `(d/db conn)` invokes bounded two-argument `d/sync`, verifies the returned basis, and evaluates exactly at the token basis rather than the newer synchronized head.
+- [x] 1.3 Add timeout and below-floor regressions proving no `d/as-of` or authorization work occurs and errors retain requested basis, observed basis, timeout, and stable freshness reasons.
+- [x] 1.4 Prove timeout and interruption cancel the Datomic `ListenableFuture`; interruption remains classified cancellation and preserves the thread interruption contract.
+- [x] 1.5 Add malformed/contradictory Datomic locator tests proving non-integer locators and `revision != exact-locator` fail before synchronization.
+- [x] 1.6 Add provider-failure regressions proving unexpected sync/as-of/storage failures preserve phase and cause and never become `nil`, snapshot expiry, or a newer-snapshot answer.
+- [x] 1.7 Exercise direct public `:at-exact-snapshot`, Datomic bespoke cursor recovery, and shared Relay cursor recovery so every route uses the corrected adapter behavior.
+
+## 2. Implement Bounded Cancellable Datomic Catch-Up
+
+- [x] 2.1 Extract or reuse one targeted-sync helper that compares the authenticated locator with one local database, synchronizes only when behind, applies the remaining timeout, verifies the resulting basis, and owns waiter cancellation.
+- [x] 2.2 Update Datomic `:select-exact` to validate its backend-specific token invariant, catch up to a newer locator, and construct its immutable adapter from `(d/as-of caught-up-db locator)` with exact selected metadata.
+- [x] 2.3 Preserve EACL freshness errors unchanged; wrap only foreign provider failures as classified selection failures and avoid catching fatal JVM errors as retryable application outcomes.
+- [x] 2.4 Remove the future-locator-as-unavailable guard and every undocumented Datomic out-of-range/retention-expiry branch.
+- [x] 2.5 Confirm minimize-latency, fully-consistent, and at-least-as-fresh semantics remain unchanged except for any deliberately shared waiter-cancellation helper.
+
+## 3. Make Cursor Lifetime Follow History Capability
+
+- [x] 3.1 Change Datomic cursor minting so absent `:cursor-ttl-seconds` omits expiry; retain exact configured-TTL validation and expired-cursor behavior.
+- [x] 3.2 Remove the Datomic five-minute default from cache/cursor lifetime coupling and keep cache capacity/TTL options independent from cursor age.
+- [x] 3.3 Add cross-backend tests that resume non-expiring cursors well beyond five minutes, after ordinary schema and relationship mutations, and after checkpoint/page-cache eviction.
+- [x] 3.4 Add stable-key/shared-lifecycle restart and cross-Peer cursor tests proving private continuation state is optional and exact deterministic replay preserves the remaining sequence.
+- [x] 3.5 Separate immutable query/principal/configuration scope from schema/dependency snapshot proof in shared Relay cursor validation so a changed current schema can reach exact fallback.
+- [x] 3.6 Preserve invalid-cursor outcomes for query/configuration/ABI mismatch, configured expiry for explicit TTL, lifecycle mismatch for history replacement, and deadline/resource errors for bounded replay.
+- [x] 3.7 Verify an old cursor remains a query-bound historical enumeration and document that applications needing current entitlement recheck authorization while consuming results.
+
+## 4. Make Datahike Exact-History Claims Durable and Honest
+
+- [x] 4.1 Change EACL-created Datahike database defaults to `:keep-history? true` and document the storage/write-amplification trade-off plus the explicit opt-out.
+- [x] 4.2 Certify configuration-specific capabilities for temporal history, retained-commit-only exact selection, and no exact reconstruction.
+- [x] 4.3 Add a real Datahike cutoff-GC regression proving temporal history reconstructs an exact revision after its named commit record is unavailable.
+- [x] 4.4 Preserve exact-snapshot unavailable only for a history-disabled configuration whose named commit was genuinely collected; provider failures remain classified failures.
+- [x] 4.5 Add lifecycle-rotation tests for purge, branch force, reset, or equivalent destructive history replacement boundaries without attempting to support those operations concurrently with authorization traffic.
+
+## 5. Reuse Snapshot-Exact Completed Answers
+
+- [x] 5.1 Define one canonical snapshot-exact key containing source/branch/lifecycle, native revision and exact locator, exact view kind, adapter/identity semantics, engine/order ABI, normalized request/result shape/demand, and answer-affecting limits.
+- [x] 5.2 Refactor the bounded exact completed-answer tier to retain multiple canonical snapshot generations or provide an equivalently safe composite-key store; preserve weight/LRU/admission bounds and late-publication isolation.
+- [x] 5.3 Permit `:at-exact-snapshot` to probe and publish only the matching snapshot-exact tier after successful exact selection.
+- [x] 5.4 Prohibit managed proof-backed lookup/publication for exact requests and prohibit current/no-history stamp validation of historical answers.
+- [x] 5.5 Rebuild response tokens, cursor envelopes, cache basis, external identifiers, and all public snapshot metadata from the selected exact adapter on every hit.
+- [x] 5.6 Add hit/miss/collision regressions for same `T`, different `T`, repeated numeric revisions across lifecycle rotation, different view kinds, adapter/identity changes, arbitrary DB views, disabled cache, eviction, and late historical publication.
+- [x] 5.7 Add result-shape coverage for decisions, counts, pages, relationship reads, subject/resource lookups, and permission-tree expansion without caching partial traversal or pre-encoded expiring cursors.
+
+## 6. Documentation, Specs, and Assurance
+
+- [x] 6.1 Update README and backend guides with Datomic targeted exact catch-up, no default cursor expiry, Datahike temporal-history defaults, conditional retained-commit behavior, and snapshot-exact cache reuse.
+- [x] 6.2 Reconcile stale main specs that still describe mutation graphs, DataScript exact registries, mandatory cursor expiry, or generic storage-expired behavior after delta specs are synced.
+- [x] 6.3 Update operational guidance: Datomic excision and Datahike purge/cutoff history destruction require quiescence, completion, source-lifecycle rotation, cache detachment, and deliberate key/version policy.
+- [x] 6.4 Audit generated consistency/cache/cursor decisions, formal smoke fixtures, mutation registry, and assurance matrix. State explicitly that backend I/O effects, full-history retention, future cancellation, and canonical cache-key truthfulness remain certified adapter assumptions rather than proved kernel facts.
+- [x] 6.5 Regenerate the public-source closure ledger with `node bin/public-source-closure.mjs write` after public source or assurance changes.
+
+## 7. Verification
+
+- [x] 7.1 Discover project nREPLs and run targeted shared consistency, cursor, cache, Datomic, and Datahike namespaces with `:reload`.
+- [x] 7.2 Run the CI-equivalent non-benchmark battery through an nREPL started with the required test aliases; resolve failures without weakening exact identity, replay, or error classification.
+- [x] 7.3 Run isolated real-backend evidence for cross-Peer Datomic catch-up and Datahike history-enabled cutoff GC; do not treat same-JVM mocks alone as distribution/retention proof.
+- [x] 7.4 If shared CLJC changes, restart as required and run the DataScript ClojureScript build last, matching CI ordering.
+- [x] 7.5 Run affected formal smoke/mutation checks and `openspec validate sync-datomic-exact-snapshots --type change --strict`; record intentionally deferred long-running verification separately.

--- a/openspec/specs/backend-native-revision-consistency/spec.md
+++ b/openspec/specs/backend-native-revision-consistency/spec.md
@@ -19,26 +19,57 @@ EACL SHALL encode revision tokens with a version, backend identity, configured s
 - **THEN** EACL rejects it with a stable token-format or upgrade error
 
 ### Requirement: Datomic forward-history selection
-Within one unreplaced Datomic database history, EACL SHALL use authenticated database scope and transaction `t` as the native causal floor, targeted synchronization for at-least selection, and retained `d/as-of` selection only for explicit exact-snapshot behavior.
+Within one unreplaced Datomic database history, EACL SHALL use authenticated database scope and transaction `t` as the native causal floor, targeted synchronization for at-least selection and for an exact token basis ahead of the local Peer, and `d/as-of` selection only for explicit exact-snapshot behavior. An authentic same-source exact basis that is ahead of one Peer SHALL be treated as propagation lag, not as an expired or out-of-range snapshot.
 
 #### Scenario: Peer is behind requested floor
 - **WHEN** a Datomic Peer receives an at-least token whose `t` is ahead of its locally observed database
 - **THEN** EACL performs a bounded targeted synchronization and selects a database with basis at least that `t` or returns a typed timeout or unavailable error
 
-#### Scenario: Explicit exact request
-- **WHEN** a caller explicitly requests an exact retained Datomic revision
-- **THEN** EACL selects that revision if available and bypasses the completed-answer cache
+#### Scenario: Peer is behind requested exact basis
+- **WHEN** a Datomic Peer receives an authenticated same-source exact token whose `t` is ahead of its locally observed database
+- **THEN** EACL performs bounded two-argument `d/sync` to `t`
+- **AND** verifies that the synchronized database has basis at least `t`
+- **AND** applies `d/as-of` so authorization evaluates exactly at `t`
+
+#### Scenario: Exact basis is already local
+- **WHEN** an authenticated same-source exact token names `t` at or below the locally observed Datomic basis
+- **THEN** EACL does not invoke `d/sync`
+- **AND** selects the exact `d/as-of` database at `t`
+
+#### Scenario: Exact catch-up times out or is interrupted
+- **WHEN** the local Peer does not observe `t` before the consistency bound, or the wait is interrupted
+- **THEN** EACL cancels the targeted-sync future
+- **AND** returns typed freshness timeout or cancellation without calling `d/as-of`
+
+#### Scenario: Exact synchronization returns behind the token
+- **WHEN** targeted synchronization returns a database whose basis is below `t`
+- **THEN** EACL returns `:eacl.consistency/freshness-unavailable` with reason `:head-behind`, requested and observed bases
+- **AND** performs no authorization evaluation
+
+#### Scenario: Datomic token fields contradict one another
+- **WHEN** the locator is not a non-negative integer or native revision differs from exact locator
+- **THEN** EACL rejects the token before storage or synchronization
+
+#### Scenario: Ordinary Datomic history grows older
+- **WHEN** an authenticated unexpired token names an older `t` in the same unreplaced ordinary Datomic history
+- **THEN** age alone does not make the exact snapshot unavailable
 
 #### Scenario: Ordinary current request
 - **WHEN** a caller requests minimize-latency or fully-consistent current behavior
 - **THEN** EACL does not call `d/as-of` merely to validate or reuse a completed answer
 
 ### Requirement: Backend capability honesty
-Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, and ordered-generation proof operations supported by its configured backend and SHALL reject unsupported consistency modes before cache access. Native revision capability SHALL remain independent of completed-answer caching and SHALL NOT depend on a cache-authority or proof-mode option.
+Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, durable-history, and ordered-generation proof operations supported by its configured backend and SHALL reject unsupported consistency modes before cache access. Exact selection from conditionally retained commits SHALL remain distinguishable from durable temporal-history reconstruction. Native revision capability SHALL remain independent of completed-answer caching and SHALL NOT depend on a cache-authority or proof-mode option.
 
-#### Scenario: Datahike retained commit capability
-- **WHEN** a Datahike configuration exposes a stable branch and retained native commit selection
-- **THEN** its adapter may advertise the corresponding at-least or exact capability using those native identities
+#### Scenario: Datahike temporal history is enabled
+- **WHEN** a Datahike source has `:keep-history? true`
+- **THEN** EACL advertises durable exact reconstruction by native revision even when a named commit record is absent
+- **AND** cutoff collection of commit records does not expire an exact cursor
+
+#### Scenario: Datahike relies only on retained commits
+- **WHEN** Datahike temporal history is disabled but its commit graph supports exact commit loading
+- **THEN** EACL advertises conditional exact selection
+- **AND** a genuinely collected named commit returns exact-snapshot unavailable rather than provider failure or a substituted snapshot
 
 #### Scenario: Datahike capability is not certified for a configuration
 - **WHEN** EACL cannot prove stable commit acquisition and branch selection for the active Datahike store configuration
@@ -103,4 +134,3 @@ Every proof, completed answer, cursor, and revision token SHALL be bound to the 
 #### Scenario: Client-local custom codec identity
 - **WHEN** a cursor was issued using an unfingerprinted custom identity codec
 - **THEN** another client lifecycle does not accept that cursor even when signing keys are shared
-

--- a/openspec/specs/cross-backend-revision-consistency/spec.md
+++ b/openspec/specs/cross-backend-revision-consistency/spec.md
@@ -1,10 +1,15 @@
 # cross-backend-revision-consistency Specification
 
 ## Purpose
-TBD - created by archiving change redesign-cross-backend-freshness-cache. Update Purpose after archive.
+Define backend-specific revision selection behind one authenticated consistency
+surface without portable mutation graphs or hidden snapshot registries.
+
 ## Requirements
+
 ### Requirement: Consistency modes select one immutable snapshot
-Consistency selection SHALL complete before cross-revision cache validation or authorization. Every engine operation, dependency read, proof read, cursor operation, and response token for one request MUST use the selected immutable snapshot.
+Consistency selection SHALL complete before cache validation or authorization.
+Every engine operation, dependency read, proof read, cursor operation, and
+response token for one request MUST use the selected immutable snapshot.
 
 #### Scenario: Concurrent commit follows selection
 - **WHEN** another transaction commits after snapshot selection
@@ -13,101 +18,104 @@ Consistency selection SHALL complete before cross-revision cache validation or a
 #### Scenario: Minimize latency
 - **WHEN** a caller requests `:minimize-latency`
 - **THEN** the adapter selects an already available complete local snapshot without an authoritative-head wait
-- **AND** the completed-answer cache is validated on that snapshot
+- **AND** cache validation, if enabled, is scoped to that selected snapshot
 
 #### Scenario: Exact snapshot
 - **WHEN** a caller requests `:at-exact-snapshot`
-- **THEN** EACL loads only the token's exact locator and verifies its source scope and graph-head identity
-- **AND** returns snapshot-expired if that exact value is unavailable
+- **THEN** EACL authenticates source/lifecycle and exact locator before backend selection
+- **AND** validates the selected adapter's exact revision and locator postconditions
+- **AND** may probe only a matching canonical snapshot-exact completed answer
 
 ### Requirement: Fully consistent requires an authoritative selection barrier
-For `:fully-consistent`, EACL SHALL select a snapshot containing every graph mutation complete at the backend's authoritative barrier when selection began. An adapter lacking such a barrier MUST NOT advertise this capability.
+For `:fully-consistent`, EACL SHALL select a snapshot containing every
+authorization mutation complete at the backend's authoritative barrier when
+selection began. An adapter lacking such a barrier MUST NOT advertise this
+capability.
 
 #### Scenario: Datomic fully consistent selection
 - **WHEN** a Datomic caller requests `:fully-consistent`
 - **THEN** EACL uses bounded zero-argument `d/sync`
 - **AND** evaluates on the database value returned by that synchronization
 
-#### Scenario: Datahike source is a lagging replica
-- **WHEN** a Datahike source can expose only its latest locally replicated value and no writer/store head barrier
-- **THEN** it advertises latest-observed/minimize-latency behavior
-- **AND** rejects `:fully-consistent` as unsupported
+#### Scenario: Datahike source has no head barrier
+- **WHEN** a Datahike source exposes only its latest locally replicated value
+- **THEN** it advertises minimize-latency behavior and rejects `:fully-consistent`
 
 #### Scenario: DataScript connection head
 - **WHEN** a DataScript caller requests `:fully-consistent`
 - **THEN** EACL selects the current immutable value of the serialized local connection
 
-### Requirement: Datomic causal selection
-The Datomic adapter SHALL use native database identity for source scope, basis `t` as an order hint and exact locator, and the EACL mutation journal as the causal postcondition. Managed writes MUST mint tokens from the committed transaction report.
+### Requirement: Datomic causal and exact selection
+The Datomic adapter SHALL use native database identity for source scope and
+basis `t` as its causal order and exact locator. EACL-managed writes SHALL mint
+tokens from the committed transaction report without graph-journal metadata.
 
-#### Scenario: Datomic catches up to a write
-- **WHEN** the local Peer basis is below a same-source token hint
-- **THEN** EACL uses bounded two-argument `d/sync`
-- **AND** verifies that the resulting database contains the token mutation anchor
+#### Scenario: Datomic catches up to an at-least write
+- **WHEN** the local Peer basis is below an authenticated same-source token `T`
+- **THEN** EACL uses bounded `(d/sync conn T)` and verifies the selected basis is at least `T`
 
-#### Scenario: Datomic restore reuses transaction positions
-- **WHEN** a restored/divergent database later reaches a numeric basis at or above an old token but lacks its mutation id
-- **THEN** EACL rejects the old token for that history
+#### Scenario: Datomic exact token is ahead locally
+- **WHEN** an authenticated same-source exact token `T` is ahead of the local Peer
+- **THEN** EACL performs bounded targeted synchronization, verifies `basis >= T`, and evaluates `(d/as-of db T)`
+- **AND** never evaluates the newer synchronized head as the exact answer
 
-#### Scenario: Datomic exact snapshot is available
-- **WHEN** a valid exact token names a retained Datomic basis
-- **THEN** EACL selects `d/as-of` at that basis and verifies the expected graph head
+#### Scenario: Datomic exact token is already local
+- **WHEN** local basis is at least exact token `T`
+- **THEN** EACL skips synchronization and evaluates `(d/as-of local-db T)`
 
-### Requirement: Datahike causal selection
-The Datahike adapter SHALL scope tokens by stable store identity and configured branch, use mutation-anchor membership for causal freshness, and use commit id as an exact locator when available. It MUST treat `:max-tx` only as an order/polling hint.
+#### Scenario: Datomic history replacement
+- **WHEN** restore, reset, excision, or equivalent history replacement can reinterpret an old `T`
+- **THEN** operators quiesce traffic and rotate the shared source lifecycle before resuming
 
-#### Scenario: Datahike branch head advances normally
-- **WHEN** a reader refreshes to a branch head containing the token mutation id
-- **THEN** that immutable database satisfies the at-least floor
+### Requirement: Datahike causal and exact selection
+The Datahike adapter SHALL scope tokens by stable store identity, configured
+branch, and source lifecycle. It SHALL advertise durable temporal exact history
+only when `:keep-history? true`, and conditional retained-commit exact
+selection only when a commit graph is available.
 
-#### Scenario: Datahike branch is force-moved
-- **WHEN** `force-branch!` publishes a head whose `:max-tx` is equal to or newer than a token hint but whose graph lacks the token mutation anchor
-- **THEN** EACL rejects that head as not causally fresh enough
+#### Scenario: Temporal history survives commit collection
+- **WHEN** `:keep-history? true` and a named commit record has been collected
+- **THEN** EACL reconstructs the exact revision through temporal `as-of`
 
-#### Scenario: Datahike commit is retained
-- **WHEN** an exact token's commit id is retained
-- **THEN** the adapter loads it with `commit-as-db` and verifies source and graph identity
+#### Scenario: History-disabled commit is retained
+- **WHEN** temporal history is disabled and the exact commit remains retained
+- **THEN** EACL may load that exact commit
 
-#### Scenario: Datahike commit is unavailable
-- **WHEN** commit reconstruction and capability-gated temporal fallback cannot recover the exact value
-- **THEN** EACL returns `:eacl.consistency/snapshot-expired`
+#### Scenario: History-disabled commit is collected
+- **WHEN** temporal history is disabled and the exact commit was genuinely collected
+- **THEN** EACL returns exact-snapshot unavailable rather than provider failure or a substituted head
 
-### Requirement: DataScript causal selection
-The DataScript adapter SHALL use a durable random causal-family id for source scope, mutation-anchor membership as its causal postcondition, and immutable DB `:max-tx` only as an order hint. It MUST NOT infer common history from equal family ids or transaction numbers.
+#### Scenario: Branch or store history is replaced
+- **WHEN** purge, cutoff history destruction, branch force, reset, or restore changes locator meaning
+- **THEN** operators quiesce traffic and rotate the shared source lifecycle before resuming
 
-#### Scenario: DataScript connection contains the anchor
-- **WHEN** the current immutable DB contains the token's mutation id
-- **THEN** EACL may select it even when later unrelated transactions advanced `:max-tx`
+### Requirement: DataScript is current-basis only
+The DataScript adapter SHALL use connection-local immutable revisions for
+current and causal selection and SHALL NOT advertise arbitrary exact history or
+retain hidden historical database values to emulate it.
 
-#### Scenario: DataScript process restarts
-- **WHEN** a restored connection has the token's durable causal-family id and contains its mutation anchor
-- **THEN** the token remains valid across the process/connection restart
+#### Scenario: DataScript satisfies a local causal floor
+- **WHEN** the serialized connection head has revision at least the same-source token floor
+- **THEN** EACL may select that current immutable value
 
-#### Scenario: DataScript clone predates token
-- **WHEN** a cloned DB copied the family id before the token mutation
-- **THEN** the missing anchor prevents that clone from satisfying the token
+#### Scenario: DataScript exact request
+- **WHEN** a caller requests `:at-exact-snapshot`
+- **THEN** EACL rejects the unsupported capability before cache access or authorization
 
-#### Scenario: DataScript reset creates a numeric collision
-- **WHEN** `reset-conn!` installs a divergent DB with the same or greater `:max-tx` but without the token anchor
-- **THEN** EACL returns history-diverged or freshness-unavailable
-
-#### Scenario: DataScript cannot catch up
-- **WHEN** the supplied connection does not acquire the required mutation anchor before the deadline
-- **THEN** EACL returns `:eacl.consistency/freshness-unavailable`
-- **AND** does not claim a replication mechanism
-
-#### Scenario: DataScript exact value is not retained
-- **WHEN** neither the current DB nor the bounded immutable snapshot registry contains an exact token handle
-- **THEN** EACL returns snapshot-expired regardless of numeric `:max-tx` equality
+#### Scenario: DataScript process or connection is replaced
+- **WHEN** reset or replacement can reuse numeric revisions for different contents
+- **THEN** the consumer rotates source lifecycle and EACL does not infer historical equality from revision numbers
 
 ### Requirement: Capability claims are configuration-specific
-Every adapter SHALL advertise only consistency, authoritative-head, causal-wait, and exact-reconstruction guarantees supported by its configured source. Unsupported guarantees MUST fail before authorization execution with `:eacl/unsupported-capability`.
+Every adapter SHALL advertise only consistency, authoritative-head,
+causal-wait, durable-history, conditional-exact, and exact-reconstruction
+guarantees supported by its configured source. Unsupported guarantees MUST fail
+before cache access or authorization execution.
 
-#### Scenario: Cross-backend at-least conformance
-- **WHEN** the shared contract presents a token to Datomic, Datahike, or DataScript
-- **THEN** the backend either selects a same-scope snapshot containing the token anchor or returns the specified typed failure
+#### Scenario: Native revision values collide across lifecycle replacement
+- **WHEN** clone, restore, reset, branch force, or reseeding reuses an order hint for different contents
+- **THEN** lifecycle inequality prevents token, cursor, proof, or exact-cache reuse
 
-#### Scenario: Backend order hint collides
-- **WHEN** a generated clone, restore, reset, branch, or force-head trace reuses an order hint for different contents
-- **THEN** no adapter accepts equality or numeric ordering as a substitute for mutation-anchor membership
-
+#### Scenario: Completed-answer cache is disabled
+- **WHEN** native revision selection is supported but completed-answer caching is disabled
+- **THEN** EACL still issues and selects authenticated native revision tokens

--- a/openspec/specs/cursor-dependency-validity/spec.md
+++ b/openspec/specs/cursor-dependency-validity/spec.md
@@ -26,7 +26,7 @@ All backends SHALL use one page-token codec providing both authenticity and conf
 
 #### Scenario: Portable token confidentiality
 - **WHEN** a Datahike or DataScript page token is issued
-- **THEN** its payload (snapshot identifiers, graph anchors, proof digests, result ids) is not recoverable from the token without the key, and tampering is rejected before any payload parse
+- **THEN** its payload (source lifecycle, native revision/exact locator, proof digests, result ids) is not recoverable from the token without the key, and tampering is rejected before any payload parse
 
 ### Requirement: Key-management transparency
 Constructing a client without explicit token key material SHALL emit a startup warning stating that cursors and tokens will not survive process restart or load-balanced deployment. Documentation SHALL state the AEAD nonce-per-key invocation bound and rotation guidance.
@@ -34,4 +34,3 @@ Constructing a client without explicit token key material SHALL emit a startup w
 #### Scenario: Defaulted key warning
 - **WHEN** `make-client` is called with no token key option
 - **THEN** a one-time warning is emitted naming the option to set and the operational consequence of not setting it
-

--- a/openspec/specs/cursor-token-handling/spec.md
+++ b/openspec/specs/cursor-token-handling/spec.md
@@ -15,7 +15,7 @@ TBD - created by archiving change fix-audit-root-causes. Update Purpose after ar
 - **THEN** the first page is returned
 
 ### Requirement: Cursor TTL is configurable and defaults to no expiry
-Cursor expiry SHALL be off by default: tokens minted without a configured TTL SHALL carry no expiry and SHALL decode regardless of age. `make-client` SHALL accept `:cursor-ttl-seconds`; when set, minted tokens embed expiry and decoding an expired token SHALL throw `ex-info` with `:type :eacl/invalid-cursor` and `:reason :expired`.
+Cursor expiry SHALL be off by default for every backend. Tokens minted without `:cursor-ttl-seconds` SHALL carry no expiry and SHALL remain age-valid. When a positive TTL is configured, minted tokens SHALL embed an expiry and decoding at or after that instant SHALL throw `ex-info` with `:type :eacl.pagination/expired-cursor` and `:reason :expired` without restarting pagination. Cache and checkpoint retention SHALL NOT determine cursor lifetime.
 
 #### Scenario: Slow batch pagination does not restart
 - **WHEN** a client without `:cursor-ttl-seconds` resumes pagination with a token minted more than 5 minutes ago
@@ -23,7 +23,35 @@ Cursor expiry SHALL be off by default: tokens minted without a configured TTL SH
 
 #### Scenario: Configured TTL is enforced loudly
 - **WHEN** a client configured with `{:cursor-ttl-seconds 60}` decodes a token older than 60 seconds
-- **THEN** an `:eacl/invalid-cursor` error with `:reason :expired` is thrown — not a silent first page
+- **THEN** an `:eacl.pagination/expired-cursor` error with `:reason :expired` is thrown — not a silent first page
+
+#### Scenario: Key is deliberately retired
+- **WHEN** a non-expiring cursor names a key id absent from the configured keyring
+- **THEN** EACL rejects it as an invalid authenticated cursor rather than age expiry
+
+#### Scenario: Source lifecycle changes
+- **WHEN** restore, reset, excision, purge, branch replacement, or destructive history replacement rotates the source lifecycle
+- **THEN** a prior non-expiring cursor is rejected for lifecycle mismatch and never interpreted against replacement history
+
+### Requirement: Cursor query scope permits exact historical recovery
+Cursor authentication SHALL bind the complete normalized operation/query/principal and answer-affecting configuration independently from the selected snapshot's schema/dependency proof. A change to the current schema or relationship graph SHALL be allowed to reach proof comparison and exact fallback rather than being rejected prematurely as a different query.
+
+#### Scenario: Relevant schema changes after page one
+- **WHEN** current schema generation differs from the cursor's generation but operation, normalized query, principal, and configuration are unchanged
+- **THEN** EACL does not reject the cursor merely because current schema generation differs
+- **AND** a history-capable backend may reconstruct and validate the original exact schema and graph
+
+#### Scenario: Query actually changes
+- **WHEN** operation, principal, permission, resource/subject filter, direction, page shape, ordering ABI, or answer-affecting configuration differs
+- **THEN** EACL rejects it as an invalid cursor before authorization traversal
+
+#### Scenario: Checkpoint was evicted
+- **WHEN** a non-expiring cursor's private continuation checkpoint is missing or evicted
+- **THEN** EACL deterministically replays and validates its authenticated boundary on the selected exact snapshot
+
+#### Scenario: Exact replay exceeds a bound
+- **WHEN** exact replay cannot reach the authenticated boundary within the request deadline or resource limit
+- **THEN** EACL returns the typed deadline/resource outcome rather than expiring, rebasing, or restarting the cursor
 
 ### Requirement: Cursors detect permission-path changes between pages
 Cursors SHALL embed a two-part fingerprint at mint time: the schema-history digest of the minting db value, and a content digest of the query's resolved permission paths (v2) or recursive query plan (v3). On resume: an identical schema digest SHALL proceed (identical schema history implies identical paths); a differing schema digest SHALL trigger recomputation of this query's paths — if their digest matches the cursor's, pagination proceeds (the schema change did not affect this query); if it differs, `ex-info` with `:type :eacl/stale-cursor` SHALL be thrown instead of silently mis-skipping results. Tokens minted before fingerprints existed (no fingerprint field) SHALL be accepted with a logged warning for one release.
@@ -39,4 +67,3 @@ Cursors SHALL embed a two-part fingerprint at mint time: the schema-history dige
 #### Scenario: Unchanged schema resumes normally
 - **WHEN** pages are fetched across an unchanged schema (including unrelated relationship writes in between)
 - **THEN** pagination resumes exactly where it left off, with no duplicates or gaps
-

--- a/openspec/specs/datascript-current-basis-consistency/spec.md
+++ b/openspec/specs/datascript-current-basis-consistency/spec.md
@@ -34,16 +34,16 @@ or authorization evaluation with the typed unsupported capability error.
 - **THEN** EACL returns `:eacl/unsupported-capability` or the normalized exact-snapshot-unavailable error
 - **AND** does not consult a cache as a historical store
 
-#### Scenario: Graph head token
+#### Scenario: Native revision token
 - **WHEN** DataScript emits a causal token for managed current state
-- **THEN** the token carries source scope, mutation anchor, and order hint
+- **THEN** the token carries backend/source/lifecycle scope and the selected native revision
 - **AND** carries no claim that an old immutable DB can later be reconstructed
 
 ### Requirement: DataScript consistency modes preserve their guarantees
 `:minimize-latency` SHALL select the current complete local DB without an
 authoritative wait. `:fully-consistent` SHALL select the current head of the
-serialized local connection. `:at-least-as-fresh T` SHALL select a current DB
-containing authenticated mutation anchor `T` or wait within the request's
+serialized local connection. `:at-least-as-fresh T` SHALL select a same-scope
+current DB whose native revision is at least `T` or wait within the request's
 execution deadline and fail typed if the floor cannot be established.
 
 #### Scenario: Minimize latency
@@ -56,7 +56,7 @@ execution deadline and fail typed if the floor cannot be established.
 - **THEN** EACL captures the current head of the serialized connection as the request linearization point
 
 #### Scenario: At-least floor already present
-- **WHEN** the current DB contains token `T`'s same-scope mutation anchor
+- **WHEN** the current DB has the same source/lifecycle and native revision at least token `T`
 - **THEN** EACL selects that current DB without waiting
 
 #### Scenario: At-least floor unavailable
@@ -132,4 +132,3 @@ errors.
 #### Scenario: Shared conformance corpus
 - **WHEN** CLJ and CLJS replay current, at-least, cache-hit/miss, raw-write, and cursor-mutation traces
 - **THEN** public values, provenance, selected graph identity, and typed failures are equivalent
-

--- a/openspec/specs/dependency-validated-authorization-cache/spec.md
+++ b/openspec/specs/dependency-validated-authorization-cache/spec.md
@@ -16,14 +16,14 @@ EACL SHALL select one immutable snapshot satisfying the request before cross-rev
 - **THEN** every read for the in-flight request remains on the selected immutable value
 
 ### Requirement: Cache lifting is forward-only
-EACL SHALL return a cross-revision candidate only when the selected snapshot contains the candidate's computation mutation anchor and the complete proofs match. Numeric ordering or proof equality alone MUST NOT lift an answer backward from a future or sibling history.
+EACL SHALL return a cross-revision managed candidate only within one configured source lifecycle, for an ordinary current snapshot no older than the candidate's committed native generation, and when complete schema/dependency proofs match. Numeric equality alone MUST NOT lift an answer across replacement or sibling history.
 
 #### Scenario: Candidate causally precedes selected snapshot
-- **WHEN** the selected snapshot contains the candidate computation anchor and has an equal complete dependency proof
+- **WHEN** the selected snapshot is later in the same unreplaced native history and has an equal complete dependency proof
 - **THEN** EACL may proof-lift the answer
 
 #### Scenario: Candidate is from a future sibling
-- **WHEN** a shared cache returns a candidate whose computation anchor is absent from the selected snapshot
+- **WHEN** a candidate belongs to a different lifecycle or is newer than the selected snapshot
 - **THEN** EACL treats it as a miss even if numeric revisions and dependency proof values compare equal
 
 #### Scenario: Validation telemetry is reused
@@ -149,4 +149,3 @@ Provider errors, malformed entries, absent proofs, and proof-computation failure
 #### Scenario: Token anchor is missing
 - **WHEN** consistency selection cannot prove the requested mutation is present
 - **THEN** EACL rejects the request and MUST NOT hide the failure behind an uncached current read
-

--- a/openspec/specs/forward-history-cache-coherence/spec.md
+++ b/openspec/specs/forward-history-cache-coherence/spec.md
@@ -15,7 +15,7 @@ EACL SHALL select one immutable backend snapshot before schema resolution, depen
 - **THEN** the call remains correct for its selected value and any late cache publication is isolated from newer exact generations
 
 ### Requirement: Exact-current generation isolation
-The exact-current cache SHALL admit and return an entry only within the lifecycle and immutable snapshot generation for which it was computed.
+The exact-current completed-answer tier SHALL admit and return an entry only for the canonical immutable snapshot generation, source lifecycle, and complete semantic request for which it was computed. A newer current request MUST NOT observe an older exact entry, while an explicit exact request selecting that older snapshot MAY use the separately bounded snapshot-exact retention path if it remains retained.
 
 #### Scenario: Any forward transaction advances the snapshot
 - **WHEN** the selected current snapshot changes after any committed transaction
@@ -23,7 +23,48 @@ The exact-current cache SHALL admit and return an entry only within the lifecycl
 
 #### Scenario: Late old-generation publication
 - **WHEN** computation against an old snapshot finishes after a newer exact generation is installed
-- **THEN** its result cannot populate or replace the newer generation
+- **THEN** its result remains keyed to the old canonical snapshot and cannot populate, replace, or masquerade as the newer generation
+
+#### Scenario: Same authenticated exact snapshot
+- **WHEN** `:at-exact-snapshot` selects canonical snapshot `T` and a completed answer for the identical semantic request at `T` remains retained
+- **THEN** EACL may return it without traversal or managed-proof reads
+- **AND** rebuilds public snapshot metadata and tokens from the selected adapter at `T`
+
+#### Scenario: Snapshot-exact retention is bounded
+- **WHEN** weight, entry, or admission bounds evict an exact answer
+- **THEN** a later exact request recomputes on its selected immutable snapshot
+- **AND** eviction does not imply snapshot or cursor expiry
+
+### Requirement: Exact requests never use managed cross-snapshot lifting
+An `:at-exact-snapshot` request SHALL probe only completed answers bound to its identical canonical snapshot. It SHALL NOT use relation/schema proof equality to lift a managed answer computed at another revision, and SHALL NOT validate historical answers using current-only or no-history stamps.
+
+#### Scenario: Managed answer has equal dependency proof
+- **WHEN** a managed answer computed at `T2` has proof equal to the exact request's proof at `T1`
+- **THEN** the request does not use that answer unless a separate snapshot-exact entry exists for `T1`
+
+#### Scenario: Exact cache miss
+- **WHEN** no retained completed answer matches the selected exact snapshot and semantic request
+- **THEN** EACL evaluates against the already selected exact adapter
+- **AND** may publish only the completed semantic answer at that exact key
+
+#### Scenario: Public response metadata
+- **WHEN** a snapshot-exact completed answer is reused
+- **THEN** response tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the selected exact adapter
+
+### Requirement: Exact cache identity is complete and lifecycle-scoped
+The canonical snapshot-exact key SHALL include stable backend/source/branch identity, configured source lifecycle, native revision and exact locator, ordinary exact view kind, adapter fingerprint and identity contract, engine/order ABI, normalized semantic request, result kind/shape, normalized demand, and answer-affecting limits. Numeric revision equality alone SHALL NOT establish snapshot identity.
+
+#### Scenario: Source lifecycle rotates
+- **WHEN** cache expiry or history replacement installs a new source lifecycle
+- **THEN** every old snapshot-exact entry becomes unreachable even if native revision numbers repeat
+
+#### Scenario: Adapter semantics change
+- **WHEN** adapter fingerprint, identity contract, engine/order ABI, or an answer-affecting limit changes
+- **THEN** entries computed under the prior semantic identity are ineligible
+
+#### Scenario: Arbitrary historical view
+- **WHEN** a caller supplies a filtered, since, history, speculative, or otherwise uncertified database view
+- **THEN** EACL does not identify it with an ordinary current/as-of exact generation merely because source and numeric revision match
 
 ### Requirement: Complete managed dependency proof
 Managed-current reuse SHALL require an equal schema generation and an equal, canonically ordered version for every relation in the request's complete authorization dependency closure.
@@ -147,7 +188,7 @@ Cache correctness SHALL cover ordinary forward history only. Database restore, r
 
 #### Scenario: Long-running ordinary request
 - **WHEN** an ordinary request holds an older immutable current database value after a newer transaction commits
-- **THEN** it may use stores and generations captured from the same lifecycle that are valid for its selected value, but EACL makes no cache-availability promise for separately constructed `as-of` values
+- **THEN** it may use stores and generations captured from the same lifecycle that are valid for its selected value; only authenticated adapter-selected ordinary exact snapshots are eligible for historical exact retention
 
 #### Scenario: Complete lifecycle rotation
 - **WHEN** `expire-cache!` rotates a client lifecycle
@@ -315,4 +356,3 @@ Any future authorization dependency class beyond schema, relationships, selected
 #### Scenario: New unproved dependency class
 - **WHEN** an authorization operation begins consulting a domain attribute or other state not covered by the current proof
 - **THEN** managed reuse for that operation is disabled until its dependency proof is specified, implemented, and verified
-

--- a/openspec/specs/snapshot-stable-pagination/spec.md
+++ b/openspec/specs/snapshot-stable-pagination/spec.md
@@ -4,11 +4,11 @@
 TBD - created by archiving change redesign-cross-backend-freshness-cache. Update Purpose after archive.
 ## Requirements
 ### Requirement: First page binds graph and execution identity
-Every paginated lookup SHALL select one immutable snapshot before scanning. Each cursor SHALL bind under mandatory authentication, and optional advertised encryption, the backend source/branch scope, graph mutation anchor, exact locator, canonical query scope, engine/adapter/configuration fingerprints, complete schema/relation/identity dependency scope and proof, deterministic direction/position, format version, and expiry.
+Every paginated lookup SHALL select one immutable snapshot before scanning. Each cursor SHALL bind under mandatory authentication, and optional advertised encryption, the backend source/branch scope and lifecycle, native revision and exact locator, canonical query scope, engine/adapter/identity/configuration fingerprints, complete schema/relation dependency scope and proof, deterministic direction/position, format version, and optional configured expiry.
 
 #### Scenario: First page uses at-least freshness
 - **WHEN** a first-page request selects a snapshot satisfying an at-least token
-- **THEN** every emitted cursor identifies that selected graph, proof, and stable position
+- **THEN** every emitted cursor identifies that selected snapshot, proof, and stable position
 
 #### Scenario: Cursor is exposed to the caller
 - **WHEN** a portable cursor is serialized
@@ -39,7 +39,7 @@ A continuation MAY run on a different immutable snapshot when that snapshot has 
 #### Scenario: Unrelated transaction occurs between pages
 - **WHEN** the current selected snapshot differs from page one only in data outside the cursor's complete authorization dependencies
 - **THEN** EACL continues on the current snapshot without historical reconstruction
-- **AND** rebases subsequent cursors to the selected snapshot's graph anchor and proof
+- **AND** subsequent cursors bind the selected snapshot's native revision and proof
 
 #### Scenario: Relevant mutation occurs
 - **WHEN** any schema or relation dependency in the cursor proof changes
@@ -51,24 +51,33 @@ A continuation MAY run on a different immutable snapshot when that snapshot has 
 - **AND** MAY continue only through an available exact snapshot
 
 ### Requirement: Exact reconstruction is a fallback
-When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator only if the request does not require a causally newer floor. If exact reconstruction is unavailable, continuation MUST fail rather than use a changed graph.
+When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator only if the request does not require a causally newer floor. On an unreplaced full-history source, cursor age and ordinary forward mutations SHALL NOT make that locator unavailable. If the configured backend cannot reconstruct the exact value, continuation MUST fail rather than use a changed graph.
 
-#### Scenario: Datomic exact fallback
-- **WHEN** a cursor proof changed and its original Datomic basis remains available
-- **THEN** EACL may continue on the verified `d/as-of` value
+#### Scenario: Datomic exact fallback after arbitrary forward history
+- **WHEN** a cursor proof changed and its original Datomic basis belongs to the same unreplaced source lifecycle
+- **THEN** EACL catches the Peer up to that basis when necessary and continues on the verified `d/as-of` value
+- **AND** cursor age alone does not reject it
 
-#### Scenario: Datahike exact fallback
-- **WHEN** a cursor proof changed and its original commit or temporal snapshot remains available
-- **THEN** EACL may continue on the verified exact Datahike DB
+#### Scenario: Datahike temporal-history fallback
+- **WHEN** a cursor proof changed and the Datahike source has `:keep-history? true`
+- **THEN** EACL reconstructs the verified temporal snapshot even if the named commit record was collected
 
-#### Scenario: DataScript retained value
-- **WHEN** a cursor proof changed and the original immutable DB remains in the bounded registry
-- **THEN** EACL may continue on that retained DB
+#### Scenario: Datahike retained-commit fallback
+- **WHEN** temporal history is disabled and the cursor's named commit remains retained
+- **THEN** EACL may continue on that exact commit
+
+#### Scenario: DataScript current-only source
+- **WHEN** a DataScript cursor proof changes after the current basis advances
+- **THEN** EACL returns a typed stale-cursor result and does not consult a hidden historical registry
 
 #### Scenario: Original snapshot is unavailable
-- **WHEN** the proof changed and no exact mechanism can recover the original value
-- **THEN** EACL returns stale-cursor or snapshot-expired
+- **WHEN** the proof changed and a history-disabled conditional backend no longer retains the exact handle
+- **THEN** EACL returns typed stale-cursor or exact-snapshot-unavailable
 - **AND** MUST NOT silently restart or continue on current data
+
+#### Scenario: History replacement invalidates old locators
+- **WHEN** source lifecycle rotation records restore, reset, excision, purge, branch replacement, or destructive history replacement
+- **THEN** old cursors are rejected for lifecycle mismatch before exact reconstruction
 
 ### Requirement: Newer freshness and cursor stability are jointly evaluated
 A continuation carrying an additional `:at-least-as-fresh` token SHALL first select a snapshot satisfying that token and then compare its complete dependency proof with the cursor proof. A newer floor is compatible when the proofs match and incompatible when they differ.
@@ -99,26 +108,34 @@ The pagination engine SHALL define a stable total order and complete tie-breaker
 - **AND** the cursor does not reinterpret an old internal position as a different public object
 
 ### Requirement: Cursor failures are distinguishable
-EACL SHALL distinguish authentication/scope failure, envelope expiry, missing exact snapshot, changed dependency proof, and incompatible newer freshness.
+EACL SHALL distinguish authentication/query-scope failure, configured envelope expiry, source-lifecycle replacement, conditional exact-snapshot absence, changed dependency proof, incompatible newer freshness, and replay deadline/resource failure.
 
 #### Scenario: Cursor authentication fails
 - **WHEN** encrypted cursor contents, key id, or tag are invalid
 - **THEN** EACL returns `:eacl.pagination/invalid-cursor`
 
-#### Scenario: Cursor lifetime expires
+#### Scenario: Configured cursor lifetime expires
 - **WHEN** the authenticated cursor expiry has elapsed
 - **THEN** EACL returns `:eacl.pagination/expired-cursor`
 
-#### Scenario: Exact storage retention expires
-- **WHEN** a valid changed-proof cursor needs its original snapshot but storage no longer retains it
-- **THEN** EACL returns `:eacl.consistency/snapshot-expired`
+#### Scenario: Non-expiring cursor grows older
+- **WHEN** a cursor carries no expiry and its exact full-history source remains in the same lifecycle
+- **THEN** elapsed wall-clock time is not a rejection condition
+
+#### Scenario: Conditional exact storage is unavailable
+- **WHEN** a valid changed-proof cursor needs a history-disabled commit that has genuinely been collected
+- **THEN** EACL returns the typed exact-snapshot-unavailable/stale-cursor outcome
 
 #### Scenario: Proof changed without exact fallback
 - **WHEN** a valid cursor's current proof differs and the backend never supported exact history
 - **THEN** EACL returns a typed stale-cursor error
 
+#### Scenario: Replay is bounded
+- **WHEN** checkpoint-free exact replay exceeds its deadline or resource ceiling
+- **THEN** EACL returns the corresponding deadline/resource error rather than cursor expiry
+
 ### Requirement: Pagination is differential-tested against an oracle
-The shared suite SHALL compare concatenated cursor pages with a deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof.
+The shared suite SHALL compare concatenated cursor pages with a deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof, including recovery after wall-clock delay, checkpoint eviction, forward mutation, and backend catch-up.
 
 #### Scenario: Insert before cursor boundary
 - **WHEN** a relevant result is inserted before continuation
@@ -136,3 +153,10 @@ The shared suite SHALL compare concatenated cursor pages with a deterministic un
 - **WHEN** a recursive dependency revokes a result after page one
 - **THEN** EACL never emits a hybrid enumeration spanning the old and new proofs
 
+#### Scenario: Client-local checkpoint is lost
+- **WHEN** continuation runs after client restart or checkpoint eviction with stable key and source lifecycle configuration
+- **THEN** exact replay yields the same remaining sequence and boundary validation as uninterrupted enumeration
+
+#### Scenario: Lagging Datomic Peer receives cursor
+- **WHEN** a cursor minted on one Peer names a committed basis ahead of the receiving Peer
+- **THEN** bounded catch-up followed by exact `d/as-of` yields the original enumeration


### PR DESCRIPTION
## Summary

- catch lagging Datomic Peers up to an authenticated exact basis with bounded targeted sync, waiter cancellation, postcondition checks, and exact as-of selection
- make cursors non-expiring by default, preserve explicit TTL policy, and allow schema/dependency changes to reach exact historical replay
- make Datahike history retention the EACL-created default and advertise exact capabilities according to actual configuration
- add a bounded lifecycle-isolated snapshot-exact completed-answer tier without managed cross-snapshot lifting
- update formal models, generated decision bridges, mutation controls, assurance records, documentation, and OpenSpec specifications

## Verification

- CI-equivalent JVM battery: 647 tests, 26,445 assertions, 0 failures, 0 errors
- direct real two-connection Datomic exact catch-up and cursor replay regressions: passed
- real file-backed Datahike cutoff-GC history regressions: passed
- DataScript ClojureScript suite: 199 tests, 7,411 assertions, 0 failures, 0 errors
- formal ClojureScript smoke: 43 tests, 9,970 assertions, 0 failures, 0 errors
- mutation controls: 96 of 96 mutants killed
- Dafny verification: 30 projects, 8,793 obligations, 0 errors
- OpenSpec: change valid under strict validation; all 43 main specs valid
- public-source closure: 61 roots, 1,344 definitions, passed
- formatting and git diff checks: passed

The verification manifest correctly remains conditionally verified because the repository intentionally withholds fully verified status while its five existing independent/refinement assurance gates remain open; CI asserts this nonzero manifest result.