### PR TITLE
Fix per-request overheads and replace the O(subjects) point check

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -41,7 +41,7 @@ Caching does not alter results:
 | Exact completed answer | Same semantic operation and canonical ordinary immutable snapshot | Skips the complete operation with no proof read; retained historical generations share one bounded composite-key tier |
 | Proof-backed completed answer | Same semantic operation, lifecycle, schema generation, and dependency frontier | Survives unrelated forward transactions |
 | Identity projection | Same backend, identity contract, and internal id | Shares `internal-id->object` renderings while a page is externalized |
-| Sealed plan | Same source scope, lifecycle, basis, and permission root | Reuses the compiled stable-discovery plan across requests |
+| Sealed plan | Same source scope, lifecycle, schema generation, and permission root | Reuses the compiled stable-discovery plan across requests and unrelated transactions; `expire-cache!` drops it |
 | Schema paths | Same schema generation | Shares permission-path and dependency-closure derivations used for cache dependencies and cursor proofs |
 | Latest checkpoint | One authenticated query, exact snapshot, page size, and boundary | Resumes a continued page from the retained engine state plus its lookahead segment without publishing incomplete traversal as an answer |
 | Visited page | One authenticated query and immutable snapshot | Reuses an already-externalized page (and learns the adjacent opposite-direction page) |
@@ -60,9 +60,12 @@ For an ordinary current completed operation EACL resolves:
 3. engine evaluation, optionally using safe cached subproblems; and
 4. publication into every eligible exact and proof-backed tier.
 
-An exact hit performs no generation proof reads. A proof-backed hit is promoted
-into the exact store for the selected value, so the next identical request on
-that value is exact.
+An exact hit performs no generation proof reads and no schema reads: request
+validation runs on the miss path against the schema parsed once per schema
+generation (a hit implies the request validated under an equal generation;
+an unstamped database validates against a direct read). A proof-backed hit is
+promoted into the exact store for the selected value, so the next identical
+request on that value is exact.
 
 After successful authenticated `at-exact-snapshot` selection, EACL probes only
 the snapshot-exact completed-answer tier. Its composite identity includes the

--- a/docs/stable-discovery-engine.md
+++ b/docs/stable-discovery-engine.md
@@ -100,6 +100,21 @@ process-local random default is warned about and does not survive restarts
 or load balancing. The public clients take their key material from their
 own client options (`:security-key` / page-token keyrings).
 
+## Point checks
+
+`can?` is decided by a membership-probe search over the sealed plan's
+reverse index (`eacl.engine.stable-route/check-eids`): the resource's
+intermediates are enumerated (its account, teams, vpc — typically a
+handful), and the subject is always looked up by one exact-bound probe (the
+scan strictly after `subject − 1` with limit one equals the subject iff the
+tuple exists). The Boolean equals membership of the subject in the
+exhaustive reverse-discovery denotation (the reverse-enumeration form is
+retained as `enumeration-check-eids`, the test oracle), and the cost is
+bounded by reachable intermediates and the reducer budgets — never by the
+number of subjects that hold the permission (a denied check on a resource
+with 5,000 owners went from 16 ms to 24 µs). Probes and enumerations run
+through the routed read boundary below, under the same typed limits.
+
 ## Failure semantics
 
 Every routed adapter read has exactly three outcomes

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "d43a5609b20230d82ef883a68e50aa0088f0b8672f6611d26a6b86be9ceb41e6"
+      "sha256": "70b39d51ffba8c8f3465706b20e23ae85ded610e421389de00131ecfc763d734"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -97,7 +97,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/impl.clj",
-      "sha256": "f1b399dcf70f66ccb65eca9687bcc3aeb9baa726eea00e52986f92ca3d2fc5b3"
+      "sha256": "e62676a78d6c1533312ad231d54deefe6510c7d4dc21aa95369aab015a047008"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/impl/base.clj",
@@ -137,7 +137,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "ba061df40a22732f5c27c3ddf4c67cd39ad61363093f14f684217bedc30ffca5"
+      "sha256": "d545e894ceec5bcc30751f9d34ad7214e2c9f9814107942115daee679df1cbba"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -173,7 +173,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/sealed_plan.cljc",
-      "sha256": "6b1726370fec483a9c08c7a2e2b2abeaa1b63004054c62ce055c878314d78b13"
+      "sha256": "dac56dfa57c3cc1c0d9afa6753b33b11c03dd47a401b0d49f73ecdb3177cf09a"
     },
     {
       "path": "modules/eacl/src/eacl/engine/stable_page.cljc",
@@ -185,11 +185,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/stable_route.cljc",
-      "sha256": "c0c8213405382f8197f856f6304742efdca8e89f703808beea608d4bb6c36d9a"
+      "sha256": "bd6c8c920e76ca0a0b2ab5634cf4399d536f6e4482cf3573da0bef3ea8a3f0d0"
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "0621c12643a8b0ebb1d04f7efcf060e3e9e933e43015f009b1ebb58dbcc3a3e2"
+      "sha256": "3df210ed3af842f50c11123b6892c1e8937640c8c8035277860ce4799098ae61"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -265,7 +265,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/verified_kernel.cljc",
-      "sha256": "1288b39341cac10f233169bb07cfd1c70c3492a3cd018134f1da7471680b266b"
+      "sha256": "47b3f14db2c67d101909c99e51318098519ece30d32f3a38cb74d82021c8b043"
     }
   ],
   "scope": {
@@ -333,9 +333,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1351,
-    "unionInternalDefinitionIdsSha256": "30777c8bbdddbd7c459d4c9d26cd70e73ba002608645f72bd58561c8fbc6e779",
-    "unionDefinitionLocationsSha256": "cbb6c28064a8eca282ee28bc9475d8acdbbf7713f7504a55ad6c2f8c8ab91b4b",
+    "unionInternalDefinitionCount": 1360,
+    "unionInternalDefinitionIdsSha256": "af3b4d81f1bc7f13be29bf099f20d5c69b017abeeb7c528c88efbc747a5edd7a",
+    "unionDefinitionLocationsSha256": "0bf941bc87039fcfcc5337bfa4c575ab934eebc1db5f0cf1f2cd31780ed7bc60",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,
@@ -394,16 +394,16 @@
         "idsSha256": "41564ae9195b19dd851d20e77ec6d32379244f26211d5a815622b45fb2df2592"
       },
       "modules/eacl-datomic/src/eacl/datomic/core.clj": {
-        "count": 122,
-        "idsSha256": "e63dd0f06bde510f85f3360eb8cc515591d7f917927b1c4e880d693e3fdc3c53"
+        "count": 123,
+        "idsSha256": "990d542ae73d8172e90d88453a68fb854146520700a59b31e00b0165652721fb"
       },
       "modules/eacl-datomic/src/eacl/datomic/db.clj": {
         "count": 9,
         "idsSha256": "42b27bd399d2f9b4a6146d33a02954586928ab005f199e0ddd5e82f29f6509f2"
       },
       "modules/eacl-datomic/src/eacl/datomic/impl.clj": {
-        "count": 42,
-        "idsSha256": "a95c3a055b6018f9af7eb8622c1e02163c51a84507cfb5999ebddfc45f57677d"
+        "count": 43,
+        "idsSha256": "dbfe68373c03484bb7eaa7e6f3e5aae95958304b778f1838113507ec03214fb4"
       },
       "modules/eacl-datomic/src/eacl/datomic/impl/base.clj": {
         "count": 2,
@@ -470,8 +470,8 @@
         "idsSha256": "01e8ae30a26c905caa8a67c7abb5f9d161454d1a2ebe981bda3905026054b8f5"
       },
       "modules/eacl/src/eacl/engine/sealed_plan.cljc": {
-        "count": 21,
-        "idsSha256": "7ab041bdfe0d3065f838696bd3798659cd1442c47d2b9bca9edb43b4328d882d"
+        "count": 22,
+        "idsSha256": "7945a627e813db979742f1d87dbe04cab8909e03a4bff309e35001ef106f4414"
       },
       "modules/eacl/src/eacl/engine/stable_page.cljc": {
         "count": 12,
@@ -482,12 +482,12 @@
         "idsSha256": "644155693f1acb0313241f6be91da9e0e5c196216deddfb1e01aaeff4bf9c19d"
       },
       "modules/eacl/src/eacl/engine/stable_route.cljc": {
-        "count": 5,
-        "idsSha256": "2baa47acc019ed669bc2d286552110b2581701131dfbbe2d9496523c256e79da"
+        "count": 7,
+        "idsSha256": "de4e5f5c124c098eca2fad2588049fa060d9918e9ddb6f946b4b44f594c3a66e"
       },
       "modules/eacl/src/eacl/engine/v8.cljc": {
-        "count": 79,
-        "idsSha256": "478429a13246b4fe561e6ecd49a53fd494303523669fac4c659e4a60438e0814"
+        "count": 82,
+        "idsSha256": "94ffa80a3ddd6abf33c6a9c50fae4fc07948ca59dbeb09c51c9203f2274eda1e"
       },
       "modules/eacl/src/eacl/execution.cljc": {
         "count": 26,
@@ -554,8 +554,8 @@
         "idsSha256": "5ee72c82b62cbccc6b562c2ccd55940874fbb54599e21863fa6504a645f360ae"
       },
       "modules/eacl/src/eacl/verified_kernel.cljc": {
-        "count": 105,
-        "idsSha256": "c6cd34c9f628dcc67e238492015bb227771bef7e95f5036838cc8f16005ade28"
+        "count": 106,
+        "idsSha256": "5dbddf51a638b9183ab4496bab1b426b078aae0131b9d4a0ede52b5b26ebb670"
       }
     },
     "exclusions": {
@@ -569,8 +569,8 @@
   },
   "roots": {
     "eacl.engine.v8/can?": {
-      "internalDefinitionCount": 140,
-      "internalDefinitionIdsSha256": "83011848f8e1bb308b047d59b3de848573c7e9f52cf76738cdaf8e7837a9d3db",
+      "internalDefinitionCount": 122,
+      "internalDefinitionIdsSha256": "471c655848eabea63c822490c9767ff8c5e59bd17d05952b4cdf100f5ff51044",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -585,8 +585,8 @@
       ]
     },
     "eacl.engine.v8/lookup-resources": {
-      "internalDefinitionCount": 292,
-      "internalDefinitionIdsSha256": "0e04b865e0256d4b86cb300d13dbd283e515c52f5fc52d943311c9b427a85dcc",
+      "internalDefinitionCount": 297,
+      "internalDefinitionIdsSha256": "95b484ca480c48e203b321b0eb404595380ec86c1c7bfd26a379cf1b4514d0c8",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -601,8 +601,8 @@
       ]
     },
     "eacl.engine.v8/lookup-subjects": {
-      "internalDefinitionCount": 292,
-      "internalDefinitionIdsSha256": "523fbe8ba31d3e4cf0f78f574f6be0256dabc351ec08dce3c1fde6fa41a1bc28",
+      "internalDefinitionCount": 297,
+      "internalDefinitionIdsSha256": "bb56a10d9fee0eeee7c617a3c2abc23cf063cfcacdb06a91f375b19668bebc92",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -617,8 +617,8 @@
       ]
     },
     "eacl.engine.v8/count-resources": {
-      "internalDefinitionCount": 143,
-      "internalDefinitionIdsSha256": "3a794b262efa27e95dda6f2685ec1f3892a771e8381bb5ab0394aeb9ed9f83a7",
+      "internalDefinitionCount": 147,
+      "internalDefinitionIdsSha256": "c077256ec89ad041bde0937706279b7ae73fc7514beaabae1144c083b65fc70f",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -633,8 +633,8 @@
       ]
     },
     "eacl.engine.v8/count-subjects": {
-      "internalDefinitionCount": 143,
-      "internalDefinitionIdsSha256": "a89dd1b4233646f367fc3ecadac5a38ed72665bfc95c9ff5901e3b9db66c9f21",
+      "internalDefinitionCount": 147,
+      "internalDefinitionIdsSha256": "af49f0c592892fc7355c1bc99baf1e1ad8e6eb0fa0f9fb45ea57971a4919c3b6",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -649,8 +649,8 @@
       ]
     },
     "eacl.engine.relationships/execute-page": {
-      "internalDefinitionCount": 127,
-      "internalDefinitionIdsSha256": "a22870cbe2ee084c8e13c7f3a57b624c4bd4d77cd7feb22bfd92dacb6625efe6",
+      "internalDefinitionCount": 128,
+      "internalDefinitionIdsSha256": "133f32816c21607d19160c41fca555ca8b22e09116797f03234209e966d07197",
       "externalCallCount": 1,
       "externalCalls": [
         "unresolved/js/Number.isSafeInteger"
@@ -690,8 +690,8 @@
       ]
     },
     "eacl.relay/select-continuation-adapter": {
-      "internalDefinitionCount": 253,
-      "internalDefinitionIdsSha256": "115c8d8d9647b76cb3af421c1c2db749c64076a090bba364ca44a7ce2fb8821c",
+      "internalDefinitionCount": 254,
+      "internalDefinitionIdsSha256": "06b066419868b380a2bcecbd4291bf891ff750440d41663c47943df6b911466b",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -710,8 +710,8 @@
       ]
     },
     "eacl.relay/prepare-page-query": {
-      "internalDefinitionCount": 257,
-      "internalDefinitionIdsSha256": "61eac97c513a6529cd35e48d1b0b3c1ee9d1a7b96003d37df38aa9b9f1657a93",
+      "internalDefinitionCount": 258,
+      "internalDefinitionIdsSha256": "76eee0adbb88313b4fc4e43b8fb9924641860bbf863ee16ee7426042a6454bb8",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -730,8 +730,8 @@
       ]
     },
     "eacl.relay/internalize-page-query": {
-      "internalDefinitionCount": 253,
-      "internalDefinitionIdsSha256": "a1ce7577d954e7596d7308b40fe6d26be6b4cd917fb09be8cde8d4763a40ae51",
+      "internalDefinitionCount": 254,
+      "internalDefinitionIdsSha256": "810625cdd6f1b9ffdaa39eebe35cdf7b2b50939126b66bafa9e60e62623d19e1",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -816,8 +816,8 @@
       ]
     },
     "eacl.cache/resolve-current!": {
-      "internalDefinitionCount": 174,
-      "internalDefinitionIdsSha256": "777975cbcd6c98e189a8508315d1209ef129c402d7d797a6af7a7dcd98103b85",
+      "internalDefinitionCount": 175,
+      "internalDefinitionIdsSha256": "10c276a7ba04843697ccf02a661eabcf56d0842916602bd55a5325116ef7399b",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -856,8 +856,8 @@
       "externalCalls": []
     },
     "eacl.consistency/select": {
-      "internalDefinitionCount": 210,
-      "internalDefinitionIdsSha256": "c2f4415aabdfa24eec1a6f6264f52404f57b8724225a7455d7d1046cee963617",
+      "internalDefinitionCount": 211,
+      "internalDefinitionIdsSha256": "95dc5f3b9be6da99ce359514bace02ce1019ec6f3a445f977b753e21000f9e8e",
       "externalCallCount": 11,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -935,10 +935,11 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 815,
-      "internalDefinitionIdsSha256": "9c70c7a6b940f72dbff772a28917163611a82fa0c03ae8c1d49eccaf4285dbcf",
-      "externalCallCount": 36,
+      "internalDefinitionCount": 824,
+      "internalDefinitionIdsSha256": "235d99fca98493509e9f6824d1695c9916af7bb6f68dd7b7608c0f087b90c021",
+      "externalCallCount": 37,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.set/difference",
@@ -978,8 +979,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 520,
-      "internalDefinitionIdsSha256": "891f1c76a3bb46bd7613a3558139c31086ef70d022fcd991cf875b8c7a9721de",
+      "internalDefinitionCount": 523,
+      "internalDefinitionIdsSha256": "5869502550fde207a761b51aefa8ff9ed00fdde143a5f249de72013feef9c875",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1053,10 +1054,11 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 478,
-      "internalDefinitionIdsSha256": "cafde192ebbad6bd23496093c0f5bb0e32f711dcf3dcdf34d3400743731b6080",
-      "externalCallCount": 23,
+      "internalDefinitionCount": 463,
+      "internalDefinitionIdsSha256": "81c3f51383e9dbb18442ee219565652f1daa73b1d7336286bbafe51547458863",
+      "externalCallCount": 24,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
@@ -1083,10 +1085,11 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 614,
-      "internalDefinitionIdsSha256": "a261b9d2ef35b98f96075f9c78f12b2f25a13b1300d89775b0769d755a046733",
-      "externalCallCount": 23,
+      "internalDefinitionCount": 621,
+      "internalDefinitionIdsSha256": "898f85c698a2316bcf8eeb76bd4281f90fe57f04a867b3a7396ea8d69336bb66",
+      "externalCallCount": 24,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
@@ -1113,10 +1116,11 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 480,
-      "internalDefinitionIdsSha256": "f847a038b724c99dd6a43b6932f85f9a788479ff68a17f93091f4eeeb14abfbe",
-      "externalCallCount": 23,
+      "internalDefinitionCount": 487,
+      "internalDefinitionIdsSha256": "bad75986ea692653f7f4ec17891b67ab6bce3afd951301998001aa62d467b833",
+      "externalCallCount": 24,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
@@ -1143,10 +1147,11 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 614,
-      "internalDefinitionIdsSha256": "5865dc471b148a18b64f6edd85398ee1aa2b64f659c6030f42be46247a831463",
-      "externalCallCount": 23,
+      "internalDefinitionCount": 621,
+      "internalDefinitionIdsSha256": "5d6a4cf1bec5d5be589aefe64177dd3448cf13d6b95c32478ac199d1b476f2cf",
+      "externalCallCount": 24,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
@@ -1173,10 +1178,11 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 480,
-      "internalDefinitionIdsSha256": "b2427e0f7f44c6d1c7bf95717924ef44e024f8941748be1280d00a636f50cdd7",
-      "externalCallCount": 23,
+      "internalDefinitionCount": 487,
+      "internalDefinitionIdsSha256": "795da970872d28f402a47ba9ceb88c8f4f7b984f8fc940a1e5b13f86e209de69",
+      "externalCallCount": 24,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
@@ -1238,10 +1244,11 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 816,
-      "internalDefinitionIdsSha256": "6eeb31d5f3d6067cde0ddc141d838c6734aa060e2c2f9401f5da9ede8430a5a0",
-      "externalCallCount": 36,
+      "internalDefinitionCount": 825,
+      "internalDefinitionIdsSha256": "672a7baae527140394ecd7c729ffe696baef950fbd3b3fd3caf00f03ef218fe0",
+      "externalCallCount": 37,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.set/difference",
@@ -1281,10 +1288,11 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 818,
-      "internalDefinitionIdsSha256": "f9a871e4f349eec8e553043a8f8003f1e2e13603749f8a509f39f6c57ff89559",
-      "externalCallCount": 36,
+      "internalDefinitionCount": 827,
+      "internalDefinitionIdsSha256": "aeafebf3f7b1326302fc0f8a071915653bb6607cd06ce593a561f1d35f988cac",
+      "externalCallCount": 37,
       "externalCalls": [
+        "clj-kondo/unknown-namespace/db#",
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.set/difference",
@@ -1324,8 +1332,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 639,
-      "internalDefinitionIdsSha256": "1f71e68fd9846e958c8076094b68fef8b7f5acde423c877d5c21659a3ceddf6f",
+      "internalDefinitionCount": 646,
+      "internalDefinitionIdsSha256": "e23296af60f04a24f065375192d55b7718fbec6c13af9458223b2ad26530ef70",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1361,8 +1369,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 594,
-      "internalDefinitionIdsSha256": "9c397c7311b2215b562d1f974e52cbd451dee26608e85b017cdc0b4712d076be",
+      "internalDefinitionCount": 595,
+      "internalDefinitionIdsSha256": "87f020e24f1002a4da3b3fd5ddeb68df3907d5bf2305e63e91cf2bd0faee3685",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1397,8 +1405,8 @@
       ]
     },
     "eacl.datahike.core/datahike-write-relationships!": {
-      "internalDefinitionCount": 350,
-      "internalDefinitionIdsSha256": "12b7204e2cb4442aaa288e02d165702458fbbd9fa1bc5361065def48f0e5340f",
+      "internalDefinitionCount": 351,
+      "internalDefinitionIdsSha256": "93aaac6306525f3eab5119990b2d2632061a7c70cec0858aa329323e901c996f",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1431,8 +1439,8 @@
       ]
     },
     "eacl.datahike.core/datahike-delete-object!": {
-      "internalDefinitionCount": 341,
-      "internalDefinitionIdsSha256": "ba18df53ad039cab73d007a76392d3025e54b862d4a761631178e6aab7713b54",
+      "internalDefinitionCount": 342,
+      "internalDefinitionIdsSha256": "eefb96461649cd2d37045dd63b5be5d70d03ca6e5aab160fa822b0fcad022180",
       "externalCallCount": 25,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1463,8 +1471,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 593,
-      "internalDefinitionIdsSha256": "9e52eac6b11a620d4e245574198983b901941783ae97db00c7c7bcf85038d6be",
+      "internalDefinitionCount": 576,
+      "internalDefinitionIdsSha256": "dd199e6da4c42d6dbe8be2d15a2258e37b6b704e42e0102f7a51eeb775c83fc2",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1498,8 +1506,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 722,
-      "internalDefinitionIdsSha256": "7272326f4cf3dd0fa1d2eb6770e0a0ffede339f3db6780a1c60c3c8f55132f00",
+      "internalDefinitionCount": 727,
+      "internalDefinitionIdsSha256": "62af23d256faa8af11329a0a20c93a34ec560668f2d9d822d5546a80c79ed7f5",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1534,8 +1542,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 596,
-      "internalDefinitionIdsSha256": "9fb199afe8fe5613f7449acfe1df7defe994af6d496de65a62e2deb4746baf28",
+      "internalDefinitionCount": 601,
+      "internalDefinitionIdsSha256": "670332712e1cc2446b2e4e654e3057337f045a108a60ed9c66dce621daf45284",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1569,8 +1577,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 722,
-      "internalDefinitionIdsSha256": "657ebcfb3fb32236e7f39c43973ae032503db83f3994db7571bcb475af800d90",
+      "internalDefinitionCount": 727,
+      "internalDefinitionIdsSha256": "b3e15b79bdbbbba090545441798dab6d91aa525b2c36c14a90e81f62888e8928",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1605,8 +1613,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 596,
-      "internalDefinitionIdsSha256": "9e765902ad0f847d1947753a2dc15176260db83964e1cf9ab6efd7c5854c6396",
+      "internalDefinitionCount": 601,
+      "internalDefinitionIdsSha256": "2df96169cd8043de454613f950703ff034271b30a18113fb489bea7e88ded55b",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1640,8 +1648,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 369,
-      "internalDefinitionIdsSha256": "b6064fc38e4b18ef37cf117cd5eeeb5df33390046cea52bef5b217eb71f8e69d",
+      "internalDefinitionCount": 370,
+      "internalDefinitionIdsSha256": "15aba98375bdeee65d6c928a141250482fa3ca3d243c912a843ca5a6d6f44728",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1671,8 +1679,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 579,
-      "internalDefinitionIdsSha256": "1fdec765d29c5a9c3c1f65b8b58c46c21f539aab1f8e86123b7b0f3ba4c21004",
+      "internalDefinitionCount": 580,
+      "internalDefinitionIdsSha256": "c595ba4314cc84ec7f62d3c7aa50924ee0fc1bc936337c006ab9d6281a1d5f2a",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1706,8 +1714,8 @@
       ]
     },
     "eacl.datascript.core/datascript-write-relationships!": {
-      "internalDefinitionCount": 335,
-      "internalDefinitionIdsSha256": "c73609e187bdc4e8cdb966820600f29026ea30efe85ec3b6c0f6b9ac1ea6cfca",
+      "internalDefinitionCount": 336,
+      "internalDefinitionIdsSha256": "f2d40ddfcb4bd83044b6831381b1da89e05e7ced1d9ade755a4855a583abfa65",
       "externalCallCount": 26,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1739,8 +1747,8 @@
       ]
     },
     "eacl.datascript.core/datascript-delete-object!": {
-      "internalDefinitionCount": 326,
-      "internalDefinitionIdsSha256": "e148f86fa966c8f2d4e6cff4e5d1efa0afead1fa95f8b63d51db42036543bd94",
+      "internalDefinitionCount": 327,
+      "internalDefinitionIdsSha256": "bdf95a7656f406c13e2610162661a9a5da55c6d04fe1302130eb215c63a4bc16",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1770,8 +1778,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 578,
-      "internalDefinitionIdsSha256": "577c2ee61414770a6ec29319f791882cd9c60c7b45184a80e0d7cf0d65fb133b",
+      "internalDefinitionCount": 561,
+      "internalDefinitionIdsSha256": "a38d1d7cef04bf0faa1d2eda70e4311bc7a88f78acf719a3e310d9db22ace18c",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1804,8 +1812,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 707,
-      "internalDefinitionIdsSha256": "06f8bcbbcdfb2d09489f98b5defa64c7540bc055678d7106558ead62d1bb1d14",
+      "internalDefinitionCount": 712,
+      "internalDefinitionIdsSha256": "b0eb35b07224e803037594f32a7d3bdedcb53d39059fce3321b96a7f61c345cc",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1839,8 +1847,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 581,
-      "internalDefinitionIdsSha256": "547f1156cffe41e54b40e128a20bf2b96645604b2112015d73e96850379a6c24",
+      "internalDefinitionCount": 586,
+      "internalDefinitionIdsSha256": "400645ebad161f746315a47ccd7cccd86d3ff228833bec06804e8b4c7863ae66",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1873,8 +1881,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 707,
-      "internalDefinitionIdsSha256": "7b9784348bdcc89f42da70bbc59d2c679c2ee742250005d79b28faa7d2c6d5ec",
+      "internalDefinitionCount": 712,
+      "internalDefinitionIdsSha256": "6b23f4b269ec8af0f8b24977612eaa6e9c038ee3b635518f028ade37a8e4aa17",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1908,8 +1916,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 581,
-      "internalDefinitionIdsSha256": "5b5f6b3892ec3a35364956f786f4b136474e3a95621c6b894dd78e3c205c3150",
+      "internalDefinitionCount": 586,
+      "internalDefinitionIdsSha256": "6799b2f3f8c51b8e3e0613aec71ca6fa15a0350cafe070d51322c2b38e8097d6",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1942,8 +1950,8 @@
       ]
     },
     "eacl.datascript.core/make-client": {
-      "internalDefinitionCount": 354,
-      "internalDefinitionIdsSha256": "42b7504a8773f8722c13133079ab802544c11ca1bc92da77f0829a9605685fa7",
+      "internalDefinitionCount": 355,
+      "internalDefinitionIdsSha256": "2ed34081a310db7d4e2a130de1ee4b716795a3cda94fa61f849e23823b3f1ee5",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/modules/eacl-datascript/test/eacl/engine/point_check_test.clj
+++ b/modules/eacl-datascript/test/eacl/engine/point_check_test.clj
@@ -1,0 +1,146 @@
+(ns eacl.engine.point-check-test
+  "Membership-probe point check (membership-probe-point-check): the probe
+  search must equal the reverse-enumeration oracle on every frozen baseline,
+  its cost must be bounded by reachable intermediates rather than by the
+  number of subjects holding the permission, and it must honour the
+  reducer's typed limits, the cut-point hook and the observer counters."
+  (:require [clojure.string :as string]
+            [clojure.test :refer [deftest is testing]]
+            [datascript.core :as ds]
+            [eacl.baseline.capture :as capture]
+            [eacl.datascript.backend :as datascript-backend]
+            [eacl.engine.sealed-plan :as sealed-plan]
+            [eacl.engine.stable-reducer :as reducer]
+            [eacl.engine.stable-route :as route]))
+
+(defn- seeded
+  [fixture-key]
+  (let [fixture ((get capture/fixtures fixture-key))
+        {:keys [conn]} (capture/seed-client! fixture)
+        db (ds/db conn)
+        adapter (datascript-backend/snapshot-adapter
+                 db
+                 {:object-id->entid
+                  (fn [snapshot object-id]
+                    (ds/entid snapshot [:eacl/id object-id]))
+                  :entid->object-id
+                  (fn [snapshot internal-id]
+                    (:eacl/id (ds/entity snapshot internal-id)))
+                  :conn conn
+                  :source-lifecycle (str (gensym (str "point-check-"
+                                                      (name fixture-key)
+                                                      "-")))})]
+    {:fixture fixture :db db :adapter adapter
+     :plan (sealed-plan/seal-plan adapter [(:resource-type fixture)
+                                           (:permission fixture)])}))
+
+(defn- eid [db object-id] (ds/entid db [:eacl/id object-id]))
+
+(deftest probe-check-equals-enumeration-oracle-test
+  ;; Every principal against every resource that any frozen point sample
+  ;; names, plus the frozen expectation where one exists.
+  (doseq [fixture-key [:explorer-acyclic :folder-chain :mutual-mixed
+                       :cyclic-data :broad-union :group-star]]
+    (testing (str fixture-key)
+      (let [{:keys [fixture db adapter plan]} (seeded fixture-key)
+            snapshot (capture/read-snapshot fixture-key)
+            ;; Every resource the frozen point samples name, plus up to 200
+            ;; objects of the root resource type from the fixture itself.
+            resource-ids (->> (concat
+                               (->> (:points snapshot)
+                                    vals
+                                    (mapcat vals)
+                                    (map #(second (string/split (:resource %) #":" 2))))
+                               (->> (:objects fixture)
+                                    (filter #(= (:resource-type fixture) (:type %)))
+                                    (map :id)
+                                    (take 200)))
+                              distinct
+                              vec)
+            options {:adapter adapter :plan plan :subject-type :user}]
+        (is (seq resource-ids))
+        (doseq [[principal-key principal] (:principals fixture)
+                resource-id resource-ids]
+          (let [subject-eid (eid db (:id principal))
+                resource-eid (eid db resource-id)
+                probe (route/check-eids
+                       (assoc options :subject-eid subject-eid
+                              :resource-eid resource-eid))
+                oracle (route/enumeration-check-eids
+                        (assoc options :subject-eid subject-eid
+                               :resource-eid resource-eid))]
+            (is (= oracle probe)
+                (str fixture-key " " principal-key " " resource-id))))
+        (doseq [[principal-key samples] (:points snapshot)
+                [sample-key {:keys [resource can?]}] samples]
+          (let [[_ resource-id] (string/split resource #":" 2)
+                principal (get-in fixture [:principals principal-key])]
+            (is (= can?
+                   (route/check {:adapter adapter :plan plan
+                                 :subject-type :user
+                                 :subject-id (:id principal)
+                                 :resource-id resource-id}))
+                (str fixture-key " " principal-key " " sample-key))))))))
+
+(deftest probe-check-cost-is-bounded-by-intermediates-test
+  ;; A resource with a million direct subjects: the probe check answers a
+  ;; deny and an allow with one exact-bound probe each; the enumeration
+  ;; oracle would scan every subject.
+  (let [rule {:rule :relation :node [:server :view] :resource-type :server
+              :permission :view :relation-eid 100 :subject-type :user
+              :ordinal 0 :rank 1}
+        plan {:root [:server :view] :recursive? false
+              :indexes {:forward-seeds {:user [rule]}
+                        :forward-consumers {}
+                        :reverse-rules {[:server :view] [rule]}}}
+        n 1000000
+        commands (atom 0)
+        fetch-fn (fn [{:keys [bound-eid limit]}]
+                   (swap! commands inc)
+                   (let [start (inc (or bound-eid 0))]
+                     (range start (min (inc n) (+ start limit)))))
+        run (fn [subject-eid]
+              (reset! commands 0)
+              [(route/check-eids {:fetch-fn fetch-fn :plan plan
+                                  :subject-type :user
+                                  :subject-eid subject-eid
+                                  :resource-eid 1})
+               @commands])]
+    (testing "denied subject beyond every owner: one probe"
+      (is (= [false 1] (run (+ n 5)))))
+    (testing "allowed subject with the largest eid: one probe"
+      (is (= [true 1] (run n))))
+    (testing "allowed subject with the smallest eid: one probe"
+      (is (= [true 1] (run 1))))))
+
+(deftest probe-check-limits-cut-point-and-stats-test
+  (let [{:keys [fixture db adapter plan]} (seeded :explorer-acyclic)
+        [_ principal] (first (:principals fixture))
+        snapshot (capture/read-snapshot :explorer-acyclic)
+        resource-id (->> (:points snapshot) vals (mapcat vals) first
+                         :resource (#(second (string/split % #":" 2))))
+        options {:adapter adapter :plan plan :subject-type :user
+                 :subject-eid (eid db (:id principal))
+                 :resource-eid (eid db resource-id)}]
+    (testing "typed limit failure names the reducer budget"
+      (let [data (try (route/check-eids (assoc options :max-admissions 1))
+                      nil
+                      (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+        (when data
+          (is (= :eacl.reducer/limit-exceeded (:eacl/error data)))
+          (is (= :max-admissions (:limit data)))
+          (is (= 1 (:max-admissions data))))))
+    (testing "the cut-point hook runs at every visit"
+      (let [calls (atom 0)]
+        (route/check-eids (assoc options :cut-point! (fn [_] (swap! calls inc))))
+        (is (pos? @calls))))
+    (testing "observer counters report visits, probes and states"
+      (let [stats (atom {})]
+        (binding [reducer/*observer-stats* stats]
+          (route/check-eids options))
+        (is (pos? (:derived-grants @stats 0)))
+        (is (pos? (:advanced-datoms @stats 0)))
+        (is (pos? (:queued-work @stats 0)))))
+    (testing "nil ids never hold"
+      (is (false? (route/check-eids (assoc options :subject-eid nil))))
+      (is (false? (route/check-eids (assoc options :resource-eid nil)))))))

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -1036,7 +1036,21 @@
                :has-next-page? false
                :has-previous-page? false}})
 
-(declare capture-result-context with-cache-info)
+(declare capture-result-context with-cache-info with-result-schema)
+
+(defn- request-schema
+  "The parsed EACL schema visible in `db`, for validating one public request.
+
+  Inside a cached computation the client binds its proof-keyed schema
+  generation (`impl.indexed/*schema-cache*`); its `:parsed-schema` is read
+  once per generation, so validation costs no schema enumeration and cache
+  hits never read the schema at all (validation runs on the miss path — no
+  entry can exist for a request that failed validation, and every tier keys
+  by an identity that fixes the schema generation). Outside a bound
+  generation the schema is read from the selected value directly."
+  [_opts db]
+  (or (some-> impl.indexed/*schema-cache* :parsed-schema force)
+      (schema/read-schema db)))
 
 (defn spiceomic-read-relationships
   [conn
@@ -1056,9 +1070,6 @@
         (capture-result-context
          conn opts (:consistency filters)
          (fn [db _decoded]
-           (schema-errors/validate-relationship-read!
-            (schema/read-schema db)
-            filters)
            (let [relation-ids
                  (impl/relationship-relation-ids db filters)]
              {:db db
@@ -1067,6 +1078,14 @@
               {:permission-nodes []
                :relation-ids relation-ids}}))
          :read-relationships decoded)
+        ;; Schema validation runs on the miss path (inside the bound schema
+        ;; generation) and on the empty short-circuits; a cache hit implies
+        ;; the request validated under an equal schema generation.
+        validate!
+        (fn []
+          (schema-errors/validate-relationship-read!
+           (request-schema opts db)
+           filters))
         selected-opts
         (assoc opts
                :selected-schema-version schema-version
@@ -1085,9 +1104,11 @@
       ;; A filter names an object that does not exist: nothing can match.
       ;; A supplied-but-unresolvable ID must not be conflated with an absent
       ;; filter — that conflation degraded this query to a global scan.
-      (if decoded
-        (cursor-anchor-stale! :read-relationships)
-        empty-page)
+      (do
+        (with-result-schema result-context validate!)
+        (if decoded
+          (cursor-anchor-stale! :read-relationships)
+          empty-page))
       (let [filters'     (cond-> filters
                            subject-id (assoc :subject/id subject-eid)
                            resource-id (assoc :resource/id resource-eid))
@@ -1098,7 +1119,11 @@
              (shared-cache/lookup-page-query-identity filters internal-query)
              :relationship-page internal-relationship-page?
              internal-page-weight
-             #(impl/read-relationships db internal-query))]
+             #(with-result-schema
+                result-context
+                (fn []
+                  (validate!)
+                  (impl/read-relationships db internal-query))))]
         (with-cache-info
          (coerce-relationship-page
           db selected-opts :read-relationships query-shape basis-t
@@ -1291,7 +1316,13 @@
         registry (:derived-schema-caches opts)]
     (or (get @registry key)
         (let [created
-              (impl.indexed/make-schema-cache db schema-generation)]
+              (cond-> (impl.indexed/make-schema-cache db schema-generation)
+                ;; Parsed once per generation for request validation
+                ;; (`request-schema`); equal generations denote equal
+                ;; definition sets. An unstamped database has no
+                ;; generation and must not latch anything.
+                (some? schema-generation)
+                (assoc :parsed-schema (delay (schema/read-schema db))))]
           (get (swap! registry
                       #(if (contains? % key)
                          %
@@ -1868,12 +1899,17 @@
   (let [{:keys [db] :as result-context}
         (capture-basic-result-context
          conn opts consistency-value)
-        _ (schema-errors/validate-permission-request!
-           (schema/read-schema db)
+        ;; Schema validation runs on the miss path (inside the bound schema
+        ;; generation) and on the unknown-object short-circuit; a cache hit
+        ;; implies the request validated under an equal schema generation.
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema opts db)
            (or (get-in opts [:execution-contract :operation]) :can?)
            {:resource-type (:type resource)
             :subject-type (:type subject)
-            :permission permission})
+            :permission permission}))
         internal-subject
         (spice-object
          (:type subject)
@@ -1883,9 +1919,11 @@
          (:type resource)
          (object->entid db resource))]
     (if-not (and (:id internal-subject) (:id internal-resource))
-      {:allowed? false
-       :cached? false
-       :cache-basis nil}
+      (do
+        (validate!)
+        {:allowed? false
+         :cached? false
+         :cache-basis nil})
       (let [query-identity
             {:public
              {:subject subject
@@ -1901,8 +1939,10 @@
              boolean-result?
              (:type resource)
              permission
-             #(impl/can? db internal-subject permission
-                         internal-resource))]
+             #(do
+                (validate!)
+                (impl/can? db internal-subject permission
+                           internal-resource)))]
         {:allowed? (:result answer)
          :cached? (:cached? answer)
          :cache-basis (:cache-basis answer)}))))
@@ -1925,12 +1965,6 @@
                  opts :lookup-resources query-shape page-req)
         prepare
         (fn [db decoded-bound]
-          (schema-errors/validate-permission-request!
-           (schema/read-schema db)
-           :lookup-resources
-           {:resource-type (:resource/type query)
-            :subject-type (:type subject)
-            :permission (:permission query)})
           (let [internal-subject (spice-object->internal db subject)
                 query' (assoc query :subject internal-subject)]
             {:db db
@@ -1949,6 +1983,17 @@
                 cache-scope schema-version]
          :as result-context}
         captured
+        ;; Schema validation runs on the miss path (inside the bound schema
+        ;; generation) and on the unknown-subject short-circuit; a cache hit
+        ;; implies the request validated under an equal schema generation.
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema opts db)
+           :lookup-resources
+           {:resource-type (:resource/type query)
+            :subject-type (:type subject)
+            :permission (:permission query)}))
         selected-opts
         (assoc opts
                :selected-schema-version schema-version
@@ -1957,13 +2002,16 @@
     (if (nil? (:id internal-subject))
       ;; Unknown subjects match nothing on a first page. A continued page may
       ;; not silently discard its authenticated anchor.
-      (if decoded
-        (cursor-anchor-stale! :lookup-resources)
-        (assoc empty-page :cached? false :cache-basis nil))
+      (do
+        (with-result-schema result-context validate!)
+        (if decoded
+          (cursor-anchor-stale! :lookup-resources)
+          (assoc empty-page :cached? false :cache-basis nil)))
       (let [compute
             #(with-result-schema
                result-context
                (fn []
+                 (validate!)
                  (impl/lookup-resources
                   db internal-query
                   {:continuation-cache-fn
@@ -2021,18 +2069,22 @@
   (let [{:keys [db] :as result-context}
         (capture-basic-result-context
          conn opts (:consistency query))
-        _ (schema-errors/validate-permission-request!
-           (schema/read-schema db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema opts db)
            :count-resources
            {:resource-type (:resource/type query)
             :subject-type (:type subject)
-            :permission (:permission query)})
+            :permission (:permission query)}))
         subject-ent (spice-object->internal db subject)
         query' (-> query
                    (assoc :subject subject-ent)
                    (dissoc :consistency :cache?))]
     (if (nil? (:id subject-ent))
-      (assoc (empty-count-response query) :cached? false :cache-basis nil)
+      (do
+        (validate!)
+        (assoc (empty-count-response query) :cached? false :cache-basis nil))
       (let [answer
             (cached-basic-authorization-result
              opts result-context :count-resources
@@ -2041,7 +2093,7 @@
              :count count-response?
              (:resource/type query')
              (:permission query')
-             #(impl/count-resources db query'))]
+             #(do (validate!) (impl/count-resources db query')))]
         (with-cache-info (:result answer) answer)))))
 
 (defn spiceomic-lookup-subjects
@@ -2056,12 +2108,6 @@
                  opts :lookup-subjects query-shape page-req)
         prepare
         (fn [db decoded-bound]
-          (schema-errors/validate-permission-request!
-           (schema/read-schema db)
-           :lookup-subjects
-           {:resource-type (:type (:resource query))
-            :subject-type (:subject/type query)
-            :permission (:permission query)})
           (let [internal-resource
                 (spice-object->internal db (:resource query))
                 query' (assoc query :resource internal-resource)]
@@ -2081,19 +2127,33 @@
                 cache-scope schema-version]
          :as result-context}
         captured
+        ;; Schema validation runs on the miss path (inside the bound schema
+        ;; generation) and on the unknown-resource short-circuit; a cache hit
+        ;; implies the request validated under an equal schema generation.
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema opts db)
+           :lookup-subjects
+           {:resource-type (:type (:resource query))
+            :subject-type (:subject/type query)
+            :permission (:permission query)}))
         selected-opts
         (assoc opts
                :selected-schema-version schema-version
                :page-cursor-context (:cursor-context captured))]
     (validate-page-token-schema! selected-opts decoded)
     (if (nil? (:id internal-resource))
-      (if decoded
-        (cursor-anchor-stale! :lookup-subjects)
-        (assoc empty-page :cached? false :cache-basis nil))
+      (do
+        (with-result-schema result-context validate!)
+        (if decoded
+          (cursor-anchor-stale! :lookup-subjects)
+          (assoc empty-page :cached? false :cache-basis nil)))
       (let [compute
             #(with-result-schema
                result-context
                (fn []
+                 (validate!)
                  (impl/lookup-subjects
                   db internal-query
                   {:continuation-cache-fn
@@ -2140,19 +2200,23 @@
   (let [{:keys [db] :as result-context}
         (capture-basic-result-context
          conn opts (:consistency query))
-        _ (schema-errors/validate-permission-request!
-           (schema/read-schema db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema opts db)
            :count-subjects
            {:resource-type (:type (:resource query))
             :subject-type (:subject/type query)
-            :permission (:permission query)})
+            :permission (:permission query)}))
         resource-ent
         (spice-object->internal db (:resource query))
         query' (-> query
                    (assoc :resource resource-ent)
                    (dissoc :consistency :cache?))]
     (if (nil? (:id resource-ent))
-      (assoc (empty-count-response query) :cached? false :cache-basis nil)
+      (do
+        (validate!)
+        (assoc (empty-count-response query) :cached? false :cache-basis nil))
       (let [answer
             (cached-basic-authorization-result
              opts result-context :count-subjects
@@ -2161,7 +2225,7 @@
              :count count-response?
              (:type resource-ent)
              (:permission query')
-             #(impl/count-subjects db query'))]
+             #(do (validate!) (impl/count-subjects db query')))]
         (with-cache-info (:result answer) answer)))))
 
 (defn spiceomic-expand-permission-tree
@@ -2169,11 +2233,13 @@
   (let [{:keys [adapter db] :as context}
         (capture-basic-result-context
          conn opts (:consistency query))
-        _ (schema-errors/validate-expansion-request!
-           (schema/read-schema db)
+        validate!
+        (fn []
+          (schema-errors/validate-expansion-request!
+           (request-schema opts db)
            :expand-permission-tree
            (:type (:resource query))
-           (:permission query))
+           (:permission query)))
         contract (:execution-contract opts)
         answer
         (cached-basic-authorization-result
@@ -2181,12 +2247,14 @@
          (dissoc query :consistency :cache? :timeout-ms :cancellation-token)
          :permission-tree map?
          (:type (:resource query)) (:permission query)
-         #(permission-tree/expand
-           adapter
-           {:limits (:permission-tree-limits opts)
-            :execution-contract contract}
-           (:resource query)
-           (:permission query)))
+         #(do
+            (validate!)
+            (permission-tree/expand
+             adapter
+             {:limits (:permission-tree-limits opts)
+              :execution-contract contract}
+             (:resource query)
+             (:permission query))))
         tree (:result answer)]
     (execution/check! contract :permission-tree-token-issuance)
     (let [token
@@ -2357,7 +2425,10 @@
        (shared-cache/expire-current! store))
      (some-> (:derived-schema-caches opts) (reset! {}))
      (some-> (:continuation-cache-store opts) continuation/clear!)
-     (some-> (:revision-checkpoints opts) :state (reset! [])))
+     (some-> (:revision-checkpoints opts) :state (reset! []))
+     ;; Sealed plans are keyed by schema generation, not lifecycle; a
+     ;; rotation after reset/restore/source replacement must drop them too.
+     (engine/expire-plans!))
    nil))
 
 (def prepare-cache-coherence!

--- a/modules/eacl-datomic/src/eacl/datomic/impl.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/impl.clj
@@ -21,17 +21,34 @@
   [subject relation resource]
   (eacl/->Relationship subject relation resource))
 
+(defonce ^:private raw-engine-lifecycle
+  ;; The engine adapters minted by this facade carry one process-stable
+  ;; lifecycle. A raw call has no client lifecycle to rotate; a fresh random
+  ;; lifecycle per call (the previous behaviour) made the engine's sealed-plan
+  ;; cache miss on every request. The lifecycle only distinguishes stores
+  ;; that alias a source scope; every raw call on one database shares it.
+  (str "eacl-datomic-raw-" (java.util.UUID/randomUUID)))
+
 (defmacro ^:private with-request-engine
   "Builds ONE snapshot adapter for the call and binds the shared engine
   context: a caller-supplied impl.indexed schema cache wins; otherwise a
   request-local derived context scoped to this adapter's immutable
   snapshot (eliminating duplicate proof reads, path walks, and plan
-  compiles inside one raw request without cross-request publication)."
+  compiles inside one raw request without cross-request publication).
+
+  The adapter carries the facade's process-stable lifecycle and the
+  request-local context carries the snapshot's schema version (one direct
+  datom read, not a proof-frame operation), so the engine's sealed plans are
+  reused across raw calls and across unrelated transactions."
   [[adapter-sym db] & body]
-  `(let [~adapter-sym (backend/snapshot-adapter ~db)]
+  `(let [db# ~db
+         ~adapter-sym (backend/snapshot-adapter
+                       db# {:source-lifecycle raw-engine-lifecycle})]
      (binding [engine/*schema-cache*
                (or impl.indexed/*schema-cache*
-                   (engine/request-schema-cache ~adapter-sym))
+                   (engine/request-schema-cache
+                    ~adapter-sym
+                    {:schema-identity (impl.indexed/schema-version db#)}))
                engine/*recursive-traversal-limits*
                impl.indexed/*recursive-traversal-limits*
                engine/*recursive-traversal-stats*

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -1082,6 +1082,9 @@
    (some->
     (get-in client [:opts :continuation-cache-store])
     continuation/clear!)
+   ;; Sealed plans are keyed by schema generation, not lifecycle; a rotation
+   ;; after reset/restore/source replacement must drop them too.
+   (engine/expire-plans!)
    nil))
 
 (defn cache-stats

--- a/modules/eacl/src/eacl/engine/sealed_plan.cljc
+++ b/modules/eacl/src/eacl/engine/sealed_plan.cljc
@@ -156,13 +156,26 @@
 ;; Canonical ordinals
 ;; ---------------------------------------------------------------------------
 
+(defn- sort-by-canonical
+  "Sorts values by their canonical encoding, computing each encoding exactly
+  once (`sort-by encode-canonical` re-encodes and re-validates both operands
+  on every comparison — measured at ~370 encodings for a 16-rule plan).
+  Returns [[encoding value] …] in canonical order; the order is identical to
+  `(sort-by secure-format/encode-canonical values)` because both compare the
+  same portable EDN strings with `compare`."
+  [values]
+  (sort-by first compare
+           (map (fn [value] [(secure-format/encode-canonical value) value])
+                values)))
+
 (defn- assign-ordinals
   "Sorts semantic rules by their canonical encoding and assigns dense
   ordinals, so byte-identical rule sets seal identically regardless of
   discovery order."
   [rules]
-  (let [sorted (vec (sort-by secure-format/encode-canonical rules))]
-    (when (not= (count sorted) (count (distinct (map secure-format/encode-canonical sorted))))
+  (let [encoded (sort-by-canonical rules)
+        sorted (mapv second encoded)]
+    (when (not= (count sorted) (count (distinct (map first encoded))))
       (compile-error! "Duplicate sealed rules." {}))
     (vec (map-indexed (fn [ordinal rule] (assoc rule :ordinal ordinal))
                       sorted))))
@@ -172,8 +185,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- plan-nodes [root-node rules]
-  (vec (sort-by secure-format/encode-canonical
-                (into #{root-node} (map :node rules)))))
+  (mapv second
+        (sort-by-canonical (into #{root-node} (map :node rules)))))
 
 (defn- permission-edges
   "Permission edges run target-node -> node with cost 0 (self-permission)

--- a/modules/eacl/src/eacl/engine/stable_route.cljc
+++ b/modules/eacl/src/eacl/engine/stable_route.cljc
@@ -1,11 +1,17 @@
 (ns eacl.engine.stable-route
   "Operation-appropriate routes on the stable-discovery engine
-  (adopt-stable-discovery-enumeration, tasks 8.1-8.2).
+  (adopt-stable-discovery-enumeration, tasks 8.1-8.2; membership-probe
+  point check, membership-probe-point-check).
 
-  - Point checks are anchored to the known resource: reverse traversal
-    from the resource with early termination on the subject's first
-    admission — the root universe is never enumerated to answer one
-    known-resource question.
+  - Point checks are anchored to the known resource and answered by a
+    membership-probe search over the sealed plan's reverse index: the few
+    intermediates a resource reaches are enumerated, the subject itself is
+    always looked up by one exact-bound probe. Cost is bounded by the number
+    of reachable intermediates, never by the number of subjects that hold
+    the permission (the reverse-enumeration check it replaces was linear in
+    that number: a denied check on a resource with 5,000 owners cost 16 ms).
+    The reverse-enumeration form is retained as `enumeration-check-eids`,
+    the test oracle.
   - Exact count exhausts the history-free reducer; its scalar discovered
     count equals the denotation cardinality. Exhaustion is unbounded by
     construction (`exhaustion-target` is infinite): a run ends at an empty
@@ -20,13 +26,183 @@
   run until the stack empties or a typed limit fails, never to a finite cap."
   reducer/exhaustion-target)
 
-(defn- found! []
-  (throw (ex-info "found" {::found true})))
+;; ---------------------------------------------------------------------------
+;; Membership-probe point check
+;; ---------------------------------------------------------------------------
+
+(defn- limit-failure!
+  [limit-key counters detail]
+  (throw (ex-info "Point-check semantic limit exceeded."
+                  (merge {:eacl/error :eacl.reducer/limit-exceeded
+                          :limit limit-key
+                          :admissions (:admissions counters)
+                          :transitions (:transitions counters)
+                          :commands (:commands counters)
+                          :discovered 0}
+                         detail))))
+
+(defn- reverse-scan
+  "Read-demand descriptor for one reverse scan, shaped exactly like the
+  reducer's so the routed fetch-fn layers (classification, retry,
+  telemetry) apply unchanged."
+  [resource-type resource-eid relation-eid subject-type bound-eid limit]
+  {:operation :resource->subjects
+   :resource-type resource-type :resource-eid resource-eid
+   :relation-eid relation-eid :subject-type subject-type
+   :bound-eid bound-eid :limit limit})
+
+(defn- probe-check-eids
+  "Iterative depth-first membership search. Returns true iff a derivation
+  of the plan's root permission on `resource-eid` bottoms out in a tuple
+  whose subject is `subject-eid`; equivalently, iff `subject-eid` belongs
+  to the exhaustive reverse denotation `run-reverse` would emit.
+
+  Reachability over the rule graph is decided by a visited set on
+  [node eid]; a base tuple is decided by one exact-bound probe (the scan
+  strictly after `subject-eid - 1`, limit one, equals `subject-eid` iff the
+  tuple exists). Only intermediates are enumerated. Typed limits mirror the
+  reducer's budgets: `:max-admissions` bounds distinct visited states,
+  `:max-transitions` visits, `:max-commands` fetches, `:max-values` fetched
+  values, `:max-stack` instantaneous stack depth."
+  [{:keys [adapter fetch-fn plan subject-type subject-eid resource-eid
+           cut-point! physical-chunk-size
+           max-admissions max-commands max-transitions max-values max-stack]
+    :or {physical-chunk-size reducer/default-physical-chunk-size
+         max-admissions reducer/default-max-admissions
+         max-commands reducer/default-max-commands
+         max-transitions reducer/default-max-transitions
+         max-values reducer/default-max-values
+         max-stack reducer/default-max-stack}}]
+  {:pre [(or (some? adapter) (some? fetch-fn)) (some? plan)
+         (keyword? subject-type) (some? subject-eid) (some? resource-eid)]}
+  (let [fetch-fn (or fetch-fn (reducer/adapter-fetch-fn adapter))
+        reverse-rules (get-in plan [:indexes :reverse-rules])
+        counters (volatile! {:admissions 0 :transitions 0 :commands 0
+                             :fetched-values 0})
+        fetch! (fn [descriptor]
+                 (when (>= (:commands @counters) max-commands)
+                   (limit-failure! :max-commands @counters
+                                   {:max-commands max-commands}))
+                 (let [values (into [] (take (:limit descriptor))
+                                    (fetch-fn descriptor))]
+                   (when (> (+ (:fetched-values @counters) (count values))
+                            max-values)
+                     (limit-failure! :max-values @counters
+                                     {:max-values max-values
+                                      :staged (count values)}))
+                   (vswap! counters #(-> %
+                                         (update :commands inc)
+                                         (update :fetched-values
+                                                 + (count values))))
+                   values))
+        probe? (fn [resource-type eid relation-eid]
+                 (= subject-eid
+                    (first (fetch! (reverse-scan resource-type eid
+                                                 relation-eid subject-type
+                                                 (dec subject-eid) 1)))))
+        intermediates (fn [resource-type eid via-relation-eid intermediate-type]
+                        (loop [bound nil acc (transient [])]
+                          (let [chunk (fetch! (reverse-scan resource-type eid
+                                                            via-relation-eid
+                                                            intermediate-type
+                                                            bound
+                                                            physical-chunk-size))
+                                acc (reduce conj! acc chunk)]
+                            (if (< (count chunk) physical-chunk-size)
+                              (persistent! acc)
+                              (recur (peek chunk) acc)))))
+        report! (fn []
+                  (when-let [stats reducer/*observer-stats*]
+                    (let [{:keys [admissions commands transitions]} @counters]
+                      (swap! stats
+                             (fn [c]
+                               (-> (or c {})
+                                   (update :derived-grants (fnil + 0) admissions)
+                                   (update :advanced-datoms (fnil + 0) commands)
+                                   (update :queued-work (fnil + 0) transitions)))))))]
+    (loop [stack [[(:root plan) resource-eid]]
+           visited (transient #{})]
+      (if (empty? stack)
+        (do (report!) false)
+        (let [[node eid :as state] (peek stack)
+              stack (pop stack)]
+          (when (>= (:transitions @counters) max-transitions)
+            (limit-failure! :max-transitions @counters
+                            {:max-transitions max-transitions}))
+          (vswap! counters update :transitions inc)
+          (when cut-point! (cut-point! @counters))
+          (if (contains? visited state)
+            (recur stack visited)
+            (let [_ (when (>= (:admissions @counters) max-admissions)
+                      (limit-failure! :max-admissions @counters
+                                      {:max-admissions max-admissions
+                                       :staged 1}))
+                  _ (vswap! counters update :admissions inc)
+                  visited (conj! visited state)
+                  rules (get reverse-rules node)]
+              ;; Base tuples first: one exact-bound probe per direct rule.
+              (if (some (fn [rule]
+                          (and (= :relation (:rule rule))
+                               (= subject-type (:subject-type rule))
+                               (probe? (:resource-type rule) eid
+                                       (:relation-eid rule))))
+                        rules)
+                (do (report!) true)
+                ;; Then the arrows: enumerate intermediates, probe or descend.
+                (let [outcome
+                      (reduce
+                       (fn [successors rule]
+                         (case (:rule rule)
+                           :self-permission
+                           (conj successors [(:target-node rule) eid])
+
+                           :arrow-permission
+                           (into successors
+                                 (map (fn [i] [(:target-node rule) i]))
+                                 (intermediates (:resource-type rule) eid
+                                                (:via-relation-eid rule)
+                                                (:intermediate-type rule)))
+
+                           :arrow-relation
+                           (if (and (= subject-type (:target-subject-type rule))
+                                    (some (fn [i]
+                                            (probe? (:intermediate-type rule) i
+                                                    (:target-relation-eid rule)))
+                                          (intermediates (:resource-type rule) eid
+                                                         (:via-relation-eid rule)
+                                                         (:intermediate-type rule))))
+                             (reduced ::found)
+                             successors)
+
+                           successors))
+                       []
+                       rules)]
+                  (if (identical? ::found outcome)
+                    (do (report!) true)
+                    (let [stack (into stack (rseq outcome))]
+                      (when (> (count stack) max-stack)
+                        (limit-failure! :max-stack @counters
+                                        {:max-stack max-stack
+                                         :staged (count outcome)}))
+                      (recur stack visited))))))))))))
 
 (defn check-eids
   "Anchored point check over pre-resolved internal ids: does the subject
-  hold the plan's root permission on the resource? Terminates on the
-  subject's first admission."
+  hold the plan's root permission on the resource? Decided by the
+  membership-probe search (`probe-check-eids`); nil ids never hold."
+  [{:keys [subject-eid resource-eid] :as options}]
+  (if (or (nil? subject-eid) (nil? resource-eid))
+    false
+    (probe-check-eids options)))
+
+(defn- found! []
+  (throw (ex-info "found" {::found true})))
+
+(defn enumeration-check-eids
+  "The reverse-enumeration point check (the pre-probe route): a reverse
+  traversal from the resource with early termination on the subject's first
+  admission. Retained as the executable oracle for `check-eids`; its cost is
+  linear in the number of subjects that hold the permission."
   [{:keys [subject-eid resource-eid] :as options}]
   (if (or (nil? subject-eid) (nil? resource-eid))
     false

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -439,6 +439,8 @@
     ;; The validated assertion generation is already the canonical routing
     ;; identity. Reusing it avoids a semantically duplicate proof acquisition.
     :routing-schema-identity known-schema-generation
+    ;; Sealed plans are keyed by this identity (see `stable-plan-key`).
+    :plan-schema-identity known-schema-generation
     :permission-roots (atom {})
     :permission-paths (atom {})
     :traversal-permissions (atom {})
@@ -480,19 +482,36 @@
 
   DataScript/Datahike raw callers invoke the engine directly on an
   adapter — bind this via engine/*schema-cache* there; the Datomic raw
-  facade binds it automatically."
-  [snapshot]
-  {:backend-id (backend/backend-id snapshot)
-   :source-scope nil
-   :schema-version nil
-   :routing-schema-identity nil
-   :request-local? true
-   :permission-roots (atom {})
-   :permission-paths (atom {})
-   :traversal-permissions (atom {})
-   :recursive-cycle-guards (atom {})
-   :relationship-dependencies (atom {})
-   :direct-grant-relations (atom {})})
+  facade binds it automatically.
+
+  An optional `:schema-identity` (the caller's own cheap read of the
+  schema generation, never a proof-frame operation) lets sealed plans be
+  reused across raw calls and across unrelated transactions; without it the
+  plan cache keys by exact basis."
+  ([snapshot]
+   (request-schema-cache snapshot nil))
+  ([snapshot {:keys [schema-identity]}]
+   {:backend-id (backend/backend-id snapshot)
+    :source-scope nil
+    :schema-version nil
+    :routing-schema-identity nil
+    :plan-schema-identity schema-identity
+    :request-local? true
+    :permission-roots (atom {})
+    :permission-paths (atom {})
+    :traversal-permissions (atom {})
+    :recursive-cycle-guards (atom {})
+    :relationship-dependencies (atom {})
+    :direct-grant-relations (atom {})}))
+
+(defn- plan-schema-identity
+  "The schema-generation identity sealed plans may be keyed by: the bound
+  schema cache's explicit plan identity, else its stamped client generation.
+  nil for unstamped raw evaluation (basis keying)."
+  []
+  (when-let [cache *schema-cache*]
+    (or (:plan-schema-identity cache)
+        (:schema-version cache))))
 
 (defn schema-cache-key
   "Identity of schema-derived state for one selected immutable snapshot.
@@ -885,18 +904,44 @@
 (defonce ^:private stable-plan-cache
   (atom {:entries {} :order []}))
 
-(defn- stable-plan
-  "Seals (or reuses) the direction-specific plan for one root at the exact
-  basis. Keyed by the adapter's declared source identity (scope AND
-  lifecycle — either alone may be caller-fixed across distinct stores) plus
-  basis and root, so re-wrapping the same source at the same basis reuses
-  the plan across requests; bounded FIFO."
+(def ^:private stable-plan-cache-capacity 256)
+
+(defn expire-plans!
+  "Drops every retained sealed plan. Called by the public clients'
+  `expire-cache!` so lifecycle rotation (reset, restore, source replacement)
+  also discards plans sealed under the replaced source history."
+  []
+  (reset! stable-plan-cache {:entries {} :order []})
+  nil)
+
+(declare plan-schema-identity)
+
+(defn- stable-plan-key
+  "A sealed plan is a pure function of the schema definitions visible at the
+  snapshot (`seal-plan` consults no relationship data), so within one source
+  (scope and lifecycle) it is keyed by the schema generation identity the
+  bound schema cache already knows — every supported schema write advances
+  it in the same transaction as the definition change, and reading it costs
+  no proof-frame operation. The native revision does not belong in the key
+  (it re-sealed every root after every unrelated transaction); the lifecycle
+  stays so that distinct stores that alias a source scope never share, and
+  a rotated lifecycle re-seals once. Without a schema identity the key
+  degrades to the exact basis."
   [db root-node]
-  (let [key [(backend/backend-id db)
-             (backend/invoke db :source-scope)
-             (backend/invoke db :source-lifecycle)
-             (backend/invoke db :native-revision)
-             root-node]]
+  [(backend/backend-id db)
+   (backend/invoke db :source-scope)
+   (backend/invoke db :source-lifecycle)
+   (if-let [identity (plan-schema-identity)]
+     [:schema identity]
+     [:basis (backend/invoke db :native-revision)])
+   root-node])
+
+(defn- stable-plan
+  "Seals (or reuses) the direction-specific plan for one root. Reuse is keyed
+  by `stable-plan-key`; the store is a bounded FIFO shared by every client
+  in the process and cleared by `expire-plans!`."
+  [db root-node]
+  (let [key (stable-plan-key db root-node)]
     (or (get-in @stable-plan-cache [:entries key])
         (let [plan (sealed-plan/seal-plan db root-node)]
           (swap! stable-plan-cache
@@ -905,7 +950,7 @@
                      cache
                      (let [order (conj order key)
                            entries (assoc entries key plan)]
-                       (if (> (count order) 128)
+                       (if (> (count order) stable-plan-cache-capacity)
                          {:entries (dissoc entries (first order))
                           :order (subvec order 1)}
                          {:entries entries :order order})))))

--- a/modules/eacl/src/eacl/verified_kernel.cljc
+++ b/modules/eacl/src/eacl/verified_kernel.cljc
@@ -62,9 +62,29 @@
   (-read-indexed-result [kernel direction state]
     "Reads the completed public render result and dimensional counters."))
 
+#?(:clj
+   (defonce ^:private kernel-classes
+     ;; Classes already known to satisfy DecisionKernel. `satisfies?` on the
+     ;; JVM walks the class hierarchy against the protocol's extension map on
+     ;; every call (the generated kernels are `extend`ed Java classes, not
+     ;; direct interface implementations), which measured ~10 µs per call and
+     ;; runs several times per request. Only positive answers are memoized:
+     ;; a class cannot stop satisfying a protocol, but a negative answer could
+     ;; become stale if the protocol were extended later.
+     (java.util.concurrent.ConcurrentHashMap.)))
+
 (defn kernel?
   [candidate]
-  (satisfies? DecisionKernel candidate))
+  #?(:clj
+     (if (nil? candidate)
+       false
+       (let [^java.util.concurrent.ConcurrentHashMap known kernel-classes
+             c (class candidate)]
+         (or (.containsKey known c)
+             (and (satisfies? DecisionKernel candidate)
+                  (do (.put known c Boolean/TRUE) true)))))
+     :cljs
+     (satisfies? DecisionKernel candidate)))
 
 (defn indexed-traversal-kernel?
   [candidate]

--- a/openspec/changes/fix-datomic-request-overhead/.openspec.yaml
+++ b/openspec/changes/fix-datomic-request-overhead/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/fix-datomic-request-overhead/README.md
+++ b/openspec/changes/fix-datomic-request-overhead/README.md
@@ -1,0 +1,3 @@
+# fix-datomic-request-overhead
+
+Remove per-request overheads found in the 2026-08-18 review: sealed-plan cache thrash (random lifecycle), seal-plan re-encoding, per-request read-schema, kernel? satisfies?, adapter construction

--- a/openspec/changes/fix-datomic-request-overhead/design.md
+++ b/openspec/changes/fix-datomic-request-overhead/design.md
@@ -1,0 +1,49 @@
+# Design: Per-Request Overhead Fixes
+
+## Plan cache
+
+`stable-plan-key` = `[backend-id source-scope source-lifecycle K root]` with
+`K = [:schema identity]` when `plan-schema-identity` is known (client
+generation cache `:plan-schema-identity`/`:schema-version`, or the raw
+facade's `request-schema-cache` `:schema-identity`), else
+`[:basis native-revision]`. Capacity 256 FIFO. `expire-plans!` clears it and
+is invoked from `expire-cache!` in the Datomic client and the shared
+Datahike/DataScript orchestration.
+
+Why the lifecycle stays: real adapters never alias a source scope across
+distinct stores (Datomic database id, Datahike store id, DataScript
+connection identity), but test adapters do (`{:source-id :test}` at a
+constant stamp); dropping the lifecycle let a global cache serve one test's
+plan to another. The raw facade's random per-call lifecycle was the thrash
+— it now mints one process-stable lifecycle for its engine adapters (that
+lifecycle affects nothing but the plan key on the raw path).
+
+Why no proof-frame op: `:raw-can` op-count envelopes pin zero proof-frame
+reads for raw checks and the exact-hit contract performs no generation proof
+reads; the identities used are already known to the caller.
+
+## seal-plan
+
+`sort-by-canonical` maps values to `[encoding value]` once and sorts by the
+encoding string with `compare` — the same total order `sort-by
+encode-canonical` produced, without O(n log n) re-encoding. Fingerprint and
+plan equality before/after were asserted in the REPL for three roots.
+
+## Request validation
+
+`request-schema` returns `(:parsed-schema impl.indexed/*schema-cache*)`
+when a stamped generation is bound, else reads the schema. Validation moved
+inside the cached computation (`compute` / `evaluate`, where the generation
+is bound) and into the unknown-object short-circuits, so a hit performs no
+schema work. Argument: a request that fails validation never produces an
+entry (validation precedes evaluation), and every tier keys by an identity
+that fixes the schema generation (exact: snapshot; snapshot-exact: exact
+snapshot; managed: schema stamp), so a hit implies validity under an equal
+schema. Typed errors are unchanged (verified for unknown permission, unknown
+type, unknown subject + unknown permission, on checks and pages).
+
+## kernel?
+
+`ConcurrentHashMap<Class,Boolean>` of classes known to satisfy
+`DecisionKernel`; negatives are not memoized (a later `extend` could make
+them stale); CLJS unchanged.

--- a/openspec/changes/fix-datomic-request-overhead/proposal.md
+++ b/openspec/changes/fix-datomic-request-overhead/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: Fix Per-Request Overheads (sealed-plan thrash, seal cost, schema reads, kernel checks)
+
+## Why
+
+Profiling the live `eacl-datomic-solidjs` demo (110k servers, 59 accounts,
+`datomic:dev://`, warm peer) on 2026-08-18 showed `check-permission` at
+**6.0 ms** and `lookup-resources :first 20` at **5.6 ms** per cache miss,
+while the traversal itself cost 30–400 µs. Stack sampling attributed the
+rest to four per-request overheads in the client and engine shells:
+
+1. **Sealed-plan cache thrash (~80 % of a `can?` miss).**
+   `eacl.engine.v8/stable-plan` keyed its global cache by source lifecycle
+   and native revision; `eacl.datomic.impl/with-request-engine` built its
+   engine adapter with no options, so `snapshot-adapter` minted a random
+   lifecycle per call — every request re-sealed the plan (128 cache entries:
+   one database, one revision, one root, 128 lifecycles).
+2. **`seal-plan` cost.** `assign-ordinals` sorted rules with
+   `sort-by secure-format/encode-canonical`, re-encoding and re-validating
+   both operands on every comparison: 368 canonical encodings (≈24 µs each)
+   for a 16-rule plan — ~4.3 ms per seal.
+3. **`read-schema` on every request (~35–40 % of what remained).** Every
+   `check-permission`, lookup, count and expansion enumerated all relation
+   and permission entities (`d/q` + `pull`) merely to validate three
+   keywords, on hits and misses alike.
+4. **`verified-kernel/kernel?`** ran `satisfies?` on an `extend`ed class
+   (~10 µs) three or four times per request.
+
+## What Changes
+
+- **Plan cache key** = `[backend-id source-scope source-lifecycle
+  (schema-identity | exact-basis) root]`: the schema-generation identity the
+  bound schema cache already knows replaces the native revision (a plan is a
+  pure function of the schema definitions; every supported schema write
+  advances the generation in the same transaction). No proof-frame
+  operation is added — the client's generation cache carries the identity,
+  and the Datomic raw facade passes its own direct schema-version read as
+  `:schema-identity` to `request-schema-cache`. The lifecycle stays in the
+  key (distinct test stores may alias a source scope); the raw facade mints
+  its engine adapters with one process-stable lifecycle instead of a random
+  one per call. `expire-plans!` is called by every client's `expire-cache!`.
+- **`seal-plan` encodes each rule/node once** (`sort-by-canonical`); the
+  composite fingerprint and plan are byte-identical (asserted).
+- **Schema validation on the miss path**: request validation reads the
+  parsed schema from the client's per-generation schema cache
+  (`:parsed-schema`, read once per generation) inside the cached
+  computation; the unknown-object short-circuits validate the same way; a
+  cache hit reads nothing. Unstamped databases (no generation) keep reading
+  directly and latch nothing. Every typed error is unchanged.
+- **`kernel?`** memoizes positive answers per class (JVM).
+
+## Evidence (live demo, warm peer, medians)
+
+| operation | before | after |
+|---|---|---|
+| `check-permission` miss (denied) | 6.0 ms | 142 µs |
+| `check-permission` hit | 383 µs | ~80–100 µs |
+| `lookup-resources :first 20` miss | 5.6 ms | ~490 µs |
+| `lookup-resources` hit | 614 µs | ~250–330 µs |
+| `seal-plan` (16 rules) | 4.3 ms | ~1 ms (once per schema generation) |
+
+In-memory fixture: `can?` miss 985 → 97 µs, page miss 2,046 → 388 µs.
+Full test battery (663 tests / 26,879 assertions) green after the plan-key
+test (`eacl.backend.v8-test`) was aligned with the new keying rule.
+
+## Non-Goals
+
+- Reducer constant factor (≈3 µs per transition; an exhaustive 110k count
+  spends 661k transitions ≈ 2 s) and union-arm subsumption in the sealed
+  plan — separate engine work.
+- Any change to the answer cache, cursors, or proof frames.

--- a/openspec/changes/fix-datomic-request-overhead/specs/kernel-boundary-efficiency/spec.md
+++ b/openspec/changes/fix-datomic-request-overhead/specs/kernel-boundary-efficiency/spec.md
@@ -1,0 +1,28 @@
+# kernel-boundary-efficiency Specification
+
+## ADDED Requirements
+
+### Requirement: Request shells add no per-request schema or plan work
+
+The public request shells SHALL reuse one sealed plan per source, lifecycle,
+schema generation and permission root across requests and unrelated
+transactions, and MUST NOT re-seal it per request or per revision. Request
+validation MUST read the schema at most once per schema generation on the
+miss path and MUST NOT read it on a cache hit; an unstamped database keeps
+reading directly. Kernel-boundary predicates MUST NOT walk protocol
+hierarchies on every request.
+
+#### Scenario: Repeated requests on one schema generation
+
+- **WHEN** many `can?` or lookup requests run against one source across unrelated transactions
+- **THEN** the sealed plan is compiled once for that source, lifecycle, schema generation and root
+
+#### Scenario: Cache hit
+
+- **WHEN** a request is served from a completed-answer tier
+- **THEN** no schema enumeration and no plan sealing occur for that request
+
+#### Scenario: Schema change
+
+- **WHEN** `write-schema!` advances the schema generation
+- **THEN** the next request seals the plan for the new generation and validates against the newly parsed schema

--- a/openspec/changes/fix-datomic-request-overhead/tasks.md
+++ b/openspec/changes/fix-datomic-request-overhead/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: Per-Request Overhead Fixes
+
+- [x] 1.1 `stable-plan-key` by schema identity (client generation cache / raw `:schema-identity`), lifecycle kept, revision dropped; capacity 256; `expire-plans!`
+- [x] 1.2 `impl/with-request-engine`: process-stable lifecycle + `:schema-identity` (direct read, no proof op)
+- [x] 1.3 `expire-cache!` (Datomic + orchestration) calls `expire-plans!`
+- [x] 1.4 `seal-plan` encode-once (`sort-by-canonical`); fingerprint/plan invariance checked
+- [x] 1.5 `request-schema` + validation on the miss path at all seven client sites; unstamped databases read directly
+- [x] 1.6 `kernel?` positive-class memo (JVM)
+- [x] 1.7 `eacl.backend.v8-test` plan-sharing expectations aligned; full battery green; source-closure ledger regenerated
+- [ ] 1.8 Docs: `docs/cache.md` cache-layers table ("Sealed plan | same source scope, lifecycle, schema generation and permission root"), `docs/v8-consistency-cache-operations.md` if it names the plan key
+- [ ] 1.9 Re-baseline `docs/benchmarks` for `can?`/lookup miss and hit on all backends
+- [ ] 1.10 Follow-ups recorded: reducer constant factor (`retain-buffer` O(cap) rebuild per release, `schedule` map churn), union-arm subsumption in the sealed plan, `secure-format` canonical encode/digest cost (24 µs per small map; 2–4 digests per page)

--- a/openspec/changes/hierarchical-demand-segment-cache/design.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/design.md
@@ -1,0 +1,283 @@
+# Design: Exact Scan-Response Cache
+
+Supersedes `review/original-design.md` (hierarchical demand-compatible
+segments). Findings that drove the rewrite are in
+[`review/REVIEW.md`](review/REVIEW.md).
+
+## Technical Approach
+
+The stable-discovery reducer has exactly one effectful call: `fetch-fn`,
+invoked from `eacl.engine.stable-reducer/fetch-values` with a read-demand
+descriptor
+
+```clojure
+{:operation     :subject->resources | :resource->subjects
+ :subject-type  kw  :subject-eid  eid      ; or :resource-type / :resource-eid
+ :relation-eid  eid
+ :resource-type kw                         ; or :subject-type (target side)
+ :bound-eid     nil | eid                  ; exclusive physical position
+ :limit         physical-chunk-size}
+```
+
+and expecting back **exactly** `min(limit, remaining)` strictly-ascending
+values greater than `:bound-eid` — fewer than `limit` only when the scan is
+exhausted after the last value returned. Physical chunk width and buffer
+retention provably cannot change the released sequence
+(`ChunkedScan.dfy`, `OneValueScanNormalization.dfy`): a fetch *is*
+`Chunk(values, offset, limit)` over one fixed sequence.
+
+This change adds one more layer at that seam:
+
+```
+reducer ─fetch-values─▶ caching-fetch-fn ─▶ retrying-fetch-fn ─▶ classified-fetch-fn ─▶ adapter-fetch-fn ─▶ adapter
+                            │
+                            ▼
+                 scan-response store  (client-private, lock-free, weight-bounded)
+                 key   = validity-scope + descriptor-key
+                 value = {:prefix [eid …] ascending from scan start, :exhausted? bool}
+```
+
+The layer answers a fetch **only when it can return exactly what the adapter
+would**; otherwise it forwards *exactly the same command* and uses the reply
+to lengthen the stored prefix. Nothing above the seam changes: admission,
+order, limits (`:max-advanced-datoms` still counts served values through
+`fetch-values`), checkpoints, cursors, telemetry.
+
+## Architecture Decisions
+
+### D1 — Cache adapter responses, never reducer emissions
+
+**Choice.** The unit of reuse is the response to one read descriptor. No plan
+node, start set, level, composition, or emitted-sequence artifact exists.
+
+**Rationale.** Emissions under a node depend on the request's global admitted
+set (interior merge points keyed by target node + entity), so context-free
+node segments are not substitutable (`CacheBoundary.dfy`,
+`ContextFreeDenotationIsNotAStableTrace`; `bounded-physical-execution`
+"sequence-refinement certificate" rule). Adapter responses are functions of
+(descriptor, relation slice at the snapshot) only. The reducer performs all
+composition; the cache only removes I/O.
+
+### D2 — Elide-only, top-up by re-issuing the original command
+
+**Choice.** For `(descriptor, bound b, limit L)`: serve iff the stored prefix
+contains ≥ L values > b, or is flagged exhausted. Otherwise forward the
+identical `(descriptor, b, L)` command. Never fetch from a different bound,
+never with a larger limit, never ahead of demand.
+
+**Rationale.** `demand-bounded-evaluation` requires cache code to add no
+backend command absent from cache-disabled execution and to retain only
+"exact backend responses that the evaluator demanded". Elide-only makes the
+cached run's command multiset a subset of the uncached run's with equal
+responses — trace refinement by construction. The price (re-reading the
+overlap between `b` and the prefix end on a short hit) is one chunk, once,
+and only when the prefix was too short.
+
+### D3 — Validity = singleton relation frontier inside the request's proved closure
+
+**Choice.** Key scope: `{backend-id, source-scope, source-lifecycle,
+adapter-fingerprint/identity-contract, order-abi + fingerprint-domain
+version, schema-stamp, relation-eid, relation-stamp}`, where
+`relation-stamp` is that relation's generation taken from the request's
+complete proof frame via `proof-frame/subset-descriptor` (map lookup, no
+provider call, fail-closed outside the closure).
+
+**Rationale.** `ScalarFrontierCoherence.EqualScalarProofPreservesAuthorizationInput`
+holds for any dependency vector, including `[r]`; a scan of relation `r` at
+schema generation `g` is a function of `r`'s slice, and every supported
+mutation of `r` advances its generation atomically. Equal scope ⇒ equal
+sequence. Unrelated writes leave the key unchanged (sharing survives them);
+`write-schema!` changes `schema-stamp`; `expire-cache!` swaps the store.
+No snapshot identity in the key: reuse across snapshots is the point.
+
+### D4 — Placement above retry/classification, below the reducer
+
+**Choice.** `caching-fetch-fn` wraps `retrying-fetch-fn`. Hits skip retry
+and classification entirely; misses see the classified/retried result and
+deposit only complete responses (a thrown failure deposits nothing).
+
+**Rationale.** Keeps the three-outcome discipline intact and keeps the cache
+out of the failure path. Served values still pass `fetch-values`' limit
+accounting; `:adapter-attempts` counts only real transport attempts.
+
+### D5 — A dedicated lock-free store, not `eacl.subproblem-cache`
+
+**Choice.** `ConcurrentHashMap<Key, Entry>` with immutable entries, CAS
+`merge` choosing the longer prefix, `LongAdder` metrics, approximate
+recency (racy last-touch tick in the entry, no CAS on hit), sampled
+eviction (Redis-style: sample N entries, evict the least recent) triggered
+when the weight budget is exceeded, per-entry `:max-prefix` cap.
+
+**Rationale.** Measured: `subproblem/lookup!` costs 1.4 µs per hit and
+serialises at ~0.5 M ops/s under eight threads (three atom `swap!`s per
+hit incl. an LRU vector conj); a page issues 20–40 scans. A CHM probe costs
+~0.1 µs. Correctness does not depend on eviction policy (any prefix of the
+sequence, or its absence, is valid), so recency may be approximate.
+
+### D6 — Eligibility mirrors managed proof
+
+**Choice.** Lookup and deposit require: client cache enabled and request
+`:cache?` true; ordinary current snapshot (no `as-of`/`since`/filtered/
+speculative/caller-supplied values); deterministic identity contract; a
+complete request proof frame that contains the scanned relation. Any
+condition failing disables the layer for that request (or that scan) — the
+plain fetch-fn runs.
+
+**Rationale.** Same boundary already documented for proof-backed answers;
+no new coherence protocol.
+
+### D7 — Prerequisite: fix plan-cache thrash first
+
+**Choice.** A separate change fixes `impl/with-request-engine`'s random
+per-request lifecycle and keys `stable-plan` by schema generation, and hoists
+`prepare`'s per-request `read-schema`. This change's benchmark gate is
+measured only after that lands.
+
+**Rationale.** Measured 2.4–6.6× on Datomic miss pages and 5.7× on `can?`;
+without it traversal-level effects are invisible.
+
+### D8 — Remove the retired tiers as part of this change
+
+**Choice.** Delete the `:denotation` tier, the relationship-projection use of
+`:projection`, dead metric keys, stale docs and spec text, and verification
+claims naming deleted vars; keep `:denotation-max-weight` accepted (ignored,
+warned) for one release, then reject.
+
+**Rationale.** The user directive and `implementation-simplicity-and-
+performance` both require superseded cache mechanisms to be deleted; the
+inventory is in `review/REVIEW.md` §"Cleanup" and tasks §7.
+
+## Data Structures
+
+```clojure
+;; key (value-equal, hashed once)
+{:scope {:backend-id kw :source-scope any :source-lifecycle any
+         :adapter-fingerprint any :identity-contract kw
+         :order-abi 1 :plan-domain "eacl.sealed-plan.v1"
+         :schema-stamp n :relation-eid eid :relation-stamp n}
+ :descriptor {:operation kw :anchor-type kw :anchor-eid eid
+              :relation-eid eid :target-type kw}}          ; = fetch descriptor minus :bound-eid/:limit
+
+;; entry (immutable; replaced by CAS)
+{:prefix     [eid …]      ; strictly ascending, from the scan's first value
+ :exhausted? boolean      ; true ⇒ prefix is the complete scan
+ :weight     n            ; 16 + 8·count(prefix)
+ :touched    long}        ; racy recency tick, eviction hint only
+```
+
+Empty exhausted entries (`{:prefix [] :exhausted? true}`) are the negative
+cache and the smallest entries.
+
+## Lookup and Deposit Algorithm
+
+```text
+fetch(descriptor, b, L):
+  key := scope(relation-eid) + descriptor-key           ; nil scope ⇒ plain fetch
+  e   := store.get(key)
+  if e:
+     avail := values of e.prefix strictly > b            ; b nil ⇒ whole prefix (binary search)
+     if |avail| ≥ L            → hit;  return take(L, avail)
+     if e.exhausted?           → hit;  return avail       ; short reply is truthful
+  values := inner(descriptor, b, L)                       ; EXACTLY the uncached command
+  exhausted := |values| < L
+  deposit(key, e, b, values, exhausted)
+  return values
+
+deposit(key, e, b, values, exhausted):
+  candidate :=
+     if b = nil                         → {values, exhausted}                 ; a prefix from the start
+     else if e and b ∈ e.prefix at i    → {e.prefix[0..i] ++ values, exhausted}
+     else if e and b = last(e.prefix)   → {e.prefix ++ values, exhausted}
+     else                               → none                                ; fragment without its start
+  if candidate and |candidate.prefix| ≤ max-prefix:
+     store.merge(key, candidate, longer-prefix-wins)     ; both are prefixes of one sequence
+     account weight; evict by sampling if over budget
+```
+
+Invariants: every stored prefix equals `values[0..k]` of the adapter's scan
+for that key; `exhausted?` ⇒ `k = |values|`; a served reply equals
+`Chunk(values, pos(b), L)`. Extension never issues an extra command.
+Failures (throw) deposit nothing.
+
+## Compatibility Rules (normative)
+
+1. **Exact-slice rule.** A served reply MUST equal the adapter's reply for the
+   same descriptor, bound and limit at any snapshot inside the key's scope.
+2. **Elide-only rule.** The layer MUST NOT issue any command absent from
+   cache-disabled execution, and MUST NOT change bound, limit, or chunk width.
+3. **Short-chunk rule.** Every fetch-fn layer MUST return fewer than `:limit`
+   values only when the scan is exhausted after the last returned value.
+4. **Scope rule.** Reuse requires equality of the complete scope, including
+   the scanned relation's generation and the schema generation.
+5. **Boundary rule.** The layer is bypassed for `:cache? false`, cache-disabled
+   clients, non-ordinary database values, unavailable proof, or relations
+   outside the proved closure. Bypass is per request or per scan, never an
+   error.
+6. **Isolation rule.** Entries are internal eids only; never externalised,
+   never inside cursors, checkpoints, or answers.
+
+## Integration Points
+
+| Component | Change |
+|---|---|
+| `eacl.engine.physical` (or new `eacl.engine.scan-cache`) | `caching-fetch-fn`, store, eviction, metrics |
+| `eacl.engine.v8/stable-fetch-fn` | wrap when a scan-cache context is bound |
+| Client layers (`eacl.datomic.core`, `eacl.client.orchestration`) | bind context `{:store :scope :proof-frame}` for eligible requests; construct/expire store per client lifecycle |
+| `eacl.proof-frame` | `subset-descriptor` per relation (exists) |
+| Config | `:scan-cache {:enabled? :max-weight :max-prefix}`; `:denotation-max-weight` deprecated |
+| Metrics | `:scan-hits :scan-misses :scan-elided-commands :scan-extensions :scan-deposits :scan-evictions :scan-weight :scan-stamp-unavailable` |
+| Specs | see `specs/` deltas |
+| Formal | new Dafny leaf, singleton-frontier lemma, gate count, assurance matrix |
+
+## Formal Obligations
+
+- **Exact slice (Dafny, new leaf `ScanResponseCache.dfy`).** For a sequence
+  `values`, prefix `p = values[0..k]`, `exhausted ⇒ k = |values|`:
+  `Serve(p, exhausted, offset, limit) = Some(c) ⇒ c = Chunk(values, offset,
+  limit)`; `Extend(p, Chunk(values, k', limit))` for `k' ≤ k` is again a prefix;
+  hence the cached fetch is one of the fetches already quantified over by
+  `ChunkSizeDoesNotChangeFlattenedScanValues` /
+  `PhysicalWidthCannotChangeLogicalReleaseOrder`.
+- **Validity (Dafny, `ScalarFrontierCoherence`).** Instantiate the main
+  theorem with `dependencies = [r]`; add
+  `SingletonFrontierIsRelationGeneration` and a reuse lemma that does not
+  require equal full dependency vectors (relax `SubproblemCanReuse` for
+  covered singletons).
+- **Adapter obligation (certified, not proved).** `subject->resources` /
+  `resource->subjects` for relation `r` is a function of `r`'s tuple slice at
+  the snapshot; every supported mutation of that slice advances `r`'s
+  generation in the same transaction (already the managed-proof assumption).
+- **Trace refinement (executable).** Differential gate: for randomized
+  graphs, orders and page sizes, cache-on command multiset ⊆ cache-off, equal
+  responses, equal results/cursors/counts/`can?`; concurrent readers with
+  interleaved supported writes.
+- **Mutation controls (must fail the gate).** (a) serve a short prefix without
+  exhaustion; (b) serve values ≤ bound; (c) reuse across a stale relation
+  stamp; (d) fetch with a widened limit or moved bound; (e) deposit a
+  fragment that does not start at the scan's first value.
+- **Existing gates unchanged.** Width/retention invariance test extended
+  with the cache in the loop; `verify-fast.sh` obligation count updated;
+  `subproblem-cache.edn` claim vocabulary extended with
+  `:exact-physical-response-prefixes`.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Hierarchical plan-node segments with start-set fingerprints and composition (original draft) | Context-dependent emissions; not substitutable; demand not per-node; exact start sets defeat sharing; needs new plan-node ids for nothing |
+| Root-prefix answer reuse (`:first N` serves `:first M ≤ N`) | Sound but buys ~85 µs after this cache; answer/checkpoint tiers already cover the common patterns |
+| Host the tier in `eacl.subproblem-cache` | 1.4 µs/hit, serialising under contention, per-snapshot exact stores |
+| Key by exact snapshot only | Loses cross-snapshot sharing, the whole point |
+| Fetch-ahead / longer chunk on miss | Violates demand-bounded evaluation |
+| Bloom/roaring summaries | Only sound if stamped identically; premature |
+| Storage-layer caching only (status quo) | Does not remove seek/realise/classify cost; 20–40 scans per sparse page |
+
+## Open Questions
+
+1. Whether to deposit from exhaustive routes (`count-*`, `:last` windows) at
+   all, or only when the store is under 50 % of budget (avoid flooding).
+2. Default `:max-prefix` (proposed 1024) and `:max-weight` (proposed 8 MiB).
+3. Whether the Datahike `:memory` backend's high cold scan cost is a konserve
+   artefact worth reporting upstream.
+4. Whether `stable-plan` should be moved off the global `defonce` onto the
+   client's schema-generation cache as part of the prerequisite change.

--- a/openspec/changes/hierarchical-demand-segment-cache/proposal.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/proposal.md
@@ -1,0 +1,189 @@
+# Proposal: Exact Scan-Response Cache (supersedes the hierarchical demand-segment draft)
+
+> Status of this rewrite: the original proposal/design/tasks were reviewed
+> adversarially on 2026-08-18 and rejected as written; see
+> [`review/REVIEW.md`](review/REVIEW.md) for findings and measurements and
+> `review/original-*.md` for the superseded text. The change keeps its
+> directory name for continuity; its content is now the design below.
+> Renaming the change to `exact-scan-response-cache` before implementation
+> is recommended but not required.
+>
+> **Round-2 status (same day, after profiling the live 110k-server demo):**
+> the two prerequisites now exist as their own changes and are implemented
+> — `fix-datomic-request-overhead` (`can?` 6.0 ms → 142 µs, pages
+> 5.6 ms → ~490 µs) and `membership-probe-point-check` (`can?` no longer
+> scales with subject count). On a warm Datomic peer the scan-response
+> cache showed **no measurable gain for lookup pages** (scans cost 2–10 µs;
+> the prototype's hit path cost the same) and its `can?` benefit is
+> superseded by the probe check. This change therefore stays
+> **proposed and gate-decided**, primarily for Datahike/remote stores;
+> the cleanup workstream (§ tasks 8) stands regardless.
+
+## Why
+
+EACL v8's stable-discovery reducer keeps two cache artifacts (latest
+checkpoint, completed answer) and treats every adapter scan as a disposable
+request-local buffer. Distinct requests that traverse the same relationship
+edges — peers who share an account or group, every subject checking the same
+resource (`can?` reverse-walks from the resource), sparse graphs where most
+intermediate scans are empty — re-issue identical adapter scans.
+
+Measured on this machine (REPL, in-memory stores; details in the review):
+
+- A sparse high-sharing forward page issues 20–40 adapter scans; an exact
+  scan-response cache elides 94–100 % of them with identical result
+  sequences, cutting reducer time 331→178 µs/page on Datomic-mem and
+  1,083→~400 µs (`:memory`) / 282→~170 µs (`:file`) per page on Datahike.
+- On shallow schemas over an in-memory Datomic peer a page issues 3–5 scans
+  of ~11 µs each; the whole reducer walk is ~100 µs. There the cache is
+  worth ≤ 10 % of a page and only after the prerequisite below.
+- The dominant cost of a Datomic cache-miss page today is not traversal at
+  all: the sealed-plan cache misses on every request (random per-request
+  `source-lifecycle` in `eacl.datomic.impl/with-request-engine`), so
+  `seal-plan` (~1 ms) reruns per call. Fixing that alone is worth
+  2.4–6.6× on miss pages and 5.7× on `can?`. Per-request `read-schema` in
+  `prepare` (~20 % of the remainder) is next.
+
+The earlier "denotation" and "hierarchical segment" designs are unsound for
+this reducer: the sequence a plan node emits depends on the request's global
+admission set, so context-free node segments cannot be substituted into
+stable enumeration (Dafny `CacheBoundary.dfy`,
+`ContextFreeDenotationIsNotAStableTrace`). The one thing that *is* context
+free is the adapter's response to one read descriptor. This change caches
+exactly that, and nothing above it.
+
+## Prerequisites (separate changes — implemented 2026-08-18)
+
+1. `fix-datomic-request-overhead`: sealed-plan cache keyed by schema
+   generation (no per-call random lifecycle, no revision), `seal-plan`
+   encode-once, request validation on the miss path from the per-generation
+   schema cache, `kernel?` memo. Measured on the live demo: `can?` miss
+   6.0 ms → 142 µs, page miss 5.6 ms → ~490 µs.
+2. `membership-probe-point-check`: `can?` decided by membership probes over
+   the sealed plan (O(intermediates), never O(subjects)); denied check on a
+   5,000-owner resource 16 ms → 24 µs; oracle-equal on every fixture and on
+   4,860 live pairs.
+
+Only after both is a traversal-level cache measurable; the gate below is
+evaluated against that baseline.
+
+## What Changes
+
+- Introduce an **exact scan-response cache**: a client-private, weight-bounded,
+  frontier-stamped store of *ascending prefixes of adapter scan responses*,
+  keyed by the read-demand descriptor (operation, anchor type + internal id,
+  relation id, target type) plus a validity scope (backend id, source scope
+  and lifecycle, adapter fingerprint/identity contract, scan-order ABI,
+  schema generation, **the generation of the one relation the descriptor
+  scans**).
+- Install it at the engine's single effectful seam (`fetch-fn`, built by
+  `eacl.engine.v8/stable-fetch-fn`) as `caching-fetch-fn ∘ retrying-fetch-fn
+  ∘ classified-fetch-fn ∘ adapter-fetch-fn`. The reducer, its limits, its
+  telemetry counters, checkpoints and cursors are untouched.
+- **Elide-only semantics.** For a fetch `(descriptor, bound, limit)` the cache
+  answers only when it can reproduce the adapter's exact response — at least
+  `limit` cached values strictly after `bound`, or a prefix known to be
+  exhausted. Otherwise it issues *exactly the command the uncached run would
+  issue* and uses the response to extend the prefix. It never widens a scan,
+  never fetches ahead, never changes chunk size, never issues a command absent
+  from cache-disabled execution.
+- Make the fetch contract explicit: a chunk shorter than `:limit` means the
+  scan is exhausted after its last value. The reducer already depends on this
+  (`stable_reducer.cljc/fetch-values`); it becomes a normative obligation on
+  every fetch-fn layer.
+- Store: lock-free (`ConcurrentHashMap` keyed by validity scope + descriptor),
+  striped or sampled CLOCK eviction, `LongAdder` metrics, per-entry prefix cap,
+  tier weight budget; **not** the weighted-LRU `eacl.subproblem-cache` store
+  (measured 1.4 µs/hit and 0.5 M ops/s under contention).
+- Scope: forward and reverse scans alike — `lookup-resources`,
+  `lookup-subjects`, `count-*`, and `can?` (reverse walk from the resource,
+  shared across all subjects checking it).
+- Config: `:scan-cache {:enabled? bool :max-weight n :max-prefix n}` under the
+  client cache options; `:cache? false` bypasses lookup and deposit for one
+  request; `expire-cache!` drops the store.
+- Cleanup: remove the retired `:denotation` tier and the relationship-projection
+  remnants (config keys with a deprecation window, tier state, dead metric
+  keys, docs, stale spec language, verification claims naming deleted vars).
+- Default: **off** until the benchmark gate passes; then on when the
+  subproblem cache is enabled.
+
+## Capabilities
+
+### New Capabilities
+
+- `exact-scan-response-cache`: elide-only, frontier-stamped reuse of exact
+  adapter scan-response prefixes at the physical read seam.
+
+### Modified Capabilities
+
+- `bounded-physical-execution`: "exactly two closed cache artifacts" becomes
+  "two semantic artifacts plus one physical accelerator"; cross-request chunk
+  retention is permitted under a validity stamp; the short-chunk rule is
+  normative. (Its source requirements are currently ADDED by the in-progress
+  `adopt-stable-discovery-enumeration` change; this change must archive after
+  it or fold its deltas into it.)
+- `verified-subproblem-cache`: retire the "complete denotation" and
+  "shared-subgraph denotation" language; the projection-chunk requirement is
+  replaced by the new capability.
+- `demand-bounded-evaluation`: the existing "cache retains only demanded work"
+  requirement gains scenarios naming the scan-response cache.
+
+### Removed / reconciled
+
+- `managed-reuse-certification` requirement that docs "SHALL state that
+  managed reuse applies to … completed denotations": stale since the
+  stable engine; removed.
+
+## Non-Goals
+
+- No caching of any reducer-emitted sequence, plan-node "segment", composed
+  multi-hop result, or completed traversal prefix. Those remain forbidden.
+- No change to cursor envelopes, checkpoint identity, or completed-answer
+  keys; no page-size sharing at the answer level (a `:first 20` after
+  `:first 50` already hits every scan and pays ~50 reducer transitions).
+- No reuse for `as-of` / `since` / filtered / speculative / caller-supplied
+  database values (same policy as managed proof).
+- No background pre-warming, no inverted indexes, no cross-process sharing.
+
+## Impact
+
+- **Performance**: 100–700 µs per page on Datahike and sparse-sharing
+  Datomic workloads after warm-up; ≤ 10 % on shallow Datomic-mem schemas;
+  `can?` on hot resources elides every reverse scan for every subject.
+- **Correctness**: preserved by construction — the reducer sees exactly the
+  adapter's response; validity reuses the proved scalar-frontier argument
+  with a singleton dependency; trace refinement (`:cache? false` oracle)
+  holds because the command set is a subset with equal responses.
+- **Complexity**: one fetch-fn layer, one lock-free store, one small Dafny
+  leaf, mutation controls; minus the removed denotation/projection remnants.
+- **Memory**: bounded by `:max-weight` and `:max-prefix`; empty-scan entries
+  are the smallest and (in sparse graphs) the most valuable.
+
+## Risks
+
+- Overhead when hit rate is zero (one map probe + binary search per scan);
+  the gate requires ≤ 1 % regression with the cache enabled and cold.
+- Concurrency: entries are immutable prefixes; concurrent extensions race
+  benignly (any prefix of the same sequence is valid; longest wins).
+- Formal surface: `verify-fast.sh` obligation count and assurance-matrix
+  claims must be updated; `SubproblemCanReuse` in
+  `ScalarFrontierCoherence.dfy` is stricter than needed and needs a
+  singleton-frontier lemma.
+- The prerequisite change may itself remove most of the visible win on
+  Datomic; the gate decides.
+
+## Success Criteria (benchmark gate, all in one process and fixture)
+
+1. Cache-vs-`:cache? false` oracle equality on randomized graphs, all three
+   backends, forward and reverse pages, counts, `can?`, with concurrent
+   readers and interleaved supported writes.
+2. Sparse high-sharing forward pages (Fixture B shape): ≥ 90 % adapter
+   commands elided after warm-up; ≥ 25 % lower p50 miss-page latency than
+   with the cache disabled on Datahike (`:file`) and ≥ 15 % on Datomic-mem,
+   measured after the prerequisite fix.
+3. `can?` on a hot resource by distinct subjects: ≥ 90 % reverse-scan
+   commands elided after the first check.
+4. Cold/disabled overhead: p50 of any measured operation regresses ≤ 1 %
+   with the cache enabled and empty.
+5. Existing gates unchanged: width/retention invariance, mutation controls,
+   checkpoint/cursor suites, coherence suites, verify-fast Dafny batch.

--- a/openspec/changes/hierarchical-demand-segment-cache/review/REVIEW.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/review/REVIEW.md
@@ -1,0 +1,324 @@
+# Adversarial review: `hierarchical-demand-segment-cache` (2026-08-18)
+
+Reviewed against the code on `docs/improve-readme` (v8 stable-discovery engine,
+head `9f23109`). The original artifacts are preserved in this folder as
+`original-*.md`; the rewritten `proposal.md`, `design.md`, `specs/` and
+`tasks.md` one level up supersede them. The REPL harness that produced every
+number below is `bench/seg_bench.clj` (REPL-only, not on any classpath).
+
+## Verdict
+
+**Reject the design as written; keep one sound kernel of it; put a
+prerequisite fix ahead of it.**
+
+1. The proposal's premise — "repeated multi-hop walks remain the dominant
+   cost" — is unmeasured in the repo and false on Datomic. No benchmark
+   compares super-user and normal-user visibility. The one artifact that
+   showed "walks dominate" was a deleted benchmark on the retired
+   merge/indexed engine under opt-in `:evaluation :complete-denotation`.
+   Measured here: on an in-memory Datomic peer the entire reducer walk of a
+   `:first 20` page is **90–120 µs** and the adapter scans **~11 µs each**
+   (3–5 per page), inside a cache-miss page that costs **1.4–2.8 ms**.
+   The dominant cost is a client-layer bug: the sealed-plan cache misses on
+   every request (Finding F1), followed by per-request schema reads.
+2. The "level-k composition" and "start-set fingerprint" mechanisms are
+   unsound for the stable reducer. The sequence a plan node emits depends on
+   the request's global admission set, not on its start set; that is exactly
+   the Dafny counterexample that killed the previous denotation tier
+   (`formal/stable-discovery/CacheBoundary.dfy`,
+   `ContextFreeDenotationIsNotAStableTrace`). "Demand" is not a per-node
+   quantity in the reducer either (Findings F2–F4).
+3. What survives is the level-1 case, restated correctly: an **exact
+   scan-response prefix cache at the `fetch-fn` seam**, keyed by the read
+   descriptor plus a per-relation validity stamp, that only ever *elides* an
+   adapter command it can reproduce exactly and never issues one the
+   uncached run would not. That is a physical accelerator (a cross-request
+   sidecar), covered by the already-proved width/retention invariance and
+   by the scalar-frontier theorem with a singleton dependency vector. It is
+   also, essentially, the retired relationship-projection tier — which the
+   stable-discovery change cut as "purely accelerative"; the numbers below
+   say when that judgement holds (Datomic-mem, shallow schemas) and when it
+   does not (Datahike, sparse high-sharing schemas, `can?` on hot resources).
+4. The existing weighted-LRU atom store cannot host a per-scan hot path
+   (1.4 µs per hit single-threaded, serialising at 0.5 M ops/s under eight
+   threads). A per-scan tier needs a lock-free structure (Finding F8).
+
+Confidence: high on F1–F4, F6–F8 (measured or read from source/Dafny);
+moderate on the Datahike absolute numbers (small fixture, warm konserve
+cache; only reducer-level timings taken there); low on how the wins
+translate to production hardware and remote stores.
+
+## Findings
+
+### F1 — The Datomic client re-seals the plan on every request (existing bug, largest cost)
+
+`eacl.engine.v8/stable-plan` keys its global 128-entry FIFO by
+`[backend-id source-scope source-lifecycle native-revision root]`.
+`eacl.datomic.impl/with-request-engine` builds the engine adapter with
+`(backend/snapshot-adapter db)` and **no options**, so
+`eacl.datomic.backend/snapshot-adapter` mints a fresh random
+`source-lifecycle` per call. After 50 pages the plan cache held 128 entries
+for one database, one revision, one root and **128 distinct lifecycles**.
+`seal-plan` costs ~1 ms on this fixture (schema-definition reads +
+canonical encoding + digest) and runs on every `lookup-resources`,
+`can?`, `count-*` call through that path — including exact-hit paths that
+need the fingerprint for the answer key.
+
+Effect, measured with a REPL-only `with-redefs` returning a pre-sealed plan:
+
+| Datomic-mem, Fixture A | thrashing (median) | plan pre-sealed | Δ |
+|---|---|---|---|
+| `lookup-resources :first 20`, `:cache? false` (owner) | 1,428–2,046 µs | 592 µs | 2.4–3.5× |
+| same, super-user | 2,826 µs | 427 µs | 6.6× |
+| exact answer hit | ~600 µs | 328 µs | 1.8× |
+| `can?` bypass | 985 µs | 172 µs | 5.7× |
+
+The Datahike client path passes its lifecycle correctly and does not thrash
+(0 new plan entries over 30 requests). Even a correct key of
+`[… lifecycle native-revision root]` re-seals after every transaction; the
+plan is a pure function of schema definitions and should be keyed by schema
+generation. This is a separate, prerequisite change.
+
+### F2 — Level-k composition is unsound; the reducer's emissions are context-dependent
+
+The reducer (`eacl.engine.stable-reducer`) is a right-edge-stack DFS with a
+**global** admission set (`work-id`, merge points keyed by target node +
+entity) and width-one release. The results emitted "under" a plan node are
+the node's scan values *filtered by everything already admitted earlier in
+this request*, interleaved with the DFS of every consumer pushed by each
+grant. Two requests with equal start sets and different admitted sets emit
+different subsequences. The proposal's `compose()` ignores admission,
+assumes products at non-root nodes consume demand (only root grants do),
+and assumes a fixed "level" that recursion (`:recursive?` plans) does not
+have. `bounded-physical-execution` already forbids substituting a flat
+subproblem sequence "without a proof that substitution preserves the
+canonical discovery sequence"; the proposal offers no such proof and one
+cannot exist for context-free node segments (`CacheBoundary.dfy`).
+
+### F3 — "Demand" is not a per-node quantity
+
+`target` is a global count of root emissions (`page-size + 1` for a page,
+`+∞` for exhaustive routes). Intermediate scans have no demand; the only
+bound they see is the physical chunk width. "A segment populated under
+demand D" is therefore ill-defined except at the raw-scan level, where the
+natural quantity is *the prefix physically fetched so far*, and the prefix
+rule is automatic.
+
+### F4 — Exact start-set fingerprints defeat the sharing the proposal wants
+
+Super-user and normal-user walks share nothing above single-intermediate
+scans (their start sets differ at every level). The DFS also means a
+super-user `:first 20` page touches *one* account's servers, so it warms
+almost nothing for other users. The sharing that exists is (a) peers who
+reach the same intermediate (same account/group scan), (b) `can?` on a hot
+resource — reverse scans from the resource are identical for every subject
+checking it, and (c) empty scans in sparse graphs (70 % of group→doc scans
+in Fixture B). All three are captured by keying on the single read
+descriptor; none by plan-node + start-set.
+
+### F5 — The proposal re-invents the retired projection tier without confronting why it was cut
+
+`openspec/changes/adopt-stable-discovery-enumeration/design.md:119`: the
+projection tier "is order-safe but purely accelerative … duplicates bytes
+the storage layer already caches … production occupancy measured trivial".
+The measurements below are the confrontation. Storage-layer byte/node
+caching does not remove the seek + realise + classify + retry cost per
+scan (~7–30 µs on Datomic-mem/Datahike-file, more on remote stores), and
+sparse schemas issue 20–40 scans per page.
+
+### F6 — The fetch contract "chunk shorter than `:limit` ⇒ exhausted" is load-bearing and unwritten
+
+`stable_reducer.cljc:239` derives `more?` from `(= (count values)
+physical-chunk-size)`; a short chunk drops the scan frame. No spec states
+this. Any cache that serves a partial prefix without topping up silently
+truncates results. The improved design makes the rule normative and makes
+the cache elide-only.
+
+### F7 — Formal fit
+
+The proved invariances (`ChunkedScan.dfy`,
+`OneValueScanNormalization.dfy`) model a fetch *as* `Chunk(values, offset,
+limit)` over one fixed sequence. A cache that returns exact slices of that
+sequence is inside the model; a cache that returns anything else is not.
+Validity follows from `ScalarFrontierCoherence` with `dependencies = [r]`
+(a singleton frontier is that relation's generation), plus the adapter
+obligation that a scan is a function of one relation's tuple slice.
+`proof-frame/subset-descriptor` already derives a single relation's stamp
+from the complete request proof, fail-closed outside the closure.
+`SubproblemCanReuse` in the Dafny model demands equal full dependency
+vectors, stricter than needed; a new small lemma is required.
+
+### F8 — The subproblem store is unfit for a per-scan hot path
+
+| operation | single-thread median | 8 threads × 20 k ops |
+|---|---|---|
+| `subproblem/lookup!` hit | 1.4 µs | 1.9 µs/op amortised, **0.52 M ops/s total** |
+| `ConcurrentHashMap.get` | 0.08 µs | 0.34 µs/op, 2.9 M ops/s |
+
+Every hit does two or three `swap!`s on the metrics atom and a `touch-entry!`
+`swap!` (LRU vector conj + compaction) on the state atom. Twenty-three hits
+per page at ~2 µs of serialised time each caps the whole process near
+20 k pages/s from cache bookkeeping alone. The store also creates a fresh
+exact store per snapshot; per-scan entries must live in a schema-generation
+scoped, lock-free structure with sampled/CLOCK eviction.
+
+### F9 — Limits and telemetry
+
+A tier that returns results without reducer transitions breaks
+`:max-derived-grants`/`:max-advanced-datoms` accounting and the observer
+counters. A fetch-fn-level cache preserves both exactly (served values still
+flow through `fetch-values`).
+
+### F10 — Smaller defects in the original text
+
+`:continuation {… :reducer-state-hash}` cannot resume anything (the
+checkpoint store already retains real resumable state); `:summaries
+{:roaring :bloom}` are premature and only sound if stamped exactly like the
+payload; "plan nodes the schema marks as high-sharing" — no such marker
+exists; reusing `:denotation-max-weight` keeps alive the key that should be
+removed; page size ≠ demand (`target = size + 1`); "super-user warm-up then
+normal-user pages" as a success criterion measures a case DFS almost never
+produces.
+
+## Measurements
+
+All on this machine, JVM warm, in-memory stores; medians of 100–300
+samples unless stated. Fixtures: **A** = proposal's motivating case
+(platform → 60 accounts × 40 servers, `server.view = account->admin +
+shared_admin`, `account.admin = owner + platform->super_admin`);
+**B** = high-sharing sparse case (300 users, 400 groups, 60 memberships
+per user, 70 % of groups own no doc, `doc.view = group->member`).
+
+### Where a Datomic-mem cache-miss page spends its time (Fixture A)
+
+| component | cost |
+|---|---|
+| raw adapter scan, 64 values realised | 10.8 µs |
+| whole reducer walk, `:first 20` (5 commands, 47 transitions) | 91–121 µs |
+| `seal-plan` | ~1,050 µs (min 558) |
+| bypass page, plan thrashing | 1,428–2,826 µs |
+| bypass page, plan pre-sealed | 427–592 µs |
+| exact answer hit, plan thrashing / pre-sealed | ~600 / 328 µs |
+
+Stack samples with the plan pre-sealed: `capture-result-context` ≈ 50 %
+inclusive (of which `eacl.datomic.schema/read-schema` from `prepare` —
+all relations and permissions read on every request — ≈ 21 %),
+`edge-page` (reducer + fetch) ≈ 26 %, adapter construction ≈ 6 %,
+`verified-kernel/kernel?` (3 calls per request) ≈ 6 %.
+
+### Best case for a scan cache (Fixture B, reducer level, Datomic-mem)
+
+Per page: 37 adapter commands, 103 transitions on average.
+
+| sweep over all 300 users, `:first 20` | µs/page | adapter calls |
+|---|---|---|
+| no cache | 331 | 11,183 |
+| scan-prefix cache, first sweep | 235 | 692 (94 % elided) |
+| scan-prefix cache, second sweep | 178 | 0 new |
+
+Result sequences identical with and without the cache for every user
+(oracle equality). The 178 µs floor is the reducer's own transition cost
+(~1.7 µs per transition), which no scan cache can touch. Full client bypass
+page on this fixture: 734 µs; so the cache is worth ~150 µs of ~700 µs
+(with the plan bug fixed) and ~7 % of today's page.
+
+### Datahike (Fixture B, 100 users, 200 groups; 34 commands per page)
+
+| store | reducer, no cache | reducer, cache warm | client bypass page | client exact hit |
+|---|---|---|---|---|
+| `:memory` | 1,083 µs | 354–433 µs | 1,281 µs | 145 µs |
+| `:file` (warm konserve) | 282 µs | 166–191 µs | 1,057 µs | 128 µs |
+
+On Datahike the client shell is lean and the walk is a large share of a
+miss; the scan cache is worth 100–700 µs per page here (moderate
+confidence: small fixture; the `:memory` backend's high cold cost was not
+investigated).
+
+### `can?` (Datomic-mem, Fixture A)
+
+Reverse walk from the resource: 2–5 commands, ~30 µs raw. Bypass 985 µs
+thrashing → 172 µs pre-sealed; exact hit 152 µs. All reverse scans for one
+resource are shared across every subject that checks it.
+
+### Page-size sharing today
+
+`:first 50` then `:first 20` on the same subject: exact miss, then miss,
+then hit only on the identical repeat (bounds are in the answer key and
+page size in the checkpoint key). Under a scan cache the second request
+hits every scan and pays only ~50 reducer transitions (~85 µs); no separate
+"prefix answer" tier is justified.
+
+## What the rewrite keeps, drops, adds
+
+Keeps: client-private, best-effort, weight-bounded, frontier-stamped reuse;
+completed-answer/cursor identities untouched; page sizes share underlying
+work; formal statement before default-on.
+
+Drops: hierarchy/levels, plan-node keys, start-set fingerprints, `:via`
+trails, composition, continuation stubs, summaries, demand as a key
+dimension, reuse of `:denotation-max-weight`.
+
+Adds: prerequisite plan-cache fix; elide-only exact-slice semantics; the
+short-chunk rule as a spec obligation; lock-free store requirement; `can?`
+and reverse pages in scope; the cleanup of retired cache remnants; a
+benchmark gate that must be cleared before default-on.
+
+## Reproduction
+
+```clojure
+;; nREPL started with: clojure -M:dev:nrepl --port 7799
+(load-file "openspec/changes/hierarchical-demand-segment-cache/review/bench/seg_bench.clj")
+(in-ns 'seg-bench)
+(def conn-a (mem-conn!))  (def acl-a (seed-a! conn-a {:accounts 60 :servers-per-account 40}))
+(bench "bypass" #(page acl-a (->user "owner-7") :server :view 20 :cache? false))
+(count (:entries @@#'eacl.engine.v8/stable-plan-cache))          ; F1
+(def conn-b (mem-conn!))  (def acl-b (seed-b! conn-b {:users 300 :groups 400 :groups-per-user 60 :empty-fraction 0.7}))
+;; see `sweep`, `scan-prefix-fetch-fn`, `store-microbench` in the harness
+```
+
+---
+
+# Round 2 (2026-08-18, later): loophole hunt, live-app profiling, implementation
+
+Directive: find every loophole in the round-1 strategy, fix, verify against
+the real workload (`eacl-datomic-solidjs`, 110k servers, nREPL 55891), and
+implement once confident. Outcome: two of the three items were implemented
+and verified; the scan-response cache stays proposed and gated.
+
+## Loopholes found in the round-1 strategy (and what was done)
+
+| # | Loophole | Resolution |
+|---|---|---|
+| R2-1 | The strategy ranked the scan-response cache first; the live app showed `seal-plan` in **80 %** of `can?` samples and `read-schema` in ~35 % of the rest — cache work was ~5 %. | Re-prioritised: `fix-datomic-request-overhead` (implemented) → `membership-probe-point-check` (implemented) → scan-response cache (gated, not implemented). |
+| R2-2 | `can?` was O(subjects holding the permission): denied check on a 5,000-owner account **16.3 ms**; the strategy did not address it. | Membership-probe check: 24 µs; oracle-equal on 4,860 live pairs + 8,680 fixture pairs; new `eacl.engine.point-check-test`. |
+| R2-3 | Scan-response cache "helps pages": on the warm Datomic peer forward-page scans cost 2–10 µs, and my prototype's hit path cost about the same → **no measurable gain for lookup pages** (156 vs 159 µs/page at 74 % hits). It helped only the many-tiny-scan reverse walk (55 → 25 µs), which the probe check now makes moot. | Proposal demoted to "conditional, backend-specific (Datahike/remote), gate-decided"; hit path must be sub-µs to matter on Datomic at all. |
+| R2-4 | Plan key by schema stamp via `:proof-frame []` would issue a proof op per request — `:raw-can` op envelope pins zero and exact hits promise no generation reads. | Key uses the identity the caller already knows (client generation cache; raw facade's direct read as `:schema-identity`); no proof op. |
+| R2-5 | Dropping the lifecycle from the plan key let test adapters aliasing `{:source-id :test}` share plans across tests (global cache). | Lifecycle kept; the raw facade mints one process-stable lifecycle (the thrash was the *random per-call* lifecycle). |
+| R2-6 | A parsed-schema memo keyed by `basis-t` is unsafe for `as-of` snapshots (their basis-t is the current one). | Validation moved to the miss path and reads the per-generation cache; unstamped databases keep reading directly (`schema-basis-test` pins that). |
+| R2-7 | `seal-plan` itself: 368 canonical encodings for 16 rules (`sort-by encode-canonical` re-encodes per comparison), ~4.3 ms. | Encode-once; fingerprint/plan byte-identical (asserted). |
+| R2-8 | `kernel?` = `satisfies?` on an `extend`ed class, ~10 µs × 3–4 per request. | Positive-class memo. |
+| R2-9 | Scan purity, closure completeness, `:limit nil`, `(locking` prohibition, boxed-Long memory, CLJS store, `count` flooding — for the scan cache. | Verified/recorded in the design (scans read only the tuple attribute; plan relations = closure on the live schema; the rest are design rules). |
+
+## Live-app measurements (warm `datomic:dev://` peer, medians)
+
+| operation | before | after all fixes |
+|---|---|---|
+| `check-permission` miss, denied | 6.0 ms | **142 µs** |
+| `check-permission` miss, allowed (super) | 6.4 ms | 134 µs |
+| `check-permission` hit | 383 µs | 77–104 µs |
+| `lookup-resources :first 20` miss | 5.6 ms | ~490 µs |
+| `lookup-resources` hit | 614 µs | 243–335 µs |
+| `count-resources` super-user (110k) miss | 1.3–2.0 s | unchanged (661k reducer transitions ≈ 3 µs each; engine item) |
+| `count-resources` hit | — | 51 µs |
+
+## Remaining engine items (measured, not addressed here)
+
+- Reducer constant factor: ~3 µs per transition (`retain-buffer` rebuilds
+  the sidecar order vector on every release; `schedule` map churn;
+  `AdmissionKey` allocation) — an exhaustive 110k count spends 661k
+  transitions (6 per result through the union arms).
+- Union-arm subsumption in the sealed plan (`account->view` where
+  `account.view = admin` re-scans every account's servers) — changes the
+  order ABI (new fingerprint), so it is a deliberate plan-version change.
+- `secure-format` canonical encode/digest cost (24 µs per small map;
+  2–4 digests per page in cursor/proof contexts).

--- a/openspec/changes/hierarchical-demand-segment-cache/review/bench/seg_bench.clj
+++ b/openspec/changes/hierarchical-demand-segment-cache/review/bench/seg_bench.clj
@@ -1,0 +1,314 @@
+(ns seg-bench
+  "REPL-only feasibility/perf harness for the segment-cache review. Not source."
+  (:require [datomic.api :as d]
+            [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datomic.core :as spiceomic]
+            [eacl.datomic.schema :as schema]
+            [eacl.datomic.impl :as impl :refer [Relationship]]
+            [eacl.datomic.backend :as dbackend]
+            [eacl.backend.v8 :as backend]
+            [eacl.engine.v8 :as engine]
+            [eacl.engine.sealed-plan :as sealed-plan]
+            [eacl.engine.stable-reducer :as reducer]
+            [eacl.engine.stable-page :as stable-page]
+            [eacl.subproblem-cache :as subproblem]
+            [eacl.cache :as cache]))
+
+;; ---------------------------------------------------------------------------
+;; timing helpers
+;; ---------------------------------------------------------------------------
+
+(defn now-ns [] (System/nanoTime))
+
+(defn median [xs]
+  (let [s (vec (sort xs)) n (count s)]
+    (if (zero? n) nil (nth s (quot n 2)))))
+
+(defn pct [xs p]
+  (let [s (vec (sort xs)) n (count s)]
+    (nth s (min (dec n) (int (Math/floor (* p n)))))))
+
+(defmacro timed-us
+  "Runs body once, returns [micros result]."
+  [& body]
+  `(let [t0# (System/nanoTime)
+         r# (do ~@body)]
+     [(/ (double (- (System/nanoTime) t0#)) 1000.0) r#]))
+
+(defn bench
+  "Runs thunk `warm` times untimed then `n` times timed; returns summary in µs."
+  [label thunk & {:keys [warm n] :or {warm 20 n 200}}]
+  (dotimes [_ warm] (thunk))
+  (let [samples (vec (repeatedly n #(first (timed-us (thunk)))))]
+    {:label label
+     :n n
+     :median-us (median samples)
+     :p90-us (pct samples 0.9)
+     :min-us (apply min samples)}))
+
+;; ---------------------------------------------------------------------------
+;; fixtures
+;; ---------------------------------------------------------------------------
+
+(def ->user (partial spice-object :user))
+(def ->account (partial spice-object :account))
+(def ->server (partial spice-object :server))
+(def ->platform (partial spice-object :platform))
+(def ->group (partial spice-object :group))
+(def ->doc (partial spice-object :doc))
+
+(defn mem-conn! []
+  (let [uri (str "datomic:mem://segbench-" (java.util.UUID/randomUUID))]
+    (d/create-database uri)
+    (let [conn (d/connect uri)]
+      @(d/transact conn schema/v7-schema)
+      conn)))
+
+(defn- tx-rels [db rels]
+  (impl/optimistic-relationship-tx-data
+   db (mapcat #(impl/tx-relationship db % {:allow-tempids? true}) rels)))
+
+(def schema-a
+  "definition user {}
+   definition platform {
+     relation super_admin: user
+   }
+   definition account {
+     relation owner: user
+     relation platform: platform
+     permission admin = owner + platform->super_admin
+   }
+   definition server {
+     relation account: account
+     relation shared_admin: user
+     permission view = account->admin + shared_admin
+   }")
+
+(defn seed-a!
+  "Fixture A: super-user reaches every account via platform; each account has
+  one owner (normal user) and `servers-per-account` servers."
+  [conn {:keys [accounts servers-per-account]}]
+  (let [acl0 (spiceomic/make-client conn {})]
+    (eacl/write-schema! acl0 schema-a)
+    @(d/transact conn
+                 (concat
+                  [{:db/id "platform" :eacl/id "platform"}
+                   {:db/id "super" :eacl/id "super"}]
+                  (tx-rels (d/db conn)
+                           [(Relationship (->user "super") :super_admin (->platform "platform"))])))
+    (doseq [a (range accounts)]
+      (let [acc-id (str "acc-" a)
+            owner-id (str "owner-" a)
+            servers (for [s (range servers-per-account)] (str "srv-" a "-" s))]
+        @(d/transact conn
+                     (concat
+                      [{:db/id acc-id :eacl/id acc-id}
+                       {:db/id owner-id :eacl/id owner-id}]
+                      (for [s servers] {:db/id s :eacl/id s})
+                      (tx-rels (d/db conn)
+                               (concat
+                                [(Relationship (->platform "platform") :platform (->account acc-id))
+                                 (Relationship (->user owner-id) :owner (->account acc-id))]
+                                (for [s servers]
+                                  (Relationship (->account acc-id) :account (->server s)))))))))
+    (spiceomic/make-client conn {})))
+
+(def schema-b
+  "definition user {}
+   definition group {
+     relation member: user
+   }
+   definition doc {
+     relation group: group
+     permission view = group->member
+   }")
+
+(defn seed-b!
+  "Fixture B: high-sharing sparse graph. `users` users, `groups` groups; each
+  user is member of `groups-per-user` random groups; each group has 0..3 docs
+  (`empty-fraction` of groups have none)."
+  [conn {:keys [users groups groups-per-user empty-fraction seed]
+         :or {empty-fraction 0.6 seed 42}}]
+  (let [acl0 (spiceomic/make-client conn {})
+        rng (java.util.Random. seed)]
+    (eacl/write-schema! acl0 schema-b)
+    ;; groups + docs
+    (doseq [batch (partition-all 50 (range groups))]
+      @(d/transact conn
+                   (mapcat (fn [g]
+                             (let [gid (str "grp-" g)
+                                   ndocs (if (< (.nextDouble rng) empty-fraction)
+                                           0 (inc (.nextInt rng 3)))
+                                   docs (for [i (range ndocs)] (str "doc-" g "-" i))]
+                               (concat [{:db/id gid :eacl/id gid}]
+                                       (for [dd docs] {:db/id dd :eacl/id dd})
+                                       (tx-rels (d/db conn)
+                                                (for [dd docs]
+                                                  (Relationship (->group gid) :group (->doc dd)))))))
+                           batch)))
+    ;; users + memberships
+    (doseq [batch (partition-all 20 (range users))]
+      @(d/transact conn
+                   (mapcat (fn [u]
+                             (let [uid (str "user-" u)
+                                   gs (take groups-per-user (shuffle (range groups)))]
+                               (concat [{:db/id uid :eacl/id uid}]
+                                       (tx-rels (d/db conn)
+                                                (for [g gs]
+                                                  (Relationship (->user uid) :member (->group (str "grp-" g))))))))
+                           batch)))
+    (spiceomic/make-client conn {})))
+
+;; ---------------------------------------------------------------------------
+;; page helpers
+;; ---------------------------------------------------------------------------
+
+(defn page
+  [acl subject rtype perm n & {:keys [cache? after] :or {cache? true}}]
+  (eacl/lookup-resources acl (cond-> {:subject subject :permission perm
+                                      :resource/type rtype :first n
+                                      :cache? cache?}
+                               after (assoc :after after))))
+
+(defn page-with-stats
+  "Runs a page with the traversal observer bound; returns [result stats]."
+  [acl subject rtype perm n & opts]
+  (let [stats (atom {})]
+    (binding [engine/*recursive-traversal-stats* stats]
+      (let [r (apply page acl subject rtype perm n opts)]
+        [r @stats]))))
+
+;; ---------------------------------------------------------------------------
+;; raw engine access (bypasses the client layers)
+;; ---------------------------------------------------------------------------
+
+(defn adapter [conn] (dbackend/snapshot-adapter (d/db conn)))
+
+(defn eid [db ext] (:db/id (d/entity db [:eacl/id ext])))
+
+(defn plan-for [adapter root-node] (sealed-plan/seal-plan adapter root-node))
+
+(defn counting-fetch-fn
+  "Wraps a fetch-fn, counting calls and accumulating adapter time in ns."
+  [fetch-fn counters]
+  (fn [descriptor]
+    (let [t0 (System/nanoTime)
+          r (fetch-fn descriptor)]
+      (swap! counters (fn [c] (-> c (update :calls (fnil inc 0))
+                                  (update :ns (fnil + 0) (- (System/nanoTime) t0)))))
+      r)))
+
+(defn run-forward-raw
+  "Runs the stable reducer directly to `target` results with a given fetch-fn."
+  [adapter plan subject-type subject-eid target fetch-fn]
+  (reducer/run-forward {:adapter adapter :fetch-fn fetch-fn :plan plan
+                        :subject-type subject-type :subject-eid subject-eid
+                        :target target}))
+
+;; ---------------------------------------------------------------------------
+;; PROTOTYPE: scan-prefix cache at the fetch-fn seam (REPL only)
+;; ---------------------------------------------------------------------------
+;; key: descriptor minus :bound-eid/:limit (validity stamps omitted here: the
+;; adapter is bound to one immutable db value, so validity is trivially fixed
+;; for the experiment).
+;; value: {:prefix [eids ascending from scan start] :exhausted? bool}
+;; contract preserved: returns exactly what the adapter would return for
+;; (bound, limit): up to `limit` values strictly after bound; fewer only when
+;; the scan is exhausted.
+
+(defn- scan-key [descriptor] (dissoc descriptor :bound-eid :limit))
+
+(defn- prefix-after
+  "Values in prefix strictly greater than bound (nil bound = from start)."
+  [^clojure.lang.PersistentVector prefix bound]
+  (if (nil? bound)
+    prefix
+    ;; binary search for first index with value > bound
+    (let [n (count prefix)]
+      (loop [lo 0 hi n]
+        (if (< lo hi)
+          (let [mid (quot (+ lo hi) 2)]
+            (if (<= (compare (nth prefix mid) bound) 0)
+              (recur (inc mid) hi)
+              (recur lo mid)))
+          (subvec prefix lo))))))
+
+(defn scan-prefix-fetch-fn
+  "Returns [fetch-fn stats-atom]. `cache` is a java.util.concurrent.ConcurrentHashMap."
+  [inner ^java.util.concurrent.ConcurrentHashMap cache]
+  (let [stats (atom {:hits 0 :misses 0 :extends 0 :adapter-calls 0})]
+    [(fn [{:keys [bound-eid limit] :as descriptor}]
+       (let [k (scan-key descriptor)
+             entry (.get cache k)
+             avail (when entry (prefix-after (:prefix entry) bound-eid))]
+         (cond
+           ;; full hit: enough values or exhausted
+           (and entry (or (>= (count avail) limit) (:exhausted? entry)))
+           (do (swap! stats update :hits inc)
+               (into [] (take limit) avail))
+
+           ;; contiguous extend: bound lies within/at end of prefix; fetch tail
+           ;; from the last cached value and append (this request would have
+           ;; fetched these values anyway: no widening).
+           (and entry (or (nil? bound-eid)
+                          (<= (compare bound-eid (peek (:prefix entry))) 0)))
+           (let [last-cached (peek (:prefix entry))
+                 fetched (inner (assoc descriptor :bound-eid last-cached :limit limit))
+                 exhausted? (< (count fetched) limit)
+                 prefix' (into (:prefix entry) fetched)]
+             (swap! stats #(-> % (update :extends inc) (update :adapter-calls inc)))
+             (.put cache k {:prefix prefix' :exhausted? exhausted?})
+             (into [] (take limit) (prefix-after prefix' bound-eid)))
+
+           ;; miss (no entry, or bound beyond prefix): plain fetch; seed only when
+           ;; the scan starts at the beginning
+           :else
+           (let [fetched (inner descriptor)]
+             (swap! stats #(-> % (update :misses inc) (update :adapter-calls inc)))
+             (when (nil? bound-eid)
+               (.put cache k {:prefix (vec fetched) :exhausted? (< (count fetched) limit)}))
+             fetched))))
+     stats]))
+
+;; ---------------------------------------------------------------------------
+;; store-overhead microbench
+;; ---------------------------------------------------------------------------
+
+(defn store-microbench
+  "Compares eacl.subproblem-cache lookup!/publish! against a ConcurrentHashMap
+  for a per-scan style hit path, single-threaded and under contention."
+  [& {:keys [threads ops] :or {threads 8 ops 20000}}]
+  (let [store (subproblem/store {})
+        chm (java.util.concurrent.ConcurrentHashMap.)
+        keys* (vec (for [i (range 256)] [:scan i]))
+        opts {:valid? (constantly true) :weight-fn (constantly 64)}]
+    (doseq [k keys*]
+      (subproblem/publish! store :projection k opts {:prefix [1 2 3]})
+      (.put chm k {:prefix [1 2 3]}))
+    (let [single-store (bench "store lookup! single"
+                              #(subproblem/lookup! store :projection (keys* (rand-int 256)) opts)
+                              :n 5000 :warm 500)
+          single-chm (bench "CHM get single"
+                            #(.get chm (keys* (rand-int 256)))
+                            :n 5000 :warm 500)
+          contended (fn [label f]
+                      (let [latch (java.util.concurrent.CountDownLatch. 1)
+                            done (java.util.concurrent.CountDownLatch. threads)
+                            ts (doall (for [_ (range threads)]
+                                        (doto (Thread. (fn []
+                                                         (.await latch)
+                                                         (dotimes [_ ops] (f))
+                                                         (.countDown done)))
+                                          .start)))
+                            t0 (System/nanoTime)]
+                        (.countDown latch)
+                        (.await done)
+                        (let [total-ns (- (System/nanoTime) t0)]
+                          {:label label :threads threads :ops-per-thread ops
+                           :ns-per-op (/ (double total-ns) (* threads ops))
+                           :throughput-mops (/ (* threads ops) (/ total-ns 1e3))})))]
+      {:single [single-store single-chm]
+       :contended [(contended "store lookup! contended"
+                              #(subproblem/lookup! store :projection (keys* (rand-int 256)) opts))
+                   (contended "CHM get contended"
+                              #(.get chm (keys* (rand-int 256))))]})))

--- a/openspec/changes/hierarchical-demand-segment-cache/review/original-design.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/review/original-design.md
@@ -1,0 +1,178 @@
+# Design: Hierarchical Demand-Compatible Segment Cache
+
+## Technical Approach
+
+Add an internal **segment tier** to the client-private subproblem cache. Segments are ordered, demand-bounded, frontier-stamped expansions of sealed-plan nodes (or short paths). The demand-bounded reducer may:
+
+1. Look up compatible segments before expanding a plan node.
+2. Take a prefix (or filtered intermediate view) when demand and start-set rules allow.
+3. Deposit new ordered prefixes only for results it actually walked under the current demand.
+
+No path may publish a segment that contains more eids than the demand that produced it. Composition of multi-hop segments is itself demand-aware and stops at the remaining demand.
+
+Public completed-answer keys, cursor identities, and exact/proof-backed tiers are unchanged. Segments are an accelerator underneath them.
+
+## Architecture Decisions
+
+### Decision: Prefix-only reuse (never widening)
+
+**Choice.** A segment stored under demand *D* may be used only for requests whose demand *D′ ≤ D*.
+
+**Rationale.** This is the dual of the evaluation-widening problem that caused the old denotation path to be disabled. Prefix reuse is sound under stable order; extending a segment would require extra work the current request did not authorize.
+
+### Decision: Key segments by plan node + start-set fingerprint + demand + validity, not by final page size
+
+**Choice.** Page size is treated as one concrete demand value. Different `:first` / `:last` sizes share the same segment when the demand inequality holds.
+
+**Rationale.** Completed answers already include bounds in their keys. Segments sit below that layer and maximize sharing across pagination shapes.
+
+### Decision: Validity = existing proof descriptor
+
+**Choice.** Every segment carries:
+
+```clojure
+{:schema-stamp     <schema-generation>
+ :dependency-stamp <max relation-version over relations used by this segment>
+ :lifecycle        <source lifecycle>
+ :plan-fingerprint <sealed-plan fingerprint>}
+```
+
+Reuse requires exact match on these fields (same rules as proof-backed completed answers).
+
+**Rationale.** Reuses the already-verified frontier machinery; no new coherence protocol.
+
+### Decision: Ordered eid payloads, not dense bitsets by default
+
+**Choice.** Primary payload is a sorted vector (or compressed run) of eids in stable-discovery order, plus optional continuation and per-intermediate references.
+
+**Rationale.** Matches the sealed-plan release-width and uniqueness contract. Optional roaring/bloom summaries may be added later for negative checks without changing the primary representation.
+
+### Decision: Hierarchical levels follow the sealed plan
+
+**Choice.**
+
+- Level 1: single plan node / single relation hop from a start-set.
+- Level *k*: demand-aware composition of lower segments (or of a segment + a fresh hop).
+
+**Rationale.** The sealed plan already defines the legal composition order and ranking. Hierarchy is therefore plan-native rather than an arbitrary graph cache.
+
+### Decision: Best-effort admission under weight budgets
+
+**Choice.** Segment entries compete for a dedicated weight budget (reuse or rename `:denotation-max-weight` / introduce `:segment-max-weight`). Overweight entries are rejected; eviction is LRU within the tier.
+
+**Rationale.** Keeps the cache bounded and client-private; matches existing subproblem-cache philosophy.
+
+## Data Structures
+
+### Segment key
+
+```clojure
+{:tier            :segment
+ :level           1|2|…
+ :plan-node       <sealed-plan node id or path vector>
+ :relation        <keyword>                    ; optional, for level-1 clarity
+ :direction       :forward|:reverse            ; optional
+ :start-set-fp    <string>                     ; stable fingerprint of sorted start eids
+ :demand          <pos-int>                    ; max results this entry may contain
+ :validity        {:schema-stamp …
+                   :dependency-stamp …
+                   :lifecycle …
+                   :plan-fingerprint …}}
+```
+
+### Segment value
+
+```clojure
+{:payload
+ {:ordered-eids   [<eid> …]                   ; ascending stable-discovery order
+  :count          <int>
+  :min-eid        <eid>
+  :max-eid        <eid>
+  :continuation   nil | {:next-boundary-ordinal …
+                         :next-eid …
+                         :reducer-state-hash …}
+  :via            [{:plan-node …
+                    :level …
+                    :intermediate-eids [<eid> …]
+                    :segment-ref <key-or-id>}]  ; optional composition trail
+  :summaries      {:roaring … :bloom …}}        ; optional
+ :weight          <bytes>
+ :admitted-at-t   <t>
+ :hits            <int>}
+```
+
+### Start-set fingerprint
+
+Initial implementation: SHA-256 (or project-standard hash) of the sorted, canonical internal eids of the starting set for that plan node. Later refinements may add common-prefix or schema-guided clustering for high-sharing intermediate nodes without changing the external segment contract.
+
+### Composition (demand-aware)
+
+```text
+compose(seg-A, hop-or-seg-B, remaining-demand):
+  result = []
+  for each intermediate in seg-A.ordered-eids:
+    if remaining-demand = 0: break
+    products = expand-or-lookup(hop-or-seg-B, intermediate, remaining-demand)
+    append products to result   ; already in stable order
+    remaining-demand -= |products|
+  return ordered segment of result with demand = original remaining-demand bound
+```
+
+Only eids actually produced under the active demand are stored. The `:via` trail records which intermediates contributed so frontier checks remain precise.
+
+## Lookup and Deposit Flow
+
+```
+1. Exact completed-answer lookup
+2. Proof-backed completed-answer lookup
+3. Hierarchical segment lookup for relevant plan nodes
+   - match validity, start-set-fp compatibility, demand ≥ request demand
+   - on hit: take prefix / filter intermediates / resume continuation
+4. On miss: run demand-bounded reducer
+5. While walking, deposit level-1 and composed segments under current frontier
+   (subject to weight budget; never deposit more than walked demand)
+6. Publish completed answer as today
+```
+
+## Compatibility Rules (normative)
+
+1. **Prefix rule.** Segment under demand *D* usable only when request demand *D′ ≤ D*.
+2. **Frontier rule.** `dependency-stamp` and `schema-stamp` (and lifecycle / plan fingerprint) must match.
+3. **Order rule.** All payloads and compositions preserve sealed-plan stable-discovery order and uniqueness.
+4. **No widening.** Cache hit may only remove work the reducer would have done; it may never issue extra scans or raise the effective demand.
+5. **Start-set rule.** Exact fingerprint match required in v1; compatible-subset / high-sharing refinements are explicit later extensions.
+6. **Cursor isolation.** Public cursors and checkpoints remain exact-snapshot and execution-identity scoped; segments are internal only unless a future authenticated segment continuation is designed.
+
+## Integration Points
+
+| Component | Change |
+|-----------|--------|
+| `eacl.cache` / subproblem store | New segment tier, keys, weight budget, LRU |
+| Sealed-plan compiler | Expose stable node ids / path vectors for keys |
+| Demand-bounded reducer | Optional segment lookup before node expansion; deposit after walk |
+| Proof / frontier | Reuse existing relation-version max over segment’s relation set |
+| Config | `:segment-max-weight` (or map denotation budget); `:segment-cache {:enabled? true}` |
+| Metrics | Segment hits, misses, prefix truncations, admission rejects, composition counts |
+
+## Alternatives Considered
+
+| Alternative | Why rejected (for now) |
+|-------------|------------------------|
+| Full multi-hop denotation publishing | Evaluation widening; hard coherence; previously removed |
+| Global resource-side inverted index | Eager materialization; demand-unbounded; schema-agnostic cost |
+| Page-size in segment key | Prevents sharing across `:first 20` vs `:first 50` |
+| Unordered sets / only bloom filters | Breaks stable order and pagination correctness |
+| Background segment pre-warm | Violates demand-bounded default; complexity |
+
+## Formal Obligations (to be stated in verification)
+
+- Soundness: any eid sequence returned from a segment under demand *D′* and frontier *F* equals the sequence the demand-bounded reducer would emit on the same snapshot for the same start set and plan node.
+- Safety: no segment causes a request to observe results beyond its demand or after a frontier advance.
+- Progress: segment miss degrades to ordinary evaluation; never blocks or fails closed incorrectly.
+
+## Open Questions
+
+1. Exact start-set fingerprint algorithm and whether high-sharing intermediate nodes get a special “shared-intermediate” key mode in v1.
+2. Whether level-*k* composition is stored eagerly or only level-1 + on-the-fly compose.
+3. Interaction with recursive-traversal limits and fuel boundaries when depositing segments mid-walk.
+4. Whether segment continuations may ever be exposed inside authenticated cursors (out of scope for initial delivery).

--- a/openspec/changes/hierarchical-demand-segment-cache/review/original-proposal.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/review/original-proposal.md
@@ -1,0 +1,67 @@
+# Proposal: Hierarchical Demand-Compatible Segment Cache
+
+## Why
+
+EACL v8’s demand-bounded evaluation and completed-answer cache correctly avoid evaluation widening and keep the relation-version frontier proof simple. However, benchmarks show substantial structural overlap between super-user object visibility and normal-user visibility for the same permission and resource type. Intermediate plan nodes (shared accounts, orgs, or other high-fan-in resources) are repeatedly expanded under the sealed plan even though the ordered results are largely shared.
+
+The earlier multi-hop denotation and aggressive projection-publishing paths were removed because they risked widening work beyond the request’s demand and complicated formal coherence. A new intermediate tier is needed that:
+
+- exploits ordered segment sharing across subjects and page sizes,
+- never materializes more results than some prior demand has already walked,
+- remains strictly compatible with demand-bounded evaluation, sealed-plan stable order, and the existing schema/dependency frontier proof,
+- avoids eager full-index materialization.
+
+Without this, repeated multi-hop walks remain the dominant cost for recursive and high-sharing schemas even when completed-answer hits are rare.
+
+## What Changes
+
+- Introduce a new **hierarchical segment** tier under the existing subproblem cache.
+- Segments are keyed by sealed-plan node (or path), start-set fingerprint, demand bound, and validity stamp (schema generation + dependency frontier).
+- A segment stores an ordered eid prefix (stable-discovery order), optional continuation, optional intermediate references, and lightweight summaries — never an unordered dense set larger than a prior demand.
+- Composition of hops is demand-aware: level-*k* segments are built only up to the active demand.
+- Prefix reuse is allowed: a segment populated under demand *D* may satisfy any later demand *D′ ≤ D* with matching frontier and compatible start set.
+- Different page sizes (`:first` / `:last`) share segments; only the demand number matters for reuse.
+- Completed-answer and public-cursor identities remain unchanged (page size and exact bounds stay in those keys).
+- Identity projections, sealed plans, and exact/proof-backed completed answers continue to work as today.
+- The denotation tier config surface may be reused or renamed for segment weight budgets; no engine path will publish unrestricted full denotations.
+
+## Capabilities
+
+### New Capabilities
+
+- `cache/hierarchical-segments`: demand-compatible, frontier-stamped, ordered segment storage and prefix/composition reuse for sealed-plan nodes.
+
+### Modified Capabilities
+
+- `cache/subproblem-cache`: gains a segment tier with explicit demand and start-set dimensions; continues to respect weight budgets and managed-proof limits.
+- `engine/demand-evaluation`: may consult and deposit hierarchical segments while remaining demand-bounded; must never widen evaluation or return results beyond the request demand.
+- `cache/coherence`: segment validity uses the same schema-stamp + dependency-stamp rules already proven for completed answers.
+
+## Non-Goals
+
+- No change to public cursor envelope formats or authentication.
+- No support for arbitrary time-travel cache reuse (as-of / since / filter views still degrade to exact-only or `:cache? false`).
+- No automatic inverted (resource-centric) global indexes; any resource-side sharing is limited to plan nodes the schema marks as high-sharing and is still demand-bounded.
+- No background pre-warming or adaptive completion APIs.
+- No requirement that every hop be cached; admission remains best-effort under weight limits.
+
+## Impact
+
+- **Performance**: reduced repeated index seeks and reducer bookkeeping for overlapping subject sets and varying page sizes on the same permission.
+- **Correctness**: preserved by prefix-only reuse, frontier stamps, and sealed-plan order.
+- **Complexity**: moderate increase in subproblem-cache surface; formal model must be extended for segment soundness.
+- **Memory**: bounded by existing (or slightly extended) weight budgets; oversized segments are rejected, not swapped in unbounded fashion.
+- **API**: no breaking public API changes; optional cache config keys for segment budgets.
+
+## Risks
+
+- Start-set fingerprint collisions or overly fine keys reduce hit rate.
+- Incorrect composition order could violate stable-discovery uniqueness.
+- Formal verification surface grows; segment theorems must be stated and tested before enabling by default.
+
+## Success Criteria
+
+- Measurable reduction in mean latency for normal-user pages after a super-user (or larger-demand) warm-up on the same schema and frontier.
+- No correctness regressions under existing cache-vs-bypass and coherence test suites.
+- Segments never cause a demand-bounded request to return more results than requested or to perform work beyond its demand.
+- Different page sizes on the same logical query share underlying segments when demand allows.

--- a/openspec/changes/hierarchical-demand-segment-cache/review/original-tasks.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/review/original-tasks.md
@@ -1,0 +1,100 @@
+# Tasks: Hierarchical Demand-Compatible Segment Cache
+
+## 1. Spec and contract scaffolding
+
+- [ ] 1.1 Add capability notes / delta requirements for hierarchical segments (demand prefix rule, frontier stamp, no widening) under the cache domain
+- [ ] 1.2 Document non-goals (no public cursor change, no time-travel segment reuse, no background pre-warm)
+- [ ] 1.3 Define config surface: `:segment-cache {:enabled? true}`, `:segment-max-weight`, optional reuse of denotation budget keys with clear deprecation note
+
+## 2. Data model and store
+
+- [ ] 2.1 Implement segment key schema (tier, level, plan-node/path, start-set-fp, demand, validity)
+- [ ] 2.2 Implement segment value schema (ordered-eids, count, min/max, continuation, via, summaries, weight, hits)
+- [ ] 2.3 Add segment tier to the client-private subproblem cache store with weighted LRU admission
+- [ ] 2.4 Implement start-set fingerprint helper (sorted canonical eids → stable hash)
+- [ ] 2.5 Reject overweight segments; never displace unbounded; track admission rejects in stats
+
+## 3. Validity and proof integration
+
+- [ ] 3.1 Attach schema-stamp + dependency-stamp (max relation-version over segment relations) + lifecycle + plan-fingerprint on every deposit
+- [ ] 3.2 Reuse existing proof-frame / frontier computation for the relations touched by a plan node
+- [ ] 3.3 Ensure frontier mismatch forces miss (no partial or stale segment reuse)
+- [ ] 3.4 Confirm segments are unavailable for filtered / speculative / caller-constructed / non-deterministic views (same policy as managed proof)
+
+## 4. Sealed-plan integration
+
+- [ ] 4.1 Expose stable plan-node ids or path vectors from the sealed-plan compiler for use as segment keys
+- [ ] 4.2 Ensure plan-fingerprint changes invalidate segment keys (same as cursor/answer fingerprint rules)
+- [ ] 4.3 Map single relation hops and multi-node paths to level-1 vs level-k keys consistently
+
+## 5. Demand-bounded reducer integration
+
+- [ ] 5.1 Before expanding a plan node, attempt segment lookup under current demand, start-set-fp, and frontier
+- [ ] 5.2 On hit with demand′ ≥ request demand: take ordered prefix (and optional intermediate filter); do not expand further for those results
+- [ ] 5.3 On miss: run ordinary demand-bounded expansion
+- [ ] 5.4 After a successful demand-bounded walk of a node/path, deposit a segment containing only the eids actually produced under that demand
+- [ ] 5.5 Enforce: deposit never writes more eids than the demand that produced them
+- [ ] 5.6 Enforce: lookup never increases effective demand or issues extra backend scans
+
+## 6. Composition
+
+- [ ] 6.1 Implement demand-aware compose of level-1 segments (or segment + fresh hop) stopping at remaining demand
+- [ ] 6.2 Record `:via` intermediate eids and segment-refs for composed entries
+- [ ] 6.3 Preserve stable-discovery order and uniqueness across composition
+- [ ] 6.4 Decide and document v1 policy: store composed level-k eagerly vs compose on read only (prefer one approach for first merge)
+
+## 7. Pagination and page-size sharing
+
+- [ ] 7.1 Confirm segment keys omit final page size; only demand is stored
+- [ ] 7.2 Verify `:first 50` segment can satisfy later `:first 20` (prefix) under same frontier and start-set
+- [ ] 7.3 Verify larger demand cannot be satisfied from a smaller segment (miss → evaluate)
+- [ ] 7.4 Ensure public cursors and completed-answer keys still include page size / bounds; no change to cursor wire format
+- [ ] 7.5 Exercise cursor continuation after a segment-prefix hit; deterministic replay still correct on miss
+
+## 8. Metrics and observability
+
+- [ ] 8.1 Extend `cache-stats` with segment hits, misses, prefix truncations, composition counts, admission rejects, weight used
+- [ ] 8.2 Log or counter for frontier-mismatch segment rejects
+- [ ] 8.3 Optional debug: expose whether a page was satisfied from segment vs full reducer (internal only)
+
+## 9. Tests — correctness
+
+- [ ] 9.1 Unit: prefix rule (D′ ≤ D hit, D′ > D miss)
+- [ ] 9.2 Unit: frontier advance invalidates segment
+- [ ] 9.3 Unit: different start-set fingerprints do not hit
+- [ ] 9.4 Unit: composition preserves order and stops at demand
+- [ ] 9.5 Integration: cache vs `:cache? false` oracle equality for point checks and pages
+- [ ] 9.6 Integration: super-user large demand warms segments; normal-user smaller demand hits prefixes
+- [ ] 9.7 Integration: same subject, different page sizes share segment when demand allows
+- [ ] 9.8 Integration: unrelated transaction does not invalidate; relationship write on a dependency relation does
+- [ ] 9.9 Integration: recursive schema under demand limits deposits only walked results
+- [ ] 9.10 Regression: existing completed-answer, checkpoint, and cursor suites still pass
+
+## 10. Tests — performance / overlap (benchmarks)
+
+- [ ] 10.1 Add or extend benchmark: super-user page warm-up then normal-user pages on shared schema
+- [ ] 10.2 Measure segment hit rate and latency delta vs segment-cache disabled
+- [ ] 10.3 Confirm no pathological memory growth under weight budgets
+- [ ] 10.4 Document expected win conditions (high intermediate sharing) and non-win cases (disjoint subjects)
+
+## 11. Formal / coherence notes
+
+- [ ] 11.1 Draft soundness statement: segment-derived sequence equals demand-bounded reducer sequence under same snapshot, start set, plan node, demand
+- [ ] 11.2 Draft safety statement: no extra results beyond demand; no use after frontier advance
+- [ ] 11.3 Align with existing Dafny/TLA+ cache theorems or add targeted properties + randomized cache-vs-bypass tests
+- [ ] 11.4 Update docs/cache.md and stable-discovery notes: segments are internal, partial denotations remain non-reusable as completed answers
+
+## 12. Documentation and rollout
+
+- [ ] 12.1 Update cache.md: segment tier, prefix rule, page-size sharing, config keys
+- [ ] 12.2 Update v8 backend / upgrade notes if any migration or default-off flag is required
+- [ ] 12.3 Default: segment cache enabled only when subproblem-cache is enabled; provide explicit disable
+- [ ] 12.4 Changelog entry describing non-breaking additive behavior
+
+## 13. Out of scope (explicit non-tasks for this change)
+
+- [ ] 13.1 Public authenticated segment continuations inside cursors
+- [ ] 13.2 Background pre-warming or complete-denotation auto-fill
+- [ ] 13.3 Global inverted resource-side indexes
+- [ ] 13.4 Arbitrary as-of/time-travel segment reuse
+- [ ] 13.5 Changing completed-answer or cursor identity schemas

--- a/openspec/changes/hierarchical-demand-segment-cache/specs/bounded-physical-execution/spec.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/specs/bounded-physical-execution/spec.md
@@ -1,0 +1,89 @@
+# bounded-physical-execution Specification
+
+> These deltas target requirements introduced by the in-progress
+> `adopt-stable-discovery-enumeration` change. Archive that change first (or
+> fold these deltas into it); the header text below matches its requirement
+> names exactly.
+
+## ADDED Requirements
+
+### Requirement: Fetch replies are exact chunks
+
+Every fetch-fn layer between the reducer and the adapter SHALL return exact chunks:
+for a descriptor with exclusive bound `b` and positive physical limit `L`, the
+layer (classification, retry, scan-response cache, telemetry) MUST return
+exactly the first `min(L, remaining)` strictly ascending values greater than
+`b` of the adapter's scan at the selected basis. A reply shorter than `L` MUST mean the
+scan is exhausted after its last value. The reducer relies on this rule to
+drop the scan frame; no layer may return a short reply for any other reason.
+
+#### Scenario: Short reply
+
+- **WHEN** a layer returns fewer than `L` values
+- **THEN** no value greater than the last returned one exists in the scan at that basis
+
+#### Scenario: Layer cannot satisfy the rule
+
+- **WHEN** a layer holds fewer than `L` cached values after `b` and does not know the scan to be exhausted
+- **THEN** it forwards the command to the next layer instead of replying
+
+## MODIFIED Requirements
+
+### Requirement: Chunk retention is bounded and disposable
+
+Each open scan frame MAY retain its current fetched chunk for request-local reuse. Retained chunks MUST be bounded per request by count and weight, MUST be excluded from cursors and checkpoints, MUST be discarded on lifecycle or basis mismatch, and MUST be reconstructible from the authoritative logical bound — eviction merely causes a reread. Deep recursion MUST NOT accumulate unbounded per-depth buffers.
+
+A client MAY additionally retain exact scan-response prefixes across requests in the scan-response cache (`exact-scan-response-cache`); such retention MUST be bounded by weight and per-entry cap, keyed by the complete validity scope including the scanned relation's generation, excluded from cursors and checkpoints, and reconstructible by reissuing the same command — its absence or eviction merely causes the original read.
+
+The shell MUST demand only the physical values the page and its single semantic lookahead require; it MUST NOT request `physical-page-size + 1` when that value forces another backing read.
+
+#### Scenario: Chunk eviction
+
+- **WHEN** an unconsumed retained chunk is evicted under memory pressure
+- **THEN** no cursor or checkpoint becomes invalid
+- **AND** the next demand reissues the read from the authoritative logical bound
+
+#### Scenario: Cross-request prefix eviction
+
+- **WHEN** a scan-response prefix is evicted under weight pressure
+- **THEN** no cursor, checkpoint, or answer becomes invalid
+- **AND** the next request issues the original command it would have issued without the cache
+
+#### Scenario: Interior storage boundary
+
+- **WHEN** requesting one additional physical value would cross a backing-store boundary
+- **THEN** the engine does not perform that read unless the canonical reducer actually needs it
+
+### Requirement: The engine keeps exactly two closed cache artifacts
+
+The engine caches exactly two semantic artifacts: progress checkpoints (complete quiescent reducer states for one exact execution identity) and completed answers (fully prepared public results). One physical accelerator is additionally permitted below the reducer: exact scan-response prefixes (`exact-scan-response-cache`), which replay adapter replies and never enter the reducer's semantic state. Byte and node caching belongs to the storage layer. An arbitrary traversal prefix MUST NOT be cached as a denotation or answer. A flat subproblem denotation MUST NOT be substituted into stable enumeration without a proof that substitution preserves the canonical discovery sequence, not merely set equality. Cancellation salvage is the latest valid checkpoint only.
+
+The completed-answer key MUST incorporate the composite fingerprint. A cached answer containing pagination cursors MUST NOT be served across a basis change unless continuation of the embedded cursors remains permitted under the continuation rules (exact-basis reselection or the certified full-read-scope dependency proof).
+
+#### Scenario: Timed-out long traversal
+
+- **WHEN** a request times out after reaching a quiescent reducer boundary
+- **THEN** the latest valid exact progress checkpoint may survive
+- **AND** the incomplete page and partial denotation are not cached
+- **AND** exact scan-response prefixes fetched before the timeout may be retained
+
+#### Scenario: Set-equal cached subproblem
+
+- **WHEN** a cached subproblem contains the correct unordered resources but lacks a sequence-refinement certificate
+- **THEN** paginated enumeration does not substitute it into the reducer
+
+#### Scenario: Scan-response prefix is not a subproblem
+
+- **WHEN** the reducer's fetch is answered from a scan-response prefix
+- **THEN** the reducer's admission, order, and discovered count are identical to the run that read the same values from the adapter
+
+#### Scenario: Order flip does not serve stale-order answers
+
+- **WHEN** the routing engine or order ABI changes within one process lifetime
+- **THEN** completed answers keyed under the previous fingerprint are not served for the new one
+
+#### Scenario: Cursor-bearing answer on a current-only topology
+
+- **WHEN** a cached page whose cursors pin a superseded basis is requested on a topology that cannot reselect that basis
+- **THEN** the answer is recomputed at a selectable basis
+- **AND** a dead cursor is not served repeatedly from cache

--- a/openspec/changes/hierarchical-demand-segment-cache/specs/demand-bounded-evaluation/spec.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/specs/demand-bounded-evaluation/spec.md
@@ -1,0 +1,29 @@
+# demand-bounded-evaluation Specification
+
+## MODIFIED Requirements
+
+### Requirement: Cache retains only demanded work
+Cache-enabled execution SHALL retain only completed artifacts and exact backend
+responses that the evaluator demanded before its stopping decision. Cache code
+MUST NOT increase adapter chunk size, scan bounds, generated fuel, traversal
+waves, or result demand. The exact scan-response cache
+(`exact-scan-response-cache`) is the only retention of backend responses: it
+stores prefixes of replies the evaluator actually commanded and, on a miss,
+forwards the evaluator's command unchanged.
+
+#### Scenario: Projection shorter than cache chunk
+- **WHEN** the evaluator commands a projection scan for five values and the backend can return more
+- **THEN** EACL requests, validates, and may retain at most the response authorized by that exact command
+- **AND** cache configuration does not fetch a sixth value
+
+#### Scenario: Scan-response miss forwards the same command
+- **WHEN** the scan-response cache cannot reproduce the evaluator's command from a stored prefix
+- **THEN** it forwards that command with the same bound and limit and does not issue any other command
+
+#### Scenario: Page sentinel reached
+- **WHEN** a page has obtained its `N+1` sentinel
+- **THEN** EACL performs no further traversal for cache population
+
+#### Scenario: Count sentinel reached
+- **WHEN** a bounded count has obtained `L+1` distinct results
+- **THEN** EACL performs no further traversal for cache population

--- a/openspec/changes/hierarchical-demand-segment-cache/specs/exact-scan-response-cache/spec.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/specs/exact-scan-response-cache/spec.md
@@ -1,0 +1,167 @@
+# exact-scan-response-cache Specification
+
+## Purpose
+
+Client-private, elide-only reuse of exact adapter scan-response prefixes at the
+stable-discovery engine's physical read seam. The cache removes adapter
+commands it can reproduce exactly; it never substitutes reducer-level
+artifacts, never widens demand, and is invisible to order, limits, cursors,
+checkpoints, and answers.
+
+## ADDED Requirements
+
+### Requirement: Cached values are exact scan-response prefixes
+
+The scan-response cache SHALL store, per read-demand descriptor (operation,
+anchor type and internal id, relation id, target type), only a strictly
+ascending prefix of the adapter's complete scan sequence for that descriptor,
+starting at the scan's first value, together with an `exhausted?` flag that
+is true only when the prefix is the complete sequence. The cache MUST NOT
+store reducer emissions, plan-node segments, composed multi-hop results,
+traversal prefixes, or any value derived from the request's admission state.
+
+#### Scenario: Prefix from the start
+
+- **WHEN** a request fetches the first physical chunk of a scan and no entry exists
+- **THEN** the cache may store exactly the returned values as the prefix, marked exhausted only when fewer than the requested limit were returned
+
+#### Scenario: Fragment without its start
+
+- **WHEN** a request fetches a chunk after a non-nil bound and no entry containing that bound exists
+- **THEN** the cache stores nothing for that descriptor
+
+#### Scenario: Negative scan
+
+- **WHEN** a scan returns no values from its start
+- **THEN** the cache may store an empty exhausted prefix and later serve it
+
+### Requirement: Served replies equal the adapter's reply
+
+For a fetch with exclusive bound `b` and physical limit `L`, the cache SHALL
+serve a reply only when its prefix contains at least `L` values strictly
+greater than `b`, or when the prefix is exhausted; the reply MUST be the
+first `L` such values (all of them when exhausted). Any other case MUST be a
+miss.
+
+#### Scenario: Full hit
+
+- **WHEN** the prefix holds at least `L` values greater than `b`
+- **THEN** the reply is exactly those first `L` values and no adapter command is issued
+
+#### Scenario: Exhausted short hit
+
+- **WHEN** the prefix is exhausted and holds fewer than `L` values greater than `b`
+- **THEN** the reply is all of them and no adapter command is issued
+
+#### Scenario: Short non-exhausted prefix
+
+- **WHEN** the prefix is not exhausted and holds fewer than `L` values greater than `b`
+- **THEN** the cache misses and the original command is issued unchanged
+
+### Requirement: The cache is elide-only
+
+On a miss the cache SHALL forward exactly the reducer's command — same
+descriptor, same exclusive bound, same limit — and MUST NOT issue any
+additional, widened, moved, or speculative command. It MAY use the reply to
+extend the stored prefix when the reply is contiguous with it (the bound is
+the prefix's last value or lies within the prefix); the extended prefix MUST
+remain a prefix of the scan sequence and MUST NOT exceed the configured
+per-entry cap.
+
+#### Scenario: Command multiset is a subset
+
+- **WHEN** the same request runs with the cache enabled and with `:cache? false` on equal snapshots
+- **THEN** every command issued with the cache enabled is also issued without it, with an equal reply, and results are identical
+
+#### Scenario: Contiguous extension
+
+- **WHEN** a miss occurs after bound `b` that is the last value of the stored prefix
+- **THEN** the stored prefix may become the old prefix followed by the reply, exhausted iff the reply was short
+
+#### Scenario: Concurrent extensions
+
+- **WHEN** two requests concurrently deposit different-length prefixes for one key
+- **THEN** either result is a valid prefix of the same sequence and the longer one is retained
+
+### Requirement: Validity scope is the singleton relation frontier
+
+Reuse SHALL require equality of the complete scope: backend id, source scope,
+source lifecycle, adapter fingerprint and identity contract, order ABI and
+plan-domain version, schema generation, the scanned relation id, and that
+relation's generation as derived from the request's complete proof frame.
+A relation outside the proved closure, an incomplete or unavailable proof, or
+a non-ordinary database value MUST disable both lookup and deposit for that
+scan.
+
+#### Scenario: Unrelated write
+
+- **WHEN** a supported mutation stamps a relation other than the scanned one
+- **THEN** entries for the scanned relation remain reusable
+
+#### Scenario: Relevant write
+
+- **WHEN** a supported mutation stamps the scanned relation
+- **THEN** entries under the previous generation are never served for the new one
+
+#### Scenario: Schema change
+
+- **WHEN** `write-schema!` advances the schema generation
+- **THEN** no entry from the previous generation is served
+
+#### Scenario: Time-travel or filtered value
+
+- **WHEN** the request selects an `as-of`, `since`, filtered, speculative, or caller-supplied database value
+- **THEN** the cache neither serves nor deposits
+
+### Requirement: The cache is a physical accelerator outside every semantic identity
+
+Cached prefixes MUST NOT appear in cursors, checkpoints, completed answers, or
+proof descriptors; MUST hold internal ids only; MUST NOT change reducer
+admission, order, discovered counts, or limit accounting (served values still
+count toward `:max-advanced-datoms` exactly as fetched values do); and MUST be
+bypassable per request with `:cache? false` and per client with a disabled
+cache.
+
+#### Scenario: Limits unaffected
+
+- **WHEN** a request that would exceed `:max-advanced-datoms` without the cache runs with every scan served from cache
+- **THEN** it exceeds the limit at the same transition and fails with the same typed error
+
+#### Scenario: Bypass
+
+- **WHEN** a request passes `:cache? false`
+- **THEN** no scan lookup or deposit occurs for that request
+
+### Requirement: The store is bounded and lock-free on the hit path
+
+The store SHALL be weight-bounded with a per-entry prefix cap and approximate
+recency eviction; a hit MUST NOT perform a compare-and-set on shared state;
+metrics MUST be observable (`hits`, `misses`, `elided-commands`,
+`extensions`, `deposits`, `evictions`, `weight`, `stamp-unavailable`).
+`expire-cache!` MUST make the entire store unreachable.
+
+#### Scenario: Weight pressure
+
+- **WHEN** a deposit would exceed the weight budget
+- **THEN** entries are evicted by approximate recency until the budget holds and the request itself is unaffected
+
+#### Scenario: Oversized prefix
+
+- **WHEN** an extension would exceed the per-entry cap
+- **THEN** the existing shorter prefix is retained unchanged
+
+### Requirement: Adoption is gated by measured benefit
+
+The cache SHALL ship disabled by default until a reproducible gate shows, in
+one process and fixture after the sealed-plan cache fix: cache-vs-bypass
+oracle equality under concurrency and interleaved supported writes on every
+bundled backend; at least 90 percent of adapter commands elided on the sparse
+high-sharing forward-page and hot-resource `can?` workloads after warm-up;
+p50 miss-page latency at least 25 percent lower on Datahike and 15 percent
+lower on Datomic than with the cache disabled; and at most 1 percent p50
+regression with the cache enabled and empty.
+
+#### Scenario: Gate refused
+
+- **WHEN** any threshold or the oracle equality fails
+- **THEN** the default remains disabled and the verification manifest records the refusal

--- a/openspec/changes/hierarchical-demand-segment-cache/specs/managed-reuse-certification/spec.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/specs/managed-reuse-certification/spec.md
@@ -1,0 +1,16 @@
+# managed-reuse-certification Specification
+
+## MODIFIED Requirements
+
+### Requirement: Documentation matches shipped reuse
+Cache documentation SHALL state exactly which artifacts managed cross-revision
+reuse applies to — completed answers under the schema/dependency frontier and
+exact scan-response prefixes under the singleton relation frontier — the
+exact writer contract each depends on, and the status of its formal proof.
+Documentation MUST state that no denotation, projection-tier, or
+plan-node-segment reuse exists, and MUST NOT describe such reuse as merely
+disabled.
+
+#### Scenario: Doc/behavior audit
+- **WHEN** the cache documentation is compared against the implemented resolution and fetch layers
+- **THEN** every documented reuse rule matches an implemented rule, every implemented cross-revision reuse path is documented, and no retired tier is described as present or as disabled-but-available

--- a/openspec/changes/hierarchical-demand-segment-cache/specs/verified-subproblem-cache/spec.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/specs/verified-subproblem-cache/spec.md
@@ -1,0 +1,50 @@
+# verified-subproblem-cache Specification
+
+## MODIFIED Requirements
+
+### Requirement: Cache values denote complete immutable subproblems
+The cache SHALL store only values of three kinds, each equal to a complete
+artifact on one selected immutable graph or validity scope: completed answers
+(fully prepared public results), latest progress checkpoints (complete
+quiescent reducer states for one exact execution identity), and exact
+scan-response prefixes (ascending prefixes of one adapter scan reply under a
+complete validity scope; see `exact-scan-response-cache`). It MUST NOT publish
+call-stack-dependent recursion guards, partial worklists, partially rendered
+pages, reducer emissions, plan-node segments, composed multi-hop results, or
+traversal-order-dependent state as reusable subproblem answers. Complete
+anchored denotations are no longer a cache artifact.
+
+#### Scenario: Recursive traversal stops at a page boundary
+- **WHEN** a recursive page returns before its anchored reachable worklist is exhausted
+- **THEN** the engine may retain its latest checkpoint and the exact scan replies it fetched, but does not publish any denotation or emitted-sequence artifact
+
+#### Scenario: Scan reply retained without its context
+- **WHEN** a request fetches a chunk of one relation scan
+- **THEN** the retained prefix carries no admission state, no start-set identity, and no demand, and is served only as the adapter's exact reply
+
+### Requirement: Recursive caching refines least-fixed-point semantics
+Request-local and shared recursive evaluation SHALL compute the same least
+fixed point as the cache-free positive ReBAC semantics. False results derived
+under a non-empty DFS visited set MUST NOT be treated as context-free cached
+answers.
+
+#### Scenario: Cycle becomes reachable through another rule
+- **WHEN** a recursive state is first encountered through a cyclic path and later receives a grant through a different rule
+- **THEN** the fixed-point evaluator includes the grant and no earlier cycle guard can suppress it
+
+#### Scenario: Cached scan reply inside a recursive walk
+- **WHEN** a recursive traversal's scan is answered from an exact scan-response prefix
+- **THEN** the traversal admits, orders, and terminates exactly as it would reading the same values from the adapter
+
+## REMOVED Requirements
+
+### Requirement: Shared-subgraph cache exceeds the completed-answer baseline
+**Reason**: The gate measured the retired denotation tier (`:denotation-hits`,
+`:acyclic-denotation-hits`), whose producing engine and benchmark were
+removed; the counters are permanently zero. The replacement gate is the
+adoption requirement of `exact-scan-response-cache` (elided commands, miss-page
+latency, cold overhead, oracle equality).
+
+**Migration**: `formal/verification/performance-gates.edn` entries asserting
+denotation hits are retired; the new gate records elided adapter commands and
+latency deltas per backend.

--- a/openspec/changes/hierarchical-demand-segment-cache/tasks.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/tasks.md
@@ -1,0 +1,87 @@
+# Tasks: Exact Scan-Response Cache
+
+Supersedes `review/original-tasks.md`. Nothing from the original list is
+carried over unchanged; the design it implemented was rejected
+(`review/REVIEW.md`).
+
+## 0. Prerequisite change (separate change, blocks §7 gate) — `fix-datomic-plan-cache-thrash`
+
+- [ ] 0.1 `eacl.datomic.impl/with-request-engine`: build the engine adapter with the client's `:source-lifecycle`/`:source-scope` (or reuse the selected adapter) so `eacl.engine.v8/stable-plan` keys stop varying per request; add a regression test asserting the plan cache holds one entry per (source, schema generation, root) across repeated requests
+- [ ] 0.2 Key `stable-plan` by schema generation instead of native revision + lifecycle (the plan is a pure function of schema definitions); keep lifecycle in the key only if a caller-fixed lifecycle can span schema histories — decide and document
+- [ ] 0.3 Move the per-request `eacl.datomic.schema/read-schema` performed by `spiceomic-lookup-resources`'s `prepare` (and siblings) into the schema-generation cache; add an op-count regression test (zero `read-relations`/`read-permissions` on a warm client)
+- [ ] 0.4 Replace the per-request `verified-kernel/kernel?` reflective check with a cached predicate; avoid rebuilding the snapshot adapter more than once per request
+- [ ] 0.5 Re-baseline `docs/benchmarks` for `can?` and `lookup-resources` miss/hit on all three backends after 0.1–0.4 (expected: Datomic miss page 2.4–6.6× faster, `can?` ~5×)
+
+## 1. Spec and contract
+
+- [ ] 1.1 Land the delta specs in `specs/` (new `exact-scan-response-cache`; MODIFIED `bounded-physical-execution`, `verified-subproblem-cache`, `managed-reuse-certification`, `demand-bounded-evaluation`) and sequence archiving after `adopt-stable-discovery-enumeration` (or fold the `bounded-physical-execution` deltas into it)
+- [ ] 1.2 Write the short-chunk rule ("fewer than `:limit` ⇒ exhausted") into the fetch contract docs (`docs/stable-discovery-engine.md`) and the SPI docstrings of `eacl.engine.physical` and `eacl.engine.stable-reducer/fetch-values`
+- [ ] 1.3 Define config: `:scan-cache {:enabled? false :max-weight (* 8 1024 1024) :max-prefix 1024}` under the client cache map; deprecate `:denotation-max-weight` (accepted + warning for one release, then `:eacl/invalid-config`)
+
+## 2. Store and fetch layer (`eacl.engine.scan-cache`, CLJC)
+
+- [ ] 2.1 Key: `{:scope {...} :descriptor {...}}` per design; canonical value equality; precomputed hash
+- [ ] 2.2 Entry: immutable `{:prefix :exhausted? :weight :touched}`; `serve` with binary search on the exclusive bound; `deposit` with the contiguity rules (start-anchored, bound within prefix, bound = last)
+- [ ] 2.3 Store: `ConcurrentHashMap`, `merge` with longer-prefix-wins, `LongAdder` metrics, racy `touched` tick, sampled recency eviction to weight budget, per-entry cap; `clear!`; `stats`
+- [ ] 2.4 `caching-fetch-fn`: wraps the retrying/classified fetch-fn; hit path allocation-free apart from the reply vector; misses forward the identical command; failures deposit nothing
+- [ ] 2.5 Property tests: served reply == `Chunk(values, offset, limit)` for random sequences, bounds, limits, prefix lengths, exhausted flags; extension preserves prefix-ness; concurrent merges keep a valid prefix
+
+## 3. Engine and client integration
+
+- [ ] 3.1 `eacl.engine.v8/stable-fetch-fn`: wrap with `caching-fetch-fn` when a scan-cache context `{:store :scope :proof-frame}` is bound; unchanged otherwise
+- [ ] 3.2 Per-scan stamp: `proof-frame/subset-descriptor` on the relation id from the request's complete frame; nil ⇒ plain fetch for that scan; count `:scan-stamp-unavailable`
+- [ ] 3.3 Datomic client (`eacl.datomic.core`): create the store per client lifecycle; bind the context only on managed-eligible current-snapshot compute paths (never in `resolve-exact!`, `:cache? false`, `no-cache`, historical/filtered/speculative selections); `expire-cache!` swaps it
+- [ ] 3.4 Datahike/DataScript client (`eacl.client.orchestration`): same binding discipline; CLJS build compiles (no JVM-only classes on the CLJC path — provide a CLJS store shim or gate the tier to CLJ)
+- [ ] 3.5 `can?`, `count-*`, `lookup-subjects` reach the same seam automatically; add tests that reverse scans are shared across subjects checking one resource
+
+## 4. Metrics and observability
+
+- [ ] 4.1 `cache-stats` gains `:scan-cache {:hits :misses :elided-commands :extensions :deposits :evictions :weight :entries :stamp-unavailable}` on all three clients
+- [ ] 4.2 `*recursive-traversal-stats*`/`:adapter-attempts` keep counting only real transport attempts; document that `:advanced-datoms` counts served values too (limit semantics unchanged)
+
+## 5. Tests — correctness
+
+- [ ] 5.1 Differential: cache-on vs `:cache? false` on randomized graphs (forward/reverse pages, all page sizes, `:after`/`:before`, counts, `can?`), all three backends, asserting equal results, cursors, has-next, and command-multiset subset with equal replies
+- [ ] 5.2 Concurrency: N threads mixing reads with interleaved supported writes (create/delete relationships, `delete-object!`, `write-schema!`); oracle equality at every step; no stale-stamp reuse
+- [ ] 5.3 Mutation controls (each must fail the gate): short prefix served without exhaustion; values ≤ bound served; stale relation stamp reused; widened limit or moved bound on miss; fragment deposited without its start
+- [ ] 5.4 Width/retention invariance test (`stable_reducer_test/physical-width-and-retention-invariance-test`) extended with the caching fetch-fn in the loop, chunk sizes {1,2,7,64}, caps {0,1}, cold and warm store
+- [ ] 5.5 Limits: `:max-advanced-datoms` trips at the same transition with every scan served from cache
+- [ ] 5.6 Bypass/eligibility: `:cache? false`, `no-cache`, `at-exact-snapshot`, `as-of`, filtered db, incomplete proof, relation outside closure ⇒ no lookup, no deposit
+- [ ] 5.7 Regression: checkpoint, cursor, coherence, and cache-vs-bypass suites unchanged
+
+## 6. Formal
+
+- [ ] 6.1 New Dafny leaf `formal/stable-discovery/ScanResponseCache.dfy`: `Serve`/`Extend` over a prefix of one fixed sequence; lemmas `ServedReplyIsExactChunk`, `ExtendPreservesPrefix`, `ExhaustedMeansComplete`; register in `verify-fast.sh` and update the obligation count
+- [ ] 6.2 `ScalarFrontierCoherence.dfy`: `SingletonFrontierIsRelationGeneration`; a covered-singleton reuse lemma not requiring equal full dependency vectors
+- [ ] 6.3 Adapter certification: assert (all three adapters) that `subject->resources`/`resource->subjects` for relation `r` are unchanged by supported mutations of other relations and change only with `r`'s generation
+- [ ] 6.4 Update `formal/verification/subproblem-cache.edn` (`:represented-entry-kinds` gains `:exact-physical-response-prefixes`), `assurance-matrix.edn`, `execution-contract.edn` (drop the deleted `completed-denotation-public-order` / `recursive-denotation-key` symbols), and `ASSURANCE_COVERAGE.md`
+- [ ] 6.5 Certify: verified status for the tier only after 6.1–6.4 are green and 5.3 mutants are red
+
+## 7. Benchmarks and gate
+
+- [ ] 7.1 Promote `review/bench/seg_bench.clj` into `^:benchmark` tests: Fixture A (accounts), Fixture B (sparse shared groups), hot-resource `can?`; Datomic, Datahike `:file`, DataScript
+- [ ] 7.2 Record elided-command ratio, p50/p95 miss-page latency cache-on vs off, cold-overhead delta, allocation per page; write results to `docs/benchmarks/results/`
+- [ ] 7.3 Gate per `exact-scan-response-cache` adoption requirement; default-on only when it passes on every backend
+
+## 8. Cleanup — remove retired cache mechanisms
+
+- [ ] 8.1 `eacl.subproblem-cache`: drop `:denotation` from `known-tiers`, its budget/state/ceiling code, `:denotation-hits`, `:acyclic-denotation-hits`, `:recursive-component-hits`, `:managed-denotation-hits`, `:fetched-projection-values`; keep `:denotation-max-weight` as a warned no-op for one release
+- [ ] 8.2 `eacl.engine.v8`: remove `direct-match-datoms-in-relationship-index` (no src caller) and the stale `:denotation-key-builds`/`:denotation-dependency-calcs` docstring keys; decide the fate of `:complete-denotation` evaluation mode (adopt-stable task 8.3) and either keep it as the explicit exhaustive-`:last` opt-in with new wording or replace it with a typed error
+- [ ] 8.3 `eacl.datomic.core` docstrings and `docs/cache.md`, `docs/v8-subproblem-cache.md`, `docs/stable-discovery-engine.md`: remove "denotation"/"projection tier accepted but unused" language; document the scan-response cache and its config
+- [ ] 8.4 Formal artefacts: retire `formal/dafny/SubproblemCache.dfy` `RecursiveDenotationKey` sections, `RootDenotation.dfy`/`IndexedRootDenotation.dfy` manifest pins, `formal/tla/EaclTieredSubproblemCache.tla` denotation budget, mutants `:partial-denotation-hit`/`:coupled-tier-budgets`, performance-gate entries asserting denotation hits; re-pin the manifest
+- [ ] 8.5 Retire `eacl.engine.portable-indexed` (CLJS twin) by wrapping the decision kernel directly in `production_kernel_cljs.cljs`; remove `IndexedTraversalKernel` traversal methods with no callers
+- [ ] 8.6 Reconcile stale specs: `managed-reuse-certification` (delta here), `nonblocking-cache-coordination` projection wording (already REMOVED by adopt-stable), `verified-subproblem-cache` shared-subgraph gate (delta here)
+- [ ] 8.7 Remove `exploration/stable-discovery/source_benchmark.clj` or fix its references to deleted vars; move `CacheBoundary.dfy` from exploration-only status into the release leaf set if it is cited as justification
+
+## 9. Documentation and rollout
+
+- [ ] 9.1 `docs/cache.md`: new "Scan-response cache" section (unit, scope, elide-only rule, config, metrics, what it is not); update the cache-layers table
+- [ ] 9.2 Release notes: prerequisite fix (Datomic plan-cache thrash), scan-response cache (default off → on after gate), deprecated `:denotation-max-weight`
+- [ ] 9.3 Optional: rename the change directory to `exact-scan-response-cache`
+
+## 10. Out of scope (explicit non-tasks)
+
+- [ ] 10.1 Any reducer-emission, plan-node, composed, or hierarchical segment cache
+- [ ] 10.2 Answer-level page-size prefix reuse
+- [ ] 10.3 Cross-process or storage-layer caching changes
+- [ ] 10.4 Time-travel reuse

--- a/openspec/changes/membership-probe-point-check/.openspec.yaml
+++ b/openspec/changes/membership-probe-point-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/membership-probe-point-check/README.md
+++ b/openspec/changes/membership-probe-point-check/README.md
@@ -1,0 +1,3 @@
+# membership-probe-point-check
+
+Replace the reverse-enumeration point check with an O(intermediates) membership-probe evaluator over the sealed plan (denied checks on popular resources are currently linear in subject count)

--- a/openspec/changes/membership-probe-point-check/design.md
+++ b/openspec/changes/membership-probe-point-check/design.md
@@ -1,0 +1,63 @@
+# Design: Membership-Probe Point Check
+
+## Approach
+
+`eacl.engine.stable-route/check-eids` = `probe-check-eids`, an iterative
+depth-first search over `(get-in plan [:indexes :reverse-rules])`:
+
+```
+stack ← [[root resource-eid]]; visited ← #{}
+loop: pop [node eid]; count a visit; run cut-point!; skip if visited; mark
+  1. for each :relation rule at node whose subject-type = requested type:
+       probe (eid, relation) — fetch {:bound-eid (dec subject-eid) :limit 1};
+       hit iff first value = subject-eid → return true
+  2. successors in plan order:
+       :self-permission   → push [target-node eid]
+       :arrow-permission  → for I in intermediates(eid, via, intermediate-type): push [target-node I]
+       :arrow-relation    → for I in intermediates(...): probe (I, target-relation) → true on hit
+     push successors reversed (canonical order); enforce :max-stack
+stack empty → false
+```
+
+Reads go through the routed `fetch-fn` (same descriptor shape as the
+reducer's `resource->subjects` scans), so classification, retry, and
+`:adapter-attempts` telemetry apply unchanged; intermediates are fetched in
+`physical-chunk-size` chunks until a short chunk. Counters
+`{:admissions :transitions :commands :fetched-values}` mirror the reducer's
+and are reported to `eacl.engine.stable-reducer/*observer-stats*` under the
+public names. Limit failures use the reducer's `:eacl.reducer/limit-exceeded`
+shape with the budget key so `with-public-limit-errors` maps them.
+
+## Correctness argument
+
+Let G be the rule graph over states (node, entity). The reducer's reverse
+run emits subject U iff there is a derivation from (root, R) to a base tuple
+containing U — that is, iff a path exists in G from (root, R) to a state
+whose direct rule holds a tuple with U (or an arrow-relation whose
+intermediate holds one). Depth-first search with a visited set is complete
+for reachability in finite graphs (a state pruned as visited was, or will
+be, fully explored from its first visit); base tuples are decided exactly by
+the ordered-scan obligations (`:strict-order :unique :inclusive-exclusive-
+bounds`): the first value strictly after `U − 1` is `U` iff `U` is present.
+The reducer's admission dedup keys (target node + entity) coincide with the
+visited set, so the explored state space is the same set the reducer
+admits; only the leaves are probed rather than enumerated.
+
+## Alternatives rejected
+
+- Forward search from the subject: linear in the subject's grants (a
+  super-user with 110k servers).
+- Bidirectional meet-in-the-middle: unnecessary once leaves are probes;
+  keep as a future heuristic for resources with very high intermediate
+  fan-in.
+- A dedicated `:tuple-exists?` SPI op: not needed — the existing bounded
+  scan is an exact probe; may be added later for adapters where a seek is
+  costlier than a point lookup.
+
+## Follow-ups
+
+- Dafny leaf stating probe-search membership = reverse-denotation membership
+  (bridge: `BidirectionalReachability.ReverseLookupEqualsForwardAuthorization`).
+- The `:raw-can` op-count envelope (`recursive-op-count-envelopes.edn`)
+  still holds (probes are scans); re-record if a fixture's probe count
+  exceeds the recorded `:maximum-backend-scans`.

--- a/openspec/changes/membership-probe-point-check/proposal.md
+++ b/openspec/changes/membership-probe-point-check/proposal.md
@@ -1,0 +1,84 @@
+# Proposal: Membership-Probe Point Check
+
+## Why
+
+The stable-discovery engine answered `can?` by running the reverse reducer
+from the resource and stopping at the subject's first admission
+(`eacl.engine.stable-route/check-eids`). That is correct, but its cost is
+linear in the number of subjects that hold the permission: every subject
+that sorts before the checked one is enumerated, and a *denied* check
+enumerates all of them. Measured (2026-08-18, in-memory Datomic, one
+account with 5,000 owners): denied `can?` **16.3 ms** (5,009 admissions,
+10,009 transitions, 83 scans); allowed `can?` for the highest-eid owner
+**12.9 ms**; on the live 110k-server demo (`eacl-datomic-solidjs`, warm
+peer) a denied check spent ~65 % of its post-plan-fix time in the reverse
+walk (13 scans, 25 transitions, ~110 µs raw). Any deployment with popular
+resources (a document shared with an organisation, an account with
+thousands of members) pays this on the hottest path in the API.
+
+A point check does not need stable order — only a Boolean. Membership can
+be decided by *probing* the subject with one exact-bound scan (limit one,
+exclusive bound `subject-eid − 1`: the first value equals the subject iff
+the tuple exists), enumerating only the intermediates a resource reaches
+(its account, its teams, its vpc — typically a handful). This is the
+classic ReBAC check (Zanzibar/SpiceDB "check" semantics) expressed over
+EACL's sealed plan.
+
+## What Changes
+
+- `eacl.engine.stable-route/check-eids` becomes an iterative depth-first
+  membership search over the sealed plan's reverse index:
+  `:relation` rules for the subject type → one exact-bound probe;
+  `:self-permission` → descend on the same entity; `:arrow-permission` →
+  enumerate intermediates, descend; `:arrow-relation` → enumerate
+  intermediates, probe each. Visited set on `[node eid]`; base tuples first,
+  arrows second; explicit stack (no recursion depth limit).
+- Same read seam and budgets as the reducer: probes and enumerations go
+  through the routed `fetch-fn` (classification, retry, telemetry);
+  `:max-admissions` bounds visited states, `:max-transitions` visits,
+  `:max-commands` fetches, `:max-values` fetched values, `:max-stack` stack
+  depth, all failing with the reducer's typed `:eacl.reducer/limit-exceeded`
+  shape so the public `:eacl.recursive-traversal/limit-exceeded` mapping is
+  unchanged; the cut-point hook runs at every visit; observer counters
+  (`:derived-grants`, `:advanced-datoms`, `:queued-work`) are reported.
+- The reverse-enumeration form is retained as `enumeration-check-eids` —
+  the executable oracle.
+- Public behaviour: identical Booleans; the exception-based early exit is
+  gone (no `ex-info` per allowed check).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `stable-discovery-enumeration`: "Point checks and counts keep
+  operation-appropriate plans" now requires the membership-probe route and
+  bounds its cost by reachable intermediates, never by subject count.
+
+## Evidence
+
+- Differential (probe vs enumeration): 2,680 (subject, server) pairs on the
+  5,000-owner fixture, 6,000 pairs on a 300-user/400-group sparse fixture,
+  4,860 pairs on the live 110k-server database — 0 disagreements; frozen
+  baseline point samples (`eacl.baseline.capture`) all reproduced.
+- Cost: denied check on the popular resource 14.5 ms → 24 µs; allowed
+  high-eid owner 14.1 ms → 11 µs; live demo denied check 67 → 34 µs raw,
+  4,860-pair batch 133 → 44 µs per check; synthetic resource with 1,000,000
+  direct subjects: deny and allow each cost exactly one probe.
+- Tests: `eacl.engine.point-check-test` (baseline differential across six
+  fixtures, O(intermediates) property, limits, cut-point, observer stats,
+  nil ids).
+
+## Non-Goals
+
+- No change to `lookup-subjects`/`count-subjects` (they enumerate by
+  contract), to cursors, or to caching identities.
+- No forward/bidirectional check heuristics in this change (the resource
+  side is enumerated; the subject is always probed).
+
+## Formal obligation (follow-up)
+
+State and check the equivalence "membership-probe search returns true iff
+the subject belongs to the exhaustive reverse-discovery denotation" as a
+Dafny leaf next to `formal/stable-discovery/BidirectionalReachability.dfy`
+(`ReverseLookupEqualsForwardAuthorization` is the bridge). Until then the
+oracle differential and the frozen baselines are the evidence.

--- a/openspec/changes/membership-probe-point-check/specs/stable-discovery-enumeration/spec.md
+++ b/openspec/changes/membership-probe-point-check/specs/stable-discovery-enumeration/spec.md
@@ -1,0 +1,31 @@
+# stable-discovery-enumeration Specification
+
+> This delta targets a requirement introduced by the in-progress
+> `adopt-stable-discovery-enumeration` change; archive that change first or
+> fold this delta into it. The header text matches its requirement name.
+
+## MODIFIED Requirements
+
+### Requirement: Point checks and counts keep operation-appropriate plans
+
+Point authorization MUST remain anchored to the known subject and resource; it MUST NOT enumerate the root universe to answer one known-resource question, and it MUST NOT enumerate the subjects that hold the permission either. A point check SHALL be decided by a membership-probe search over the sealed plan's reverse index: direct relation rules for the subject's type are decided by one exact-bound probe (the scan strictly after `subject − 1` with limit one equals the subject iff the tuple exists), self-permission rules descend on the same entity, arrow rules enumerate only the resource's intermediates and then probe or descend, with a visited set on [node entity]. Its Boolean MUST equal membership of the subject in the exhaustive reverse-discovery denotation. Its cost is bounded by the number of reachable intermediates and the reducer budgets (`:max-admissions` visited states, `:max-transitions` visits, `:max-commands` fetches, `:max-values` fetched values, `:max-stack` depth), which fail typed exactly like the reducer's. Exact count MUST exhaust the exact history-free stable-discovery reducer by default; its result equals the cardinality of the complete denotation. Count MAY use an order-insensitive specialization only if that route is independently proven equal to the lookup denotation. Stable discovery order is required for paginated enumeration, not for internal aggregation.
+
+#### Scenario: Point authorization
+
+- **WHEN** the caller asks whether one known resource is authorized
+- **THEN** EACL does not enumerate unrelated roots merely to reuse the forward page engine
+
+#### Scenario: Popular resource
+
+- **WHEN** a resource has one million direct subjects and the caller checks a subject that is not among them
+- **THEN** the check issues one probe for that relation and does not enumerate the subjects
+
+#### Scenario: Probe equals the reverse denotation
+
+- **WHEN** the same subject and resource are checked by the membership-probe search and by exhaustive reverse discovery
+- **THEN** both return the same Boolean
+
+#### Scenario: Exact count specialization
+
+- **WHEN** a backend-specific count route is selected
+- **THEN** its returned count equals the cardinality of the complete stable-discovery denotation

--- a/openspec/changes/membership-probe-point-check/tasks.md
+++ b/openspec/changes/membership-probe-point-check/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Membership-Probe Point Check
+
+## 1. Engine
+- [x] 1.1 `probe-check-eids` in `eacl.engine.stable-route`; `check-eids` routes to it; nil ids never hold
+- [x] 1.2 Reducer budgets (`:max-admissions/:max-transitions/:max-commands/:max-values/:max-stack`), typed `:eacl.reducer/limit-exceeded` with the budget key, cut-point per visit, observer counters
+- [x] 1.3 Reads through the routed fetch-fn (classified/retried/telemetry), chunked intermediate enumeration
+- [x] 1.4 Keep `enumeration-check-eids` as the oracle
+
+## 2. Tests
+- [x] 2.1 `eacl.engine.point-check-test`: probe = enumeration on six frozen baselines (all principals × up to 200 resources + frozen point samples)
+- [x] 2.2 O(intermediates) property: 1,000,000 direct subjects, deny/allow cost one probe each
+- [x] 2.3 Limits, cut-point, observer stats, nil ids
+- [x] 2.4 Existing suites (`physical_route_test/anchored-point-check-test`, differential and contract suites) pass in a fresh JVM
+- [ ] 2.5 Add a randomized cache-vs-bypass differential that includes popular resources (thousands of direct subjects) on all three backends
+
+## 3. Formal
+- [ ] 3.1 Dafny leaf: probe-search membership equals reverse-denotation membership; register in `verify-fast.sh` and the assurance matrix
+- [ ] 3.2 Update `docs/stable-discovery-engine.md` and `docs/formal-verification.md` (point-check route)
+
+## 4. Docs
+- [x] 4.1 `stable-route` namespace docstring
+- [ ] 4.2 Release notes: `can?` cost no longer scales with subject count


### PR DESCRIPTION
## Summary

Two prerequisite changes that came out of the adversarial review of `openspec/changes/hierarchical-demand-segment-cache` (the review record and the rewritten, now gated, scan-response-cache proposal are in that change directory):

**`fix-datomic-request-overhead`**
- Sealed-plan cache keyed by source scope + lifecycle + **schema generation identity** (no native revision, no proof-frame op); the Datomic raw facade stops minting a random lifecycle per call and passes its direct schema-version read as `:schema-identity`, so plans are reused across raw calls and unrelated transactions instead of being re-sealed on every request; `expire-plans!` wired into both clients' `expire-cache!`.
- `seal-plan` encodes each rule/node once (was 368 canonical encodings for a 16-rule plan; fingerprint and plan byte-identical).
- Request validation on the miss path from the client's per-generation parsed schema; cache hits read no schema; unstamped databases keep reading directly; typed errors unchanged.
- `verified-kernel/kernel?` memoizes classes known to satisfy `DecisionKernel`.

**`membership-probe-point-check`**
- `stable-route/check-eids` is an iterative membership-probe search over the sealed plan's reverse index (direct rules: one exact-bound probe; arrows: enumerate only intermediates), visited set on `[node eid]`, reducer budgets/typed limits, cut-point, observer counters. Cost is bounded by reachable intermediates, never by the number of subjects holding the permission. The reverse-enumeration form is retained as `enumeration-check-eids` (test oracle).

## Measured (eacl-datomic-solidjs, 110k servers, warm `datomic:dev://` peer, medians)

| operation | before | after |
|---|---|---|
| `check-permission` miss (denied) | 6.0 ms | 142 µs |
| `check-permission` hit | 383 µs | ~80–100 µs |
| `lookup-resources :first 20` miss | 5.6 ms | ~490 µs |
| denied `can?` on a 5,000-owner resource (in-memory fixture) | 16.3 ms | 24 µs |

## Verification

- Fresh-JVM CI battery: 663 tests / 26,879 assertions, 0 failures; DataScript CLJS build: 199 tests / 7,411 assertions, 0 failures; source-closure ledger regenerated.
- Probe check vs reverse-enumeration oracle: 0 disagreements over six frozen baselines, 8,680 fixture pairs and 4,860 live pairs; new `eacl.engine.point-check-test`.
- **Formal status (honest):** no Dafny/TLA sources changed, so existing proofs stand, but nothing new is mechanically proven — the probe/enumeration equivalence is an open Dafny obligation (recorded in the change), the plan-cache key rests on "a sealed plan is a pure function of schema definitions" (documented + tested), and `bin/formal verify` was not run locally; CI's formal workflow will run it here.

## Not in this PR
- The exact scan-response cache stays proposed and gate-decided (no measurable gain for lookup pages on a warm Datomic peer).
- Reducer constant factor (~3 µs/transition; exhaustive 110k count ≈ 2 s) and union-arm subsumption — recorded as follow-ups.