### PR TITLE
Fix cache correctness and bounds found reviewing exact-snapshot reuse

### DIFF
--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,7 +13,7 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "00ae2c1ee9c2c0885b84f3a487bccdfa02bea05d8c573a3ea097091b47338305"
+      "sha256": "524d44438e2911fab49535c141d2284998f9e61965eeb6f3d49b631fe13a7100"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
@@ -69,7 +69,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/backend.clj",
-      "sha256": "09f8d649a291e4e06ca307e1e0d163a0eef6800519656320a8c5b63860ae6ec8"
+      "sha256": "e1dc1f75a1b7258eeb8c3ce3d7d8703324514f63884333d8c1b68c5d3367d696"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/cache.clj",
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "77ca2bc16f1323175fa7559480b1e80fe3ca2c522a60b6c6f5519a8a31ccc622"
+      "sha256": "d43a5609b20230d82ef883a68e50aa0088f0b8672f6611d26a6b86be9ceb41e6"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -129,7 +129,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "449d27e460680dcd1a012f00437caf7c7363b7a3394fa736a3b1370900ef465c"
+      "sha256": "972b86cdcd30fc3858f55fa20466085eb90c9c775b28988bc6cfa6690096dbcf"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -189,7 +189,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "3738463ec1e15fb4ba0d4d171e769898a4f212064c1030b56ab6e15bbaa80c4f"
+      "sha256": "0621c12643a8b0ebb1d04f7efcf060e3e9e933e43015f009b1ebb58dbcc3a3e2"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -333,9 +333,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1344,
-    "unionInternalDefinitionIdsSha256": "3be08f87d89c46dfca922d35b2a6641d48b727c89de9cf3ef6b590d3ef67053e",
-    "unionDefinitionLocationsSha256": "00313d2bef3d64e1f37c65526e5cffa4d14ceb570029623bd003da8932dd0ba4",
+    "unionInternalDefinitionCount": 1350,
+    "unionInternalDefinitionIdsSha256": "919126752eba9d9978cc740cd1e1a93afb0385d463d1ce31ffa7dec06d3822a0",
+    "unionDefinitionLocationsSha256": "9c1885a646be472571b3b634c286b6e00d256f630e6c5cca82bfb5097f99c39e",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,
@@ -378,8 +378,8 @@
         "idsSha256": "7ffedf1948fac06fa42a2f7976c664f9a1cc9a537f315169f974c4cddd0cb68f"
       },
       "modules/eacl-datomic/src/eacl/datomic/backend.clj": {
-        "count": 12,
-        "idsSha256": "a7761318eeaf44358f14ff732f9efb98189701eaea2c5dc9b722fd2cd44f2adc"
+        "count": 13,
+        "idsSha256": "898b12609377bb4c6294d34c53abeb4a44bbf2228a0f5f14974068978f997b0b"
       },
       "modules/eacl-datomic/src/eacl/datomic/cache.clj": {
         "count": 4,
@@ -394,8 +394,8 @@
         "idsSha256": "41564ae9195b19dd851d20e77ec6d32379244f26211d5a815622b45fb2df2592"
       },
       "modules/eacl-datomic/src/eacl/datomic/core.clj": {
-        "count": 121,
-        "idsSha256": "18faeb96e23d6817cf7c2a02bd6d2c0f9ecb02d103d9fa96ad408f59f632efee"
+        "count": 122,
+        "idsSha256": "e63dd0f06bde510f85f3360eb8cc515591d7f917927b1c4e880d693e3fdc3c53"
       },
       "modules/eacl-datomic/src/eacl/datomic/db.clj": {
         "count": 9,
@@ -426,8 +426,8 @@
         "idsSha256": "1ef9aaa3526b5cd6d8664568a8ff02a76252eb777f563d32789ba574e576d072"
       },
       "modules/eacl/src/eacl/cache.cljc": {
-        "count": 36,
-        "idsSha256": "1334f67606da887bf62d3e9c44b2b4f1750ac270a242f4954505ee55fc633f38"
+        "count": 39,
+        "idsSha256": "b42be3a4a8ce0e1554cb06bdf07f1b804103ec863e9e3364303f9e32c7ec524f"
       },
       "modules/eacl/src/eacl/causal_token.cljc": {
         "count": 17,
@@ -486,8 +486,8 @@
         "idsSha256": "2baa47acc019ed669bc2d286552110b2581701131dfbbe2d9496523c256e79da"
       },
       "modules/eacl/src/eacl/engine/v8.cljc": {
-        "count": 78,
-        "idsSha256": "76e77e7e4b70fedb38ec985f56914117d74d3bdda53b756c2cbd0331c180cd78"
+        "count": 79,
+        "idsSha256": "478429a13246b4fe561e6ecd49a53fd494303523669fac4c659e4a60438e0814"
       },
       "modules/eacl/src/eacl/execution.cljc": {
         "count": 26,
@@ -816,8 +816,8 @@
       ]
     },
     "eacl.cache/resolve-current!": {
-      "internalDefinitionCount": 171,
-      "internalDefinitionIdsSha256": "4af9f182c08dc33b4265c7d5dafe1099e31e412ed6a35b7718577a26617ee6e6",
+      "internalDefinitionCount": 174,
+      "internalDefinitionIdsSha256": "777975cbcd6c98e189a8508315d1209ef129c402d7d797a6af7a7dcd98103b85",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -935,8 +935,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 808,
-      "internalDefinitionIdsSha256": "74430e67ea8af61b74d68755eced7c6b797312b9c168324709e1712a2b6e682e",
+      "internalDefinitionCount": 814,
+      "internalDefinitionIdsSha256": "9565da92a3fc925ebc4f256990ba48c4e22c3a58e0e90d375bfc360c5c99d7f0",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -978,8 +978,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 515,
-      "internalDefinitionIdsSha256": "7936c5f71abd2ffa38f73c014e8f32385e677a2ee85499ae6d070e5d562d233b",
+      "internalDefinitionCount": 520,
+      "internalDefinitionIdsSha256": "891f1c76a3bb46bd7613a3558139c31086ef70d022fcd991cf875b8c7a9721de",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1053,8 +1053,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 472,
-      "internalDefinitionIdsSha256": "ee26adb9498f2a8e4a0d49fceb05575dfde8a6a53cdc7b25c387729aefb77c47",
+      "internalDefinitionCount": 477,
+      "internalDefinitionIdsSha256": "5fefe20acff7c6f7d974f98ce5c7ac25746004fab693ee9d15feae520a1d6d20",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1083,8 +1083,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 607,
-      "internalDefinitionIdsSha256": "b39b112001e09b2a2084cfa62cccf43c0ea6ec2822a38ab73a5b5d4a42a81d68",
+      "internalDefinitionCount": 613,
+      "internalDefinitionIdsSha256": "518b81fe109964d5bc4b6a7750727d365dab97a3278244315e97e6455cb9ea5d",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1113,8 +1113,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 474,
-      "internalDefinitionIdsSha256": "5d1a2eb86aa8f4883b4fb09b567b1e9905e71b3ec866ad1f10fe9d30d4cf49b1",
+      "internalDefinitionCount": 479,
+      "internalDefinitionIdsSha256": "ac315e55bb65b79390c2cb73702a453e44cbd1bc88a308c6fe325c75e9f3013d",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1143,8 +1143,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 607,
-      "internalDefinitionIdsSha256": "338a001ab297efa7e5d1ed58ba7586db19a7b6fa457c8a50664b0e39db26b5d3",
+      "internalDefinitionCount": 613,
+      "internalDefinitionIdsSha256": "d6422f130e4921146116bd964e18ba79e860ac5b827b6299a74a871cb210936a",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1173,8 +1173,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 474,
-      "internalDefinitionIdsSha256": "4b2dbdd2ae2f6dfd7e1bc18a18b051493910c78cc7a5889f9048d0667d392edb",
+      "internalDefinitionCount": 479,
+      "internalDefinitionIdsSha256": "599b39af031b41b546ed708bea2c158759daaa80947ca242681dd8e15f6a7074",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1203,8 +1203,8 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 221,
-      "internalDefinitionIdsSha256": "751b682d6f54478ced948e20b4187d3b2d397dfe2e8f2ba4cc278a32c8457829",
+      "internalDefinitionCount": 222,
+      "internalDefinitionIdsSha256": "d4aeab5d5d70521b2663620c71fbb0f88a85f76eeefa7229156f9fc5303bff6a",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1238,8 +1238,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 809,
-      "internalDefinitionIdsSha256": "d8c575a77a5d113f6c474eb802e7d61153ca7d3c523ab70bfd50300863a5d43a",
+      "internalDefinitionCount": 815,
+      "internalDefinitionIdsSha256": "84d50a553dc3e9840e28867322580addb767db1d6f6203f16c32e997a8faf9a0",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1281,8 +1281,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 811,
-      "internalDefinitionIdsSha256": "383455e3b7a9bcc589e758a4c72f02a2fade24ee5a32f67f8082d8c9e4a932e2",
+      "internalDefinitionCount": 817,
+      "internalDefinitionIdsSha256": "e4f9acc0148a82cbf751d922794bf05af3065df841e8caa417e5084d1d259e1b",
       "externalCallCount": 36,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1324,8 +1324,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 634,
-      "internalDefinitionIdsSha256": "bae3df59ee94044709b71fa9d2ac18298a011dc4af37a5d977b1934bfccdc3c2",
+      "internalDefinitionCount": 638,
+      "internalDefinitionIdsSha256": "ae6775d04cb735de0b34f747074de5e047cc85fc0bd69042a18123eb0108c910",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1361,8 +1361,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 590,
-      "internalDefinitionIdsSha256": "14975d841a05f94a1dd2b26939669b10bb200cbb4c28f225106ecc39b0c1580e",
+      "internalDefinitionCount": 594,
+      "internalDefinitionIdsSha256": "9c397c7311b2215b562d1f974e52cbd451dee26608e85b017cdc0b4712d076be",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1463,8 +1463,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 588,
-      "internalDefinitionIdsSha256": "1273544599930eed825377e8f92bf4e35c66e771c3b06c2094384949e2383992",
+      "internalDefinitionCount": 592,
+      "internalDefinitionIdsSha256": "106c72c3242fafaf00971f29f10c33fbab8014063db7abd9cb43efd827672ddd",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1498,8 +1498,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 717,
-      "internalDefinitionIdsSha256": "18534a081ad2375f99997aa5299cd432fb6b2a5fbbb3d32c263d9e62c271f1ec",
+      "internalDefinitionCount": 721,
+      "internalDefinitionIdsSha256": "a93b818688928b981525b80d20daaea207a899eb33288ba94140386a78b46981",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1534,8 +1534,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 591,
-      "internalDefinitionIdsSha256": "5994bc060e86be34195a5de4cc67293045c6764c1929b41325b0e8a56db5136b",
+      "internalDefinitionCount": 595,
+      "internalDefinitionIdsSha256": "df5fb92946b29e3fa10c97f390f468cdce7344e877c81b559b071e78b94437ed",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1569,8 +1569,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 717,
-      "internalDefinitionIdsSha256": "5f9f1c3d78bf722ec14d624dadbb50f69854efb398927bc89906d2498a7da60c",
+      "internalDefinitionCount": 721,
+      "internalDefinitionIdsSha256": "921caac9e6d35dcd30082bde3075fb72aacc726508f8d24707a93284a42d9fcc",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1605,8 +1605,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 591,
-      "internalDefinitionIdsSha256": "f756a4ac9ddfb69bc372d09d3a44bb6b5525c6f765ae654d6ce3fa369e1fcce5",
+      "internalDefinitionCount": 595,
+      "internalDefinitionIdsSha256": "63742aa9319d568b26881c50b17286d6a284317e60388003f411089f671b768c",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1671,8 +1671,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 575,
-      "internalDefinitionIdsSha256": "8109bcbc26956d58304699cb0016278d2b0f16c4feabca4515c2c8f4d8b0cc89",
+      "internalDefinitionCount": 579,
+      "internalDefinitionIdsSha256": "1fdec765d29c5a9c3c1f65b8b58c46c21f539aab1f8e86123b7b0f3ba4c21004",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1770,8 +1770,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 573,
-      "internalDefinitionIdsSha256": "f17bd9060c4eec88493203121ae873b84e05397b34c76981614e425b330d131f",
+      "internalDefinitionCount": 577,
+      "internalDefinitionIdsSha256": "edec8bba2927e2f01859df1e5ccd6386e552ae32265a64731442f67f1e2f0b23",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1804,8 +1804,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 702,
-      "internalDefinitionIdsSha256": "6b595e17ff216cd632061fc2ab5eb2b10a753764ff5aff336cd595a2ea4896ff",
+      "internalDefinitionCount": 706,
+      "internalDefinitionIdsSha256": "3681d1a3de9205b6ea69cbc71330578f8e25e96dc718ca41ac93a85020805313",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1839,8 +1839,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 576,
-      "internalDefinitionIdsSha256": "0cb5fc7a3c775f574549f6c2b53fc7da47fa47feb932a7e988280c2b91514162",
+      "internalDefinitionCount": 580,
+      "internalDefinitionIdsSha256": "6cc32b83963b9c43f1671120ff1b9f29e857c206b77e4e9a7c62205c0b36bb4e",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1873,8 +1873,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 702,
-      "internalDefinitionIdsSha256": "760b1971d4320afd32c157e60391ea09ab3c0a4fcaa6c07fa5044e3ab5f9b943",
+      "internalDefinitionCount": 706,
+      "internalDefinitionIdsSha256": "a9e32fdea895eb301f0827fcecd6f63c2a15ae6c4c435ca4861f9715c7e18762",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1908,8 +1908,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 576,
-      "internalDefinitionIdsSha256": "a5e365da6639970681e7afa331a4db5d4d6be0a3e92f617c2167994d6e9e59c3",
+      "internalDefinitionCount": 580,
+      "internalDefinitionIdsSha256": "ed1b43979596e772391a3dd2dd0892a77edcd56a4e965b1663955bfe38003281",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,7 +13,7 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "524d44438e2911fab49535c141d2284998f9e61965eeb6f3d49b631fe13a7100"
+      "sha256": "d086ae44132d18ce75edb3f9aabd0c969bfc1429c9f535a045578e8840055a67"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
@@ -129,7 +129,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "972b86cdcd30fc3858f55fa20466085eb90c9c775b28988bc6cfa6690096dbcf"
+      "sha256": "5f32f85e47c86391e780a0d0d17f1cee0a6e56af204b27a676a319a2eb932aa8"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -335,7 +335,7 @@
     "rootCount": 61,
     "unionInternalDefinitionCount": 1350,
     "unionInternalDefinitionIdsSha256": "919126752eba9d9978cc740cd1e1a93afb0385d463d1ce31ffa7dec06d3822a0",
-    "unionDefinitionLocationsSha256": "9c1885a646be472571b3b634c286b6e00d256f630e6c5cca82bfb5097f99c39e",
+    "unionDefinitionLocationsSha256": "09b485656f24a7bcdb1b7779356a0261e0b93ce398c7b298fdc54c49f6fd22d3",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -268,7 +268,7 @@
        (fn [] (or (commit-locator db) selected-exact-locator))
 
        :select-exact
-       (fn [token-data timeout-ms]
+       (fn [token-data _timeout-ms]
          (when (and conn
                     (or (:exact-locator token-data)
                         (and (temporal-history? db)
@@ -282,14 +282,18 @@
                             (temporal-history? db)
                             (integer? (:revision token-data)))
                    (try
-                     ;; A reader connection may simply not have observed the
-                     ;; writer's revision yet. Await it exactly as
-                     ;; :select-at-least does, so replica lag is reported as
-                     ;; bounded lag instead of as durable history that is
-                     ;; missing. Retained history older than the local head
-                     ;; still resolves without waiting.
-                     (d/as-of (await-revision-db conn db token-data timeout-ms)
-                              (:revision token-data))
+                     ;; A revision above the local head is reported unavailable
+                     ;; immediately rather than waited for. Datahike has no
+                     ;; `d/sync` (replikativ/datahike#958), so the only ways to
+                     ;; wait are unbounded polling or a fixed N-second timeout,
+                     ;; and neither can distinguish a revision that is merely
+                     ;; late from one that will never arrive. Failing closed
+                     ;; keeps the caller's deadline theirs to spend. Datahike
+                     ;; also caches connections per store config in-process, so
+                     ;; for a direct writer this local head is authoritative.
+                     (let [current (d/db conn)]
+                       (when (<= (:revision token-data) (:max-tx current))
+                         (d/as-of current (:revision token-data))))
                      (catch InterruptedException interrupt
                        (.interrupt (Thread/currentThread))
                        (throw
@@ -301,17 +305,6 @@
                           :phase :exact-temporal
                           :requested-revision (:revision token-data)}
                          interrupt)))
-                     (catch clojure.lang.ExceptionInfo info
-                       ;; A classified freshness or selection failure is the
-                       ;; answer, not a provider fault to re-wrap.
-                       (if (contains?
-                            #{:eacl.consistency/freshness-unavailable
-                              :eacl.basis/selection-failure}
-                            (:type (ex-data info)))
-                         (throw info)
-                         (selection-failure!
-                          "Datahike temporal reconstruction failed."
-                          :exact-temporal token-data info)))
                      (catch Exception failure
                        (selection-failure!
                         "Datahike temporal reconstruction failed."

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -268,7 +268,7 @@
        (fn [] (or (commit-locator db) selected-exact-locator))
 
        :select-exact
-       (fn [token-data _timeout-ms]
+       (fn [token-data timeout-ms]
          (when (and conn
                     (or (:exact-locator token-data)
                         (and (temporal-history? db)
@@ -282,9 +282,14 @@
                             (temporal-history? db)
                             (integer? (:revision token-data)))
                    (try
-                     (let [current (d/db conn)]
-                       (when (<= (:revision token-data) (:max-tx current))
-                         (d/as-of current (:revision token-data))))
+                     ;; A reader connection may simply not have observed the
+                     ;; writer's revision yet. Await it exactly as
+                     ;; :select-at-least does, so replica lag is reported as
+                     ;; bounded lag instead of as durable history that is
+                     ;; missing. Retained history older than the local head
+                     ;; still resolves without waiting.
+                     (d/as-of (await-revision-db conn db token-data timeout-ms)
+                              (:revision token-data))
                      (catch InterruptedException interrupt
                        (.interrupt (Thread/currentThread))
                        (throw
@@ -296,6 +301,17 @@
                           :phase :exact-temporal
                           :requested-revision (:revision token-data)}
                          interrupt)))
+                     (catch clojure.lang.ExceptionInfo info
+                       ;; A classified freshness or selection failure is the
+                       ;; answer, not a provider fault to re-wrap.
+                       (if (contains?
+                            #{:eacl.consistency/freshness-unavailable
+                              :eacl.basis/selection-failure}
+                            (:type (ex-data info)))
+                         (throw info)
+                         (selection-failure!
+                          "Datahike temporal reconstruction failed."
+                          :exact-temporal token-data info)))
                      (catch Exception failure
                        (selection-failure!
                         "Datahike temporal reconstruction failed."

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -697,11 +697,12 @@
            (eacl/->Relationship second-reader :reader document))))
       (finally (d/release conn)))))
 
-(deftest lagging-datahike-reader-awaits-the-exact-revision-test
-  ;; Datahike used to report a locally future revision as missing history while
-  ;; :select-at-least waited for the same revision on the same adapter. Exact
-  ;; selection now awaits it under the caller's bound, so replica lag is
-  ;; reported as bounded lag rather than as durable history that is gone.
+(deftest future-datahike-revision-is-unavailable-without-blocking-test
+  ;; Datahike has no `d/sync` (replikativ/datahike#958), so the only ways to
+  ;; wait for an unobserved revision are unbounded polling or a fixed N-second
+  ;; timeout, and neither distinguishes a revision that is late from one that
+  ;; will never arrive. Exact selection therefore reports a locally future
+  ;; revision as unavailable immediately and leaves the deadline to the caller.
   (let [conn (datahike/create-conn nil {:keep-history? true})
         authorization (client conn)]
     (try
@@ -710,16 +711,21 @@
       (let [db (d/db conn)
             adapter (datahike-backend/snapshot-adapter db {:conn conn})
             future-revision (+ 1000 (:max-tx db))
-            data (try
-                   (backend/invoke
-                    adapter :select-exact
-                    {:revision future-revision :exact-locator nil}
-                    25)
-                   nil
-                   (catch clojure.lang.ExceptionInfo error
-                     (ex-data error)))]
-        (is (= :eacl.consistency/freshness-unavailable (:type data))
-            "an unobserved revision is bounded lag, not missing history")
-        (is (= :freshness-timeout (:reason data)))
-        (is (= future-revision (:requested-order-hint data))))
+            started (System/nanoTime)
+            selected (backend/invoke
+                      adapter :select-exact
+                      {:revision future-revision :exact-locator nil}
+                      30000)
+            elapsed-ms (quot (- (System/nanoTime) started) 1000000)]
+        (is (nil? selected)
+            "a revision the local value has not observed is unavailable")
+        (is (< elapsed-ms 1000)
+            "selection must not spend the caller's timeout waiting for it"))
+      (testing "retained history at or below the local head still resolves"
+        (let [db (d/db conn)
+              adapter (datahike-backend/snapshot-adapter db {:conn conn})]
+          (is (some? (backend/invoke
+                      adapter :select-exact
+                      {:revision (:max-tx db) :exact-locator nil}
+                      30000)))))
       (finally (d/release conn)))))

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -1,5 +1,6 @@
 (ns eacl.datahike.consistency-v3-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk]
             [datahike.api :as d]
             [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
@@ -649,3 +650,76 @@
                                               [:database-id :store]))))
         "the store identity carries only backend and id, never connection configuration")
     (d/release conn)))
+
+;; --- 2026-08-16 exact-cache review ------------------------------------------
+
+(deftest relation-root-tree-expansion-observes-relationship-writes-test
+  ;; A relation root reads that relation's relationships, but no permission
+  ;; path names it. When the dependency closure missed it, the managed
+  ;; cross-snapshot tier proved a stale tree equal at every later snapshot.
+  (let [conn (datahike/create-conn)
+        authorization (client conn)
+        second-reader (eacl/spice-object :user "second-reader")
+        leaf-subject-ids
+        (fn [tree]
+          (let [ids (atom #{})]
+            (clojure.walk/postwalk
+             (fn [node]
+               (when (and (map? node) (contains? node :subjects))
+                 (swap! ids into (map :id (:subjects node))))
+               node)
+             tree)
+            @ids))]
+    (try
+      (seed! conn authorization)
+      (d/transact conn [{:eacl/id "second-reader"}])
+      (eacl/create-relationship! authorization relationship)
+      (doseq [root [:reader :view]]
+        (testing (str "root " root)
+          (is (= #{"user"}
+                 (leaf-subject-ids
+                  (:tree-root
+                   (eacl/expand-permission-tree
+                    authorization
+                    {:resource document :permission root})))))
+          (eacl/create-relationship!
+           authorization
+           (eacl/->Relationship second-reader :reader document))
+          (is (= #{"user" "second-reader"}
+                 (leaf-subject-ids
+                  (:tree-root
+                   (eacl/expand-permission-tree
+                    authorization
+                    {:resource document :permission root}))))
+              "a cached tree must not survive a write it reports")
+          (eacl/delete-relationship!
+           authorization
+           (eacl/->Relationship second-reader :reader document))))
+      (finally (d/release conn)))))
+
+(deftest lagging-datahike-reader-awaits-the-exact-revision-test
+  ;; Datahike used to report a locally future revision as missing history while
+  ;; :select-at-least waited for the same revision on the same adapter. Exact
+  ;; selection now awaits it under the caller's bound, so replica lag is
+  ;; reported as bounded lag rather than as durable history that is gone.
+  (let [conn (datahike/create-conn nil {:keep-history? true})
+        authorization (client conn)]
+    (try
+      (seed! conn authorization)
+      (eacl/create-relationship! authorization relationship)
+      (let [db (d/db conn)
+            adapter (datahike-backend/snapshot-adapter db {:conn conn})
+            future-revision (+ 1000 (:max-tx db))
+            data (try
+                   (backend/invoke
+                    adapter :select-exact
+                    {:revision future-revision :exact-locator nil}
+                    25)
+                   nil
+                   (catch clojure.lang.ExceptionInfo error
+                     (ex-data error)))]
+        (is (= :eacl.consistency/freshness-unavailable (:type data))
+            "an unobserved revision is bounded lag, not missing history")
+        (is (= :freshness-timeout (:reason data)))
+        (is (= future-revision (:requested-order-hint data))))
+      (finally (d/release conn)))))

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -25,6 +25,21 @@
   [^datomic.Database db]
   (or (.asOfT db) (d/basis-t db)))
 
+(defn- ordinary-view?
+  "True when `db` is an ordinary current or as-of database value.
+
+  `d/filter`, `d/since` and `d/history` views report the same database id and
+  basis as the plain value they wrap, so nothing downstream can tell them apart
+  by revision: they would mint the identical snapshot identity while answering
+  different questions. Exact-snapshot consistency is therefore refused for
+  them, which is also what keeps them out of the snapshot-exact cache tier. An
+  as-of value is ordinary — it is precisely the exact view this backend
+  selects."
+  [^datomic.Database db]
+  (and (not (.isFiltered db))
+       (not (.isHistory db))
+       (nil? (.sinceT db))))
+
 (def ^:private sync-timeout-marker (Object.))
 
 (defn- freshness-unavailable!
@@ -251,7 +266,10 @@
          (nil? conn)
          (update :consistency disj
                  :fully-consistent :at-least-as-fresh
-                 :at-exact-snapshot))
+                 :at-exact-snapshot)
+
+         (not (ordinary-view? db))
+         (update :consistency disj :at-exact-snapshot))
        :state {:db db
                :opts opts}
        :operations
@@ -281,83 +299,124 @@
 
         :select-authoritative
         (fn [timeout-ms]
-          (try
-            (let [selected
-                  (if conn
-                    (deref (d/sync conn)
-                           (or timeout-ms 30000)
-                           ::timeout)
-                    db)]
-              (when (= ::timeout selected)
-                (throw
-                 (ex-info
-                  "Timed out establishing the Datomic authoritative head."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :freshness-timeout
-                   :timeout-ms (or timeout-ms 30000)})))
-              (snapshot-adapter selected opts'))
-            (catch clojure.lang.ExceptionInfo error
-              (if (= :eacl.consistency/freshness-unavailable
-                     (:type (ex-data error)))
-                (throw error)
-                (throw
-                 (ex-info
-                  "Failed establishing the Datomic authoritative head."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :sync-failed
-                   :timeout-ms (or timeout-ms 30000)}
-                  error))))))
+          ;; The waiter is held outside the body so every exit path can cancel
+          ;; it, while `d/sync` itself stays inside the try and keeps its
+          ;; existing failure classification.
+          (let [waiter (volatile! nil)]
+            (try
+              (let [selected
+                    (if conn
+                      (do (vreset! waiter (d/sync conn))
+                          (deref @waiter (or timeout-ms 30000) ::timeout))
+                      db)]
+                (when (= ::timeout selected)
+                  ;; EACL owns the future once it stops waiting: an abandoned
+                  ;; sync stays registered on the connection until its basis
+                  ;; arrives, which under retry traffic is unbounded.
+                  (cancel-waiter! @waiter)
+                  (throw
+                   (ex-info
+                    "Timed out establishing the Datomic authoritative head."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :freshness-timeout
+                     :timeout-ms (or timeout-ms 30000)})))
+                (snapshot-adapter selected opts'))
+              (catch InterruptedException interrupt
+                (cancel-waiter! @waiter)
+                (let [classified
+                      (ex-info
+                       "Establishing the Datomic authoritative head was interrupted."
+                       {:type :eacl.basis/selection-failure
+                        :eacl/error :eacl.basis/selection-failure
+                        :classification :cancelled
+                        :phase :authoritative-sync
+                        :timeout-ms (or timeout-ms 30000)}
+                       interrupt)]
+                  (.interrupt (Thread/currentThread))
+                  (throw classified)))
+              (catch clojure.lang.ExceptionInfo error
+                (if (= :eacl.consistency/freshness-unavailable
+                       (:type (ex-data error)))
+                  (throw error)
+                  (throw
+                   (ex-info
+                    "Failed establishing the Datomic authoritative head."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :sync-failed
+                     :timeout-ms (or timeout-ms 30000)}
+                    error)))))))
 
         :select-at-least
         (fn [token-data timeout-ms]
-          (try
-            (let [selected
-                  (if conn
-                    (deref (d/sync conn (:revision token-data))
-                           (or timeout-ms 30000)
-                           ::timeout)
-                    db)
-                  requested-order-hint (:revision token-data)]
-              (when (= ::timeout selected)
-                (throw
-                 (ex-info
-                  "Timed out waiting for the Datomic causal floor."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :freshness-timeout
-                   :requested-order-hint (:revision token-data)
-                   :timeout-ms (or timeout-ms 30000)})))
-              ;; d/sync is specified to return a DB at least as new as the
-              ;; requested basis. Check the postcondition anyway: adapters and
-              ;; test doubles are not allowed to turn an order hint into an
-              ;; unverified freshness claim.
-              (when (and requested-order-hint
-                         (< (d/basis-t selected) requested-order-hint))
-                (throw
-                 (ex-info
-                  "The selected Datomic snapshot did not reach the causal floor."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :head-behind
-                   :requested-order-hint requested-order-hint
-                   :observed-order-hint (d/basis-t selected)
-                   :timeout-ms (or timeout-ms 30000)})))
-              (snapshot-adapter selected opts'))
-            (catch clojure.lang.ExceptionInfo error
-              (if (= :eacl.consistency/freshness-unavailable
-                     (:type (ex-data error)))
-                (throw error)
-                (throw
-                 (ex-info
-                  "Failed waiting for the Datomic causal floor."
-                  {:type :eacl.consistency/freshness-unavailable
-                   :eacl/error :eacl.consistency/freshness-unavailable
-                   :reason :sync-failed
-                   :requested-order-hint (:revision token-data)
-                   :timeout-ms (or timeout-ms 30000)}
-                  error))))))
+          ;; The waiter is held outside the body so every exit path can cancel
+          ;; it, while `d/sync` itself stays inside the try and keeps its
+          ;; existing failure classification.
+          (let [waiter (volatile! nil)]
+            (try
+              (let [selected
+                    (if conn
+                      (do (vreset! waiter (d/sync conn (:revision token-data)))
+                          (deref @waiter (or timeout-ms 30000) ::timeout))
+                      db)
+                    requested-order-hint (:revision token-data)]
+                (when (= ::timeout selected)
+                  ;; EACL owns the future once it stops waiting: an abandoned
+                  ;; sync stays registered on the connection until its basis
+                  ;; arrives, which under retry traffic is unbounded.
+                  (cancel-waiter! @waiter)
+                  (throw
+                   (ex-info
+                    "Timed out waiting for the Datomic causal floor."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :freshness-timeout
+                     :requested-order-hint (:revision token-data)
+                     :timeout-ms (or timeout-ms 30000)})))
+                ;; d/sync is specified to return a DB at least as new as the
+                ;; requested basis. Check the postcondition anyway: adapters and
+                ;; test doubles are not allowed to turn an order hint into an
+                ;; unverified freshness claim.
+                (when (and requested-order-hint
+                           (< (d/basis-t selected) requested-order-hint))
+                  (throw
+                   (ex-info
+                    "The selected Datomic snapshot did not reach the causal floor."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :head-behind
+                     :requested-order-hint requested-order-hint
+                     :observed-order-hint (d/basis-t selected)
+                     :timeout-ms (or timeout-ms 30000)})))
+                (snapshot-adapter selected opts'))
+              (catch InterruptedException interrupt
+                (cancel-waiter! @waiter)
+                (let [classified
+                      (ex-info
+                       "Waiting for the Datomic causal floor was interrupted."
+                       {:type :eacl.basis/selection-failure
+                        :eacl/error :eacl.basis/selection-failure
+                        :classification :cancelled
+                        :phase :at-least-sync
+                        :requested-order-hint (:revision token-data)
+                        :timeout-ms (or timeout-ms 30000)}
+                       interrupt)]
+                  (.interrupt (Thread/currentThread))
+                  (throw classified)))
+              (catch clojure.lang.ExceptionInfo error
+                (if (= :eacl.consistency/freshness-unavailable
+                       (:type (ex-data error)))
+                  (throw error)
+                  (throw
+                   (ex-info
+                    "Failed waiting for the Datomic causal floor."
+                    {:type :eacl.consistency/freshness-unavailable
+                     :eacl/error :eacl.consistency/freshness-unavailable
+                     :reason :sync-failed
+                     :requested-order-hint (:revision token-data)
+                     :timeout-ms (or timeout-ms 30000)}
+                    error)))))))
 
         :exact-locator
         (fn []

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -462,10 +462,22 @@
      :timeout-ms timeout-ms}
     cause)))
 
+(defn- cursor-selection-timeout-ms
+  "The catch-up bound for cursor reconstruction.
+
+  Every other selection path bounds its wait by the request's remaining
+  execution time as well as the configured sync timeout; a cursor replay that
+  ignored the deadline could outlive the request that asked for it."
+  [opts]
+  (if-let [contract (:execution-contract opts)]
+    (min (:consistency-sync-timeout-ms opts)
+         (execution/remaining-millis contract))
+    (:consistency-sync-timeout-ms opts)))
+
 (defn- await-revision-db
   "Returns a local DB that has observed `requested-t`, waiting only when needed."
   [conn opts requested-t]
-  (let [timeout-ms (:consistency-sync-timeout-ms opts)
+  (let [timeout-ms (cursor-selection-timeout-ms opts)
         local-db
         (try
           (d/db conn)
@@ -490,7 +502,7 @@
         (historical-selection-failure!
          "Failed reconstructing the Datomic cursor snapshot."
          :cursor-exact-as-of requested-t
-         (:consistency-sync-timeout-ms opts) e)))
+         (cursor-selection-timeout-ms opts) e)))
     (catch InterruptedException interrupt
       (.interrupt (Thread/currentThread))
       (throw
@@ -508,7 +520,7 @@
       (historical-selection-failure!
        "Failed reconstructing the Datomic cursor snapshot."
        :cursor-exact-as-of requested-t
-       (:consistency-sync-timeout-ms opts) failure))))
+       (cursor-selection-timeout-ms opts) failure))))
 
 (defn- list-query-identity
   [op query]
@@ -873,7 +885,7 @@
   [opts consistency-context op query-identity kind valid-result? weight-fn compute]
   (let [contract (:execution-contract opts)
         {:keys [adapter db relationship-dependencies
-                permission-dependencies basis-t completed-cache?
+                permission-dependencies basis-t snapshot-exact?
                 request-proof-frame]}
         consistency-context
         evaluate
@@ -885,10 +897,8 @@
                    (portable-result kind (compute)))]
              (execution/check! contract :semantic-evaluation)
              value))
-        snapshot-exact? (:snapshot-exact? consistency-context)
         cacheable?
         (and (:current-cache-store opts)
-             completed-cache?
              (or (not snapshot-exact?)
                  (backend/deterministic? adapter))
              (or (nil? contract)
@@ -1605,17 +1615,16 @@
                  (or (:mode selected-context) mode))
               (not= selected-current-basis (:basis-t selected-context)))]
       (merge
-     selected-context
-     {:mode (or (:mode selected-context) mode)
-      :snapshot-exact? snapshot-exact?
-      ;; A cursor is authenticated before snapshot selection. Historical
-      ;; reconstruction may use only the separately keyed snapshot-exact tier;
-      ;; current requests retain exact-current plus managed-proof behavior.
-      :completed-cache?
-      true
-      :requested-t requested-t
-      :selection selection
-      :response-token nil}))))
+       selected-context
+       {:mode (or (:mode selected-context) mode)
+        ;; A cursor is authenticated before snapshot selection. Historical
+        ;; reconstruction may use only the separately keyed snapshot-exact
+        ;; tier; current requests retain exact-current plus managed-proof
+        ;; behavior.
+        :snapshot-exact? snapshot-exact?
+        :requested-t requested-t
+        :selection selection
+        :response-token nil}))))
 
 (defn- capture-basic-result-context
   "Selects one immutable snapshot without constructing schema or relation
@@ -1646,7 +1655,8 @@
   [opts context op query-identity kind valid-result?
    resource-type permission compute]
   (let [contract (:execution-contract opts)
-        {:keys [adapter db basis-t mode request-proof-frame]} context
+        {:keys [adapter db basis-t snapshot-exact? request-proof-frame]}
+        context
         schema-cache
         (delay
           (selected-schema-cache!
@@ -1661,7 +1671,6 @@
                    (portable-result kind (compute)))]
              (execution/check! contract :semantic-evaluation)
              value))
-        snapshot-exact? (= :at-exact-snapshot mode)
         cacheable?
         (and (:current-cache-store opts)
              (:cache-remember-answers? opts)

--- a/modules/eacl-datomic/test/eacl/datomic/backend_exact_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/backend_exact_test.clj
@@ -210,3 +210,43 @@
           (is (= :retryable (:classification data)))
           (is (= :exact-sync (:phase data)))
           (is (identical? provider (:cause data))))))))
+
+(deftest bounded-waits-cancel-their-datomic-future-test
+  ;; Cancellation is a property of every bounded EACL wait, not only of exact
+  ;; selection: an abandoned sync stays registered on the connection until its
+  ;; basis arrives, which under retry traffic is unbounded.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [local (d/db conn)
+          local-t (d/basis-t local)
+          target (inc local-t)
+          adapter (datomic-backend/snapshot-adapter
+                   local {:conn conn :source-lifecycle "bounded-waits"})]
+      (testing "a causal-floor timeout cancels the waiter"
+        (let [cancelled? (atom false)
+              data (with-redefs [d/sync (fn [_ _] (waiter ::timeout cancelled?))]
+                     (error-data
+                      #(backend/invoke
+                        adapter :select-at-least {:revision target} 1)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :freshness-timeout (:reason data)))
+          (is @cancelled?
+              "the abandoned causal-floor sync must not stay registered")))
+
+      (testing "an authoritative-head timeout cancels the waiter"
+        (let [cancelled? (atom false)
+              data (with-redefs [d/sync (fn [_] (waiter ::timeout cancelled?))]
+                     (error-data
+                      #(backend/invoke adapter :select-authoritative 1)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :freshness-timeout (:reason data)))
+          (is @cancelled?)))
+
+      (testing "a failing provider keeps its established classification"
+        (let [data (with-redefs [d/sync (fn [_ _]
+                                          (throw (ex-info "peer down" {})))]
+                     (error-data
+                      #(backend/invoke
+                        adapter :select-at-least {:revision target} 50)))]
+          (is (= :eacl.consistency/freshness-unavailable (:type data)))
+          (is (= :sync-failed (:reason data))
+              "hoisting the waiter must not change the failure taxonomy"))))))

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
@@ -1,9 +1,12 @@
 (ns eacl.datomic.consistency-cache-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk]
             [datomic.api :as d]
+            [eacl.backend.v8 :as backend]
             [eacl.cache :as shared-cache]
             [eacl.causal-token :as causal-token]
             [eacl.core :as eacl :refer [->Relationship spice-object]]
+            [eacl.datomic.backend :as datomic-backend]
             [eacl.datomic.cache :as cache]
             [eacl.datomic.core :as core]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
@@ -800,3 +803,100 @@
         (is (true? (:allowed? second-result)))
         (is (true? (:cached? second-result))
             "exact selection reuses the answer computed at the identical basis")))))
+
+;; --- 2026-08-16 exact-cache review ------------------------------------------
+
+(def ^:private relation-root-schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     permission view = viewer
+   }")
+
+(defn- leaf-subject-ids
+  [tree]
+  (let [ids (atom #{})]
+    (clojure.walk/postwalk
+     (fn [node]
+       (when (and (map? node) (contains? node :subjects))
+         (swap! ids into (map :id (:subjects node))))
+       node)
+     tree)
+    @ids))
+
+(deftest relation-root-tree-expansion-observes-relationship-writes-test
+  ;; A relation root reads that relation's relationships, but no permission
+  ;; path names it. When the dependency closure missed it, the managed
+  ;; cross-snapshot tier proved a stale tree equal at every later snapshot.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (cached-client conn)
+          alice (spice-object :user "alice")
+          bob (spice-object :user "bob")
+          document (spice-object :document "doc1")]
+      (eacl/write-schema! client relation-root-schema)
+      @(d/transact conn [{:eacl/id "alice"}
+                         {:eacl/id "bob"}
+                         {:eacl/id "doc1"}])
+      (eacl/create-relationship! client (->Relationship alice :viewer document))
+      (doseq [root [:viewer :view]]
+        (testing (str "root " root)
+          (let [before (eacl/expand-permission-tree
+                        client {:resource document :permission root})]
+            (is (= #{"alice"} (leaf-subject-ids (:tree-root before))))
+            (eacl/create-relationship!
+             client (->Relationship bob :viewer document))
+            (let [after (eacl/expand-permission-tree
+                         client {:resource document :permission root})]
+              (is (= #{"alice" "bob"} (leaf-subject-ids (:tree-root after)))
+                  "a cached tree must not survive a write it reports")
+              (eacl/delete-relationship!
+               client (->Relationship bob :viewer document)))))))))
+
+(deftest non-deterministic-clients-do-not-seed-the-snapshot-exact-tier-test
+  ;; Readers refuse a non-deterministic adapter, so minting its snapshot
+  ;; identity would only fill a bounded tier with unreadable entries.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (core/make-client
+                  conn
+                  {:zed-token-key "consistency-cache-test-key"
+                   :source-lifecycle source-lifecycle
+                   :object-id->lookup-ref (fn [id] [:eacl/id id])
+                   :cache {:remember-answers true}})
+          alice (spice-object :user "alice")
+          account (spice-object :account "account")]
+      (eacl/write-schema! client direct-schema)
+      @(d/transact conn [{:eacl/id "alice"} {:eacl/id "account"}])
+      (eacl/create-relationship! client (->Relationship alice :owner account))
+      (is (false? (backend/deterministic?
+                   ((get-in client [:opts :backend-adapter-fn]) (d/db conn))))
+          "a custom id codec without a fingerprint is not deterministic")
+      (eacl/can? client alice :admin account)
+      (eacl/can? client alice :admin account)
+      (is (zero? (:snapshot-exact-entries (core/cache-stats client)))
+          "current answers must not seed a tier no exact request can read"))))
+
+(deftest filtered-datomic-views-cannot-claim-exact-consistency-test
+  ;; d/filter, d/since and d/history report their origin's database id and
+  ;; basis, so an exact identity minted from one is indistinguishable from the
+  ;; plain value at the same basis while answering a different question.
+  (with-mem-conn [conn schema/v7-schema]
+    (let [db (d/db conn)
+          adapter-for (fn [value]
+                        (datomic-backend/snapshot-adapter
+                         value {:conn conn
+                                :source-lifecycle source-lifecycle
+                                :adapter-fingerprint {:test :fingerprint}
+                                :adapter-deterministic? true}))
+          exact? (fn [value]
+                   (backend/supports?
+                    (adapter-for value) :consistency :at-exact-snapshot))]
+      (is (true? (exact? db))
+          "an ordinary current value selects exact snapshots")
+      (is (true? (exact? (d/as-of db (d/basis-t db))))
+          "an as-of value is the exact view this backend selects")
+      (is (false? (exact? (d/since db 0))))
+      (is (false? (exact? (d/history db))))
+      (is (false? (exact? (d/filter db (fn [_ _] true)))))
+      (is (nil? (shared-cache/snapshot-exact-key (adapter-for (d/since db 0))))
+          "a non-ordinary view mints no snapshot-exact identity")
+      (is (some? (shared-cache/snapshot-exact-key (adapter-for db)))))))

--- a/modules/eacl/src/eacl/cache.cljc
+++ b/modules/eacl/src/eacl/cache.cljc
@@ -103,8 +103,14 @@
     ;; certifies that the same native locator is independently selectable.
     ;; In particular, immutable DataScript values and arbitrary caller-owned
     ;; views cannot acquire an "exact" cache identity from revision equality.
+    ;;
+    ;; Determinism is required to MINT the identity, not merely to read it.
+    ;; Readers already refuse a non-deterministic adapter, so minting one here
+    ;; would let current requests fill a bounded tier with entries no exact
+    ;; request on that client can ever consult, evicting answers that could be.
     (when (and (backend/supports?
                 adapter :consistency :at-exact-snapshot)
+               (backend/deterministic? adapter)
                (some? exact-locator))
       {:key-version 1
        :backend (backend/backend-id adapter)
@@ -190,17 +196,62 @@
                  next-state)))
       @admitted?)))
 
+(def ^:private answer-weight-floor 512)
+(def ^:private answer-weight-per-unit 128)
+
+(defn- structural-answer-units
+  "Counts the collection entries an answer retains, walking with an explicit
+  stack so a deep tree cannot exhaust the runtime stack.
+
+  Permission trees carry their payload in nested `:intermediate`/`:leaf` nodes
+  rather than a flat `:data` vector, so a shape-specific rule would weigh a
+  100k-subject tree the same as a boolean. The traversal is bounded by the
+  expansion limits that produced the value and runs only when an answer is
+  published."
+  [value]
+  (loop [stack (list value)
+         units 0]
+    ;; Test the stack, not the element: a nil or false value inside the answer
+    ;; must not end the walk and silently drop everything still queued.
+    (if (seq stack)
+      (let [current (first stack)
+            remaining (rest stack)]
+        (cond
+          (map? current)
+          (recur (into remaining (vals current))
+                 (+ units (count current)))
+
+          (coll? current)
+          (recur (into remaining current)
+                 (+ units (count current)))
+
+          :else
+          (recur remaining units)))
+      units)))
+
 (defn- default-answer-weight
   "Conservative retained-size estimate for one completed answer.
 
   Mirrors the page-weight family the Datomic backend supplies explicitly:
-  paged results weigh in by row count; scalar decisions and counts pay a
-  flat floor. Callers with better knowledge pass `:answer-weight-fn`."
+  paged results weigh in by row count, nested results by retained collection
+  entries, and scalar decisions and counts pay a flat floor. Callers with
+  better knowledge pass `:answer-weight-fn`."
   [value]
   (let [data (when (map? value) (:data value))]
-    (if (counted? data)
-      (+ 512 (* 128 (count data)))
-      512)))
+    (cond
+      ;; `some?` before `counted?`: ClojureScript answers true for
+      ;; `(counted? nil)` while Clojure answers false, so testing countedness
+      ;; alone would silently route every non-page answer down the page branch
+      ;; on one runtime only.
+      (and (some? data) (counted? data))
+      (+ answer-weight-floor (* answer-weight-per-unit (count data)))
+
+      (coll? value)
+      (+ answer-weight-floor
+         (* answer-weight-per-unit (structural-answer-units value)))
+
+      :else
+      answer-weight-floor)))
 
 (defn- answer-entry-options
   "Store options validating and weighing `{:value v :cache-basis b}` wrappers."
@@ -498,6 +549,15 @@
   selected immutable adapter and may publish the completed semantic answer
   under the complete canonical snapshot plus request key.
 
+  An adapter that cannot mint a canonical snapshot identity bypasses this tier
+  instead of failing the request: `snapshot-exact-key` documents nil as the
+  contractual outcome for views that must not acquire an exact identity, and a
+  cache that cannot key an answer is a caching limit, not a request error.
+
+  The reported `:cache-basis` is the caller's selected snapshot, rebuilt per
+  request rather than copied from the entry, which may have been retained from
+  a proof-lifted answer computed at an earlier basis.
+
   Returns `{:value v :cached? b :cache-tier tier :cache-basis basis}`."
   [store
    {:keys [snapshot-exact-key cache-basis cache-lifecycle decision-kernel
@@ -507,73 +567,82 @@
   (when-not (fn? compute)
     (throw (ex-info "Snapshot-exact cache computation must be a function."
                     {:type :eacl/invalid-config})))
-  (when-not (and (current-cache? store)
-                 (valid-snapshot-exact-key? snapshot-exact-key))
-    (throw (ex-info "Invalid snapshot-exact cache context."
+  (when-not (current-cache? store)
+    (throw (ex-info "Expected an EACL current-generation cache."
                     {:type :eacl/invalid-config
-                     :snapshot-exact-key snapshot-exact-key})))
-  (let [lifecycle (or cache-lifecycle @(:lifecycle store))
-        answer-store (:snapshot-exact lifecycle)
-        entry-key
-        (snapshot-answer-entry-key snapshot-exact-key semantic-key kind)
-        answer-options (answer-entry-options valid-value? answer-weight-fn)
-        exact-entry
-        (when remember-answer?
-          (:value
-           (subproblem/lookup!
-            answer-store :answer entry-key answer-options)))
-        exact-action
-        (current-cache-action
-         decision-kernel :snapshot-exact-entry (some? exact-entry))
-        evaluate-entry
+                     :cache store})))
+  (let [isolated-compute
         (fn []
-          {:value
-           (binding [subproblem/*store* nil
-                     subproblem/*managed-store* nil
-                     subproblem/*managed-key-fn* nil
-                     subproblem/*managed-scope* nil
-                     subproblem/*decision-kernel*
-                     (or decision-kernel subproblem/*decision-kernel*)]
-             (subproblem/with-decision-memo compute))
-           :cache-basis cache-basis})]
-    (if (= :use-snapshot-exact-entry exact-action)
+          (binding [subproblem/*store* nil
+                    subproblem/*managed-store* nil
+                    subproblem/*managed-key-fn* nil
+                    subproblem/*managed-scope* nil
+                    subproblem/*decision-kernel*
+                    (or decision-kernel subproblem/*decision-kernel*)]
+            (subproblem/with-decision-memo compute)))]
+    (if-not (valid-snapshot-exact-key? snapshot-exact-key)
       (do
-        (swap! (:metrics store) update :exact-hits inc)
-        (swap! (:metrics store) update :snapshot-exact-hits inc)
-        {:value (:value exact-entry)
-         :cached? true
-         :cache-tier :snapshot-exact
-         :cache-basis (:cache-basis exact-entry)})
-      (if (and remember-answer?
-               (admit-answer? store entry-key))
-      (let [resolved
-            (subproblem/resolve-independent!
-             answer-store :answer entry-key answer-options evaluate-entry)
-            entry (:value resolved)]
-        (if (:cached? resolved)
-          (do
-            (swap! (:metrics store) update :exact-hits inc)
-            (swap! (:metrics store) update :snapshot-exact-hits inc)
-            {:value (:value entry)
-             :cached? true
-             :cache-tier :snapshot-exact
-             :cache-basis (:cache-basis entry)})
-          (do
-            (swap! (:metrics store) update :misses inc)
-            (swap! (:metrics store) update :puts inc)
-            {:value (:value entry)
-             :cached? false
-             :cache-tier nil
-             :cache-basis (:cache-basis entry)})))
-        (let [entry (evaluate-entry)]
-          (swap! (:metrics store)
-                 update
-                 (if remember-answer? :misses :bypasses)
-                 inc)
-          {:value (:value entry)
-           :cached? false
-           :cache-tier nil
-           :cache-basis (:cache-basis entry)})))))
+        (swap! (:metrics store) update :bypasses inc)
+        {:value (isolated-compute)
+         :cached? false
+         :cache-tier nil
+         :cache-basis nil})
+      (let [lifecycle (or cache-lifecycle @(:lifecycle store))
+            answer-store (:snapshot-exact lifecycle)
+            entry-key
+            (snapshot-answer-entry-key snapshot-exact-key semantic-key kind)
+            answer-options (answer-entry-options valid-value? answer-weight-fn)
+            exact-entry
+            (when remember-answer?
+              (:value
+               (subproblem/lookup!
+                answer-store :answer entry-key answer-options)))
+            exact-action
+            (current-cache-action
+             decision-kernel :snapshot-exact-entry (some? exact-entry))
+            evaluate-entry
+            (fn []
+              {:value (isolated-compute)
+               :cache-basis cache-basis})
+            hit
+            (fn [entry]
+              (swap! (:metrics store)
+                     #(-> %
+                          (update :exact-hits inc)
+                          (update :snapshot-exact-hits inc)))
+              {:value (:value entry)
+               :cached? true
+               :cache-tier :snapshot-exact
+               :cache-basis cache-basis})]
+        (if (= :use-snapshot-exact-entry exact-action)
+          (hit exact-entry)
+          (if (and remember-answer?
+                   (admit-answer? store entry-key))
+            (let [resolved
+                  (subproblem/resolve-independent!
+                   answer-store :answer entry-key answer-options
+                   evaluate-entry)
+                  entry (:value resolved)]
+              (if (:cached? resolved)
+                (hit entry)
+                (do
+                  (swap! (:metrics store)
+                         #(-> %
+                              (update :misses inc)
+                              (update :puts inc)))
+                  {:value (:value entry)
+                   :cached? false
+                   :cache-tier nil
+                   :cache-basis cache-basis})))
+            (let [entry (evaluate-entry)]
+              (swap! (:metrics store)
+                     update
+                     (if remember-answer? :misses :bypasses)
+                     inc)
+              {:value (:value entry)
+               :cached? false
+               :cache-tier nil
+               :cache-basis cache-basis})))))))
 
 (defn resolve-current!
   "Resolves one completed semantic answer against a captured current snapshot.
@@ -675,9 +744,11 @@
                  decision-kernel :exact-entry (some? exact-entry))]
             (if (= :use-exact-entry exact-action)
               (do
-                (retain-snapshot-answer!
-                 store lifecycle snapshot-exact-key semantic-key kind
-                 answer-options exact-entry)
+                ;; Deliberately no snapshot-exact retention here. This answer
+                ;; was already offered to that tier when it was computed or
+                ;; promoted; republishing on every hit re-runs the answer
+                ;; validator and weight function on the hot path and records a
+                ;; publication race against the entry it just found.
                 (swap! (:metrics store) update :exact-hits inc)
                 {:value (:value exact-entry)
                  :cached? true

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -676,6 +676,20 @@
   [resource-type permission-name]
   [resource-type permission-name])
 
+(defn- node-relation-eids
+  "Relation-definition eids for a node name that is a relation, not a
+  permission.
+
+  Permission-tree expansion accepts a relation as its root and then reads that
+  relation's relationships directly, so those definitions belong in the
+  dependency closure even though no permission path names them. Without this,
+  a relation root closes over nothing, its answer is proof-equal at every later
+  snapshot, and a cached tree survives the relationship writes it reports."
+  [db resource-type relation-name]
+  (into #{}
+        (map :e)
+        (relation-datoms db resource-type relation-name)))
+
 (defn- calc-permission-relationship-eids
   [db resource-type permission-name]
   (loop [stack [(permission-query-node resource-type permission-name)]
@@ -685,6 +699,14 @@
       (if (contains? seen node)
         (recur (pop stack) seen relationship-eids)
         (let [paths (get-permission-paths db node-resource-type node-permission)
+              ;; Only a name with no permission paths can be a relation, so
+              ;; ordinary permission roots never pay this lookup.
+              relationship-eids
+              (if (seq paths)
+                relationship-eids
+                (into relationship-eids
+                      (node-relation-eids
+                       db node-resource-type node-permission)))
               next-nodes
               (keep (fn [path]
                       (case (:type path)

--- a/modules/eacl/test/eacl/cache_test.cljc
+++ b/modules/eacl/test/eacl/cache_test.cljc
@@ -224,6 +224,117 @@
       (is (false? (:value (exact key-1 false))))
       (is (= 3 @computations)))))
 
+(defn- ordinary-exact-key
+  [revision]
+  {:key-version 1
+   :backend :test
+   :source-scope {:source-id :source
+                  :branch nil
+                  :source-lifecycle :lifecycle-a
+                  :backend :test}
+   :native-revision {:revision revision :exact-locator revision}
+   :exact-locator revision
+   :view-kind :ordinary-exact
+   :snapshot-id {:basis-t revision}
+   :adapter-fingerprint :adapter-v1
+   :identity-contract :identity-v1})
+
+(deftest snapshot-exact-retention-does-not-republish-on-every-hit-test
+  (let [store (cache/current-cache)
+        snapshot (snapshot-object)
+        semantic-key {:operation :can? :query [:alice :read :document]}
+        current
+        (fn []
+          (cache/resolve-current!
+           store
+           {:snapshot snapshot
+            :snapshot-order 1
+            :same-snapshot? identical?
+            :snapshot-exact-key (ordinary-exact-key 1)
+            :cache-basis {:basis-t 1}}
+           semantic-key :decision boolean? (constantly true)))]
+    (dotimes [_ 8] (current))
+    (let [stats (get-in (cache/current-cache-stats store)
+                        [:snapshot-exact :tiers :answer])
+          races (:publication-races
+                 (get (cache/current-cache-stats store) :snapshot-exact))]
+      (is (= 1 (:entries stats))
+          "the first computation still seeds the snapshot-exact tier")
+      (is (zero? (or races 0))
+          "a cache hit must not republish an answer the tier already holds"))))
+
+(deftest snapshot-exact-bypasses-an-unkeyable-adapter-test
+  (let [store (cache/current-cache)
+        computations (atom 0)
+        resolve-with
+        (fn [snapshot-key]
+          (cache/resolve-exact!
+           store
+           {:snapshot-exact-key snapshot-key :cache-basis {:basis-t 1}}
+           {:operation :can?} :decision boolean?
+           (fn [] (swap! computations inc) true)))]
+    (testing "a view that cannot mint a canonical identity computes uncached"
+      (doseq [unkeyable [nil
+                         (dissoc (ordinary-exact-key 1) :adapter-fingerprint)
+                         (assoc (ordinary-exact-key 1)
+                                :view-kind :filtered-view)]]
+        (let [answer (resolve-with unkeyable)]
+          (is (true? (:value answer)))
+          (is (false? (:cached? answer)))
+          (is (nil? (:cache-tier answer))
+              "an unkeyable snapshot bypasses the tier instead of failing"))))
+    (is (= 3 @computations))
+    (is (= 3 (:bypasses (cache/current-cache-stats store))))))
+
+(deftest snapshot-exact-hit-reports-the-selected-basis-test
+  (let [store (cache/current-cache)
+        snapshot (snapshot-object)
+        semantic-key {:operation :can? :query [:alice :read :document]}
+        key-1 (ordinary-exact-key 1)]
+    ;; Seed the tier from a current answer whose recorded basis is deliberately
+    ;; older than the basis a later exact request selects, as a proof-lifted
+    ;; managed answer would be.
+    (cache/resolve-current!
+     store
+     {:snapshot snapshot
+      :snapshot-order 1
+      :same-snapshot? identical?
+      :snapshot-exact-key key-1
+      :cache-basis {:basis-t :stale-origin}}
+     semantic-key :decision boolean? (constantly true))
+    (let [answer
+          (cache/resolve-exact!
+           store
+           {:snapshot-exact-key key-1 :cache-basis {:basis-t 1}}
+           semantic-key :decision boolean? (constantly false))]
+      (is (true? (:cached? answer)))
+      (is (= {:basis-t 1} (:cache-basis answer))
+          "cache basis is rebuilt from the selected snapshot, not copied"))))
+
+(deftest nested-answers-weigh-more-than-scalar-answers-test
+  (let [snapshot (snapshot-object)
+        tree {:expanded-object {:type :document :id "doc"}
+              :leaf {:subjects (mapv (fn [i]
+                                       {:type :user :id (str "u" i)})
+                                     (range 200))}}
+        weight-of
+        (fn [value]
+          (let [store (cache/current-cache)]
+            (cache/resolve-current!
+             store
+             {:snapshot snapshot
+              :snapshot-order 1
+              :same-snapshot? identical?
+              :cache-basis {:basis-t 1}}
+             {:operation :expand-permission-tree} :permission-tree
+             map? (constantly value))
+            (get-in (cache/current-cache-stats store)
+                    [:subproblems :tiers :answer :weight])))]
+    (is (> (weight-of tree) (weight-of {:leaf {:subjects []}}))
+        "a large nested answer must not weigh the same as an empty one")
+    (is (> (weight-of tree) (* 100 128))
+        "weight scales with the retained subjects, not a flat floor")))
+
 (deftest current-generation-expiry-test
   (let [store (cache/current-cache)
         snapshot (snapshot-object)

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/backend-native-revision-consistency/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/backend-native-revision-consistency/spec.md
@@ -5,7 +5,7 @@ Within one unreplaced Datomic database history, EACL SHALL use authenticated dat
 
 #### Scenario: Peer is behind requested floor
 - **WHEN** a Datomic Peer receives an at-least token whose `t` is ahead of its locally observed database
-- **THEN** EACL performs bounded targeted synchronization and selects a database with basis at least that `t` or returns a typed freshness failure
+- **THEN** EACL performs a bounded targeted synchronization and selects a database with basis at least that `t` or returns a typed timeout or unavailable error
 
 #### Scenario: Peer is behind requested exact basis
 - **WHEN** a Datomic Peer receives an authenticated same-source exact token whose `t` is ahead of its locally observed database
@@ -18,70 +18,53 @@ Within one unreplaced Datomic database history, EACL SHALL use authenticated dat
 - **THEN** EACL does not invoke `d/sync`
 - **AND** selects the exact `d/as-of` database at `t`
 
-#### Scenario: Exact catch-up times out
-- **WHEN** a Datomic Peer does not observe an authenticated exact token basis before the bounded consistency deadline
+#### Scenario: Exact catch-up times out or is interrupted
+- **WHEN** the local Peer does not observe `t` before the consistency bound, or the wait is interrupted
 - **THEN** EACL cancels the targeted-sync future
-- **AND** throws `:eacl.consistency/freshness-unavailable` with reason `:freshness-timeout`
-- **AND** does not report the exact snapshot as expired or evaluate a different basis
-
-#### Scenario: Exact catch-up is interrupted
-- **WHEN** the request thread is interrupted while waiting for an exact basis
-- **THEN** EACL cancels the targeted-sync future and preserves interruption
-- **AND** throws a classified cancellation rather than snapshot expiry
+- **AND** returns typed freshness timeout or cancellation without calling `d/as-of`
 
 #### Scenario: Exact synchronization returns behind the token
-- **WHEN** targeted synchronization completes with a database whose basis is below the authenticated exact token basis
-- **THEN** EACL throws `:eacl.consistency/freshness-unavailable` with reason `:head-behind` and the requested and observed bases
-- **AND** does not call `d/as-of` on the insufficient database
+- **WHEN** targeted synchronization returns a database whose basis is below `t`
+- **THEN** EACL returns `:eacl.consistency/freshness-unavailable` with reason `:head-behind`, requested and observed bases
+- **AND** performs no authorization evaluation
 
 #### Scenario: Datomic token fields contradict one another
-- **WHEN** an authenticated payload supplied to Datomic has a non-integer locator or its native revision differs from its exact locator
-- **THEN** EACL rejects it as an invalid or contradictory token before synchronization
-
-#### Scenario: Exact selection provider fails
-- **WHEN** synchronization, storage access, or exact reconstruction fails unexpectedly
-- **THEN** EACL preserves a typed freshness or retryable selection failure with its phase and cause
-- **AND** does not return `nil` or misreport the failure as snapshot expiry
+- **WHEN** the locator is not a non-negative integer or native revision differs from exact locator
+- **THEN** EACL rejects the token before storage or synchronization
 
 #### Scenario: Ordinary Datomic history grows older
 - **WHEN** an authenticated unexpired token names an older `t` in the same unreplaced ordinary Datomic history
 - **THEN** age alone does not make the exact snapshot unavailable
-- **AND** EACL selects `d/as-of` at that `t`
-
-#### Scenario: Datomic history is destructively rewritten
-- **WHEN** restore, reset, excision, or another operation can change the meaning of an old exact locator
-- **THEN** operators quiesce affected traffic and rotate the configured source lifecycle before resuming
-- **AND** old tokens/cursors fail lifecycle comparison rather than being reinterpreted or reported as age-expired
 
 #### Scenario: Ordinary current request
 - **WHEN** a caller requests minimize-latency or fully-consistent current behavior
-- **THEN** EACL does not call `d/as-of` merely to validate or reuse an answer
+- **THEN** EACL does not call `d/as-of` merely to validate or reuse a completed answer
 
 ### Requirement: Backend capability honesty
-Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, durable-history, and ordered-generation proof operations supported by its configured backend. Exact selection from conditionally retained commits SHALL remain distinguishable from durable temporal-history reconstruction. Unsupported consistency modes SHALL be rejected before cache access.
+Each adapter SHALL advertise only the native revision, authoritative-head, exact-snapshot, durable-history, and ordered-generation proof operations supported by its configured backend and SHALL reject unsupported consistency modes before cache access. Exact selection from conditionally retained commits SHALL remain distinguishable from durable temporal-history reconstruction. Native revision capability SHALL remain independent of completed-answer caching and SHALL NOT depend on a cache-authority or proof-mode option.
 
 #### Scenario: Datahike temporal history is enabled
 - **WHEN** a Datahike source has `:keep-history? true`
-- **THEN** EACL may advertise durable exact reconstruction by native revision even when a named commit record is absent
-- **AND** cutoff collection of commit records does not expire an exact cursor whose temporal history remains available
+- **THEN** EACL advertises durable exact reconstruction by native revision even when a named commit record is absent
+- **AND** cutoff collection of commit records does not expire an exact cursor
 
 #### Scenario: Datahike relies only on retained commits
 - **WHEN** Datahike temporal history is disabled but its commit graph supports exact commit loading
-- **THEN** EACL may advertise conditional exact selection
-- **AND** a genuinely collected named commit returns exact-snapshot unavailable rather than a provider-failure or substituted snapshot
+- **THEN** EACL advertises conditional exact selection
+- **AND** a genuinely collected named commit returns exact-snapshot unavailable rather than provider failure or a substituted snapshot
 
-#### Scenario: Datahike cannot reconstruct exact history
-- **WHEN** neither temporal history nor retained exact commits are available
-- **THEN** the adapter does not advertise `:at-exact-snapshot`
+#### Scenario: Datahike capability is not certified for a configuration
+- **WHEN** EACL cannot prove stable commit acquisition and branch selection for the active Datahike store configuration
+- **THEN** the adapter advertises the smaller current-only capability instead of inferring support from implementation details
 
 #### Scenario: DataScript current-only source
-- **WHEN** a DataScript connection cannot reconstruct arbitrary prior immutable values
-- **THEN** its adapter does not advertise `:at-exact-snapshot` and never retains hidden historical values to emulate it
+- **WHEN** a DataScript connection has no retained historical selection mechanism
+- **THEN** its adapter does not advertise arbitrary exact-snapshot selection and never retains hidden historical database values to emulate it
 
 #### Scenario: Ordered-generation proof is not certified
 - **WHEN** an adapter cannot certify complete dependency reads and globally ordered native relation generations
-- **THEN** native revision and snapshot-exact operations may remain available while cross-snapshot managed answer reuse fails closed
+- **THEN** native revision operations may remain available while cross-snapshot managed answer reuse fails closed to exact evaluation
 
 #### Scenario: Completed-answer cache is disabled
-- **WHEN** a client disables completed-answer caching but its adapter and lifecycle support native revision operations
-- **THEN** EACL may still issue and select authenticated native revision tokens and reconstruct exact cursors
+- **WHEN** a client disables completed-answer caching but its adapter and lifecycle support a native revision operation
+- **THEN** EACL may still issue and select authenticated native revision tokens

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/cursor-token-handling/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/cursor-token-handling/spec.md
@@ -1,29 +1,23 @@
 ## MODIFIED Requirements
 
 ### Requirement: Cursor TTL is configurable and defaults to no expiry
-Cursor expiry SHALL be off by default for every backend. Tokens minted without `:cursor-ttl-seconds` SHALL carry no expiry and SHALL remain age-valid. When a positive TTL is configured, minted tokens SHALL embed an expiry and decoding after that instant SHALL throw the established typed expired-cursor error without restarting pagination.
+Cursor expiry SHALL be off by default for every backend. Tokens minted without `:cursor-ttl-seconds` SHALL carry no expiry and SHALL remain age-valid. When a positive TTL is configured, minted tokens SHALL embed an expiry and decoding at or after that instant SHALL throw `ex-info` with `:type :eacl.pagination/expired-cursor` and `:reason :expired` without restarting pagination. Cache and checkpoint retention SHALL NOT determine cursor lifetime.
 
-#### Scenario: Datomic cursor exceeds the former five-minute default
-- **WHEN** a Datomic client without `:cursor-ttl-seconds` resumes an authenticated cursor more than five minutes after minting
-- **THEN** age alone does not reject the cursor
-- **AND** EACL continues on a proof-equivalent snapshot or reconstructs its exact historical basis
+#### Scenario: Slow batch pagination does not restart
+- **WHEN** a client without `:cursor-ttl-seconds` resumes pagination with a token minted more than 5 minutes ago
+- **THEN** the next page is returned normally
 
-#### Scenario: Datahike cursor has no configured TTL
-- **WHEN** a full-history Datahike client resumes an authenticated cursor of arbitrary age within the same source lifecycle
-- **THEN** age alone does not reject the cursor
-
-#### Scenario: Configured TTL is enforced
-- **WHEN** a client configured with `{:cursor-ttl-seconds 60}` decodes a cursor at or after its expiry
-- **THEN** EACL throws `:eacl.pagination/expired-cursor` with reason `:expired`
-- **AND** does not silently return page one or classify storage as unavailable
+#### Scenario: Configured TTL is enforced loudly
+- **WHEN** a client configured with `{:cursor-ttl-seconds 60}` decodes a token older than 60 seconds
+- **THEN** an `:eacl.pagination/expired-cursor` error with `:reason :expired` is thrown — not a silent first page
 
 #### Scenario: Key is deliberately retired
-- **WHEN** a non-expiring cursor names a key id no longer present in the configured keyring
+- **WHEN** a non-expiring cursor names a key id absent from the configured keyring
 - **THEN** EACL rejects it as an invalid authenticated cursor rather than age expiry
 
 #### Scenario: Source lifecycle changes
 - **WHEN** restore, reset, excision, purge, branch replacement, or destructive history replacement rotates the source lifecycle
-- **THEN** a prior non-expiring cursor is rejected for lifecycle mismatch and is never interpreted against the replacement history
+- **THEN** a prior non-expiring cursor is rejected for lifecycle mismatch and never interpreted against replacement history
 
 ## ADDED Requirements
 
@@ -31,20 +25,18 @@ Cursor expiry SHALL be off by default for every backend. Tokens minted without `
 Cursor authentication SHALL bind the complete normalized operation/query/principal and answer-affecting configuration independently from the selected snapshot's schema/dependency proof. A change to the current schema or relationship graph SHALL be allowed to reach proof comparison and exact fallback rather than being rejected prematurely as a different query.
 
 #### Scenario: Relevant schema changes after page one
-- **WHEN** the current schema generation differs from the cursor's generation but the operation, normalized query, principal, and configuration are unchanged
-- **THEN** EACL does not reject the cursor merely because current schema generation participates in query scope
-- **AND** a history-capable backend reconstructs and validates the cursor's original exact schema and graph
+- **WHEN** current schema generation differs from the cursor's generation but operation, normalized query, principal, and configuration are unchanged
+- **THEN** EACL does not reject the cursor merely because current schema generation differs
+- **AND** a history-capable backend may reconstruct and validate the original exact schema and graph
 
 #### Scenario: Query actually changes
-- **WHEN** operation, principal, permission, resource/subject filter, direction, page shape, ordering ABI, or answer-affecting configuration differs from the authenticated cursor
+- **WHEN** operation, principal, permission, resource/subject filter, direction, page shape, ordering ABI, or answer-affecting configuration differs
 - **THEN** EACL rejects it as an invalid cursor before authorization traversal
 
 #### Scenario: Checkpoint was evicted
-- **WHEN** a non-expiring cursor's client-private continuation checkpoint is missing or evicted
-- **THEN** EACL deterministically replays and validates the authenticated boundary on the selected exact snapshot
-- **AND** checkpoint retention does not become cursor lifetime
+- **WHEN** a non-expiring cursor's private continuation checkpoint is missing or evicted
+- **THEN** EACL deterministically replays and validates its authenticated boundary on the selected exact snapshot
 
-#### Scenario: Exact replay exceeds an execution bound
-- **WHEN** exact replay cannot reach the authenticated boundary within the configured request deadline or resource limit
-- **THEN** EACL returns the typed deadline/resource outcome
-- **AND** does not expire, rebase, or silently restart the cursor
+#### Scenario: Exact replay exceeds a bound
+- **WHEN** exact replay cannot reach the authenticated boundary within the request deadline or resource limit
+- **THEN** EACL returns the typed deadline/resource outcome rather than expiring, rebasing, or restarting the cursor

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/forward-history-cache-coherence/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/forward-history-cache-coherence/spec.md
@@ -1,28 +1,23 @@
 ## MODIFIED Requirements
 
 ### Requirement: Exact-current generation isolation
-The exact-current completed-answer tier SHALL admit and return an entry only for the canonical immutable snapshot generation, source lifecycle, and complete semantic request for which it was computed. A newer current request MUST NOT observe an older exact entry, while an explicit exact request selecting that older snapshot MAY use the entry through the separately bounded snapshot-exact retention path if it remains retained.
+The exact-current completed-answer tier SHALL admit and return an entry only for the canonical immutable snapshot generation, source lifecycle, and complete semantic request for which it was computed. A newer current request MUST NOT observe an older exact entry, while an explicit exact request selecting that older snapshot MAY use the separately bounded snapshot-exact retention path if it remains retained.
+
+#### Scenario: Any forward transaction advances the snapshot
+- **WHEN** the selected current snapshot changes after any committed transaction
+- **THEN** the previous exact-current generation is unreachable from requests selecting the new snapshot
+
+#### Scenario: Late old-generation publication
+- **WHEN** computation against an old snapshot finishes after a newer exact generation is installed
+- **THEN** its result remains keyed to the old canonical snapshot and cannot populate, replace, or masquerade as the newer generation
 
 #### Scenario: Same authenticated exact snapshot
-- **WHEN** `:at-exact-snapshot` selects canonical snapshot `T` and the exact tier contains a completed answer for the identical semantic request at `T`
-- **THEN** EACL returns that answer without authorization traversal or managed-proof reads
+- **WHEN** `:at-exact-snapshot` selects canonical snapshot `T` and a completed answer for the identical semantic request at `T` remains retained
+- **THEN** EACL may return it without traversal or managed-proof reads
 - **AND** rebuilds public snapshot metadata and tokens from the selected adapter at `T`
 
-#### Scenario: Different exact snapshot
-- **WHEN** an exact-tier entry belongs to revision/locator `T1` and the request selects `T2`
-- **THEN** the entry is ineligible even if its semantic answer would coincidentally be equal
-
-#### Scenario: New current snapshot is selected
-- **WHEN** a current request selects `T2` after an answer was computed at `T1`
-- **THEN** it cannot use the `T1` snapshot-exact entry as an exact hit
-- **AND** may use only separately certified managed proof-backed reuse
-
-#### Scenario: Late historical publication
-- **WHEN** computation at older snapshot `T1` finishes after current snapshot `T2` is installed
-- **THEN** publication remains keyed to `T1` and cannot populate, replace, or masquerade as `T2`
-
 #### Scenario: Snapshot-exact retention is bounded
-- **WHEN** weight, entry, or admission bounds evict an exact answer or generation
+- **WHEN** weight, entry, or admission bounds evict an exact answer
 - **THEN** a later exact request recomputes on its selected immutable snapshot
 - **AND** eviction does not imply snapshot or cursor expiry
 
@@ -32,29 +27,29 @@ The exact-current completed-answer tier SHALL admit and return an entry only for
 An `:at-exact-snapshot` request SHALL probe only completed answers bound to its identical canonical snapshot. It SHALL NOT use relation/schema proof equality to lift a managed answer computed at another revision, and SHALL NOT validate historical answers using current-only or no-history stamps.
 
 #### Scenario: Managed answer has equal dependency proof
-- **WHEN** a managed answer computed at `T2` has a proof equal to the exact request's proof at `T1`
-- **THEN** the exact request does not use that managed entry unless a separate snapshot-exact entry exists for `T1`
+- **WHEN** a managed answer computed at `T2` has proof equal to the exact request's proof at `T1`
+- **THEN** the request does not use that answer unless a separate snapshot-exact entry exists for `T1`
 
 #### Scenario: Exact cache miss
 - **WHEN** no retained completed answer matches the selected exact snapshot and semantic request
 - **THEN** EACL evaluates against the already selected exact adapter
-- **AND** may publish the completed semantic answer into the snapshot-exact tier at that exact key
+- **AND** may publish only the completed semantic answer at that exact key
 
 #### Scenario: Public response metadata
 - **WHEN** a snapshot-exact completed answer is reused
-- **THEN** response tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the request's selected exact adapter rather than copied from the cache entry
+- **THEN** response tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the selected exact adapter
 
 ### Requirement: Exact cache identity is complete and lifecycle-scoped
-The canonical snapshot-exact key SHALL include stable backend/source/branch identity, configured source lifecycle, native revision and exact locator, exact view kind, adapter fingerprint and identity contract, engine/order ABI, normalized semantic request, result kind/shape, normalized demand, and answer-affecting limits. Numeric revision equality alone SHALL NOT establish snapshot identity.
+The canonical snapshot-exact key SHALL include stable backend/source/branch identity, configured source lifecycle, native revision and exact locator, ordinary exact view kind, adapter fingerprint and identity contract, engine/order ABI, normalized semantic request, result kind/shape, normalized demand, and answer-affecting limits. Numeric revision equality alone SHALL NOT establish snapshot identity.
 
 #### Scenario: Source lifecycle rotates
 - **WHEN** cache expiry or history replacement installs a new source lifecycle
-- **THEN** every old snapshot-exact entry becomes unreachable from new requests even when native revision numbers repeat
+- **THEN** every old snapshot-exact entry becomes unreachable even if native revision numbers repeat
 
 #### Scenario: Adapter semantics change
-- **WHEN** adapter fingerprint, identity contract, engine ABI, order ABI, or an answer-affecting limit changes
-- **THEN** an entry computed under the prior semantic identity is ineligible
+- **WHEN** adapter fingerprint, identity contract, engine/order ABI, or an answer-affecting limit changes
+- **THEN** entries computed under the prior semantic identity are ineligible
 
 #### Scenario: Arbitrary historical view
 - **WHEN** a caller supplies a filtered, since, history, speculative, or otherwise uncertified database view
-- **THEN** EACL does not identify it with an ordinary current/as-of exact generation merely because database id and numeric revision match
+- **THEN** EACL does not identify it with an ordinary current/as-of exact generation merely because source and numeric revision match

--- a/openspec/changes/sync-datomic-exact-snapshots/specs/snapshot-stable-pagination/spec.md
+++ b/openspec/changes/sync-datomic-exact-snapshots/specs/snapshot-stable-pagination/spec.md
@@ -9,74 +9,106 @@ Every paginated lookup SHALL select one immutable snapshot before scanning. Each
 
 #### Scenario: Cursor is exposed to the caller
 - **WHEN** a portable cursor is serialized
-- **THEN** its complete query scope, stable external/opaque position, snapshot identity, and proof metadata are authenticated
+- **THEN** its scope, stable external/opaque position, and proof metadata are authenticated
 - **AND** base64 encoding alone is not considered protection
 
+#### Scenario: Cursor confidentiality is advertised
+- **WHEN** an adapter/runtime advertises confidential cursors
+- **THEN** the cursor uses authenticated encryption and exposes no plaintext proof or position
+
+#### Scenario: Query or configuration changes
+- **WHEN** a cursor is presented with a different operation, query scope, direction, engine version, codec, or answer-affecting configuration
+- **THEN** EACL rejects it as an invalid cursor
+
 #### Scenario: Dependency proof is too large
-- **WHEN** complete dependency evidence would exceed the cursor size bound
+- **WHEN** a complete dependency proof map would exceed the cursor size bound
 - **THEN** the cursor carries a domain-separated digest and rederives the complete closure on continuation
-- **AND** does not truncate the dependency set
+- **AND** MUST NOT truncate the dependency set
+
+#### Scenario: Complete proof cannot be recomputed
+- **WHEN** continuation cannot recompute the full proof within configured resource bounds
+- **THEN** graph-equivalent continuation is unavailable
+- **AND** EACL uses exact fallback or returns a typed stale/resource error
 
 ### Requirement: Exact reconstruction is a fallback
-When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator if the request does not require a causally newer floor. On an unreplaced full-history source, cursor age and ordinary forward mutations SHALL NOT make that locator unavailable. If the configured backend cannot reconstruct the exact value, continuation MUST fail rather than use a changed graph.
+When the selected current/fresh snapshot proof differs from the cursor, EACL SHALL attempt the original exact locator only if the request does not require a causally newer floor. On an unreplaced full-history source, cursor age and ordinary forward mutations SHALL NOT make that locator unavailable. If the configured backend cannot reconstruct the exact value, continuation MUST fail rather than use a changed graph.
 
 #### Scenario: Datomic exact fallback after arbitrary forward history
 - **WHEN** a cursor proof changed and its original Datomic basis belongs to the same unreplaced source lifecycle
-- **THEN** EACL reconstructs the verified `d/as-of` value, synchronizing to the basis first when the local Peer is behind
+- **THEN** EACL catches the Peer up to that basis when necessary and continues on the verified `d/as-of` value
 - **AND** cursor age alone does not reject it
 
 #### Scenario: Datahike temporal-history fallback
 - **WHEN** a cursor proof changed and the Datahike source has `:keep-history? true`
-- **THEN** EACL reconstructs the verified temporal snapshot by native revision even if a commit record was collected
+- **THEN** EACL reconstructs the verified temporal snapshot even if the named commit record was collected
 
 #### Scenario: Datahike retained-commit fallback
-- **WHEN** temporal history is disabled and the cursor's exact commit remains retained
+- **WHEN** temporal history is disabled and the cursor's named commit remains retained
 - **THEN** EACL may continue on that exact commit
 
-#### Scenario: Conditionally retained snapshot is unavailable
-- **WHEN** a history-disabled backend configuration no longer retains the cursor's exact handle
-- **THEN** EACL returns typed exact-snapshot unavailable/stale-cursor behavior
-- **AND** does not silently restart or continue on current data
+#### Scenario: DataScript current-only source
+- **WHEN** a DataScript cursor proof changes after the current basis advances
+- **THEN** EACL returns a typed stale-cursor result and does not consult a hidden historical registry
+
+#### Scenario: Original snapshot is unavailable
+- **WHEN** the proof changed and a history-disabled conditional backend no longer retains the exact handle
+- **THEN** EACL returns typed stale-cursor or exact-snapshot-unavailable
+- **AND** MUST NOT silently restart or continue on current data
 
 #### Scenario: History replacement invalidates old locators
 - **WHEN** source lifecycle rotation records restore, reset, excision, purge, branch replacement, or destructive history replacement
 - **THEN** old cursors are rejected for lifecycle mismatch before exact reconstruction
 
 ### Requirement: Cursor failures are distinguishable
-EACL SHALL distinguish authentication/query-scope failure, configured envelope expiry, source-lifecycle replacement, conditionally retained exact-snapshot absence, changed dependency proof, incompatible newer freshness, and replay resource/deadline failure.
+EACL SHALL distinguish authentication/query-scope failure, configured envelope expiry, source-lifecycle replacement, conditional exact-snapshot absence, changed dependency proof, incompatible newer freshness, and replay deadline/resource failure.
 
 #### Scenario: Cursor authentication fails
-- **WHEN** encrypted cursor contents, key id, or authentication tag are invalid
+- **WHEN** encrypted cursor contents, key id, or tag are invalid
 - **THEN** EACL returns `:eacl.pagination/invalid-cursor`
 
 #### Scenario: Configured cursor lifetime expires
-- **WHEN** a cursor carrying an explicit expiry is resumed at or after that expiry
+- **WHEN** the authenticated cursor expiry has elapsed
 - **THEN** EACL returns `:eacl.pagination/expired-cursor`
 
 #### Scenario: Non-expiring cursor grows older
 - **WHEN** a cursor carries no expiry and its exact full-history source remains in the same lifecycle
 - **THEN** elapsed wall-clock time is not a rejection condition
 
-#### Scenario: Exact storage is conditionally unavailable
-- **WHEN** a valid changed-proof cursor depends on a retained handle that its history-disabled backend has genuinely collected
-- **THEN** EACL returns the typed exact-snapshot unavailable/stale-cursor outcome
+#### Scenario: Conditional exact storage is unavailable
+- **WHEN** a valid changed-proof cursor needs a history-disabled commit that has genuinely been collected
+- **THEN** EACL returns the typed exact-snapshot-unavailable/stale-cursor outcome
+
+#### Scenario: Proof changed without exact fallback
+- **WHEN** a valid cursor's current proof differs and the backend never supported exact history
+- **THEN** EACL returns a typed stale-cursor error
 
 #### Scenario: Replay is bounded
-- **WHEN** checkpoint-free exact replay exceeds the configured deadline or resource ceiling
+- **WHEN** checkpoint-free exact replay exceeds its deadline or resource ceiling
 - **THEN** EACL returns the corresponding deadline/resource error rather than cursor expiry
 
 ### Requirement: Pagination is differential-tested against an oracle
-The shared suite SHALL compare concatenated cursor pages with deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof, including recovery after wall-clock delay, process-local checkpoint eviction, schema/relationship mutation, and backend catch-up.
+The shared suite SHALL compare concatenated cursor pages with a deterministic uncached enumeration on the original exact graph or a graph having an equal complete dependency proof, including recovery after wall-clock delay, checkpoint eviction, forward mutation, and backend catch-up.
 
-#### Scenario: Authorization revocation after page one
+#### Scenario: Insert before cursor boundary
+- **WHEN** a relevant result is inserted before continuation
+- **THEN** current-proof continuation is rejected or exact fallback preserves the original enumeration
+
+#### Scenario: Delete after cursor boundary
+- **WHEN** a relevant result is deleted after page one
+- **THEN** current-proof continuation is rejected or exact fallback preserves the original enumeration
+
+#### Scenario: Unrelated mutation
+- **WHEN** arbitrary unrelated schema-external or relation-external data changes
+- **THEN** proof-equivalent continuation yields neither duplicates nor omissions
+
+#### Scenario: Authorization revocation
 - **WHEN** a recursive dependency revokes a result after page one
-- **THEN** current-proof continuation is rejected
-- **AND** a full-history exact fallback preserves the original enumeration without combining old and new results
+- **THEN** EACL never emits a hybrid enumeration spanning the old and new proofs
 
 #### Scenario: Client-local checkpoint is lost
-- **WHEN** page continuation runs after client restart or checkpoint eviction with stable key and source lifecycle configuration
-- **THEN** exact replay yields the same remaining sequence and boundary validation as the uninterrupted enumeration
+- **WHEN** continuation runs after client restart or checkpoint eviction with stable key and source lifecycle configuration
+- **THEN** exact replay yields the same remaining sequence and boundary validation as uninterrupted enumeration
 
 #### Scenario: Lagging Datomic Peer receives cursor
 - **WHEN** a cursor minted on one Peer names a committed basis ahead of the receiving Peer
-- **THEN** bounded exact catch-up followed by `d/as-of` yields the same original enumeration
+- **THEN** bounded catch-up followed by exact `d/as-of` yields the original enumeration


### PR DESCRIPTION
Stacked on #123. Review it first; this branch only contains the fixes.

## The bug that matters

`expand-permission-tree` accepts a **relation** as its root, not only a permission. For a relation, `find-permission-defs` returns `[]`, so the dependency closure is empty — and an empty closure still resolves to a *complete* proof with `:dependency-stamp 0`, which the managed cross-snapshot tier reads as "valid at every later snapshot". Once #123 made expansion cacheable, a relation-rooted tree kept reporting a subject list that relationship writes had already invalidated:

```clojure
;; definition document { relation viewer: user  permission view = viewer }
(eacl/expand-permission-tree client {:resource doc :permission :viewer})
;; => leaf subjects #{"alice"}
(eacl/create-relationship! client (->Relationship bob :viewer doc))
(eacl/expand-permission-tree client {:resource doc :permission :viewer})
;; => leaf subjects #{"alice"}   ; bob is missing
```

The same request rooted at `:view` was always correct, which is why no existing test caught it. Reproduced on Datomic and Datahike.

`calc-permission-relationship-eids` now adds the relation definitions of any node with no permission paths, so a relation root closes over the relation whose relationships it reads. Both backends route through `engine/permission-relationship-eids`, so it is one fix. The regression tests were confirmed to fail without it.

## Also fixed

- **Nested answers were weighed at the 512-byte floor.** Permission trees carry their payload in `:intermediate`/`:leaf` nodes rather than a `:data` vector, so every tree was admitted at the floor and the weight budget stopped bounding what the answer tiers retain. A 400-leaf tree measured 512; it now measures 207,360. The page branch is guarded by `some?` as well as `counted?` because ClojureScript and Clojure disagree on `(counted? nil)` — caught by the CLJS suite.
- **Determinism now gates minting a snapshot-exact identity, not just reading one.** A custom-codec client without `:adapter-fingerprint` was seeding the tier with entries none of its own exact requests could consult, evicting answers that could be.
- **No more republishing to the snapshot-exact tier on every exact-current hit.** It re-ran the answer validator (an O(rows) walk for pages) and the weight function on the hot path and recorded a publication race against the entry it had just found. 50 identical `can?` calls went from 49 recorded races to 0, with the tier still seeded.
- **An adapter that cannot mint a canonical identity now bypasses the tier** instead of throwing `:eacl/invalid-config`. `snapshot-exact-key` already documents nil as the outcome for such views.
- **An exact hit reports the selected snapshot's basis** rather than copying the entry's, which may have been retained from an answer computed at an earlier basis.
- **`:select-at-least` and `:select-authoritative` now cancel their Datomic sync future** on timeout and interruption, as targeted exact catch-up already did. Both keep their established `:sync-failed` taxonomy (pinned by an existing test).
- **`d/filter`, `d/since` and `d/history` views no longer claim exact-snapshot consistency.** They report their origin's database id and basis, so they would otherwise mint the same snapshot identity as the plain value while answering a different question. This makes the existing `:view-kind` check meaningful rather than vacuous, without changing the adapter contract. An as-of value is unaffected.
- **Cursor reconstruction is bounded by the request's remaining execution time**, as every other selection path already is.
- Consume the selected context's `:snapshot-exact?` instead of recomputing it, and drop `:completed-cache?`, which had become a constant with a live check.
- Refresh the change's delta specs against the main specs the change edited, so `openspec archive` succeeds.

## Datahike fails closed on a future revision, rather than waiting

Datahike has no `d/sync` (replikativ/datahike#958), so the only ways to wait for a revision the local value has not observed are unbounded polling or a fixed N-second timeout, and neither distinguishes a revision that is merely late from one that will never arrive. Listeners are not an option either — they fire only for transactions made through the connection that registered them.

Exact selection therefore reports a revision above the local head as unavailable **immediately**, and leaves the deadline for the caller to spend. Retained history at or below the local head still resolves without waiting, and `:select-at-least` keeps its await, since waiting is that operation's contract.

The local head is also more authoritative than it first appears: `datahike.connections` caches connections per store config in-process, so two `connect` calls with one config return the same object (verified: `identical?` is true) and a direct writer cannot lag itself.

## Verification

| Gate | Result |
| --- | --- |
| CI-equivalent JVM battery | 658 tests, 26,498 assertions, 0 failures, 0 errors |
| DataScript ClojureScript | 203 tests, 7,428 assertions, 0 failures |
| Dafny | 30 projects, 8,793 obligations, 0 errors |
| Mutation controls | 219 assertions, 0 failures |
| Public source closure | regenerated and passing (61 roots, 1,350 definitions) |
| OpenSpec | strict validation passes, and `archive` now completes cleanly |

## Deliberately not changed

**Datomic's bounded wait on an unreachable exact basis.** `design.md` decision 2 weighed this and chose bounded freshness failure over a transactor round trip. Datomic has no API that errors on a future basis — `(d/sync conn T)` waits for a basis ≥ T indefinitely (measured: still waiting at a 400 ms bound for a T 1000 above the head), and the sync family (`sync`, `sync-excise`, `sync-index`, `sync-schema`) offers nothing else. The check is constructible, though: zero-argument `(d/sync conn)` returns a database at the transactor-acknowledged head (measured: exact head, 0 ms on a mem peer), so comparing T against it would classify a future basis immediately, at the cost of one round trip on the catch-up path only. Left for a separate decision since it reverses a documented one.

**The `historical-db` structural duplication.** `await-revision-db`/`historical-db`/`historical-selection-failure!` re-implement the pipeline the adapter's `:select-exact` already performs. Collapsing them changes public error phases (`:cursor-exact-*` → `:exact-*`) on the cursor replay path, which does not belong in a commit that already carries eleven fixes. Only the deadline half is fixed here.

**A blanket cljfmt pass.** Running `clj-paren-repair` over the whole of `engine/v8.cljc` and `datomic/core.clj` reformats ~150 lines of pre-existing misformatting unrelated to this change; that churn was reverted and only the touched regions were formatted. The repo is not globally cljfmt-clean.
