### PR TITLE
Deploy v8 Clojars: main → v8.0.0-SNAPSHOT (shared-client validation-on-miss, investigation report)

### DIFF
--- a/docs/reports/2026-08-19-hierarchical-cache-investigation.md
+++ b/docs/reports/2026-08-19-hierarchical-cache-investigation.md
@@ -1,0 +1,160 @@
+# The hierarchical demand-segment cache investigation (2026-08-18/19)
+
+Status: closed. What started as an adversarial review of the
+`hierarchical-demand-segment-cache` proposal ended with that design rejected,
+two unrelated but far larger performance defects found and fixed on all
+three backends, the point-check route replaced, a new Dafny leaf, and the
+`8.0.0-SNAPSHOT` deployed to Clojars (build 6, 2026-08-18T22:23Z). This
+report is the durable record for future optimization work: what was
+measured, what was decided, what shipped, and what is still on the table.
+
+## Artefacts
+
+| Kind | Where |
+|---|---|
+| The reviewed change (rewritten) | [`openspec/changes/hierarchical-demand-segment-cache/`](../../openspec/changes/hierarchical-demand-segment-cache/) — [proposal](../../openspec/changes/hierarchical-demand-segment-cache/proposal.md), [design](../../openspec/changes/hierarchical-demand-segment-cache/design.md), [tasks](../../openspec/changes/hierarchical-demand-segment-cache/tasks.md), delta specs under [`specs/`](../../openspec/changes/hierarchical-demand-segment-cache/specs/) (`exact-scan-response-cache`, `bounded-physical-execution`, `verified-subproblem-cache`, `demand-bounded-evaluation`, `managed-reuse-certification`) |
+| Review record + REPL harness | [`review/REVIEW.md`](../../openspec/changes/hierarchical-demand-segment-cache/review/REVIEW.md), [`review/bench/seg_bench.clj`](../../openspec/changes/hierarchical-demand-segment-cache/review/bench/seg_bench.clj), the original proposal/design/tasks under `review/original-*.md` |
+| Shipped changes | [`fix-datomic-request-overhead`](../../openspec/changes/fix-datomic-request-overhead/) (PRs [#131](https://github.com/theronic/eacl/pull/131), [#135](https://github.com/theronic/eacl/pull/135)), [`membership-probe-point-check`](../../openspec/changes/membership-probe-point-check/) (PRs [#131](https://github.com/theronic/eacl/pull/131), [#132](https://github.com/theronic/eacl/pull/132), [#133](https://github.com/theronic/eacl/pull/133)) and its delta spec [`specs/stable-discovery-enumeration/spec.md`](../../openspec/changes/membership-probe-point-check/specs/stable-discovery-enumeration/spec.md); deploy PR [#134](https://github.com/theronic/eacl/pull/134) |
+| Formal | [`formal/stable-discovery/MembershipProbeCheck.dfy`](../../formal/stable-discovery/MembershipProbeCheck.dfy) (in `verify-fast.sh`, 528 obligations); [`docs/formal-verification.md`](../formal-verification.md) |
+| Engine docs | [`docs/stable-discovery-engine.md`](../stable-discovery-engine.md) (point checks), [`docs/cache.md`](../cache.md) (cache layers table) |
+
+## 1. What the proposal claimed and why it was rejected
+
+The proposal ([original](../../openspec/changes/hierarchical-demand-segment-cache/review/original-proposal.md))
+asserted that "repeated multi-hop walks remain the dominant cost" and
+proposed a hierarchical tier of per-plan-node "segments" keyed by start-set
+fingerprint and demand, composed across levels.
+
+Findings (details and citations in
+[REVIEW.md](../../openspec/changes/hierarchical-demand-segment-cache/review/REVIEW.md)):
+
+1. **The premise was unmeasured and, on Datomic, false.** No benchmark in
+   the repo compared super-user and normal-user visibility; the one artefact
+   showing "walks dominate" was a deleted benchmark on the retired engine
+   under opt-in `:complete-denotation`. Measured on an in-memory Datomic
+   peer, the whole reducer walk of a `:first 20` page was 90–120 µs and the
+   3–5 adapter scans ~11 µs each, inside a 1.4–2.8 ms miss page.
+2. **Level-k composition is unsound for the stable reducer.** Emissions
+   under a plan node depend on the request's *global* admission set, so
+   context-free node segments cannot be substituted into stable enumeration
+   — precisely the counterexample that retired the previous denotation tier
+   (`CacheBoundary.dfy`, `ContextFreeDenotationIsNotAStableTrace`).
+   "Demand" is not a per-node quantity (only root grants consume `target`),
+   and exact start-set fingerprints defeat the sharing the proposal wanted.
+3. **The sound kernel is an exact scan-response prefix cache** at the
+   `fetch-fn` seam (elide-only, keyed by read descriptor + the scanned
+   relation's generation) — essentially the retired projection tier, which
+   the stable-discovery change had cut as "purely accelerative". Measured
+   honestly it removes 94–100 % of adapter commands on sparse high-sharing
+   shapes with oracle-identical results, but on a warm Datomic peer forward
+   scans cost 2–10 µs, and the prototype's hit path cost about the same:
+   **no measurable gain for lookup pages** (156 vs 159 µs/page at 74 %
+   hits). It helped only tiny-scan reverse walks (55 → 25 µs), which the
+   probe check (below) made moot. It stays proposed and gate-decided,
+   primarily for Datahike/remote stores. Two constraints for anyone building
+   it: the fetch contract "chunk shorter than `:limit` ⇒ exhausted" is
+   load-bearing (`stable_reducer.cljc/fetch-values`) and was written in no
+   spec until this change's delta; and the weighted-LRU
+   `eacl.subproblem-cache` store cannot host a per-scan hot path (1.4 µs per
+   hit single-threaded, ~0.5 M ops/s under eight threads).
+
+## 2. What was actually slow (live demo, 110k servers, warm `datomic:dev://` peer)
+
+Profiling the running `eacl-datomic-solidjs` demo (not a fixture) found the
+real costs, none of them traversal:
+
+| cause | share of a `check-permission` miss | fix |
+|---|---|---|
+| Sealed-plan cache thrash: `stable-plan` keyed by lifecycle + native revision; the Datomic raw facade minted a random lifecycle per call, so `seal-plan` (~4.3 ms on the 16-rule demo schema) reran on **every request** | ~80 % | key by schema generation identity; process-stable facade lifecycle; `expire-plans!` |
+| `seal-plan` itself: `sort-by encode-canonical` re-encoded and re-validated rules on every comparison (368 encodings for 16 rules) | most of the seal | encode once |
+| `read-schema` on every request (all relations + permissions via `d/q` + `pull`) to validate three keywords | ~35–40 % of what remained | validate on the miss path from a per-generation parsed schema; hits read nothing (Datomic client in #131, Datahike/DataScript client in #135) |
+| `verified-kernel/kernel?` = `satisfies?` on an `extend`ed class, 3–4× per request | ~14 % of a hit | positive-class memo |
+| **`can?` was O(#subjects holding the permission)**: reverse enumeration with early exit; a denied check on a 5,000-owner account cost **16 ms** | traversal share of a fixed check | membership-probe search, O(intermediates) |
+
+Live results (medians): `check-permission` miss **6.0 ms → 142 µs**, hit
+383 → ~80–100 µs; `lookup-resources :first 20` miss **5.6 ms → ~490 µs**,
+hit 614 → ~250–330 µs; popular-resource denied check 16.3 ms → 24 µs
+(fixture). Shared client: DataScript `can?` hit 200 → 133 µs, Datahike
+187 → 104 µs after #135. Through the demo's HTTP layer: check ~0.7–1.0 ms
+(was 9.1 ms average), page ~2.5–3.9 ms (was 13.2 ms).
+
+## 3. Correctness and formal status
+
+- The probe check equals the reverse-enumeration oracle on six frozen
+  baselines, 8,680 fixture pairs and 4,860 live pairs (0 disagreements);
+  `eacl.engine.point-check-test` is the executable evidence, registered in
+  `formal/verification/execution-contract.edn`.
+- `MembershipProbeCheck.dfy` proves, over the `StableReducer` program model
+  with leaf result nodes, that the probe answer equals reverse-denotation
+  membership (`ProbeAnswerEqualsReachability`,
+  `ProbeCheckEqualsEnumerationCheck`); the fast gate is pinned at 528
+  obligations. The plan-cache key rests on "a sealed plan is a pure
+  function of the schema definitions" (documented and tested); `seal-plan`
+  encode-once was asserted fingerprint-identical; validation-on-miss rests
+  on "every cache tier keys by an identity that fixes the schema
+  generation" (argued in the change designs, exercised by the suites).
+- The release manifest still withholds verified status for the same five
+  standing obligations as before; nothing here changed that.
+
+## 4. Loopholes met on the way (worth remembering)
+
+- Keying the global plan cache without the lifecycle let test adapters
+  that alias `{:source-id :test}` share plans across tests; the lifecycle
+  stays in the key, the *random per-call* lifecycle was the bug.
+- A parsed-schema memo keyed by `basis-t` is unsafe under `d/as-of`
+  (the as-of value keeps the current basis); the per-generation memo is
+  correct by construction. Unstamped databases must not latch anything
+  (`schema-basis-test`).
+- The `:raw-can` op envelope pins zero `:proof-frame` reads for raw checks
+  and exact hits promise no generation reads — the plan key must use an
+  identity the caller already knows.
+- `(identical? ::kw …)` is false in ClojureScript (#132); the CLJS suite
+  must be built clean (`-d` to a fresh output dir) to see new code.
+- After **any** public-source edit, regenerate the source-closure ledger
+  (`node bin/public-source-closure.mjs write`); a stale ledger fails
+  `bin/formal source-closure` in CI (it did, on the deploy branch).
+- The Explorer latency gate (`eacl.bench.explorer-enumeration-test`) is
+  host-matched to the recording machine and only meaningful when idle; on a
+  loaded box both old and new code miss it by ~7× (A/B showed no
+  regression, pages faster).
+- Deploying: PR from `main` into `v8.0.0-SNAPSHOT` (branch-local
+  SNAPSHOT-aware release guard), branch protection wants an approving
+  review, and the `clojars` environment needs a manual approval that also
+  holds the release concurrency group — a stale waiting run blocks new ones.
+
+## 5. Remaining opportunities (measured, in priority order)
+
+1. **Reducer constant factor** — ~3 µs per transition on the warm demo
+   (`retain-buffer` rebuilds the sidecar order vector on every release,
+   `schedule` persistent-map churn, `AdmissionKey` allocation). An
+   exhaustive super-user count of 110k servers spends 661k transitions
+   (six per result through the union arms) ≈ 2 s cold; the answer cache
+   serves repeats in ~50 µs. This is the largest remaining engine cost.
+2. **Union-arm subsumption in the sealed plan** — `server.view = admin +
+   account->view + …` with `account.view = admin` re-scans every account's
+   servers through a second arm; pruning subsumed arms halves the walk but
+   changes the order ABI (a deliberate plan-version change with a new
+   fingerprint).
+3. **`secure-format` canonical encode/digest** — ~24 µs per small map;
+   pages spend 2–4 digests in cursor/proof contexts (~27 % of a fixed miss
+   page), cursors are ~1.8 KB.
+4. **Adapter scan realisation** — the lazy `take-while`/`map` chain over
+   `d/seek-datoms` costs several µs per chunk; a tighter chunk realiser
+   would help exhaustive walks (44 % of a cold count).
+5. **Exact scan-response cache** — gate-decided; worth it on Datahike/remote
+   stores and sparse high-sharing schemas, not on a warm Datomic peer; needs
+   a sub-µs hit path (lock-free, `long[]` prefixes) to matter at all.
+6. Demo app: request/response work outside EACL (JSON, cursor tokens)
+   dominates its remaining latency; its redundant EACL semaphore was
+   removed (Jetty bounds concurrency).
+
+## 6. Reproduction
+
+```clojure
+;; from an nREPL started with: clojure -M:dev:nrepl
+(load-file "openspec/changes/hierarchical-demand-segment-cache/review/bench/seg_bench.clj")
+(in-ns 'seg-bench)
+(def conn-a (mem-conn!)) (def acl-a (seed-a! conn-a {:accounts 60 :servers-per-account 40}))
+(bench "can? bypass" #(eacl/can? acl-a {:subject (->user "owner-7") :permission :view :resource (->server "srv-7-3") :cache? false}))
+;; live demo: eacl-solidjs.system/!system on the demo's nREPL; profile with the sampler in the review
+```

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "70b39d51ffba8c8f3465706b20e23ae85ded610e421389de00131ecfc763d734"
+      "sha256": "a21e4619ecda4b7f67a77898f1c33261e3cf68fcfbfacf4fa0c06851dcc5a485"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -137,7 +137,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "d545e894ceec5bcc30751f9d34ad7214e2c9f9814107942115daee679df1cbba"
+      "sha256": "b1f42f574e76081b591b731944b961fd1bfff599f86cbff0d152937adba87b13"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -189,7 +189,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "3df210ed3af842f50c11123b6892c1e8937640c8c8035277860ce4799098ae61"
+      "sha256": "ab5241b2556265ba811b954743a1355b87fbbda800baa27ea30b23facbd34ed3"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -333,9 +333,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1360,
-    "unionInternalDefinitionIdsSha256": "af3b4d81f1bc7f13be29bf099f20d5c69b017abeeb7c528c88efbc747a5edd7a",
-    "unionDefinitionLocationsSha256": "20616de61a25650d89fd4aa920fd7413c598e8d7f117c805494560a132cc958e",
+    "unionInternalDefinitionCount": 1361,
+    "unionInternalDefinitionIdsSha256": "6d87683676144824fb984aa4e1e0f6301b5d6e59aa5e2538aefcdd728abe3bf5",
+    "unionDefinitionLocationsSha256": "c0646778e94d18a8ea27e6eb4fd367d9e1a29b42534476f9ae1cac8aa5ac5262",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,
@@ -434,8 +434,8 @@
         "idsSha256": "75c0ad0273fa5828aca5833652de740c7b968ed2565099995d8ca177fdc1d1b4"
       },
       "modules/eacl/src/eacl/client/orchestration.cljc": {
-        "count": 35,
-        "idsSha256": "a0c946441b76c367c4a8c4a259d64423150d17d3547be862ac92068a10e011ea"
+        "count": 36,
+        "idsSha256": "83570759734f5231360960e92f1f69e6a5b2fa96435eabdf7cadb5c63b44d216"
       },
       "modules/eacl/src/eacl/consistency.cljc": {
         "count": 16,
@@ -1332,8 +1332,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 646,
-      "internalDefinitionIdsSha256": "e23296af60f04a24f065375192d55b7718fbec6c13af9458223b2ad26530ef70",
+      "internalDefinitionCount": 647,
+      "internalDefinitionIdsSha256": "282480d877c2bf4ce276f70e1ff40fdb2bbcdb7068e805feb4dbc9b9887f2d26",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1369,8 +1369,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 595,
-      "internalDefinitionIdsSha256": "87f020e24f1002a4da3b3fd5ddeb68df3907d5bf2305e63e91cf2bd0faee3685",
+      "internalDefinitionCount": 596,
+      "internalDefinitionIdsSha256": "fdd72deabb9761cfc70929e1822cc6c645ab41493fcc7645b2d71acfba043f2a",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1471,8 +1471,8 @@
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 576,
-      "internalDefinitionIdsSha256": "dd199e6da4c42d6dbe8be2d15a2258e37b6b704e42e0102f7a51eeb775c83fc2",
+      "internalDefinitionCount": 577,
+      "internalDefinitionIdsSha256": "b557de79b564f024e77beb41ae58a29fa558f7a994d84786edd0c2dced9391f5",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1506,8 +1506,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 727,
-      "internalDefinitionIdsSha256": "62af23d256faa8af11329a0a20c93a34ec560668f2d9d822d5546a80c79ed7f5",
+      "internalDefinitionCount": 728,
+      "internalDefinitionIdsSha256": "a2cf3026e9e42bb9ee5c058d492f42e7d74c1e8e4f98e4feb419684c3ef63472",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1542,8 +1542,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 601,
-      "internalDefinitionIdsSha256": "670332712e1cc2446b2e4e654e3057337f045a108a60ed9c66dce621daf45284",
+      "internalDefinitionCount": 602,
+      "internalDefinitionIdsSha256": "abf5d75d9da776f2afc69fa71b8a16f22f72447de7083775db2eac182dfa2505",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1577,8 +1577,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 727,
-      "internalDefinitionIdsSha256": "b3e15b79bdbbbba090545441798dab6d91aa525b2c36c14a90e81f62888e8928",
+      "internalDefinitionCount": 728,
+      "internalDefinitionIdsSha256": "766891669032941da4f95ff788285f79cae0386880c8a9bcc4079187326ae1d5",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1613,8 +1613,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 601,
-      "internalDefinitionIdsSha256": "2df96169cd8043de454613f950703ff034271b30a18113fb489bea7e88ded55b",
+      "internalDefinitionCount": 602,
+      "internalDefinitionIdsSha256": "a4c094a9e7ba6e7fda50086101b73e777b5a68bf36ac1e629ecd1be8b391cc23",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1679,8 +1679,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 580,
-      "internalDefinitionIdsSha256": "c595ba4314cc84ec7f62d3c7aa50924ee0fc1bc936337c006ab9d6281a1d5f2a",
+      "internalDefinitionCount": 581,
+      "internalDefinitionIdsSha256": "d9fc3f2848ea4d22e94b051ab7caa0b26f786968a475ae39bc573e46c00c007b",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1778,8 +1778,8 @@
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 561,
-      "internalDefinitionIdsSha256": "a38d1d7cef04bf0faa1d2eda70e4311bc7a88f78acf719a3e310d9db22ace18c",
+      "internalDefinitionCount": 562,
+      "internalDefinitionIdsSha256": "3fc15b366eb4b74ca163051140b086d9a6bd699e05c92b9d1cdfd109dffaf9b9",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1812,8 +1812,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 712,
-      "internalDefinitionIdsSha256": "b0eb35b07224e803037594f32a7d3bdedcb53d39059fce3321b96a7f61c345cc",
+      "internalDefinitionCount": 713,
+      "internalDefinitionIdsSha256": "14cd5b39a1e6b95bd0b108a26123d91396a2fa21002e4a34749e52aa64d9ef43",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1847,8 +1847,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 586,
-      "internalDefinitionIdsSha256": "400645ebad161f746315a47ccd7cccd86d3ff228833bec06804e8b4c7863ae66",
+      "internalDefinitionCount": 587,
+      "internalDefinitionIdsSha256": "0db42e8ca77ca720cf00596601ce6ac345cd240fec185875c53d1501c4fa5012",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1881,8 +1881,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 712,
-      "internalDefinitionIdsSha256": "6b23f4b269ec8af0f8b24977612eaa6e9c038ee3b635518f028ade37a8e4aa17",
+      "internalDefinitionCount": 713,
+      "internalDefinitionIdsSha256": "fb4b3855808fcd410626c72e9c70562f96cfd00af24579f1ab3633abef1e1570",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1916,8 +1916,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 586,
-      "internalDefinitionIdsSha256": "6799b2f3f8c51b8e3e0613aec71ca6fa15a0350cafe070d51322c2b38e8097d6",
+      "internalDefinitionCount": 587,
+      "internalDefinitionIdsSha256": "dff6e24636f2af102d381df0b088e87458aaa9d6ba9f082131cc2e557ba958ef",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -1049,8 +1049,12 @@
   by an identity that fixes the schema generation). Outside a bound
   generation the schema is read from the selected value directly."
   [_opts db]
-  (or (some-> impl.indexed/*schema-cache* :parsed-schema force)
-      (schema/read-schema db)))
+  (let [cache impl.indexed/*schema-cache*
+        slot (:parsed-schema cache)]
+    (if (and slot (some? (:schema-version cache)))
+      (or @slot
+          (reset! slot (schema/read-schema db)))
+      (schema/read-schema db))))
 
 (defn spiceomic-read-relationships
   [conn
@@ -1316,13 +1320,7 @@
         registry (:derived-schema-caches opts)]
     (or (get @registry key)
         (let [created
-              (cond-> (impl.indexed/make-schema-cache db schema-generation)
-                ;; Parsed once per generation for request validation
-                ;; (`request-schema`); equal generations denote equal
-                ;; definition sets. An unstamped database has no
-                ;; generation and must not latch anything.
-                (some? schema-generation)
-                (assoc :parsed-schema (delay (schema/read-schema db))))]
+              (impl.indexed/make-schema-cache db schema-generation)]
           (get (swap! registry
                       #(if (contains? % key)
                          %

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -442,6 +442,26 @@
       (:recursive-traversal-limits opts)}
      {:request-proof-frame (:request-proof-frame opts)})))
 
+(defn- request-schema
+  "The parsed public schema visible in `db`, for validating one request.
+
+  Inside a cached computation the engine binds the client's proof-keyed
+  schema generation (`engine/*schema-cache*`); its `:parsed-schema` slot is
+  read once per generation, so validation costs no schema enumeration and
+  cache hits never read the schema at all (validation runs on the miss
+  path — no entry can exist for a request that failed validation, and every
+  tier keys by an identity that fixes the schema generation). An unstamped
+  database (no schema generation) or an unbound generation reads the schema
+  directly."
+  [api db]
+  (let [cache engine/*schema-cache*
+        slot (:parsed-schema cache)
+        read-schema (get-in api [:schema :read-schema])]
+    (if (and slot (some? (:schema-version cache)))
+      (or @slot
+          (reset! slot (read-schema db)))
+      (read-schema db))))
+
 (defn read-relationships
   [api db
    {:as opts
@@ -457,9 +477,14 @@
          page-query :query}
         (page-context
          opts selection :read-relationships filters nil nil)
-        _ (schema-errors/validate-relationship-read!
-           ((get-in api [:schema :read-schema]) page-db)
-           filters)
+        ;; Schema validation runs on the miss path (inside the bound schema
+        ;; generation) and on the unknown-object short-circuit; a cache hit
+        ;; implies the request validated under an equal schema generation.
+        validate!
+        (fn []
+          (schema-errors/validate-relationship-read!
+           (request-schema api page-db)
+           filters))
         base-filters
         (apply dissoc filters
                [:first :last :after :before :consistency :cache?
@@ -478,9 +503,11 @@
               resource-id (assoc :resource/id resource-eid)))]
     (if (or (and subject-id (nil? subject-eid))
             (and resource-id (nil? resource-eid)))
-      (if (cursor-request? filters)
-        (stale-cursor-anchor! :read-relationships)
-        (assoc relay/empty-page :cached? false :cache-basis nil))
+      (do
+        (validate!)
+        (if (cursor-request? filters)
+          (stale-cursor-anchor! :read-relationships)
+          (assoc relay/empty-page :cached? false :cache-basis nil)))
       (or
        (relay/lookup-visited-page
         adapter cursor-opts :read-relationships filters)
@@ -490,8 +517,10 @@
               (cache/lookup-page-query-identity filters internal-query)
               nil nil
               #(and (map? %) (vector? (:data %)) (map? (:page-info %)))
-              #((get-in api [:impl :read-relationships])
-                page-db internal-query (:decision-kernel cursor-opts)))
+              #(do
+                 (validate!)
+                 ((get-in api [:impl :read-relationships])
+                  page-db internal-query (:decision-kernel cursor-opts))))
              page
              (with-cache-info
                (relay/externalize-relationship-page
@@ -634,19 +663,23 @@
         opts (assoc opts
                     :completed-cache? completed-cache?
                     :snapshot-exact? snapshot-exact?)
-        _ (schema-errors/validate-permission-request!
-           ((get-in api [:schema :read-schema]) selected-db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema api selected-db)
            (or (:request-operation opts) :can?)
            {:resource-type (:type resource)
             :subject-type (:type subject)
-            :permission permission})
+            :permission permission}))
         internal-subject (spice-object->internal selected-db subject)
         internal-resource (spice-object->internal selected-db resource)]
     (if-not (and (:id internal-subject) (:id internal-resource))
-      {:allowed? false
-       :cached? false
-       :cache-basis nil
-       :evaluation (get-in opts [:execution-contract :evaluation])}
+      (do
+        (validate!)
+        {:allowed? false
+         :cached? false
+         :cache-basis nil
+         :evaluation (get-in opts [:execution-contract :evaluation])})
       (let [answer
             (cached-engine-result
              adapter opts :can?
@@ -656,8 +689,10 @@
              (:type internal-resource)
              permission
              boolean?
-             #(engine/can?
-               adapter internal-subject permission internal-resource))]
+             #(do
+                (validate!)
+                (engine/can?
+                 adapter internal-subject permission internal-resource)))]
         {:allowed? (:value answer)
          :cached? (:cached? answer)
          :cache-basis (:cache-basis answer)
@@ -681,17 +716,21 @@
         (page-context
          opts selection :lookup-resources query
          (:resource/type query) (:permission query))
-        _ (schema-errors/validate-permission-request!
-           ((get-in api [:schema :read-schema]) selected-db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema api selected-db)
            :lookup-resources
            {:resource-type (:resource/type query)
             :subject-type (:type subject)
-            :permission (:permission query)})
+            :permission (:permission query)}))
         internal-subject (spice-object->internal selected-db subject)]
     (if (nil? (:id internal-subject))
-      (if (cursor-request? query)
-        (stale-cursor-anchor! :lookup-resources)
-        (assoc relay/empty-page :cached? false :cache-basis nil))
+      (do
+        (validate!)
+        (if (cursor-request? query)
+          (stale-cursor-anchor! :lookup-resources)
+          (assoc relay/empty-page :cached? false :cache-basis nil)))
       (or
        (relay/lookup-visited-page
         adapter cursor-opts :lookup-resources query)
@@ -708,12 +747,14 @@
               (:permission internal-query)
               #(and (map? %) (vector? (:data %))
                     (map? (:page-info %)))
-              #(engine/lookup-resources
-                adapter
-                internal-query
-                {:continuation-cache
-                 (continuation-context
-                  adapter cursor-opts :lookup-resources query)}))
+              #(do
+                 (validate!)
+                 (engine/lookup-resources
+                  adapter
+                  internal-query
+                  {:continuation-cache
+                   (continuation-context
+                    adapter cursor-opts :lookup-resources query)})))
              page
              (with-cache-info
                (binding [subproblem/*store*
@@ -739,18 +780,22 @@
         opts (assoc opts
                     :completed-cache? completed-cache?
                     :snapshot-exact? snapshot-exact?)
-        _ (schema-errors/validate-permission-request!
-           ((get-in api [:schema :read-schema]) selected-db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema api selected-db)
            :count-resources
            {:resource-type (:resource/type query)
             :subject-type (:type subject)
-            :permission (:permission query)})
+            :permission (:permission query)}))
         internal-subject (spice-object->internal selected-db subject)]
     (if-not (:id internal-subject)
-      (assoc
-       (cond-> {:count 0 :limit (or (:count-limit query) -1)}
-         (contains? query :count-limit) (assoc :truncated? false))
-       :cached? false :cache-basis nil)
+      (do
+        (validate!)
+        (assoc
+         (cond-> {:count 0 :limit (or (:count-limit query) -1)}
+           (contains? query :count-limit) (assoc :truncated? false))
+         :cached? false :cache-basis nil))
       (let [internal-query
             (-> query
                 (assoc :subject internal-subject)
@@ -765,7 +810,8 @@
              (:resource/type internal-query)
              (:permission internal-query)
              #(and (map? %) (integer? (:count %)))
-             #(engine/count-resources adapter internal-query))]
+             #(do (validate!)
+                  (engine/count-resources adapter internal-query)))]
         (with-cache-info (:value answer) answer)))))
 
 (defn lookup-subjects
@@ -780,12 +826,14 @@
         (page-context
          opts selection :lookup-subjects query
          (:type (:resource query)) (:permission query))
-        _ (schema-errors/validate-permission-request!
-           ((get-in api [:schema :read-schema]) selected-db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema api selected-db)
            :lookup-subjects
            {:resource-type (:type (:resource query))
             :subject-type (:subject/type query)
-            :permission (:permission query)})
+            :permission (:permission query)}))
         internal-resource
         (spice-object->internal selected-db (:resource query))]
     (when (contains? query :subject/relation)
@@ -793,9 +841,11 @@
                       {:eacl/error :eacl.pagination/unsupported-filter
                        :filter :subject/relation})))
     (if-not (:id internal-resource)
-      (if (cursor-request? query)
-        (stale-cursor-anchor! :lookup-subjects)
-        (assoc relay/empty-page :cached? false :cache-basis nil))
+      (do
+        (validate!)
+        (if (cursor-request? query)
+          (stale-cursor-anchor! :lookup-subjects)
+          (assoc relay/empty-page :cached? false :cache-basis nil)))
       (or
        (relay/lookup-visited-page
         adapter cursor-opts :lookup-subjects query)
@@ -812,12 +862,14 @@
               (:permission internal-query)
               #(and (map? %) (vector? (:data %))
                     (map? (:page-info %)))
-              #(engine/lookup-subjects
-                adapter
-                internal-query
-                {:continuation-cache
-                 (continuation-context
-                  adapter cursor-opts :lookup-subjects query)}))
+              #(do
+                 (validate!)
+                 (engine/lookup-subjects
+                  adapter
+                  internal-query
+                  {:continuation-cache
+                   (continuation-context
+                    adapter cursor-opts :lookup-subjects query)})))
              page
              (with-cache-info
                (binding [subproblem/*store*
@@ -843,19 +895,23 @@
         opts (assoc opts
                     :completed-cache? completed-cache?
                     :snapshot-exact? snapshot-exact?)
-        _ (schema-errors/validate-permission-request!
-           ((get-in api [:schema :read-schema]) selected-db)
+        validate!
+        (fn []
+          (schema-errors/validate-permission-request!
+           (request-schema api selected-db)
            :count-subjects
            {:resource-type (:type (:resource query))
             :subject-type (:subject/type query)
-            :permission (:permission query)})
+            :permission (:permission query)}))
         internal-resource
         (spice-object->internal selected-db (:resource query))]
     (if-not (:id internal-resource)
-      (assoc
-       (cond-> {:count 0 :limit (or (:count-limit query) -1)}
-         (contains? query :count-limit) (assoc :truncated? false))
-       :cached? false :cache-basis nil)
+      (do
+        (validate!)
+        (assoc
+         (cond-> {:count 0 :limit (or (:count-limit query) -1)}
+           (contains? query :count-limit) (assoc :truncated? false))
+         :cached? false :cache-basis nil))
       (let [internal-query
             (-> query
                 (assoc :resource internal-resource)
@@ -870,7 +926,8 @@
              (:type (:resource internal-query))
              (:permission internal-query)
              #(and (map? %) (integer? (:count %)))
-             #(engine/count-subjects adapter internal-query))]
+             #(do (validate!)
+                  (engine/count-subjects adapter internal-query)))]
         (with-cache-info (:value answer) answer)))))
 
 (defn expand-permission-tree
@@ -886,11 +943,13 @@
         opts (assoc opts
                     :completed-cache? completed-cache?
                     :snapshot-exact? snapshot-exact?)
-        _ (schema-errors/validate-expansion-request!
-           ((get-in api [:schema :read-schema]) db)
+        validate!
+        (fn []
+          (schema-errors/validate-expansion-request!
+           (request-schema api db)
            :expand-permission-tree
            (:type (:resource query))
-           (:permission query))
+           (:permission query)))
         answer
         (cached-engine-result
          adapter opts :expand-permission-tree
@@ -898,12 +957,14 @@
          (:type (:resource query))
          (:permission query)
          map?
-         #(permission-tree/expand
-           adapter
-           {:limits (:permission-tree-limits opts)
-            :execution-contract contract}
-           (:resource query)
-           (:permission query)))
+         #(do
+            (validate!)
+            (permission-tree/expand
+             adapter
+             {:limits (:permission-tree-limits opts)
+              :execution-contract contract}
+             (:resource query)
+             (:permission query))))
         tree (:value answer)]
     (execution/check! contract :permission-tree-token-issuance)
     (let [token

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -441,6 +441,10 @@
     :routing-schema-identity known-schema-generation
     ;; Sealed plans are keyed by this identity (see `stable-plan-key`).
     :plan-schema-identity known-schema-generation
+    ;; Client-owned memo of the parsed public schema for this generation
+    ;; (request validation reads it on the miss path); the engine never
+    ;; fills it. Left nil-valued for unstamped generations by the clients.
+    :parsed-schema (atom nil)
     :permission-roots (atom {})
     :permission-paths (atom {})
     :traversal-permissions (atom {})

--- a/openspec/changes/fix-datomic-request-overhead/proposal.md
+++ b/openspec/changes/fix-datomic-request-overhead/proposal.md
@@ -1,5 +1,7 @@
 # Proposal: Fix Per-Request Overheads (sealed-plan thrash, seal cost, schema reads, kernel checks)
 
+> Investigation report: [`docs/reports/2026-08-19-hierarchical-cache-investigation.md`](../../../docs/reports/2026-08-19-hierarchical-cache-investigation.md) — measurements, decisions, what shipped, remaining opportunities.
+
 ## Why
 
 Profiling the live `eacl-datomic-solidjs` demo (110k servers, 59 accounts,

--- a/openspec/changes/fix-datomic-request-overhead/tasks.md
+++ b/openspec/changes/fix-datomic-request-overhead/tasks.md
@@ -4,7 +4,7 @@
 - [x] 1.2 `impl/with-request-engine`: process-stable lifecycle + `:schema-identity` (direct read, no proof op)
 - [x] 1.3 `expire-cache!` (Datomic + orchestration) calls `expire-plans!`
 - [x] 1.4 `seal-plan` encode-once (`sort-by-canonical`); fingerprint/plan invariance checked
-- [x] 1.5 `request-schema` + validation on the miss path at all seven client sites; unstamped databases read directly
+- [x] 1.5 `request-schema` + validation on the miss path at all seven client sites; unstamped databases read directly (Datomic client in #131; the shared Datahike/DataScript client `eacl.client.orchestration` in #135 via the engine's `:parsed-schema` generation slot)
 - [x] 1.6 `kernel?` positive-class memo (JVM)
 - [x] 1.7 `eacl.backend.v8-test` plan-sharing expectations aligned; full battery green; source-closure ledger regenerated
 - [ ] 1.8 Docs: `docs/cache.md` cache-layers table ("Sealed plan | same source scope, lifecycle, schema generation and permission root"), `docs/v8-consistency-cache-operations.md` if it names the plan key

--- a/openspec/changes/hierarchical-demand-segment-cache/proposal.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/proposal.md
@@ -1,5 +1,7 @@
 # Proposal: Exact Scan-Response Cache (supersedes the hierarchical demand-segment draft)
 
+> Investigation report: [`docs/reports/2026-08-19-hierarchical-cache-investigation.md`](../../../docs/reports/2026-08-19-hierarchical-cache-investigation.md) — measurements, decisions, what shipped, remaining opportunities.
+
 > Status of this rewrite: the original proposal/design/tasks were reviewed
 > adversarially on 2026-08-18 and rejected as written; see
 > [`review/REVIEW.md`](review/REVIEW.md) for findings and measurements and

--- a/openspec/changes/hierarchical-demand-segment-cache/review/REVIEW.md
+++ b/openspec/changes/hierarchical-demand-segment-cache/review/REVIEW.md
@@ -1,5 +1,7 @@
 # Adversarial review: `hierarchical-demand-segment-cache` (2026-08-18)
 
+> Consolidated report: [`docs/reports/2026-08-19-hierarchical-cache-investigation.md`](../../../../docs/reports/2026-08-19-hierarchical-cache-investigation.md).
+
 Reviewed against the code on `docs/improve-readme` (v8 stable-discovery engine,
 head `9f23109`). The original artifacts are preserved in this folder as
 `original-*.md`; the rewritten `proposal.md`, `design.md`, `specs/` and

--- a/openspec/changes/membership-probe-point-check/proposal.md
+++ b/openspec/changes/membership-probe-point-check/proposal.md
@@ -1,5 +1,7 @@
 # Proposal: Membership-Probe Point Check
 
+> Investigation report: [`docs/reports/2026-08-19-hierarchical-cache-investigation.md`](../../../docs/reports/2026-08-19-hierarchical-cache-investigation.md) — measurements, decisions, what shipped, remaining opportunities.
+
 ## Why
 
 The stable-discovery engine answered `can?` by running the reverse reducer


### PR DESCRIPTION
Merges `main` into the deployment branch for the next `8.0.0-SNAPSHOT` build.

Since build 6 (9b27f62): #135 — the shared Datahike/DataScript client validates requests on the miss path from a per-generation parsed schema (DataScript `can?` hit 200 → 133 µs, Datahike 187 → 104 µs), plus the investigation report `docs/reports/2026-08-19-hierarchical-cache-investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)