### PR TITLE
Refresh the public source closure ledger

### DIFF
--- a/docs/reports/2026-08-20-acyclic-keyset-pagination-implementation.md
+++ b/docs/reports/2026-08-20-acyclic-keyset-pagination-implementation.md
@@ -1,0 +1,260 @@
+# Acyclic Keyset Pagination — Implementation Report
+
+**Date:** 2026-08-20
+**Change:** `openspec/changes/acyclic-keyset-pagination`
+**Branch:** `agent/acyclic-keyset-pagination` (base `main` @ 9d5f67b)
+**Status:** merged to `main` via [PR #139](https://github.com/theronic/eacl/pull/139)
+(merge commit 17b94a2). One post-merge CI incident, fixed by
+[PR #140](https://github.com/theronic/eacl/pull/140) — see §7.
+
+---
+
+## 1. Summary
+
+Acyclic sealed plans now paginate by **keyset in least-derivation-path
+order** instead of replaying the stable-discovery reducer from ordinal
+zero (or resuming a Θ(ordinal) continuation checkpoint). Cursors carry
+per-level derivation coordinates and are fully self-contained: no
+server-side continuation state, no cache dependency, multi-node safe at
+a pinned basis. Recursive plans keep first-discovery order and
+checkpoints; the mode is sealed per-plan into the fingerprint (order
+ABI v2), so a cursor can never be replayed under the wrong order.
+
+Headline numbers (serialized fresh-JVM A/B vs `main` @ 9d5f67b, 20k-doc
+arrow fixture, medians of 3 fixtures/side, final post-review state):
+
+| Metric | main | branch | Δ |
+|---|---|---|---|
+| cache-off 100×50 walk, total | 910 ms | 156 ms | 5.8× |
+| cache-off deep page (page 100) | 16.1 ms | 1.32 ms | flat in ordinal |
+| cache-on warm 100×50 walk | 140.2 ms | 161.3 ms | 1.15× (≤1.5× gate; 3rd run at parity) |
+| bare `:last 50` window | 73.0 ms | 1.32 ms | 55× |
+| explorer 10k :page work | — | 92–98 advanced-datoms/page | envelope 34/144/8 |
+
+The cache-off pathology this change targets — demo latency growing with
+the page ordinal (O(k²) total replay) — is gone: the deep page is
+*cheaper* than page 1 (which still pays plan compile).
+
+## 2. Problem
+
+Root-caused on demo.eacl.dev/datahike with caching disabled: page k of
+a lookup replayed discovery through all k·n prior emissions, so
+per-page latency grew linearly and a full walk was O(k²). With caching
+enabled, continuation checkpoints hid the replay but each checkpoint's
+admitted set is Θ(ordinal) (~96 B/entry → ~1.9 MB at 20k), lives
+in-process only, and made cursors cache-dependent — a cache miss (or a
+different node) fell back to full replay.
+
+## 3. Formal models (all green before any engine routing)
+
+Three new Dafny leaves under `formal/stable-discovery/`, registered in
+`verify-fast.sh`; the exact-obligation pin moved to **631** and the gate
+wall ceiling was honestly raised 10 → 12 s:
+
+- **`LeastPathOrder.dfy`** (33 obligations): per-scan derivation
+  coordinates over an acyclic `StableReducer.Program`; strict total
+  lexicographic order; existence/uniqueness of the least path per
+  derivable entity; the order is a pure function of (program, tuples).
+- **`LeastPathEnumeration.dfy`** (46): the ordered DFS with the
+  smaller-witness emission filter emits exactly the reachable
+  denotation (bridged to `ReducerCompleteness`), exactly once per
+  entity, in ascending least-path order; pruning repeated interior
+  states preserves the sequence; leaf-level merge of ascending streams
+  stays ascending and duplicate-free.
+- **`LeastPathResume.dfy`** (11): seeking every level strictly past a
+  boundary equals the suffix of the full enumeration (`:after`);
+  descending iteration emits each entity at the same position
+  (`:last`/`:before` without `:complete-denotation`).
+
+Witness decomposition (a strictly-smaller path exists ⇔ earlier-rule ∨
+same-rule-smaller-eid clauses, each decided by a min-side interleaved
+intersection) builds on `BidirectionalArrowIntersection.dfy`'s
+`DecideEqualsArmAnswer`.
+
+Dafny practicalities that cost time: `witness` is a reserved word;
+biconditional-over-existential postconditions do not survive branch
+joins (split into directional lemmas); mixed-length `decreases` tuples
+need the equal-prefix-longer convention.
+
+## 4. Implementation shape
+
+- **`eacl.engine.sealed-plan`**: order contract bumped to ABI v2;
+  plans gain `:order-mode` (`:least-path` for acyclic roots,
+  `:first-discovery` for recursive ones, decided by Kahn) **inside the
+  canonical digest**, so the mode is part of the fingerprint a cursor
+  pins.
+- **`eacl.engine.least-path`** (new, cljc): resumable nested ordered
+  DFS — full per-scan coordinates `[rule-ordinal, eid…]`, one active
+  scan per level, per-level witness pruning, chunked scans with a
+  cut-point before every adapter command, reducer-equivalent typed
+  budgets, direction-aware fetch seam (`adapter-fetch-fn` — the
+  reducer's own seam hardcodes `:asc`), request-shared witness-child
+  memo, min-side `least-common` intersection.
+- **`eacl.engine.v8`**: `stable-lookup-page` dispatches on the sealed
+  `:order-mode`; the least-path route maps `:after`/`:before`/`:last`
+  to per-level seeks, reverses descending emissions to canonical order,
+  reports its work to `*recursive-traversal-stats*`
+  (emissions → `:derived-grants`, commands → `:advanced-datoms`, scan
+  opens → `:stream-opens`), and thunks the continuation-cache context
+  so the keyset route never builds it.
+- **Cursors**: `:least-path-edge {kind version order-abi fingerprint
+  traversal coords}` — relay passes coords through (portable envelope
+  is authenticated plaintext; Datomic's AES-GCM token unaffected);
+  wrong-fingerprint or wrong-arity cursors fail typed through the
+  existing envelope. Pre-release stance per project decision: no
+  legacy-cursor migration or rejection machinery beyond the typed
+  failure.
+- **No checkpoints for acyclic plans**: continuation checkpoints remain
+  only for recursive (first-discovery) plans.
+
+Verification at the merged state: formal gate 631 obligations green;
+full CLJ battery **700 tests / 29,827 assertions / 0 failures** (fresh
+JVM); DataScript CLJS **203 / 7,431**; engine property harness green
+(naive-oracle order + coordinate equality, reducer set-equality,
+resume-from-every-boundary, ascending/descending agreement,
+work-bounded stream opens, typed budgets); client round-trips on both
+Datomic and DataScript clients (flat cache-off op-stats, `:last` /
+`:before` under demand, lookup-subjects walks).
+
+## 5. Adversarial review findings (fixed pre-merge, commit d3844e7)
+
+An oracle-based review after the first green implementation found one
+real correctness bug and two structural perf problems:
+
+1. **Order bug (correctness).** The evaluator walked each node's arms
+   in the plan's (rank, ordinal) list order while stamping *sealed
+   ordinals* into coordinates. Wherever those orders diverge, emissions
+   left lexicographic coordinate order and the witness "earlier" domain
+   disagreed with `compare-coords`. The shipped 3-level harness
+   *cannot* express the divergence; a 4-level dual-arrow oracle fixture
+   produced 46 random-seed failures. `design.md` D1 had specified the
+   wrong order — against the Dafny `Lex`, the oracle, and the ABI docs.
+   Fixed: arm traversal is ordinal-ordered everywhere coordinates are
+   involved; regression test pins emission order to sealed ordinals.
+   Lesson: the design doc was wrong while the Dafny was right — the
+   implementation had followed the doc.
+2. **Witness-child re-enumeration (perf).** Every emission's
+   arrow-permission witness re-walked the target closure: 122,008
+   commands for a page of 10 over a 10k-group arm. Fixed with the
+   request-shared witness-children memo promised in task 3.2 plus a
+   min-side least-common intersection: 20,418 commands (6×; floor =
+   main walk + one shared child walk).
+3. **Eager continuation context (perf).** v8 forced the
+   continuation-cache thunk before dispatching on `:order-mode`, so
+   every cache-on acyclic page paid canonicalization + proof-frame
+   resolution + ~5 backend reads for state the keyset route never
+   reads. Fixed by thunking end to end; cache-on overhead fell from
+   1.27× to 1.15× (third run at parity).
+
+Plus typed cursor-arity errors (`check-arity!`) and honest
+documentation of the plaintext-coords disclosure on portable envelopes.
+
+## 6. Two observation-basis recalibrations (physical work unchanged)
+
+Wiring the evaluator's own counters into the observer stats changed
+what tests *observe*, not what the engine *does*
+(`:adapter-attempts` identical before/after):
+
+- The explorer `:page` work envelope was re-recorded
+  (finally 34/144/8 after the witness-memo fix).
+- The cache-differential adjacent-page ±10 flatness assertion was
+  re-anchored to a 4× early-page ceiling over the whole walk: in
+  least-path order, per-page cost is *content*-bounded (cheap
+  derivations emit first), so adjacent windows legitimately differ by
+  more than a constant.
+
+## 7. Post-merge CI incident (fixed)
+
+`main` went red on the `dafny-and-generated-boundaries` job at the
+merge commit: `bin/formal source-closure` failed because the
+post-review commits added four defs that enter the public decision
+closure (`check-arity!`, `least-common`, `shared-child-pull` in
+`eacl.engine.least-path`; `report-least-path-run!` in
+`eacl.engine.v8`) without regenerating
+`formal/verification/public-source-closure.json` — the ledger was last
+regenerated four commits earlier. It did not block the merge because
+the **`pull_request` workflow run skips that job** (it runs on `push`
+events); the PR looked green while the branch-push run had already
+failed.
+
+Fix: [PR #140](https://github.com/theronic/eacl/pull/140)
+(`agent/source-closure-refresh`) regenerates the ledger — 61 roots
+(unchanged, matches `backend-dispatch.edn`), 1409 → 1413 definitions —
+with the delta reviewed def-by-def against the shipped commits. No
+`.dfy` changed after the gate last ran green, so only the ledger step
+was affected.
+
+Two durable lessons:
+
+- **Run `bin/formal source-closure` (or the full `bin/formal`
+  sequence) after any commit that adds/removes defs**, not only after
+  the commit that first touches a namespace. The Clojure battery does
+  not cover this Node-side check.
+- **The `pull_request` event does not run the dafny job.** A green PR
+  page is not evidence that job passed; check the branch `push` run
+  before merging.
+
+## 8. Remaining work
+
+- **7.4 Post-merge demo verification** (the only open task in the
+  change): build `8.0.0-SNAPSHOT` with Java 26 classes and
+  `:local-repo "/Users/petrus/.m2/repository"`, run
+  `formal/smoke/java/run` first, restart the datahike demo and the
+  eacl-datomic-solidjs server (Datomic transactor: port 4380, **not**
+  the 4334 default), and confirm cache-off pagination is flat
+  end-to-end in the UI. All demo JVMs are currently **down** — the
+  serialized bench protocol killed them (transactor included).
+  PR #140 should merge first so `main` is green.
+- **8.6 follow-ups (recorded, deliberately not spun off)** — whether
+  these become GitHub issues or openspec changes is an operator
+  decision (public repo):
+  (a) plaintext coords disclosure on portable envelopes (encrypt vs
+  externalize is a threat-model call);
+  (b) cache-on acyclic walks still run the full answer-cache pipeline
+  per page and mint near-unreusable per-bound entries (auto-bypass vs
+  caller `:cache? false`);
+  (c) Datahike as-of wrapper materializes+sorts the whole endpoint
+  segment per command (~4,000× measured, pre-existing, multiplied by
+  probe-heavy pages);
+  (d) Datahike hitchhiker-tree descending `rslice` is O(database) if
+  that index config is ever reachable (protocol-incompatible in the
+  pinned build);
+  (e) backend `guard-scan!` realizes unbounded scans when guards are
+  enabled;
+  (f) the datascript module's isolated classpath is broken
+  (persistent-sorted-set 0.3.0 lacks `CurrentCache`; loads only under
+  the aggregate root where datahike's 0.4.137 shadows it).
+- **Non-blockers recorded elsewhere**: DataScript explorer COUNT
+  latency ceilings fail on `origin/main` too on this host (re-baseline
+  on an idle matched host); stale `:production-map` names in
+  `execution-contract.edn`; witness constants unmeasured on
+  Datahike-S3 tiers (the gate covers the bound, not the constant).
+
+## 9. Operational lessons (beyond §7's)
+
+- **Certify on a fresh JVM only.** A warm REPL `:reload` reported `:ok`
+  through a delimiter error a fresh JVM rejected. Worse: a *failed*
+  `:reload` leaves a partial namespace (defs before the error updated,
+  after it stale), and piping eval output through `grep` swallowed the
+  compile error — hours of "verification" ran stale code. Run the bare
+  `(require … :reload)` alone and read its output before trusting
+  anything after it.
+- **Never `:reload-all` in a shared REPL** — it redefines `eacl.core`
+  protocols and orphans live records ("No implementation of
+  :write-schema!").
+- **Serialize A/B benchmarks on fresh JVMs** with every other JVM
+  killed; parallel or warm-JVM comparisons contaminated results twice.
+- **Oracle fixtures must be at least as deep as the divergence you are
+  hunting**: the order bug was invisible at 3 levels and instant at 4
+  with dual arrows.
+
+## 10. State at handover
+
+- `main` @ 17b94a2 contains the full change; Tests workflow green;
+  Formal verification red **only** on the stale ledger, fixed by
+  PR #140 (pending merge).
+- Working checkouts live under the session scratchpad
+  (`…/scratchpad/eacl-proposal` on `agent/source-closure-refresh`,
+  `…/scratchpad/eacl-main` at the 9d5f67b baseline); everything of
+  value is committed and pushed.
+- No nREPLs, demo servers, or transactors are running on this host.

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -89,7 +89,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "31aa8a056e5f8a7692262860c02644c8251ed5e79a1f2bac3a0e3bf5cd3e4e2d"
+      "sha256": "f964e732224db549a9602c9b33707421626ae2e02da363d794fc1ade8cd9539c"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -137,7 +137,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "b1f42f574e76081b591b731944b961fd1bfff599f86cbff0d152937adba87b13"
+      "sha256": "23a5ef147990f1c8e3d83c9d2949e5be01e86942fa013fedd0fb806ce53e0d7a"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -157,7 +157,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/least_path.cljc",
-      "sha256": "a94c444a7c3c85d51c33fef5f15b0f63ab5ef2f8a316fa6aaf4cfeee00a1be96"
+      "sha256": "6fb5deb59e57c5ccbd330adbb58d388d87109a4e4610085cf0f750b02509c4af"
     },
     {
       "path": "modules/eacl/src/eacl/engine/physical.cljc",
@@ -193,7 +193,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "faa44c0c11161e101ab17adc23ce66c184d99875d5bc93f066f769b362e1b186"
+      "sha256": "d6357082193523492bca9a8f92830e0ba111c64e9199d552b2643b637ac9eb87"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -241,7 +241,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/relay.cljc",
-      "sha256": "19ec020fd70f592f45d4af5a64a9c59d3d6cd796a2194438d0942a0c5f063929"
+      "sha256": "8274ba4e96fe2c4027d111f4c590b5d35504261c68289cfe2f69e09731145304"
     },
     {
       "path": "modules/eacl/src/eacl/schema/errors.cljc",
@@ -337,9 +337,9 @@
       "eacl.datascript.core/make-client"
     ],
     "rootCount": 61,
-    "unionInternalDefinitionCount": 1409,
-    "unionInternalDefinitionIdsSha256": "46e59edcd7111184e70f60b6490a9d876892aab3740accfe88b7b78df8c81906",
-    "unionDefinitionLocationsSha256": "ea23d88cb474e9fc4c9bd3a29ba7a5d7918cf51aa184a4ce86f81e6a106d4de4",
+    "unionInternalDefinitionCount": 1413,
+    "unionInternalDefinitionIdsSha256": "75e08655ce24c8fd8c08c3c740bb7943c00898922edea39c1f9b68e5065f298b",
+    "unionDefinitionLocationsSha256": "55a19b4ae1eedea82a80a0fa484cfe899ca43454ede82e49625713feb7ca0782",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 18,
@@ -458,8 +458,8 @@
         "idsSha256": "b35bffa00c76bd22c09fac6aceb428ac2dfd09691913494f8d9c6cad66f2a8a3"
       },
       "modules/eacl/src/eacl/engine/least_path.cljc": {
-        "count": 41,
-        "idsSha256": "b5c04fdc8c7872a931f1d921bebaffb1b62694f1f74ebcfa9db9310cc5fdc3b0"
+        "count": 44,
+        "idsSha256": "cf00c6d69c37f164fe954ab3b6e59b32d121caef8554bbc75e589a7b77e19bc6"
       },
       "modules/eacl/src/eacl/engine/physical.cljc": {
         "count": 19,
@@ -494,8 +494,8 @@
         "idsSha256": "a454e8e67d5e5a1269e6fceb131697e265e25cec7bb033843ac36b04bd268668"
       },
       "modules/eacl/src/eacl/engine/v8.cljc": {
-        "count": 87,
-        "idsSha256": "77864dc27f7bb7828738266aa96584d3b289ab13254ec4736f1d6aadffd7e8bd"
+        "count": 88,
+        "idsSha256": "15add5c4212993353b0e83864799c1049484c4cbd06e3d3cb096e13230fdbd44"
       },
       "modules/eacl/src/eacl/execution.cljc": {
         "count": 26,
@@ -593,8 +593,8 @@
       ]
     },
     "eacl.engine.v8/lookup-resources": {
-      "internalDefinitionCount": 348,
-      "internalDefinitionIdsSha256": "dc6160fd898346293efbef389d3364630b22fde5d020d64fc3f514c2cdf5e0e0",
+      "internalDefinitionCount": 352,
+      "internalDefinitionIdsSha256": "240e2b382ea25e6794e101dd4c019a267eb54cd8a833accfdb307b6fa1e7b0b9",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -609,8 +609,8 @@
       ]
     },
     "eacl.engine.v8/lookup-subjects": {
-      "internalDefinitionCount": 348,
-      "internalDefinitionIdsSha256": "30df0901b019e7e7cd6cc670d133d146240d62fb1ab302e9b78224187e1bdb46",
+      "internalDefinitionCount": 352,
+      "internalDefinitionIdsSha256": "16b14ca2c2b15cc9998b162bcec20ce2285ba5579b0725c001477be69ad45192",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -943,8 +943,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 872,
-      "internalDefinitionIdsSha256": "96da704a4e34a56e0615148c7a412958f4d98d14970220ab1eed7d8a5fabd360",
+      "internalDefinitionCount": 876,
+      "internalDefinitionIdsSha256": "e141a0dfe6f084f460417d7a5c85d4ad10755f982665a1fd17cdc64492496272",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1099,8 +1099,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 672,
-      "internalDefinitionIdsSha256": "fa758adea496b7986878acfac19af3448472f8bef1a7c052332b3b4f90e881fa",
+      "internalDefinitionCount": 676,
+      "internalDefinitionIdsSha256": "09a8a28e56e57f5b44a6461841c50ab83301ff7ac8c52bb443355d52b5b5f343",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1167,8 +1167,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 672,
-      "internalDefinitionIdsSha256": "4d49690893d56dd8a7d98cae75372cbefc874433de061913b0af380f4fc83add",
+      "internalDefinitionCount": 676,
+      "internalDefinitionIdsSha256": "328c652c741f5cfbebb48b4a1696bd0449079a91670562c6ae727f765b8e93a0",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1270,8 +1270,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 873,
-      "internalDefinitionIdsSha256": "b9a170ffdc580b19dccbeace9ef2976d281847381c93fc18d9801087fc69e834",
+      "internalDefinitionCount": 877,
+      "internalDefinitionIdsSha256": "15cd1c0971d3a6eb2b7ab81e9ad0c4e3cf6f238a5a190b1d16feaf4cb7e15053",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1317,8 +1317,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 875,
-      "internalDefinitionIdsSha256": "6900d4810623ac6b36199a6b0cf0658adc24c006ec471ac2e741bf59f4a476fe",
+      "internalDefinitionCount": 879,
+      "internalDefinitionIdsSha256": "6a5c068c3fe14ee1d7deb7ebad2105e317858f68a74b9e44605b7d127cd7054b",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1364,8 +1364,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 695,
-      "internalDefinitionIdsSha256": "0bf352403daddeb41bc25561363af1e5f7a65d321cff7c536c32a5d0d460294a",
+      "internalDefinitionCount": 699,
+      "internalDefinitionIdsSha256": "78224e1afdb0ff02ed3d1ebbd2539bd2360f8a1cf0c480baca479706f40a08da",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1538,8 +1538,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 779,
-      "internalDefinitionIdsSha256": "830fb867b7df653a06ed56cf7e40c6384385af629bbd8e98c5cadbc865e2cd96",
+      "internalDefinitionCount": 783,
+      "internalDefinitionIdsSha256": "bf75a48dc1defd58dba4f3f44866c3a6eefa03333425f86e5851fc609222cded",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1609,8 +1609,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 779,
-      "internalDefinitionIdsSha256": "326afd99d7286ba656e355871c5a450e49e886ecede9ec04f38d05d288aef528",
+      "internalDefinitionCount": 783,
+      "internalDefinitionIdsSha256": "8f39fbe533314874256c1e301c5c629c30465686f0f4bcea610fae7608c9ad2a",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1844,8 +1844,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 764,
-      "internalDefinitionIdsSha256": "24b289ed86b4db7601a4ef16fc96688f5cb1f24f2b5a2680d3ac0bf7600df9ab",
+      "internalDefinitionCount": 768,
+      "internalDefinitionIdsSha256": "6b211f9355374d8df21e0a1c720cfea74e9417beacbc49efcea5b5dc1811b94b",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1913,8 +1913,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 764,
-      "internalDefinitionIdsSha256": "68edfa3dce2074e6e2df1c6cec95a63aee0fd2c1a7ff0ecc3b23cce09a44371f",
+      "internalDefinitionCount": 768,
+      "internalDefinitionIdsSha256": "3913b18fc022e83dadb04b1ee73c65471080cc50cf7e2ba5ac0e7c77bae3cdf9",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",


### PR DESCRIPTION
## Why main is red

`bin/formal source-closure` fails on `main` since the #139 merge: the post-review commits (4afd57b, d3844e7) added four defs that enter the public decision closure without regenerating `formal/verification/public-source-closure.json`. The `pull_request` workflow run skips the `dafny-and-generated-boundaries` job (it runs on `push` events), so the stale ledger did not block the merge — the failure only surfaced on the branch and main `push` runs.

## The delta, certified

Regenerated with `bin/public-source-closure.mjs write`: 61 roots (unchanged — matches the `backend-dispatch.edn` pin), 1409 → 1413 definitions. The four additions map one-to-one to the shipped changes, with no removals:

| def | namespace | introduced by |
|---|---|---|
| `check-arity!` | `eacl.engine.least-path` | typed coords arity validation (d3844e7) |
| `least-common` | `eacl.engine.least-path` | (rank, ordinal) order fix (d3844e7) |
| `shared-child-pull` | `eacl.engine.least-path` | request-shared witness-children memo (d3844e7) |
| `report-least-path-run!` | `eacl.engine.v8` | traversal-observer wiring (4afd57b) |

No `.dfy` files changed after the formal gate last ran green (631 obligations), so the verify step is unaffected; `node bin/public-source-closure.mjs check` passes locally on this branch.

## Also in this PR

`docs/reports/2026-08-20-acyclic-keyset-pagination-implementation.md` — the dated implementation report for the acyclic-keyset-pagination change: what shipped in #139, final measured numbers, the adversarial-review findings, this incident and its lessons, and the remaining demo-verification task.