### PR TITLE
Compare the probe-check sentinel by value for ClojureScript

### DIFF
--- a/modules/eacl/src/eacl/engine/stable_route.cljc
+++ b/modules/eacl/src/eacl/engine/stable_route.cljc
@@ -177,7 +177,9 @@
                            successors))
                        []
                        rules)]
-                  (if (identical? ::found outcome)
+                  ;; Value comparison, not `identical?`: ClojureScript keyword
+                  ;; literals are not interned objects.
+                  (if (= ::found outcome)
                     (do (report!) true)
                     (let [stack (into stack (rseq outcome))]
                       (when (> (count stack) max-stack)


### PR DESCRIPTION
One-line CLJS portability fix for #131: `identical?` on a keyword literal is false in ClojureScript, so an allow found through an arrow-relation rule fell through to `rseq` on the sentinel and failed the CLJS parity + DataScript suites on main (Tests run 32179360592, Formal run 32179363841). Value comparison is identical on the JVM.

Verification: clean CLJS build 203 tests / 7,428 assertions green; fresh-JVM battery 663 / 26,879 green.