### PR TITLE
Add Datalevin backend support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,6 +157,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # eacl-datalevin joins this matrix only after its maintained fork is
+        # published from an immutable public source commit.
         module: [eacl, eacl-datomic, eacl-datascript, eacl-datahike]
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🦅 **EACL**: Enterprise Access ControL
 
-EACL is a situated [ReBAC](https://en.wikipedia.org/wiki/Relationship-based_access_control) authorization library inspired by [SpiceDB](https://authzed.com/spicedb), built in Clojure and backed by [Datomic Pro](https://www.datomic.com/), [Datahike](https://datahike.io/) or [DataScript](https://github.com/tonsky/datascript/).
+EACL is a situated [ReBAC](https://en.wikipedia.org/wiki/Relationship-based_access_control) authorization library inspired by [SpiceDB](https://authzed.com/spicedb), built in Clojure and backed by [Datomic Pro](https://www.datomic.com/), [Datahike](https://datahike.io/), [DataScript](https://github.com/tonsky/datascript/), or a qualified embedded [Datalevin](https://datalevin.org/) deployment.
 
 | Authentication (AuthN)                     | Authorization (AuthZ)    |
 |--------------------------------------------|--------------------------|
@@ -37,12 +37,12 @@ Yes.
 | [Datomic Pro](https://www.datomic.com/)             | [eacl-datomic](https://clojars.org/dev.eacl/eacl-datomic)       | DynamoDB (recommended), Cassandra or SQL                                 |
 | [Datahike](https://datahike.io/)                    | [eacl-datahike](https://clojars.org/dev.eacl/eacl-datahike)     | DynamoDB, S3 (cheaper, but slower), LMDB, SQL, Redis, GCS or IndexedDB.  |
 | [DataScript](https://github.com/tonsky/datascript/) | [eacl-datascript](https://clojars.org/dev.eacl/eacl-datascript) | In-memory, but can persist to disk or add a SQL adapter. No time-travel. |
-| [Datalevin](https://datalevin.org/)                 | _Coming soon._                                                  | Embedded.                                                                |
+| [Datalevin](https://datalevin.org/)                 | [`eacl-datalevin`](modules/eacl-datalevin) — implemented, publication pending | Embedded LMDB; certified sole-writer topology only.                       |
 
 
 S3-backed Datahike is attractive for infrequently-accessed apps, because you can trade latency for reduced storage cost, and it supports [serverless](https://github.com/replikativ/datahike-serverless) to reduce running Peer / Transactor costs.
 
-*Note:* DataScript does not store full history, so it has no `at-exact-snapshot` semantics. Datahike requires a retained commit graph or temporal history to support exact snapshots.
+*Note:* DataScript and Datalevin have no `at-exact-snapshot` semantics. Datahike requires a retained commit graph or temporal history to support exact snapshots. Datalevin additionally omits ordered-generation cache proofs and only reuses answers at the identical selected revision.
 
 ## Overview of EACL
 
@@ -181,7 +181,25 @@ If you need cache provenance, use `check-permission` instead of `can?`, otherwis
 
 "Which `<resources>` does `<subject>` have `<permission>` on, as-of `<10 seconds ago, or newer>`?"
 
-(These require `{:cache {:checkpoints true}}`, but this will soon be the default.)
+```clojure
+(eacl/lookup-resources acl
+  {:subject       subject
+   :permission    permission
+   :resource/type resource-type
+   :first         page-size N ; or :last N
+   :cursor
+   :consistency   (consistency/at-least-as-fresh token-10s-ago)})
+=> {:data [{:type :product :id "product-1"}
+           {:type :product :id "product-7"}
+           ...
+           {:type :product :id "product-63"}]
+    :page-info ...
+    :cached? true|false>
+    ...}
+```
+
+The `:consistency` argument is optional. The default is `minimize-latency`, which means _locally-consistent_ to the Peer. Presently, `at-least-as-fresh` semantics require config `{:cache {:checkpoints true}}`, but this will soon be the default.
+
 
 ```clojure
 (def token-10s-ago (datomic/zed-token-at-least-seconds-ago acl 10))
@@ -200,8 +218,6 @@ If you need cache provenance, use `check-permission` instead of `can?`, otherwis
     :cached? true|false>
     ...}
 ``` 
-
-The `:consistency` argument is optional. The default is `minimize-latency`, which means _locally-consistent_ to the Peer.
 
 ```clojure
 (eacl/lookup-resources acl query)
@@ -253,7 +269,7 @@ As long as the DB basis is recent enough for our consistency demands, we can avo
      Since you have to hit the DB anyway to show anything useful, we might as well compute permissions on the Peer, which has the database – which is what EACL does.
 
 2. **Time Travel**: Unlike Spice cursors, EACL cursors do not expire (and are encrypted for UI exposure) unless you specify a TTL, so we can reconstruct selected snapshots if the backend retains it.
-   - Note that DataScript does not store full history, so does not support `at-exact-snapshot` in the past.
+   - DataScript and the initial Datalevin adapter do not support `at-exact-snapshot`.
 
 3. **Consistency:** Syncing to an external system introduces eventual consistency. With situated AuthZ, queries are at least locally-consistent as-of time `T`.
     - In **single-Peer environments**, EACL reads from the database currently visible to the local Peer.
@@ -390,7 +406,7 @@ Even in a fast-moving DB, EACL will reuse cache segments that are unaffected by 
        - EACL will throw if `T` is newer than the Transactor has seen.
        - EACL will only reuse cache segments that are valid for `T`.
     - Supported by Datahike if history is enabled.
-    - `at-exact-snapshot` is not supported by DataScript, because it requires full history.
+    - `at-exact-snapshot` is not supported by DataScript or Datalevin. Both fail closed instead of emulating history.
 
 The EACL engine and cache benefit from monotonic `txId` (transaction IDs), i.e. the `t` in `[e a v t]`, so cache segments are keyed by basis `T`. The engine will only use cache segments valid @ `T`.
 
@@ -402,7 +418,7 @@ Unsupported modes by backend will return an error. Refer [Consistency and ZedTok
 
 ## Data Structures
 
-EACL co-exists with your data in Datomic, Datahike or DataScript. As a result, EACL installs and maintains some attributes in your data store, all of which are prefixed by `:eacl*`.
+EACL co-exists with your data in Datomic, Datahike, DataScript, or Datalevin. As a result, EACL installs and maintains some attributes in your data store, all of which are prefixed by `:eacl*`.
 
 Presently, EACL Relationships are stored in history to support auditability, `d/as-of` & `at-exact-snapshot` semantics, but in a future version of EACL, history could be optional to save on storage, but then you lose time travel & auditability. For many applications that only care about permissions as-of "now", this would be acceptable.
 
@@ -448,14 +464,14 @@ But you will probably forget one day, so there are helpers to fined & clean up g
 - Datomic permission arrows: `:eacl.permission/resource-type+source-relation-name+target-type+permission-name`
 - Datomic relation arrows: `:eacl.permission/resource-type+source-relation-name+target-type+target-name`
 - Datomic full key: `:eacl.permission/resource-type+source-relation-name+target-type+target-name+permission-name`
-- Datahike and DataScript full key: `:eacl.permission/full-key`
+- Datahike, DataScript, and Datalevin full key: `:eacl.permission/full-key`
 
 ### Schema Tracking
 
 - `:eacl/id` uniquely identifies Relations & Permissions. It's a string to match SpiceDB IDs, but you can also use it for external ID. Like in SpiceDB, Some IDs are reserved by EACL internals (todo: document EACL ID prefixes).
 - `:eacl/schema-string` stores a valid schema string was written via `eacl/write-schema!`.
 - `:eacl/schema-version` track the schema revision in Datomic Pro.
-- `:eacl/schema-generation` and `:eacl/schema-write-fence` track schema writes in Datahike and DataScript.
+- `:eacl/schema-generation` and `:eacl/schema-write-fence` track schema writes in Datahike, DataScript, and Datalevin.
 - `:eacl/storage-version` identifies Datomic's current Relationship storage model, e.g. version 7 (current).
 - `:eacl.fn/assert-relation-unused` is a Transactor function in Datomic that guards removing Relations with active Relationships (to avoids orphaned Relationships).
 
@@ -526,6 +542,9 @@ EACL supports multiple backends. Each adapter will bring in the shared EACL engi
 ;; DataScript
 {:deps {dev.eacl/eacl-datascript {:mvn/version "8.0.0-SNAPSHOT"}}}
 
+;; Datalevin (coordinate reserved; publication remains gated)
+{:deps {dev.eacl/eacl-datalevin {:mvn/version "8.0.0-SNAPSHOT"}}}
+
 ;; Core-only consumers and backend authors (you typically won't need this)
 {:deps {dev.eacl/eacl {:mvn/version "8.0.0-SNAPSHOT"}}}
 ```
@@ -557,7 +576,7 @@ Java 26; source builds may target Java 8 through Java 26, subject to their
 backend and application dependencies. See [formal/README.md](formal/README.md)
 for tool versions and the full verification commands.
 
-For module selection, current capability differences, cache mutation rules, and recursive controls, see the [backend guide](docs/v8-backend-modules-and-upgrade.md). Backend authors should also read the [adapter boundary](docs/v8-backend-adapter-boundary.md).
+For module selection, current capability differences, cache mutation rules, and recursive controls, see the [backend guide](docs/v8-backend-modules-and-upgrade.md). Datalevin setup, mandatory topology/lifecycle/watermark inputs, and publication status are documented in the [`eacl-datalevin` module README](modules/eacl-datalevin/README.md). Backend authors should also read the [adapter boundary](docs/v8-backend-adapter-boundary.md) and [snapshot-provider migration guide](docs/v8-snapshot-provider-migration.md).
 
 ### Schema & Relationships
 
@@ -1214,7 +1233,10 @@ I suspect SpiceDB does not support counting for the same reason. EACL currently 
 
 `at-exact-snapshot` semantics always call `(d/as-of conn T)`, but EACL can still reuse cache segments that are valid for snapshot _S_ with basis _B_ at time `T`.
 
-Unlike SpiceDB, EACL cursors do not expire, because EACL's backends support time-travel over full history (except for DataScript).
+Unlike SpiceDB, EACL cursors do not expire by default. History-capable
+backends can reconstruct exact continuations; current-only DataScript and
+Datalevin continuations fail closed after their selected snapshot is no longer
+available.
 
 ### Cache Coherence
 
@@ -1326,8 +1348,8 @@ no EACL cursor-retention window.
 EACL-created Datahike databases retain temporal history by default. External
 history-enabled Datahike stores can reconstruct exact revisions after commit
 record collection; history-disabled stores advertise only conditional exact
-selection while a named commit is retained. DataScript does not provide
-general historical snapshot reconstruction. If a backend cannot satisfy the
+selection while a named commit is retained. DataScript and Datalevin do not
+provide general historical snapshot reconstruction. If a backend cannot satisfy the
 requested guarantee, EACL returns a typed error rather than silently selecting
 a different snapshot.
 
@@ -1398,7 +1420,8 @@ The portable deletion sequence is:
 
 `delete-object!` removes relationships but does not delete the application
 entity. It is idempotent. The Datomic implementation batches high-degree
-cleanup; the Datahike and DataScript implementations use one transaction.
+cleanup; the Datahike, DataScript, and Datalevin implementations use one
+transaction in their certified in-process topologies.
 
 Backends that support transaction functions also provide an optional atomic
 `:eacl.fn/retractEntity`. It removes both relationship halves and the target
@@ -1411,6 +1434,7 @@ schema; enabling it is an explicit deployment step.
 | DataScript CLJ/CLJS | Named or direct in-process function |
 | Datahike with an in-process writer | Named or direct, depending on schema configuration |
 | Datahike remote/function-unsafe writer | Use `delete-object!` and ordinary deletion |
+| Datalevin qualified embedded writer | Direct in-process function |
 
 Datomic example:
 

--- a/bin/public-source-closure.mjs
+++ b/bin/public-source-closure.mjs
@@ -12,6 +12,7 @@ const sourcePaths = [
   "modules/eacl-datomic/src",
   "modules/eacl-datahike/src",
   "modules/eacl-datascript/src",
+  "modules/eacl-datalevin/src",
 ];
 const reportPath = "formal/verification/public-source-closure.json";
 const toolchainPath = "formal/toolchain.lock.json";
@@ -77,6 +78,15 @@ const roots = [
   "eacl.datascript.core/datascript-lookup-subjects",
   "eacl.datascript.core/datascript-count-subjects",
   "eacl.datascript.core/make-client",
+  "eacl.datalevin.core/datalevin-read-relationships",
+  "eacl.datalevin.core/datalevin-write-relationships!",
+  "eacl.datalevin.core/datalevin-delete-object!",
+  "eacl.datalevin.core/datalevin-can?",
+  "eacl.datalevin.core/datalevin-lookup-resources",
+  "eacl.datalevin.core/datalevin-count-resources",
+  "eacl.datalevin.core/datalevin-lookup-subjects",
+  "eacl.datalevin.core/datalevin-count-subjects",
+  "eacl.datalevin.core/make-client",
 ];
 const ignoredRuntimeNamespaces = new Set(["clojure.core", "cljs.core"]);
 

--- a/deps.edn
+++ b/deps.edn
@@ -32,6 +32,38 @@
                                "modules/eacl-datomic/test"
                                "modules/eacl-datascript/test"
                                "modules/eacl-datahike/test"]}
+           ;; The fork is deliberately opt-in until its immutable source commit
+           ;; and Maven artifact are public. This keeps ordinary workspace CI
+           ;; from silently depending on a sibling checkout.
+           :datalevin-dev
+           {:extra-paths ["modules/eacl-datalevin/src"
+                          "modules/eacl-datalevin/test"
+                          "modules/eacl/test"]
+            :extra-deps
+            {dev.eacl/datalevin-embedded-eacl {:local/root "../datalevin"}}
+            :jvm-opts ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+                       "--add-opens=java.base/java.nio=ALL-UNNAMED"
+                       "--add-opens=java.base/java.util=ALL-UNNAMED"
+                       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+                       "--enable-native-access=ALL-UNNAMED"]}
+           :datalevin-test
+           {:extra-paths ["modules/eacl-datalevin/src"
+                          "modules/eacl-datalevin/test"
+                          "modules/eacl/test"]
+            :extra-deps
+            {dev.eacl/datalevin-embedded-eacl {:local/root "../datalevin"}
+             io.github.cognitect-labs/test-runner
+             {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+            :jvm-opts ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+                       "--add-opens=java.base/java.nio=ALL-UNNAMED"
+                       "--add-opens=java.base/java.util=ALL-UNNAMED"
+                       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+                       "--enable-native-access=ALL-UNNAMED"]
+            :exec-fn cognitect.test-runner.api/test
+            :exec-args {:dirs ["modules/eacl-datalevin/test"
+                               "modules/eacl/test"]
+                        :patterns ["^(?!eacl[.]bench[.])(?!eacl[.]characterization-fixture-test$)(?!eacl[.]formal[.]).*-test$"]
+                        :excludes [:benchmark]}}
            :build-eacl {:extra-paths ["modules/eacl" "src-build"]
                         :ns-default build
                         :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}}}
@@ -44,6 +76,9 @@
            :build-eacl-datascript {:extra-paths ["modules/eacl-datascript" "src-build"]
                                    :ns-default build
                                    :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}}}
+           :build-eacl-datalevin {:extra-paths ["modules/eacl-datalevin" "src-build"]
+                                  :ns-default build
+                                  :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}}}
            :build-test {:extra-paths ["src-build"]
                         :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}}}
            :release-guard

--- a/docs/benchmarks/results/2026-08-22-datalevin-local.md
+++ b/docs/benchmarks/results/2026-08-22-datalevin-local.md
@@ -1,0 +1,100 @@
+# Datalevin local adapter benchmark — 2026-08-22
+
+This is the retained output of
+`eacl.bench.datalevin-test/run-benchmark!` after the bounded-scan, snapshot,
+schema-cache, and adapter-allocation fixes. It is local development evidence,
+not Linux ARM64 release qualification or a production capacity claim.
+
+## Environment and method
+
+- macOS, ARM64 (`aarch64`)
+- Eclipse Adoptium Java 26.0.2
+- Datalevin 1.0.2 maintained-fork worktree
+- 256 documents, one direct viewer relationship per document
+- 25 warmups plus 51 measured calls; relationship writes use five warmups
+  plus 21 measured alternating touch/delete commits
+- wall latency from `System/nanoTime`; current-thread allocation from
+  `ThreadMXBean`
+- all times below are microseconds; allocation columns are bytes per call
+
+| Operation | Samples | Min | p50 | p95 | p99 | Max | Mean | Alloc p50 | Alloc p95 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Bounded forward adapter scan, limit 25 | 51 | 97.333 | 113.708 | 204.833 | 230.291 | 239.125 | 127.010 | 77,440 | 77,496 |
+| Warm permission check | 51 | 376.250 | 486.167 | 815.417 | 900.542 | 1,021.000 | 523.622 | 403,624 | 403,712 |
+| First resource page, 25 | 51 | 237.542 | 308.125 | 741.417 | 785.334 | 808.416 | 372.415 | 331,712 | 331,768 |
+| Exact resource count | 51 | 237.459 | 268.500 | 463.084 | 526.292 | 650.792 | 311.930 | 406,464 | 406,592 |
+| Explicit snapshot acquire/info/close | 51 | 79.625 | 93.083 | 124.292 | 195.209 | 309.750 | 102.547 | 200,728 | 200,728 |
+| Provider acquire/adapt/release | 51 | 113.417 | 132.500 | 304.375 | 497.875 | 603.750 | 162.822 | 229,944 | 229,944 |
+| Explicit snapshot cache-bypass read | 51 | 164.834 | 194.833 | 323.750 | 385.208 | 447.583 | 221.930 | 298,032 | 298,032 |
+| Relationship write commit | 21 | 4,848.625 | 5,994.667 | 6,096.458 | 6,096.458 | 6,174.791 | 5,898.329 | 1,031,224 | 1,032,904 |
+| Acquire/info/close while 32 readers remain open | 51 | 69.500 | 84.166 | 153.584 | 174.375 | 241.584 | 95.884 | 201,184 | 201,240 |
+
+## Before/after p50 evidence
+
+The following pre-fix samples were captured in the same local fixture before
+the adapter changes. They are paired-run engineering evidence, not a formal
+statistical confidence interval.
+
+| Operation | Pre-fix p50 µs | Fixed p50 µs | Latency reduction | Pre-fix alloc p50 | Fixed alloc p50 | Allocation reduction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Provider acquire/adapt/release | 535.834 | 132.500 | 75.3% | 1,265,448 | 229,944 | 81.8% |
+| Warm permission check | 1,178.500 | 486.167 | 58.7% | 1,446,640 | 403,624 | 72.1% |
+| First resource page, 25 | 856.500 | 308.125 | 64.0% | 1,366,944 | 331,712 | 75.7% |
+| Exact resource count | 995.800 | 268.500 | 73.0% | 1,449,512 | 406,464 | 72.0% |
+| Relationship write commit | 6,881.750 | 5,994.667 | 12.9% | 1,879,912 | 1,031,224 | 45.1% |
+
+The read-path reductions come primarily from avoiding repeated schema digest
+work, avoiding duplicate snapshot schema derivation, bounding native seeks to
+the logical page budget, and keeping proof-unavailable schema derivations
+request-local. The write benchmark benefits indirectly from cheaper response
+snapshot construction; Datalevin transaction commit remains the dominant
+cost.
+
+## Resource observations
+
+| Measurement | Value |
+| --- | ---: |
+| Used heap before measured operations | 471,771,776 bytes |
+| Used heap after measured operations, without forced GC | 681,486,976 bytes |
+| Database directory before measured operations | 491,653 bytes |
+| Database directory after measured operations | 557,189 bytes |
+| Held explicit readers in pressure fixture | 32 |
+| Oldest-reader age at pressure observation | 4.060 ms |
+| Active readers after every benchmark scope closed | 0 |
+
+The held-reader fixture did not increase snapshot acquisition p50 in this
+short run (84.166 µs versus 93.083 µs without held readers). That is only a
+32-reader local observation. It does not characterize exhaustion,
+long-duration LMDB page retention, map growth under sustained writes, RSS,
+native memory, or tail behavior under concurrent load. Those remain separate
+Linux and deployment gates.
+
+## Live demo request and heap observation
+
+The local Jetty demo was also sampled through loopback HTTP after the composed
+snapshot change. Each p50 is the middle of 21 sequential warmed requests,
+including Ring, JSON encoding/decoding, request orchestration, and loopback
+HTTP; this is diagnostic evidence rather than a load or capacity test.
+
+| Endpoint | Warm p50 |
+| --- | ---: |
+| `check-permission` | 5.747 ms |
+| `lookup-resources`, page 10 | 10.203 ms |
+| permission-filtered `read-relationships`, page 10 | 29.546 ms |
+
+The filtered relationship path remains the slowest because it performs scalar
+point authorization for each physical candidate and an exact lookahead for a
+logical `hasNextPage`. Those calls now share one selected snapshot, proof
+frame, request-local schema cache, deadline, and cancellation budget; a fused
+or batch point-check operation is still a separate core optimization.
+
+The first uncapped demo process inherited a 9 GiB ergonomic maximum heap from
+the 36 GiB host. Immediately before an explicit collection it had 1,882,804 KiB
+used heap, of which only about 24 MiB was old-generation live data, and
+2,248,352 KiB RSS. An explicit collection reduced used heap to 73,038 KiB,
+demonstrating accumulation of short-lived request allocations rather than a
+retained EACL/Datalevin object graph. The local `:run` profile now uses
+`-Xms128m -Xmx1g -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError`. After restart and
+63 warmed HTTP requests, the process reported 132,954 KiB used heap,
+380,928 KiB committed heap, and 585,712 KiB RSS. The 1 GiB ceiling is a local
+run-profile bound, not the pending production sizing decision.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 # 🦅 EACL: Enterprise Access ControL
 
 EACL is a situated relationship-based authorization library for Clojure and
-ClojureScript, backed by Datomic Pro, Datahike, or DataScript. Authorization
+ClojureScript, backed by Datomic Pro, Datahike, DataScript, or a qualified
+embedded Datalevin deployment. Authorization
 data lives beside application data and is evaluated against one immutable
 database value per request.
 
@@ -18,6 +19,9 @@ Choose the adapter for your database; it brings the core module transitively:
 
 ;; DataScript
 {:deps {dev.eacl/eacl-datascript {:mvn/version "8.0.0-SNAPSHOT"}}}
+
+;; Datalevin (implemented; publication pending maintained-fork release)
+{:deps {dev.eacl/eacl-datalevin {:mvn/version "8.0.0-SNAPSHOT"}}}
 ```
 
 The [repository README](https://github.com/theronic/eacl#readme) contains the
@@ -48,6 +52,7 @@ retraction, or explicitly install/use the backend's optional
 - [Consistency and cache operations](v8-consistency-cache-operations.md)
 - [Backend modules and capabilities](v8-backend-modules-and-upgrade.md)
 - [Backend adapter contract](v8-backend-adapter-boundary.md)
+- [Snapshot-provider migration](v8-snapshot-provider-migration.md)
 - [Answer cache and subproblem store](v8-subproblem-cache.md)
 - [Formal assurance boundary](formal-verification.md)
 - [Audit reports](reports/) — dated records; the 2026-08-15 stable-engine audit lists open bugs and optimizations

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -33,6 +33,12 @@ EACL v8.0 is a workspace with independently consumable modules:
   storage now matches Datomic's two cardinality-many heterogeneous endpoint
   tuples. DataScript uses the same component order in ordinary vectors because
   DataScript 1.7.8 does not support heterogeneous tuple declarations.
+- `modules/eacl-datalevin` contains a CLJ-only adapter for a qualified
+  embedded, one-JVM, one-connection, one-writer Datalevin topology. It owns a
+  public explicit native read snapshot per request. Publication remains
+  blocked until the maintained `dev.eacl/datalevin-embedded-eacl` fork is
+  available from immutable public SCM and passes packaged Linux ARM64
+  qualification.
 
 Existing Datomic namespace imports do not change. Consumers replace the root
 Git dependency with `:deps/root "modules/eacl-datomic"`; this packaging change
@@ -40,7 +46,7 @@ does not alter v7 relationship storage. Tokens, cursors, cache envelopes, and
 the additive native-generation schema are deliberately new v8 formats; no
 downgrade or dual-format cache/token mode is provided. Third-party adapters
 implement the validated v8 operation/capability contract (`eacl.backend.v8`);
-the pre-v8 six-function SPI is gone. The three built-in adapters share
+the pre-v8 six-function SPI is gone. The four built-in adapters share
 permission-plan compilation, the stable-discovery reducer, pagination,
 counting, and portable cache validation.
 
@@ -99,6 +105,11 @@ schemas, relationships, caches, and tokens require no rewrite.
   to authenticated `T` with bounded two-argument `d/sync` before exact
   `d/as-of T`; DataScript rejects exact mode before cache access because it has
   no EACL time-travel registry.
+- Datalevin supports minimize-latency, fully-consistent local head, and
+  at-least-as-fresh revision-floor selection through fresh explicit readers.
+  It rejects exact selection. Its initial adapter advertises no ordered
+  generations and no proof frame, so it never lifts a cached answer across a
+  different revision.
 - Low-level operations accepting an arbitrary `db`, including caller-created
   `d/as-of`, `d/with`, prospective, or filtered views, bypass completed-answer
   caching.
@@ -133,10 +144,14 @@ permission check.
   ghost repair. Integrity reports detect damage when the old eid is unknown.
 - Relationship update operations are validated before endpoint resolution. `delete-object!`
   reports actual committed relationship-datom retractions across all batches.
+- Datalevin commits matching forward/reverse tuples, relation stamps, and the
+  schema write fence atomically through its serialized writer. Object deletion
+  rescans inside the commit transaction. These claims apply only to the
+  certified direct synchronous sole-writer topology.
 
 ## Completed-answer cache
 
-Each Datomic, Datahike, and DataScript client owns a bounded native cache. It
+Each Datomic, Datahike, DataScript, and Datalevin client owns a bounded native cache. It
 has three sound reuse rules:
 
 1. **Exact-current:** accept an entry only for the identical immutable selected
@@ -158,6 +173,9 @@ backend time travel.
 - Datahike uses immutable DB object identity.
 - DataScript uses a private opaque identity handle for the immutable DB object,
   avoiding numeric `max-tx` collisions after reset.
+- Datalevin uses backend/source/lifecycle/revision plus an independently
+  captured physical-schema fingerprint. It performs exact selected-revision
+  reuse only.
 - A transaction replaces the exact generation. No schema/relationship proof
   calculation occurs on an exact hit.
 - Publication captures the generation/lifecycle. A delayed computation cannot
@@ -168,8 +186,9 @@ backend time travel.
 
 ### Managed-current tier
 
-Proof-backed ("managed") reuse is unconditional on every backend: EACL's
-writers publish the relation generations the proof needs, and the
+Proof-backed ("managed") reuse is enabled only when the adapter advertises
+certified ordered generations. Datomic, Datahike, and DataScript writers
+publish the relation generations the proof needs, and the
 `:coherence-authority` option that once selected between `:unknown` and
 `:managed` no longer exists (supplying it is invalid configuration). The
 contract is that every authorization-affecting relationship and schema write
@@ -195,19 +214,26 @@ projections) under one relation-stamp framing:
   frontier; an unrelated write leaves it unchanged.
 - Missing/malformed stamps disable managed reuse rather than becoming a
   reusable zero value.
-- All backends read the current physical `:eacl/relation-version` assertion;
+- All proof-capable backends read the current physical `:eacl/relation-version` assertion;
   a missing assertion is a fail-closed miss and has no fallback.
 - Custom object-ID codecs remain exact-current-only unless they supply the
   additional deterministic dependency contract.
 - Randomized cached-versus-cache-free differential oracles run with the
-  managed tier active on all three backends, interleaving EACL-API writes
+  managed tier active on the three ordered-proof backends, interleaving EACL-API writes
   with checks, lookups, and counts.
+- Datalevin maintains relation versions for mutation fencing and a future
+  proof-capable design, but does not expose those values through a proof frame:
+  persistent datom transaction identity is not certified as an ordered
+  generation.
 
 ### Cache operations
 
 - `eacl.datomic.core/expire-cache!`
 - `eacl.datahike.core/expire-cache!`
 - `eacl.datascript.core/expire-cache!`
+
+Datalevin lifecycle rotation is external and durable;
+`eacl.datalevin.core/expire-cache!` rejects process-local rotation.
 
 These rotate source/token scope and replace the entire client lifecycle. Use them after reset,
 restore, branch force, manual history manipulation, or unstamped bulk repair.

--- a/docs/v8-backend-adapter-boundary.md
+++ b/docs/v8-backend-adapter-boundary.md
@@ -1,7 +1,7 @@
 # Backend adapter boundary
 
 `eacl.backend.v8` is the only production boundary between the shared
-authorization engine and Datomic, Datahike, or DataScript mechanics. Shared
+authorization engine and Datomic, Datahike, DataScript, or Datalevin mechanics. Shared
 code invokes validated logical operations and never inspects backend database,
 datom, attribute-id, or tuple implementation types.
 
@@ -45,6 +45,13 @@ The runtime proof validator rejects missing, malformed, duplicate,
 non-canonical, oversized, or partial evidence. The adapter does not choose a
 coherence or proof mode.
 
+Snapshot acquisition and ownership are separate from the immutable adapter.
+`eacl.backend.snapshot-provider` selects borrowed or owned snapshots for the
+complete request lifetime. Owned providers must close rejected causal
+candidates and release on success, typed/foreign failure, timeout,
+cancellation, proof resolution, cache publication, and cursor/token
+construction. See [the provider migration guide](v8-snapshot-provider-migration.md).
+
 ## Ordered-generation certification
 
 Shared cache proofs assume that:
@@ -77,3 +84,10 @@ selection establishes a native revision floor only inside the authenticated
 backend/source/lifecycle scope; exact selection additionally establishes the
 exact locator. Source replacement requires lifecycle rotation before cached or
 token-bearing traffic resumes.
+
+Datalevin demonstrates the conservative capability policy: its persistent
+datoms do not expose the original transaction in a form certified for EACL's
+proof order. The adapter therefore omits `:ordered-generations` and the
+`:proof-frame` operation. It may reuse answers only for the same certified
+semantic snapshot identity and never interprets a datom `:tx` as a relation
+generation.

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -12,11 +12,33 @@ depend on one adapter module; backend authors depend on core.
 | `eacl-datomic` | Clojure/JVM | current Peer DB, explicit sync barrier, causal floor, targeted catch-up plus exact `d/as-of T` | authenticated; proof-equivalent current continuation or full-history exact reconstruction |
 | `eacl-datahike` | Clojure/JVM | current connection DB; durable temporal history when enabled, otherwise conditional retained-commit selection | authenticated; proof-equivalent current continuation or configuration-honest exact reconstruction |
 | `eacl-datascript` | Clojure and ClojureScript | current connection DB; no arbitrary exact selection | authenticated proof-equivalent current continuation |
+| `eacl-datalevin` | Clojure/JVM | fresh owned native read snapshot at the local embedded head; causal-floor polling; no historical exact selection | authenticated revision-bound continuation; no ordered-proof lifting |
 | `eacl` | Clojure and ClojureScript | supplied by an adapter | shared protocol, engine, proof, and cache implementation |
 
 Capabilities are configuration-specific and are validated before
 authorization. Ordinary calls select one current immutable snapshot and do not
 perform historical selection.
+
+`eacl-datalevin` is implemented but not yet published. It depends on the
+explicit public read-snapshot API in the maintained
+`dev.eacl/datalevin-embedded-eacl` fork. Neither coordinate may be treated as
+released until a clean remote-only consumer resolves both from immutable
+public SCM revisions.
+
+## Consistency matrix
+
+| Backend | Minimize latency | Fully consistent | At least as fresh | Exact snapshot | Ordered-generation cache proof |
+| --- | --- | --- | --- | --- | --- |
+| Datomic Pro | current Peer value | bounded `d/sync` then current | targeted catch-up | `d/as-of T` | yes |
+| Datahike | current connection value | qualified writer head | revision/commit catch-up | durable with temporal history; otherwise retained-commit conditional | yes |
+| DataScript | serialized current value | serialized current head | waits for connection revision | unsupported | yes, in the in-process mutation topology |
+| Datalevin | fresh explicit native reader | same local sole-writer head guarantee | retries fresh readers to the authenticated revision floor | unsupported | no; exact selected-revision reuse only |
+
+Datalevin's fully-consistent mode is not a replica barrier. The certified
+topology has one embedded connection and one direct synchronous writer, so a
+fresh read transaction is already the authoritative local head. Remote,
+replica, HA, WAL, multi-connection, multi-writer, and virtual-thread profiles
+are rejected during construction.
 
 All public list operations use Relay controls: `:first`/`:after` or
 `:last`/`:before`. Counts use optional `:count-limit`. `delete-object!` is
@@ -34,6 +56,10 @@ disabled:
 (datascript/make-client conn {:cache cache/no-cache})
 (datahike/make-client conn {:cache cache/no-cache})
 (datomic/make-client conn {:cache cache/no-cache})
+(datalevin/make-client conn {:cache cache/no-cache
+                             ;; plus mandatory lifecycle, watermark,
+                             ;; signing, and topology options
+                             })
 ```
 
 Exact immutable-snapshot lookup is always first. After an exact miss, complete
@@ -66,6 +92,12 @@ The exact lifecycle functions are:
 (eacl.datascript.core/expire-cache! acl)
 ```
 
+Datalevin deliberately has no process-local lifecycle rotation. A restore or
+rollback must durably rotate the externally owned source lifecycle and reset
+its external revision watermark before constructing a replacement client.
+`eacl.datalevin.core/expire-cache!` rejects attempts to fake that operation in
+memory.
+
 See [cache operations](v8-consistency-cache-operations.md) for proof
 availability, custom-codec, time-travel, and multi-process lifecycle rules.
 
@@ -90,6 +122,11 @@ or history replacement require quiescence, completion, shared source-lifecycle
 rotation, complete client/cache detachment, and deliberate signing-key/wire
 version policy before traffic resumes.
 
+Datalevin cursors are current-revision continuations. Because the adapter has
+no historical selector, a continuation whose selected revision is no longer
+the current semantic snapshot fails closed; it is not reconstructed from LMDB
+history.
+
 ## Optional atomic entity retraction
 
 Every embedded bundled backend can support EACL's safe target-only retraction
@@ -104,6 +141,7 @@ peer-only ghost; a missing lookup ref cannot recover the former eid.
 | DataScript direct in-process form | `eacl.datascript.safe-retraction/prepare!` |
 | Datahike function-safe named topology | `eacl.datahike.safe-retraction/install!` |
 | Datahike direct in-process topology | `eacl.datahike.safe-retraction/prepare!` |
+| Datalevin qualified embedded topology | `eacl.datalevin.safe-retraction/prepare!` |
 | Function-unsafe remote topology | use `delete-object!`, then native entity deletion |
 
 Do not combine relationship additions involving a target with safe retraction
@@ -158,7 +196,8 @@ Rejections are `:eacl.service/admission-rejected` and
 Client construction fails closed with `:eacl.topology/unqualified` when the
 backend adapter's declared execution profile does not certify the strict,
 unique, replayable, strict-progress, atomic scan contract over an immutable
-basis that stable discovery requires (the three bundled adapters do).
+basis that stable discovery requires (the four bundled adapters do within
+their certified topologies).
 
 ## Permission-tree expansion
 
@@ -213,3 +252,10 @@ a correct exact-current adapter.
 Backend authors should follow the [adapter boundary
 inventory](v8-backend-adapter-boundary.md) and run the shared public API,
 recursive, cache, mutation, and independent-oracle contracts.
+
+Adapters over live or closeable database handles must also implement the
+[snapshot-provider lifecycle](v8-snapshot-provider-migration.md). A borrowed
+provider is correct only for an already immutable value. An owned reader must
+declare its thread/runtime restrictions, keep the handle inside the complete
+request scope, eagerly realize all returned data, and release every accepted
+and rejected candidate deterministically.

--- a/docs/v8-snapshot-provider-migration.md
+++ b/docs/v8-snapshot-provider-migration.md
@@ -1,0 +1,97 @@
+# v8 snapshot-provider migration
+
+EACL v8 clients construct a long-lived `eacl.backend.snapshot-provider`
+instead of reading a database value during client construction or at every
+orchestration checkpoint. The provider publishes snapshot-free capability,
+topology, traversal, ownership, and execution metadata. Each public request
+then acquires one selected immutable adapter and releases it after proof,
+cache, cursor, token, ID conversion, and response realization are complete.
+
+## Compatibility path for immutable values
+
+Backends whose database values are genuinely immutable may use
+`borrowed-adapter-provider`. The static adapter is inspected but not retained;
+every acquisition callback must return the adapter selected for that request.
+The provider declares `:snapshot-ownership :borrowed`, and its release
+operation is a no-op. Datomic, Datahike, and DataScript use this path without
+changing their public client APIs or capability declarations.
+
+The borrowed path is invalid for a mutable handle, an adapter that consults a
+live connection after construction, or any value that owns a native reader,
+cursor, transaction, file, socket, or lease. Object identity and
+`identical?` are not snapshot equality.
+
+## Required owned-provider behavior
+
+An owned provider must:
+
+1. declare the closed execution constraints and ownership policy at client
+   construction without acquiring a request snapshot;
+2. return exactly `{:adapter adapter :ownership :owned :release-token token}`
+   from every successful acquisition;
+3. ensure the adapter is immutable and all of its operations are bound to the
+   selected native snapshot;
+4. make every bounded scan finite, eager, strictly ordered, and free of native
+   iterator escape;
+5. close rejected candidates, including every at-least retry, on the required
+   release thread;
+6. keep release retryable when native close fails and make a completed release
+   idempotent; and
+7. reject unsupported runtimes and thread escape before native access.
+
+Core attempts cleanup for every map returned by an acquisition callback,
+including a malformed map that omitted `:release-token` (the cleanup callback
+receives nil). A provider that throws before returning must clean any native
+state it acquired internally because core has no release token.
+
+## Semantic snapshot identity
+
+Cache and cursor decisions use the captured semantic identity, not adapter or
+database object identity. The identity contains exactly:
+
+```clojure
+{:backend ...
+ :source-id ...
+ :branch ...
+ :source-lifecycle ...
+ :revision ...
+ :exact-locator ...
+ :schema-identity ...
+ :backend-snapshot-id ...}
+```
+
+The adapter's native revision must agree with both `:order-hint` and
+`:exact-locator`. `:schema-identity` is required when schema can change without
+the native revision changing; otherwise it may be nil. Independently acquired
+snapshots may compare equal only when every EACL-visible dimension above is
+equal. Mutable values, directory paths, credentials, and process-local object
+identities must not appear in tokens or portable cache identity.
+
+For at-least and exact modes, the selected adapter is compared directly with
+the authenticated token's backend, source, branch, and lifecycle. A lifecycle
+rotation racing selection therefore fails closed instead of producing a
+hybrid request.
+
+## Write boundary
+
+Read planning and validation run inside an owned snapshot scope. That scope
+must close before writer acquisition. The commit result—not a post-commit
+head read—must supply the acknowledged native revision used for response
+tokens, invalidation, and any external monotonic watermark hook.
+
+## Migration checklist
+
+- Replace client-construction DB retention with a provider constructor.
+- Keep a compatibility provider only for certified immutable values.
+- Count acquisitions and releases for every public operation and error path.
+- Test cancellation immediately after acquisition and failure during context
+  construction, proof, cache publication, cursor recovery, and response
+  externalization.
+- Test use-after-close, double close, foreign-thread access/release, release
+  failure/retry, and unsupported runtime rejection.
+- Test equal revision, changed revision, lifecycle/source/branch changes, and
+  independent schema drift in semantic cache identity.
+- Prove returned public values can be fully traversed after release without
+  backend access.
+- Do not advertise exact history, ordered proofs, concurrency, durability, or
+  topology properties that are not independently certified.

--- a/formal/verification/backend-dispatch.edn
+++ b/formal/verification/backend-dispatch.edn
@@ -5,13 +5,18 @@
  ["modules/eacl/src"
   "modules/eacl-datomic/src"
   "modules/eacl-datahike/src"
-  "modules/eacl-datascript/src"]
+  "modules/eacl-datascript/src"
+  "modules/eacl-datalevin/src"]
  :runtime-passes
  {:clj
-  {;; 59 -> 61 (2026-08-20): eacl.engine.least-path/adapter-fetch-fn
-   ;; adds one :subject->resources and one :resource->subjects literal
-   ;; dispatch (the direction-aware keyset seam); no new operations.
-   :invoke-call-count 61
+  {;; 61 -> 75 (2026-08-22): snapshot-provider-backed consistency
+   ;; selection adds fourteen literal adapter observations while moving
+   ;; acquisition/release ownership behind the provider and cross-checking
+   ;; native revision against both order and exact locators; no new operations.
+   ;; 75 -> 77 (2026-08-22): the synchronous composed-snapshot view captures
+   ;; its fixed provider's source scope and lifecycle through the same literal,
+   ;; guarded dispatch boundary; again, no new operation keys are introduced.
+   :invoke-call-count 77
    :operations
    #{:snapshot-id
      :source-scope
@@ -33,7 +38,7 @@
      :all-permission-nodes
      :proof-frame}}
   :cljs
-  {:invoke-call-count 61
+  {:invoke-call-count 77
    :operations
    #{:snapshot-id
      :source-scope

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,11 +13,11 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "d086ae44132d18ce75edb3f9aabd0c969bfc1429c9f535a045578e8840055a67"
+      "sha256": "95bb960cf2a77b9c8940d01f2dda7031a9e232219927f9e8c0f47f4938fa625d"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
-      "sha256": "11b608e656a397ca206314bffee83a5bffa259c91d9184534bb5e17f498f6fc7"
+      "sha256": "d85c6e0f8c8568368f3404505d1577b4b2c0609b315ddd2ebcc9958c247e30ab"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/db.clj",
@@ -40,12 +40,40 @@
       "sha256": "6407122c005ae40e280bfc35c72b2b4706b1cf4df25e851cf45a46ce9556c496"
     },
     {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc",
+      "sha256": "7e86724edc77da904ca050b0084e09ea960aebadc928de9857848eef344c13ce"
+    },
+    {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/core.cljc",
+      "sha256": "85c1c2b32ef49d0523242f346652a75bb015e6d3f87360cddbb83b81a9af587c"
+    },
+    {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/db.cljc",
+      "sha256": "1cd129344e86dcbce26a44fd51f292e237a2b08ff9446b0d57dad1b537070563"
+    },
+    {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/impl.cljc",
+      "sha256": "5c84fdc12d47be603eca228c1ce9937d50f1c7973113eeeddbfb492ca13a32c2"
+    },
+    {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/integrity.cljc",
+      "sha256": "30b22c0938b8e7e61c30780c18a10f22057dea8f640490a55f59e1a9cc7c2b39"
+    },
+    {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/safe_retraction.cljc",
+      "sha256": "4796ed3530633eda84d2425e31ddd49a36b9b6c296fbae193a0cffbc7d37e460"
+    },
+    {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/schema.cljc",
+      "sha256": "1919a34b9296278ce85e59f1c02b03087334a9b656e460f01f5e9a0b549a37ec"
+    },
+    {
       "path": "modules/eacl-datascript/src/eacl/datascript/backend.cljc",
-      "sha256": "d82a64b3badfddde88b5175f6933af4b157160ce77f7f3296d8cf71b0bb70310"
+      "sha256": "0635d6560f064e0555cacf3a24aecf6a851241bc7fc8cb2591496bcc97d30dc0"
     },
     {
       "path": "modules/eacl-datascript/src/eacl/datascript/core.cljc",
-      "sha256": "e0895b418b6fec7168ff3fbd61f2f52a1e5452539dac936321da08144d44a54f"
+      "sha256": "ab2493de6dfec5f048498f4f43b5b1f2c58287f88ef96e2b8b0017de2d8452c9"
     },
     {
       "path": "modules/eacl-datascript/src/eacl/datascript/db.cljc",
@@ -69,7 +97,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/backend.clj",
-      "sha256": "a1a1163ca4473603e4774c190de42a940d3622749945e11e4a253ffce8449242"
+      "sha256": "5b8949a8d783c9fc413f3669b08faab49c3253227cb0657151c78cb13f953ac2"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/cache.clj",
@@ -89,7 +117,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/core.clj",
-      "sha256": "f964e732224db549a9602c9b33707421626ae2e02da363d794fc1ade8cd9539c"
+      "sha256": "ae879f7af95e756f51798b60ce9c855168e7a6eb5de78add77a698d635bc3a7c"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/db.clj",
@@ -124,6 +152,10 @@
       "sha256": "896c7280a2694e1d1da0520ff479ed86731350ad5531755d09e4a32d6d51bd13"
     },
     {
+      "path": "modules/eacl/src/eacl/backend/snapshot_provider.cljc",
+      "sha256": "936483a098f0a906084096d676bb81241e9aa4e8604509b8be22ae2ec528d9d7"
+    },
+    {
       "path": "modules/eacl/src/eacl/backend/v8.cljc",
       "sha256": "1084053e5761ff07ffbb0c8519aba0ba3465634a437b6a19e49301d9ac69f005"
     },
@@ -137,11 +169,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "23a5ef147990f1c8e3d83c9d2949e5be01e86942fa013fedd0fb806ce53e0d7a"
+      "sha256": "696f029ac90cc1a89d717c47fcd386a7408f9c213437b70f2e05f000372030a4"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
-      "sha256": "8e5526e42d8dfb4534086de1dd14aa36f1dc783299a9a29574ec6fd42d13f3e5"
+      "sha256": "f84d477e307fcdc32d16d9d51bdc875e9439ed1b50a64e09b612752704bf57e1"
     },
     {
       "path": "modules/eacl/src/eacl/continuation.cljc",
@@ -161,7 +193,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/physical.cljc",
-      "sha256": "6b031873e3bfd06984b92b80af357e11a22626791349733811287feeb80a4aa6"
+      "sha256": "c3464d2fb6beeea368f6d3d18bd461274ae4716f7e1cd3e729af79462c615816"
     },
     {
       "path": "modules/eacl/src/eacl/engine/portable_decisions.cljc",
@@ -185,7 +217,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/stable_reducer.cljc",
-      "sha256": "a224d0fb3d8b55e1efa2ca515ea39a87adad9641021096ed94dcfc6a7b66ae89"
+      "sha256": "52ee8e6d278e68a12af9b64b93070fddc1f8767fe3048994975f5a590ee9656d"
     },
     {
       "path": "modules/eacl/src/eacl/engine/stable_route.cljc",
@@ -241,7 +273,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/relay.cljc",
-      "sha256": "8274ba4e96fe2c4027d111f4c590b5d35504261c68289cfe2f69e09731145304"
+      "sha256": "764c833255f1b5bab1c5d48073b604f24391f14fec0e6c3e2ac924f85da44447"
     },
     {
       "path": "modules/eacl/src/eacl/schema/errors.cljc",
@@ -334,16 +366,25 @@
       "eacl.datascript.core/datascript-count-resources",
       "eacl.datascript.core/datascript-lookup-subjects",
       "eacl.datascript.core/datascript-count-subjects",
-      "eacl.datascript.core/make-client"
+      "eacl.datascript.core/make-client",
+      "eacl.datalevin.core/datalevin-read-relationships",
+      "eacl.datalevin.core/datalevin-write-relationships!",
+      "eacl.datalevin.core/datalevin-delete-object!",
+      "eacl.datalevin.core/datalevin-can?",
+      "eacl.datalevin.core/datalevin-lookup-resources",
+      "eacl.datalevin.core/datalevin-count-resources",
+      "eacl.datalevin.core/datalevin-lookup-subjects",
+      "eacl.datalevin.core/datalevin-count-subjects",
+      "eacl.datalevin.core/make-client"
     ],
-    "rootCount": 61,
-    "unionInternalDefinitionCount": 1413,
-    "unionInternalDefinitionIdsSha256": "75e08655ce24c8fd8c08c3c740bb7943c00898922edea39c1f9b68e5065f298b",
-    "unionDefinitionLocationsSha256": "55a19b4ae1eedea82a80a0fa484cfe899ca43454ede82e49625713feb7ca0782",
+    "rootCount": 70,
+    "unionInternalDefinitionCount": 1584,
+    "unionInternalDefinitionIdsSha256": "ce9d9618b070398ad067ddf76d1bb0db32cf91be7550cde79b0c0b503d96a641",
+    "unionDefinitionLocationsSha256": "ebbba20464cd0ca9b197cafe1de77390592563bd0b6c1231b0dc7470321dab01",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
-        "count": 18,
-        "idsSha256": "68a9242fa3ee650da550e530db88f9be79e8a233dd1410402279e9aa65e87a2e"
+        "count": 19,
+        "idsSha256": "4fc24bb8bba8549034ca89c8486fee619e656145cf78f586a2e292dccc06bbe8"
       },
       "modules/eacl-datahike/src/eacl/datahike/core.clj": {
         "count": 13,
@@ -361,9 +402,29 @@
         "count": 16,
         "idsSha256": "e7758084592618de87ad53f7f4300196866a1548b1d7d0ae364e29310f78d540"
       },
+      "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc": {
+        "count": 13,
+        "idsSha256": "87552c173ede6e3494105dc411850cad85e379eda16b111578f2056ab22d95c1"
+      },
+      "modules/eacl-datalevin/src/eacl/datalevin/core.cljc": {
+        "count": 22,
+        "idsSha256": "2dc21c8f73be2d36781653b151a20c5317c570d59e22a2c27bc7fcbe23809e19"
+      },
+      "modules/eacl-datalevin/src/eacl/datalevin/db.cljc": {
+        "count": 10,
+        "idsSha256": "38aedbf94b1b1c38e4635e480b754005e7fe4c39cac188304fa2451f8f09cad0"
+      },
+      "modules/eacl-datalevin/src/eacl/datalevin/impl.cljc": {
+        "count": 38,
+        "idsSha256": "a46481cfe3f1f6cf0afda89739b543fb8002126fad8c0e5ee764cfc843b4c2ba"
+      },
+      "modules/eacl-datalevin/src/eacl/datalevin/schema.cljc": {
+        "count": 19,
+        "idsSha256": "5d470063af9c1b929c4462cd664b616c7ce2f742f3a434e68784f5b164ad2ff0"
+      },
       "modules/eacl-datascript/src/eacl/datascript/backend.cljc": {
-        "count": 8,
-        "idsSha256": "5e337c84950ce84c6d7a79a23d2208aad01e0f29da399d95e0ea7cba713d83b3"
+        "count": 9,
+        "idsSha256": "75c9841e78293684f600508c02bdcc64f3a44325b55f8864643273c67fc21e05"
       },
       "modules/eacl-datascript/src/eacl/datascript/core.cljc": {
         "count": 12,
@@ -382,8 +443,8 @@
         "idsSha256": "7ffedf1948fac06fa42a2f7976c664f9a1cc9a537f315169f974c4cddd0cb68f"
       },
       "modules/eacl-datomic/src/eacl/datomic/backend.clj": {
-        "count": 13,
-        "idsSha256": "898b12609377bb4c6294d34c53abeb4a44bbf2228a0f5f14974068978f997b0b"
+        "count": 14,
+        "idsSha256": "7e6447cb58eaa345acbdbc251b23c6d3b67ed807e232afde92f99df2ebc31b96"
       },
       "modules/eacl-datomic/src/eacl/datomic/cache.clj": {
         "count": 4,
@@ -398,8 +459,8 @@
         "idsSha256": "41564ae9195b19dd851d20e77ec6d32379244f26211d5a815622b45fb2df2592"
       },
       "modules/eacl-datomic/src/eacl/datomic/core.clj": {
-        "count": 123,
-        "idsSha256": "990d542ae73d8172e90d88453a68fb854146520700a59b31e00b0165652721fb"
+        "count": 124,
+        "idsSha256": "d2d42710750e15b2a56c2829091cd50afa35ea360c1e333fb5ff2f3b09a7f707"
       },
       "modules/eacl-datomic/src/eacl/datomic/db.clj": {
         "count": 9,
@@ -425,6 +486,10 @@
         "count": 18,
         "idsSha256": "6354f20b566cbf72654812e5404ad861a32ed262bf7c3ebf678b2e9f199a323b"
       },
+      "modules/eacl/src/eacl/backend/snapshot_provider.cljc": {
+        "count": 42,
+        "idsSha256": "71aceb7f31d4ab66d5cc72796228c8a9c117fcb97e318463456ccca6159d7555"
+      },
       "modules/eacl/src/eacl/backend/v8.cljc": {
         "count": 41,
         "idsSha256": "1ef9aaa3526b5cd6d8664568a8ff02a76252eb777f563d32789ba574e576d072"
@@ -438,12 +503,12 @@
         "idsSha256": "75c0ad0273fa5828aca5833652de740c7b968ed2565099995d8ca177fdc1d1b4"
       },
       "modules/eacl/src/eacl/client/orchestration.cljc": {
-        "count": 36,
-        "idsSha256": "83570759734f5231360960e92f1f69e6a5b2fa96435eabdf7cadb5c63b44d216"
+        "count": 46,
+        "idsSha256": "1e113f58d79ed1d6d7a934a86dbcfb02e890c1ea7b2ad4fa9d2148f06322b164"
       },
       "modules/eacl/src/eacl/consistency.cljc": {
-        "count": 16,
-        "idsSha256": "47559d3a9ea648dbfd15120b6cd931ca3a6b3e9a46182d5916924988e81a7989"
+        "count": 28,
+        "idsSha256": "acde0f0c54e259bceef118dc5fa82e85c3496bb4a726f1c13f8f76758e9e4ee9"
       },
       "modules/eacl/src/eacl/continuation.cljc": {
         "count": 15,
@@ -462,8 +527,8 @@
         "idsSha256": "cf00c6d69c37f164fe954ab3b6e59b32d121caef8554bbc75e589a7b77e19bc6"
       },
       "modules/eacl/src/eacl/engine/physical.cljc": {
-        "count": 19,
-        "idsSha256": "a37ae90b6035df8dab25985bf335d5e0a1a4e8eb78eb3d33d4a9acdd2a7414ce"
+        "count": 20,
+        "idsSha256": "cefb00aaa240835179d025f865eb22296f3a5d77cb44dfa17fcd176645d7ad3c"
       },
       "modules/eacl/src/eacl/engine/portable_decisions.cljc": {
         "count": 30,
@@ -535,7 +600,7 @@
       },
       "modules/eacl/src/eacl/relay.cljc": {
         "count": 57,
-        "idsSha256": "d33504b8bf1a0d5e39182dcb72cb8c51e304a13288b401ab5592c6f2e130ec75"
+        "idsSha256": "bd485744705861a49f708e44ff42e9c1d4fd31ef0f4cab4654e05e0214c8554d"
       },
       "modules/eacl/src/eacl/schema/errors.cljc": {
         "count": 10,
@@ -698,8 +763,8 @@
       ]
     },
     "eacl.relay/select-continuation-adapter": {
-      "internalDefinitionCount": 254,
-      "internalDefinitionIdsSha256": "06b066419868b380a2bcecbd4291bf891ff750440d41663c47943df6b911466b",
+      "internalDefinitionCount": 285,
+      "internalDefinitionIdsSha256": "9e13c5154d2c2ce559732507d98ddfac01f06a670ca5aebf2125b35da737b72a",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -718,8 +783,8 @@
       ]
     },
     "eacl.relay/prepare-page-query": {
-      "internalDefinitionCount": 258,
-      "internalDefinitionIdsSha256": "76eee0adbb88313b4fc4e43b8fb9924641860bbf863ee16ee7426042a6454bb8",
+      "internalDefinitionCount": 289,
+      "internalDefinitionIdsSha256": "a43197abccc2b609beb2369bfb9d3db93babab7cc7cc96a87b249016730873d0",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -864,8 +929,8 @@
       "externalCalls": []
     },
     "eacl.consistency/select": {
-      "internalDefinitionCount": 211,
-      "internalDefinitionIdsSha256": "95dc5f3b9be6da99ce359514bace02ce1019ec6f3a445f977b753e21000f9e8e",
+      "internalDefinitionCount": 259,
+      "internalDefinitionIdsSha256": "847e4c675fa15f05c05352ca560049c018fb132cca29bfe7ebcce8a78a974a4d",
       "externalCallCount": 11,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -943,8 +1008,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 876,
-      "internalDefinitionIdsSha256": "e141a0dfe6f084f460417d7a5c85d4ad10755f982665a1fd17cdc64492496272",
+      "internalDefinitionCount": 924,
+      "internalDefinitionIdsSha256": "7f8727dc788d0376d6483a6de30de40f719923fe8d3b130b20f9fe6364d0d63f",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -990,8 +1055,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 523,
-      "internalDefinitionIdsSha256": "5869502550fde207a761b51aefa8ff9ed00fdde143a5f249de72013feef9c875",
+      "internalDefinitionCount": 570,
+      "internalDefinitionIdsSha256": "adf2e038f9a0e99fda161b76f63cd6724c0bfe192f51a9fae9d40c11d29833a0",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1020,53 +1085,57 @@
       ]
     },
     "eacl.datomic.core/spiceomic-write-relationships!": {
-      "internalDefinitionCount": 113,
-      "internalDefinitionIdsSha256": "b39a34f369e03cf3e7eaf826ed8a87bf7f0336a77c6befe828b009c429d4b2ee",
-      "externalCallCount": 17,
+      "internalDefinitionCount": 320,
+      "internalDefinitionIdsSha256": "b827f9897f61644c2aefa08c99fda325dcc06469de2f05ab21eca965cf46f370",
+      "externalCallCount": 19,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "com.rpl.specter/ALL",
         "com.rpl.specter/transform",
         "datomic.api/datoms",
-        "datomic.api/db",
         "datomic.api/entid",
         "datomic.api/entity",
         "datomic.api/q",
         "datomic.api/transact",
         "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
         "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
         "unresolved/js/String.fromCharCode",
         "unresolved/js/require"
       ]
     },
     "eacl.datomic.core/spiceomic-delete-object!": {
-      "internalDefinitionCount": 96,
-      "internalDefinitionIdsSha256": "6acc420d6bef555d597a127951109feb4308439bd6718293006d8d3dcc33e272",
-      "externalCallCount": 14,
+      "internalDefinitionCount": 303,
+      "internalDefinitionIdsSha256": "4b94f0160e0c6c12e6750e17c61ce18b8c54f6e4d4856e04fd929ae0c910de79",
+      "externalCallCount": 16,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "datomic.api/datoms",
-        "datomic.api/db",
         "datomic.api/entid",
         "datomic.api/entity",
         "datomic.api/transact",
         "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
         "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
         "unresolved/js/String.fromCharCode",
         "unresolved/js/require"
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 464,
-      "internalDefinitionIdsSha256": "3c957e6d37ae7a4a114b1209232454c94b7ba964cec78302bda704cc2e426507",
+      "internalDefinitionCount": 511,
+      "internalDefinitionIdsSha256": "70e5445fe79184c1e9868f434518abb693e508d45977a0a63a52cdc9f07c41ac",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1099,8 +1168,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 676,
-      "internalDefinitionIdsSha256": "09a8a28e56e57f5b44a6461841c50ab83301ff7ac8c52bb443355d52b5b5f343",
+      "internalDefinitionCount": 724,
+      "internalDefinitionIdsSha256": "89510cc4608d9f0ce188183834381f4b03d4f6c7879203d6ea510ab860da4bbe",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1133,8 +1202,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 487,
-      "internalDefinitionIdsSha256": "bad75986ea692653f7f4ec17891b67ab6bce3afd951301998001aa62d467b833",
+      "internalDefinitionCount": 534,
+      "internalDefinitionIdsSha256": "7ab22b147686981ae126a1e5f8d339eae8fdc846912c6d315b8277452b454226",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1167,8 +1236,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 676,
-      "internalDefinitionIdsSha256": "328c652c741f5cfbebb48b4a1696bd0449079a91670562c6ae727f765b8e93a0",
+      "internalDefinitionCount": 724,
+      "internalDefinitionIdsSha256": "a940ad00c62d15f8adfdac1e2206db91328c9dcceea7978a7620023146017aed",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1201,8 +1270,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 487,
-      "internalDefinitionIdsSha256": "795da970872d28f402a47ba9ceb88c8f4f7b984f8fc940a1e5b13f86e209de69",
+      "internalDefinitionCount": 534,
+      "internalDefinitionIdsSha256": "db2927ba13f5ef73016250e2a7d7532794e61d3f53a14b0a14ee3607a41927a4",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1235,8 +1304,8 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 222,
-      "internalDefinitionIdsSha256": "d4aeab5d5d70521b2663620c71fbb0f88a85f76eeefa7229156f9fc5303bff6a",
+      "internalDefinitionCount": 257,
+      "internalDefinitionIdsSha256": "f161cb4e1219de8068c2e41646c5d278219c90b2e5e8717a686b8b9217ff53da",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1270,8 +1339,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 877,
-      "internalDefinitionIdsSha256": "15cd1c0971d3a6eb2b7ab81e9ad0c4e3cf6f238a5a190b1d16feaf4cb7e15053",
+      "internalDefinitionCount": 925,
+      "internalDefinitionIdsSha256": "490a9da72aae30230757583d804ac477a50641512fe203f0985d299604b4d9eb",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1317,8 +1386,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 879,
-      "internalDefinitionIdsSha256": "6a5c068c3fe14ee1d7deb7ebad2105e317858f68a74b9e44605b7d127cd7054b",
+      "internalDefinitionCount": 927,
+      "internalDefinitionIdsSha256": "21d03d8ade73c0f165e7970317fa0b12fbd289a3b26adcb0cb44c5d47fc9f6cb",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1364,8 +1433,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 699,
-      "internalDefinitionIdsSha256": "78224e1afdb0ff02ed3d1ebbd2539bd2360f8a1cf0c480baca479706f40a08da",
+      "internalDefinitionCount": 757,
+      "internalDefinitionIdsSha256": "ee543c396a094a9183a11446a4c6d98bf5c4817a41677ac39d4ba57235897d97",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1386,8 +1455,8 @@
       ]
     },
     "eacl.client.orchestration/make-client": {
-      "internalDefinitionCount": 107,
-      "internalDefinitionIdsSha256": "ff1640b288c5972f5dfb0f482640ffe30222b687110275b64c09391e78bfad62",
+      "internalDefinitionCount": 111,
+      "internalDefinitionIdsSha256": "3b7772fc8bcd6d6f957793faf56a1e3a4e04998da1e039fd0e423b27cdfe864a",
       "externalCallCount": 8,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1401,8 +1470,8 @@
       ]
     },
     "eacl.datahike.core/datahike-read-relationships": {
-      "internalDefinitionCount": 596,
-      "internalDefinitionIdsSha256": "fdd72deabb9761cfc70929e1822cc6c645ab41493fcc7645b2d71acfba043f2a",
+      "internalDefinitionCount": 656,
+      "internalDefinitionIdsSha256": "016f01c693b7e135b0e47ae10c687e1a85127393143ad2b849b96f4097ecce57",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1437,9 +1506,9 @@
       ]
     },
     "eacl.datahike.core/datahike-write-relationships!": {
-      "internalDefinitionCount": 351,
-      "internalDefinitionIdsSha256": "93aaac6306525f3eab5119990b2d2632061a7c70cec0858aa329323e901c996f",
-      "externalCallCount": 27,
+      "internalDefinitionCount": 457,
+      "internalDefinitionIdsSha256": "e5823c33a10a57d3a426854c25ea914f10a6004e70bc7d46fae6ef23f17bc39d",
+      "externalCallCount": 30,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
@@ -1447,6 +1516,7 @@
         "clojure.set/intersection",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "clojure.walk/postwalk",
         "com.rpl.specter/ALL",
         "com.rpl.specter/transform",
@@ -1461,19 +1531,21 @@
         "datahike.api/transact",
         "datahike.db.interface/-config",
         "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
         "instaparse.core/failure?",
         "instaparse.core/get-failure",
         "instaparse.core/parser",
         "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
         "unresolved/js/String.fromCharCode",
         "unresolved/js/require"
       ]
     },
     "eacl.datahike.core/datahike-delete-object!": {
-      "internalDefinitionCount": 342,
-      "internalDefinitionIdsSha256": "eefb96461649cd2d37045dd63b5be5d70d03ca6e5aab160fa822b0fcad022180",
-      "externalCallCount": 25,
+      "internalDefinitionCount": 448,
+      "internalDefinitionIdsSha256": "2e5128ba5bafd18bd17338ca954820e35c089ddb7b1154363de7f2ead10836de",
+      "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
@@ -1481,6 +1553,7 @@
         "clojure.set/intersection",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "clojure.walk/postwalk",
         "datahike.api/as-of",
         "datahike.api/commit-as-db",
@@ -1493,18 +1566,20 @@
         "datahike.api/transact",
         "datahike.db.interface/-config",
         "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
         "instaparse.core/failure?",
         "instaparse.core/get-failure",
         "instaparse.core/parser",
         "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
         "unresolved/js/String.fromCharCode",
         "unresolved/js/require"
       ]
     },
     "eacl.datahike.core/datahike-can?": {
-      "internalDefinitionCount": 578,
-      "internalDefinitionIdsSha256": "9d9b6db8f54164908390644839e727cb36f164cce9705fb5a007611b179ce5ba",
+      "internalDefinitionCount": 637,
+      "internalDefinitionIdsSha256": "56b7e3e9d55ee6539bb1207660cdc79ce359db2d18acbaa5bd73498ab3176c95",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1538,8 +1613,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-resources": {
-      "internalDefinitionCount": 783,
-      "internalDefinitionIdsSha256": "bf75a48dc1defd58dba4f3f44866c3a6eefa03333425f86e5851fc609222cded",
+      "internalDefinitionCount": 843,
+      "internalDefinitionIdsSha256": "0f8e7c143cb05b1929415bb6f542e2881a3c7f74a5bad73007fe1f64ea311b9b",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1574,8 +1649,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-resources": {
-      "internalDefinitionCount": 602,
-      "internalDefinitionIdsSha256": "abf5d75d9da776f2afc69fa71b8a16f22f72447de7083775db2eac182dfa2505",
+      "internalDefinitionCount": 662,
+      "internalDefinitionIdsSha256": "5756d8c212625c0e7ad18cd01c9c94f5ead4a87350159d130ee1f5e16fe48df9",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1609,8 +1684,8 @@
       ]
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
-      "internalDefinitionCount": 783,
-      "internalDefinitionIdsSha256": "8f39fbe533314874256c1e301c5c629c30465686f0f4bcea610fae7608c9ad2a",
+      "internalDefinitionCount": 843,
+      "internalDefinitionIdsSha256": "734fd87fb7951854cc2df1d30128f0956bd08c3eac7f9094f75813ccabfdb971",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1645,8 +1720,8 @@
       ]
     },
     "eacl.datahike.core/datahike-count-subjects": {
-      "internalDefinitionCount": 602,
-      "internalDefinitionIdsSha256": "a4c094a9e7ba6e7fda50086101b73e777b5a68bf36ac1e629ecd1be8b391cc23",
+      "internalDefinitionCount": 662,
+      "internalDefinitionIdsSha256": "3fee4c2f9db0116e248038f1224bb9cfa600daf2a6b2048fdee8d67175a43f87",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1680,8 +1755,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 370,
-      "internalDefinitionIdsSha256": "15aba98375bdeee65d6c928a141250482fa3ca3d243c912a843ca5a6d6f44728",
+      "internalDefinitionCount": 404,
+      "internalDefinitionIdsSha256": "cb3bf01b3f7bf36d0ad499acd57f62ec1e2a8b922b63deaeef2ee43d48df938d",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1711,8 +1786,8 @@
       ]
     },
     "eacl.datascript.core/datascript-read-relationships": {
-      "internalDefinitionCount": 581,
-      "internalDefinitionIdsSha256": "d9fc3f2848ea4d22e94b051ab7caa0b26f786968a475ae39bc573e46c00c007b",
+      "internalDefinitionCount": 641,
+      "internalDefinitionIdsSha256": "1ced6c3db9aac40320b7ef84eff44e5e62cb76af3d1264c306367b6dcb4c415d",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1746,9 +1821,9 @@
       ]
     },
     "eacl.datascript.core/datascript-write-relationships!": {
-      "internalDefinitionCount": 336,
-      "internalDefinitionIdsSha256": "f2d40ddfcb4bd83044b6831381b1da89e05e7ced1d9ade755a4855a583abfa65",
-      "externalCallCount": 26,
+      "internalDefinitionCount": 442,
+      "internalDefinitionIdsSha256": "d99fad086ddeb7c9e43677942f0184de5e618f1694e074cc307f93206b58861a",
+      "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
@@ -1756,6 +1831,7 @@
         "clojure.set/intersection",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "clojure.walk/postwalk",
         "com.rpl.specter/ALL",
         "com.rpl.specter/transform",
@@ -1769,19 +1845,21 @@
         "datascript.core/seek-datoms",
         "datascript.core/transact!",
         "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
         "instaparse.core/failure?",
         "instaparse.core/get-failure",
         "instaparse.core/parser",
         "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
         "unresolved/js/String.fromCharCode",
         "unresolved/js/require"
       ]
     },
     "eacl.datascript.core/datascript-delete-object!": {
-      "internalDefinitionCount": 327,
-      "internalDefinitionIdsSha256": "bdf95a7656f406c13e2610162661a9a5da55c6d04fe1302130eb215c63a4bc16",
-      "externalCallCount": 24,
+      "internalDefinitionCount": 433,
+      "internalDefinitionIdsSha256": "a07f9f337faff76e950771737bd2dd4e2585559101bc1a2ae1a944cfecb7024a",
+      "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
@@ -1789,6 +1867,7 @@
         "clojure.set/intersection",
         "clojure.string/join",
         "clojure.string/replace",
+        "clojure.string/starts-with?",
         "clojure.walk/postwalk",
         "datascript.core/datoms",
         "datascript.core/db",
@@ -1800,18 +1879,20 @@
         "datascript.core/seek-datoms",
         "datascript.core/transact!",
         "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
         "instaparse.core/failure?",
         "instaparse.core/get-failure",
         "instaparse.core/parser",
         "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
         "unresolved/js/Number.isSafeInteger",
         "unresolved/js/String.fromCharCode",
         "unresolved/js/require"
       ]
     },
     "eacl.datascript.core/datascript-can?": {
-      "internalDefinitionCount": 563,
-      "internalDefinitionIdsSha256": "8f48298c3eb0134b6b28656e4beef0496df451a51381c6a3f7305398c9017885",
+      "internalDefinitionCount": 622,
+      "internalDefinitionIdsSha256": "bdf4f4db708aa6a63f1549f398a9951a18961ea96a9d58cfc97998c20c493900",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1844,8 +1925,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-resources": {
-      "internalDefinitionCount": 768,
-      "internalDefinitionIdsSha256": "6b211f9355374d8df21e0a1c720cfea74e9417beacbc49efcea5b5dc1811b94b",
+      "internalDefinitionCount": 828,
+      "internalDefinitionIdsSha256": "dfeee3cf422913f7859f7789e867e44a80e757e4b52b357b54c1a64144b3a41c",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1879,8 +1960,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-resources": {
-      "internalDefinitionCount": 587,
-      "internalDefinitionIdsSha256": "0db42e8ca77ca720cf00596601ce6ac345cd240fec185875c53d1501c4fa5012",
+      "internalDefinitionCount": 647,
+      "internalDefinitionIdsSha256": "15c9bc1f62a95a27da38426c39aad8f3eb80201b95d2c9d965254799317132af",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1913,8 +1994,8 @@
       ]
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
-      "internalDefinitionCount": 768,
-      "internalDefinitionIdsSha256": "3913b18fc022e83dadb04b1ee73c65471080cc50cf7e2ba5ac0e7c77bae3cdf9",
+      "internalDefinitionCount": 828,
+      "internalDefinitionIdsSha256": "3a24e77c5a3dbef4513e9466d36a7bdf1ab807295ca90f9cdb9aa53accbb18da",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1948,8 +2029,8 @@
       ]
     },
     "eacl.datascript.core/datascript-count-subjects": {
-      "internalDefinitionCount": 587,
-      "internalDefinitionIdsSha256": "dff6e24636f2af102d381df0b088e87458aaa9d6ba9f082131cc2e557ba958ef",
+      "internalDefinitionCount": 647,
+      "internalDefinitionIdsSha256": "accea5ec18df6f89328a70a2185705821c6288063539006421f4489de89d56d1",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1982,8 +2063,8 @@
       ]
     },
     "eacl.datascript.core/make-client": {
-      "internalDefinitionCount": 355,
-      "internalDefinitionIdsSha256": "2ed34081a310db7d4e2a130de1ee4b716795a3cda94fa61f849e23823b3f1ee5",
+      "internalDefinitionCount": 389,
+      "internalDefinitionIdsSha256": "545743d8190cfd7dd413eccf6c872c44882dab4366a1472d6e730dc668cfb604",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2007,6 +2088,362 @@
         "instaparse.core/get-failure",
         "instaparse.core/parser",
         "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/console.warn",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-read-relationships": {
+      "internalDefinitionCount": 663,
+      "internalDefinitionIdsSha256": "dee23f25d74fa0ec3b0e9a8ae86bf757f96ddc266a210a50a5b8533fbdc2ce59",
+      "externalCallCount": 33,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/split",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-write-relationships!": {
+      "internalDefinitionCount": 465,
+      "internalDefinitionIdsSha256": "342109f38b867ba32e3f43f2f2c8fbc988bd8af7d4f9114b6679b528ba1ccb95",
+      "externalCallCount": 34,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "com.rpl.specter/ALL",
+        "com.rpl.specter/transform",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-delete-object!": {
+      "internalDefinitionCount": 456,
+      "internalDefinitionIdsSha256": "6b2ccf395a6e3d35b2ef5695a1016b8f8c10468a2e6537b92a7659371283d1ff",
+      "externalCallCount": 32,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-can?": {
+      "internalDefinitionCount": 646,
+      "internalDefinitionIdsSha256": "4c3cf5fa9970d111074bbbdcc1925765942ff1243a0ce2c70ee72ec11ddcdbde",
+      "externalCallCount": 32,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-lookup-resources": {
+      "internalDefinitionCount": 850,
+      "internalDefinitionIdsSha256": "5e3ff19fd4fd8182305560e0aab0ce99b2e602f8c836f5b4d7d723c70264de71",
+      "externalCallCount": 33,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/split",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-count-resources": {
+      "internalDefinitionCount": 671,
+      "internalDefinitionIdsSha256": "8f8d7ad93fac75456a692d3a9afd1963aaa29459f9e8ed60880f3f6847d15df2",
+      "externalCallCount": 32,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-lookup-subjects": {
+      "internalDefinitionCount": 850,
+      "internalDefinitionIdsSha256": "a0d4a430df6c0b4c963cf328c525113103ff8414fddb86a71fb2baa764f27b70",
+      "externalCallCount": 33,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/split",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/datalevin-count-subjects": {
+      "internalDefinitionCount": 671,
+      "internalDefinitionIdsSha256": "099b8d59d34e95f079756cf1d15fd83453f1f158b700fda246fdfdd9e2ccfe7f",
+      "externalCallCount": 32,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.string/starts-with?",
+        "clojure.walk/postwalk",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "goog.crypt/utf8ByteArrayToString",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Date.now",
+        "unresolved/js/Math.floor",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
+        "unresolved/js/require"
+      ]
+    },
+    "eacl.datalevin.core/make-client": {
+      "internalDefinitionCount": 398,
+      "internalDefinitionIdsSha256": "1d7eaf37fc0b41fbd9ab4fc54b1d579a9a1876bdec07ea3fa8b86731e8bfb691",
+      "externalCallCount": 32,
+      "externalCalls": [
+        "cljs.reader/read-string",
+        "clojure.edn/read-string",
+        "clojure.set/difference",
+        "clojure.set/intersection",
+        "clojure.string/join",
+        "clojure.string/replace",
+        "clojure.walk/postwalk",
+        "com.rpl.specter/transform",
+        "datalevin.core/close-read-snapshot!",
+        "datalevin.core/datoms",
+        "datalevin.core/db",
+        "datalevin.core/entid",
+        "datalevin.core/entity",
+        "datalevin.core/open-read-snapshot",
+        "datalevin.core/pull",
+        "datalevin.core/read-snapshot-capabilities",
+        "datalevin.core/read-snapshot-info",
+        "datalevin.core/read-snapshot?",
+        "datalevin.core/rseek-datoms",
+        "datalevin.core/schema",
+        "datalevin.core/seek-datoms",
+        "datalevin.core/transact!",
+        "datalevin.core/update-schema",
+        "datalevin.core/with-read-snapshot",
+        "goog.crypt/stringToUtf8ByteArray",
+        "instaparse.core/failure?",
+        "instaparse.core/get-failure",
+        "instaparse.core/parser",
+        "unresolved/js/Number.isSafeInteger",
+        "unresolved/js/String.fromCharCode",
         "unresolved/js/console.warn",
         "unresolved/js/require"
       ]

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -41,19 +41,19 @@
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc",
-      "sha256": "7e86724edc77da904ca050b0084e09ea960aebadc928de9857848eef344c13ce"
+      "sha256": "498a05b7fe1da444eeb600e0de17e5da1199957d5821ae849237939626a8fff8"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/core.cljc",
-      "sha256": "85c1c2b32ef49d0523242f346652a75bb015e6d3f87360cddbb83b81a9af587c"
+      "sha256": "cbcfb65e3420a3fe3fe82476831860ad2520a2c6d11819d240f2181934d50a87"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/db.cljc",
-      "sha256": "1cd129344e86dcbce26a44fd51f292e237a2b08ff9446b0d57dad1b537070563"
+      "sha256": "3fb3cd75c2a860574a5d8c71afd8e58f62faaa3dc1cb4f51fa0687d1d8934d3b"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/impl.cljc",
-      "sha256": "5c84fdc12d47be603eca228c1ce9937d50f1c7973113eeeddbfb492ca13a32c2"
+      "sha256": "0ff2aa1413b826aeea3a314ade12804b39ef0160433558889b1a55e16d23c92e"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/integrity.cljc",
@@ -157,7 +157,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/backend/v8.cljc",
-      "sha256": "1084053e5761ff07ffbb0c8519aba0ba3465634a437b6a19e49301d9ac69f005"
+      "sha256": "f6923a1cca2834d5b64dde49ca9cd52e640774063258bbaf495a83473fbf61c3"
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
@@ -169,7 +169,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "696f029ac90cc1a89d717c47fcd386a7408f9c213437b70f2e05f000372030a4"
+      "sha256": "1265f4bbec54949e9c76cd14da941018fb1f2a8f507070c898ddd812ae424dc6"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -181,7 +181,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/core.cljc",
-      "sha256": "5d21745959018f0b6a59bb2b508d51c21418a04c54ca6518e1417fe51450fa42"
+      "sha256": "07e6710eca06534cad1f5511942410066cd47074e2b0594fda03e7d8c26401f0"
     },
     {
       "path": "modules/eacl/src/eacl/cursor.cljc",
@@ -205,7 +205,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/relationships.cljc",
-      "sha256": "9c7f5b7d5b7a2d57b22551ae3d9c727ac6f30423d6806c525dfb7408f3e6f6c2"
+      "sha256": "f3d3019defb4d68bb4f74ec75e05ae943b98d7b06809256d1b7d354b1a77b1e4"
     },
     {
       "path": "modules/eacl/src/eacl/engine/sealed_plan.cljc",
@@ -225,7 +225,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/engine/v8.cljc",
-      "sha256": "d6357082193523492bca9a8f92830e0ba111c64e9199d552b2643b637ac9eb87"
+      "sha256": "43103284d855878fe659ce91807987f1f309aecc8c7bd25cced3ffb3695d2380"
     },
     {
       "path": "modules/eacl/src/eacl/execution.cljc",
@@ -378,9 +378,9 @@
       "eacl.datalevin.core/make-client"
     ],
     "rootCount": 70,
-    "unionInternalDefinitionCount": 1584,
-    "unionInternalDefinitionIdsSha256": "ce9d9618b070398ad067ddf76d1bb0db32cf91be7550cde79b0c0b503d96a641",
-    "unionDefinitionLocationsSha256": "ebbba20464cd0ca9b197cafe1de77390592563bd0b6c1231b0dc7470321dab01",
+    "unionInternalDefinitionCount": 1587,
+    "unionInternalDefinitionIdsSha256": "931494352aabbdc3dbd1845e1a78f89562ebcf4d5f3995fb9221537d208b9a00",
+    "unionDefinitionLocationsSha256": "78b3da316d0b03d6feb4ee0e67b2ec0c8606d5c0df030064b852fabba39b970f",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 19,
@@ -415,8 +415,8 @@
         "idsSha256": "38aedbf94b1b1c38e4635e480b754005e7fe4c39cac188304fa2451f8f09cad0"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/impl.cljc": {
-        "count": 38,
-        "idsSha256": "a46481cfe3f1f6cf0afda89739b543fb8002126fad8c0e5ee764cfc843b4c2ba"
+        "count": 39,
+        "idsSha256": "ee9f35fd65d61c0798a33bcecd921a67c8933717aa581cc7c7d989d86ea757ed"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/schema.cljc": {
         "count": 19,
@@ -491,8 +491,8 @@
         "idsSha256": "71aceb7f31d4ab66d5cc72796228c8a9c117fcb97e318463456ccca6159d7555"
       },
       "modules/eacl/src/eacl/backend/v8.cljc": {
-        "count": 41,
-        "idsSha256": "1ef9aaa3526b5cd6d8664568a8ff02a76252eb777f563d32789ba574e576d072"
+        "count": 40,
+        "idsSha256": "9e39f009883453f0dc6ab5c5037463049008ff5e83f736a81c349fd938349eda"
       },
       "modules/eacl/src/eacl/cache.cljc": {
         "count": 39,
@@ -503,8 +503,8 @@
         "idsSha256": "75c0ad0273fa5828aca5833652de740c7b968ed2565099995d8ca177fdc1d1b4"
       },
       "modules/eacl/src/eacl/client/orchestration.cljc": {
-        "count": 46,
-        "idsSha256": "1e113f58d79ed1d6d7a934a86dbcfb02e890c1ea7b2ad4fa9d2148f06322b164"
+        "count": 48,
+        "idsSha256": "e25e817cfe3679e03f4ed46d359b8f4f9e3bdb4e55a33c1269271fe8ae679605"
       },
       "modules/eacl/src/eacl/consistency.cljc": {
         "count": 28,
@@ -515,8 +515,8 @@
         "idsSha256": "78e56fbb67be3d67ed11298d902cd46635d1f1352d363998458a6d59c66d20b2"
       },
       "modules/eacl/src/eacl/core.cljc": {
-        "count": 7,
-        "idsSha256": "ee25a2533f2e6a826c0afe9d39d7eda031b5f7b7b29c69c6a0b84614ae11d402"
+        "count": 8,
+        "idsSha256": "b3d3047f34d10d8db49b1f1005d3422a8d4fcc6feefe046186239b32da2418ec"
       },
       "modules/eacl/src/eacl/cursor.cljc": {
         "count": 24,
@@ -638,12 +638,12 @@
   },
   "attribution": {
     "inlineDefrecordMethods": "unattributed usages inside exact clj-kondo defrecord source spans are assigned to the containing record root",
-    "inlineDefrecordCount": 66
+    "inlineDefrecordCount": 69
   },
   "roots": {
     "eacl.engine.v8/can?": {
-      "internalDefinitionCount": 123,
-      "internalDefinitionIdsSha256": "5f17bf9b23106b6d6b5fcc48be3e0ad879734735e4180d1ed5410168163e916e",
+      "internalDefinitionCount": 122,
+      "internalDefinitionIdsSha256": "1cf448165d9e9fd8768eb4d4b410f803b64e4bfd48e965889c298343ffcd5d57",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -658,8 +658,8 @@
       ]
     },
     "eacl.engine.v8/lookup-resources": {
-      "internalDefinitionCount": 352,
-      "internalDefinitionIdsSha256": "240e2b382ea25e6794e101dd4c019a267eb54cd8a833accfdb307b6fa1e7b0b9",
+      "internalDefinitionCount": 351,
+      "internalDefinitionIdsSha256": "28f347aa298ac81cf90d6293f239a199f948b675061b215ca91456bbea47e522",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -674,8 +674,8 @@
       ]
     },
     "eacl.engine.v8/lookup-subjects": {
-      "internalDefinitionCount": 352,
-      "internalDefinitionIdsSha256": "16b14ca2c2b15cc9998b162bcec20ce2285ba5579b0725c001477be69ad45192",
+      "internalDefinitionCount": 351,
+      "internalDefinitionIdsSha256": "212da5a042ffb0e72e23667e28f8161ff5668aaf79fb9312b434900bad23860b",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -690,8 +690,8 @@
       ]
     },
     "eacl.engine.v8/count-resources": {
-      "internalDefinitionCount": 147,
-      "internalDefinitionIdsSha256": "c077256ec89ad041bde0937706279b7ae73fc7514beaabae1144c083b65fc70f",
+      "internalDefinitionCount": 146,
+      "internalDefinitionIdsSha256": "cc90ae4f13cb0c768614e00caef65f49a560f3509a35a15baebba261b75484e6",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -706,8 +706,8 @@
       ]
     },
     "eacl.engine.v8/count-subjects": {
-      "internalDefinitionCount": 147,
-      "internalDefinitionIdsSha256": "af49f0c592892fc7355c1bc99baf1e1ad8e6eb0fa0f9fb45ea57971a4919c3b6",
+      "internalDefinitionCount": 146,
+      "internalDefinitionIdsSha256": "40caaab5cb40708ca2960331259b68254c36c9b30f12c445c6bbd66bb9e480d6",
       "externalCallCount": 9,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -736,8 +736,8 @@
       "externalCalls": []
     },
     "eacl.relay/lookup-visited-page": {
-      "internalDefinitionCount": 63,
-      "internalDefinitionIdsSha256": "b7a6ed026aa1f7f2d0ea06cc46e9bcf370eb058b87348c9ccafd9fdc23e8e4df",
+      "internalDefinitionCount": 62,
+      "internalDefinitionIdsSha256": "d3f68d66ecce7a0d1ef20f46c9f0d866f96e1c716a3a06b18572d7ef45195ce0",
       "externalCallCount": 5,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -748,8 +748,8 @@
       ]
     },
     "eacl.relay/remember-visited-page!": {
-      "internalDefinitionCount": 81,
-      "internalDefinitionIdsSha256": "dd02448f9b563c32c0807551ece507bc0ef40eab21a1d80e305ca8c235630b1e",
+      "internalDefinitionCount": 80,
+      "internalDefinitionIdsSha256": "eb86795a78cd7933d698a52a827edefeebbb0e5741c45442a0250d8a864b7d40",
       "externalCallCount": 8,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -763,8 +763,8 @@
       ]
     },
     "eacl.relay/select-continuation-adapter": {
-      "internalDefinitionCount": 285,
-      "internalDefinitionIdsSha256": "9e13c5154d2c2ce559732507d98ddfac01f06a670ca5aebf2125b35da737b72a",
+      "internalDefinitionCount": 284,
+      "internalDefinitionIdsSha256": "51aba42a8c2f7eb74d6a2b4d2f597531ec4a49fbf4ae442741472f4543553d65",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -783,8 +783,8 @@
       ]
     },
     "eacl.relay/prepare-page-query": {
-      "internalDefinitionCount": 289,
-      "internalDefinitionIdsSha256": "a43197abccc2b609beb2369bfb9d3db93babab7cc7cc96a87b249016730873d0",
+      "internalDefinitionCount": 288,
+      "internalDefinitionIdsSha256": "b0cb541be7b34d3f2f4424774abed17b0c38700f14279fe8c101734ae21b96e4",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -803,8 +803,8 @@
       ]
     },
     "eacl.relay/internalize-page-query": {
-      "internalDefinitionCount": 254,
-      "internalDefinitionIdsSha256": "810625cdd6f1b9ffdaa39eebe35cdf7b2b50939126b66bafa9e60e62623d19e1",
+      "internalDefinitionCount": 253,
+      "internalDefinitionIdsSha256": "e1fb2713d0562e636e4b9f500a696fd125ff6a20c91db338c84e5079918036bb",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -823,8 +823,8 @@
       ]
     },
     "eacl.relay/externalize-page": {
-      "internalDefinitionCount": 145,
-      "internalDefinitionIdsSha256": "ebed123414ca6688dc60fc4eef901ff2100db569eb5551a96776732172c8402a",
+      "internalDefinitionCount": 144,
+      "internalDefinitionIdsSha256": "6d873e527752bccf51ebffe9501b0e038230a022611733f88f6150d1faae9c11",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -840,8 +840,8 @@
       ]
     },
     "eacl.relay/externalize-relationship-page": {
-      "internalDefinitionCount": 144,
-      "internalDefinitionIdsSha256": "9312f0ab8610e4a2eddc40346656d0c43a369f722a6bb4748c92bc5f2eb978e7",
+      "internalDefinitionCount": 143,
+      "internalDefinitionIdsSha256": "e00ececcb0e0504783868b194268def9290429af48b334bdbd5c870f41710377",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -929,8 +929,8 @@
       "externalCalls": []
     },
     "eacl.consistency/select": {
-      "internalDefinitionCount": 259,
-      "internalDefinitionIdsSha256": "847e4c675fa15f05c05352ca560049c018fb132cca29bfe7ebcce8a78a974a4d",
+      "internalDefinitionCount": 258,
+      "internalDefinitionIdsSha256": "a5fd5d3fc30876962b4e439ae0295d642062f566a964701e5a1beb553533c9ef",
       "externalCallCount": 11,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1008,8 +1008,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/Spiceomic": {
-      "internalDefinitionCount": 924,
-      "internalDefinitionIdsSha256": "7f8727dc788d0376d6483a6de30de40f719923fe8d3b130b20f9fe6364d0d63f",
+      "internalDefinitionCount": 923,
+      "internalDefinitionIdsSha256": "b8568bc456496d01d22433fe7d3e9a221b8fb243905e5d540c697b66f4844157",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1055,8 +1055,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-read-relationships": {
-      "internalDefinitionCount": 570,
-      "internalDefinitionIdsSha256": "adf2e038f9a0e99fda161b76f63cd6724c0bfe192f51a9fae9d40c11d29833a0",
+      "internalDefinitionCount": 569,
+      "internalDefinitionIdsSha256": "e6e814c6cd1e9ac844c28e9509d51db2b4426a753712683de6662883f8cb41f7",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1085,8 +1085,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-write-relationships!": {
-      "internalDefinitionCount": 320,
-      "internalDefinitionIdsSha256": "b827f9897f61644c2aefa08c99fda325dcc06469de2f05ab21eca965cf46f370",
+      "internalDefinitionCount": 319,
+      "internalDefinitionIdsSha256": "756928dbd2ad3f2067163dbb6a8ca697f53c796a5e400c4ea9f6f02bd67e8095",
       "externalCallCount": 19,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1111,8 +1111,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-delete-object!": {
-      "internalDefinitionCount": 303,
-      "internalDefinitionIdsSha256": "4b94f0160e0c6c12e6750e17c61ce18b8c54f6e4d4856e04fd929ae0c910de79",
+      "internalDefinitionCount": 302,
+      "internalDefinitionIdsSha256": "130b291ade2198cc1d39dfa5a63f7ddb0dbe4de4ac0fc72d3cd0b9e6d8659f8b",
       "externalCallCount": 16,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1134,8 +1134,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-can?": {
-      "internalDefinitionCount": 511,
-      "internalDefinitionIdsSha256": "70e5445fe79184c1e9868f434518abb693e508d45977a0a63a52cdc9f07c41ac",
+      "internalDefinitionCount": 510,
+      "internalDefinitionIdsSha256": "5a13ee19c7081ecae70bfea6ba7e81a21eee77464a18cae906db45649ea4255a",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1168,8 +1168,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-resources": {
-      "internalDefinitionCount": 724,
-      "internalDefinitionIdsSha256": "89510cc4608d9f0ce188183834381f4b03d4f6c7879203d6ea510ab860da4bbe",
+      "internalDefinitionCount": 723,
+      "internalDefinitionIdsSha256": "389683fbe2ca3b24453070c3e3514bdc2d9640e69f188dac358bef8500dd9bec",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1202,8 +1202,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-resources": {
-      "internalDefinitionCount": 534,
-      "internalDefinitionIdsSha256": "7ab22b147686981ae126a1e5f8d339eae8fdc846912c6d315b8277452b454226",
+      "internalDefinitionCount": 533,
+      "internalDefinitionIdsSha256": "9ec25532f16b074f08f984a8e75db4795322584730aa8e94b82cab942329941d",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1236,8 +1236,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-lookup-subjects": {
-      "internalDefinitionCount": 724,
-      "internalDefinitionIdsSha256": "a940ad00c62d15f8adfdac1e2206db91328c9dcceea7978a7620023146017aed",
+      "internalDefinitionCount": 723,
+      "internalDefinitionIdsSha256": "91b23e1ea39942e7ddb6f0ae59c92c8c40925a3e8dbac9373eb2386b46e55608",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1270,8 +1270,8 @@
       ]
     },
     "eacl.datomic.core/spiceomic-count-subjects": {
-      "internalDefinitionCount": 534,
-      "internalDefinitionIdsSha256": "db2927ba13f5ef73016250e2a7d7532794e61d3f53a14b0a14ee3607a41927a4",
+      "internalDefinitionCount": 533,
+      "internalDefinitionIdsSha256": "360b1a9a79710cf261d36dbf26d8b1bac37e17b685066ae7ce63ff83668ba600",
       "externalCallCount": 27,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1304,8 +1304,8 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 257,
-      "internalDefinitionIdsSha256": "f161cb4e1219de8068c2e41646c5d278219c90b2e5e8717a686b8b9217ff53da",
+      "internalDefinitionCount": 256,
+      "internalDefinitionIdsSha256": "0223ec569d216e6f6881b31f5df12cf2661b69a77f48a7e4e30d59b5586a2922",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1339,8 +1339,8 @@
       ]
     },
     "eacl.datomic.core/current-zed-token": {
-      "internalDefinitionCount": 925,
-      "internalDefinitionIdsSha256": "490a9da72aae30230757583d804ac477a50641512fe203f0985d299604b4d9eb",
+      "internalDefinitionCount": 924,
+      "internalDefinitionIdsSha256": "3e7ce1244dcf8086d12dfc4ff08dc651f48b8c19a5006ddb79691bf7a4e74d35",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1386,8 +1386,8 @@
       ]
     },
     "eacl.datomic.core/zed-token-at-least-seconds-ago": {
-      "internalDefinitionCount": 927,
-      "internalDefinitionIdsSha256": "21d03d8ade73c0f165e7970317fa0b12fbd289a3b26adcb0cb44c5d47fc9f6cb",
+      "internalDefinitionCount": 926,
+      "internalDefinitionIdsSha256": "95ff9723b3cb45e8b39c8944ab5db911238bcfc57d795e66500e837e9b82ee2f",
       "externalCallCount": 40,
       "externalCalls": [
         "clj-kondo/unknown-namespace/bound-cache#",
@@ -1433,8 +1433,8 @@
       ]
     },
     "eacl.client.orchestration/ClientAuthorization": {
-      "internalDefinitionCount": 757,
-      "internalDefinitionIdsSha256": "ee543c396a094a9183a11446a4c6d98bf5c4817a41677ac39d4ba57235897d97",
+      "internalDefinitionCount": 772,
+      "internalDefinitionIdsSha256": "6b5468eb0803175b5a35c12a3c11691119cf9236344d3e1a5e8cace90b6acda6",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1471,7 +1471,7 @@
     },
     "eacl.datahike.core/datahike-read-relationships": {
       "internalDefinitionCount": 656,
-      "internalDefinitionIdsSha256": "016f01c693b7e135b0e47ae10c687e1a85127393143ad2b849b96f4097ecce57",
+      "internalDefinitionIdsSha256": "982a32360a74f1e6282f97395912d0dcb3d80ecf5ad7a8ebe31997ef42fe7310",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1506,8 +1506,8 @@
       ]
     },
     "eacl.datahike.core/datahike-write-relationships!": {
-      "internalDefinitionCount": 457,
-      "internalDefinitionIdsSha256": "e5823c33a10a57d3a426854c25ea914f10a6004e70bc7d46fae6ef23f17bc39d",
+      "internalDefinitionCount": 456,
+      "internalDefinitionIdsSha256": "3eed1bdfdbe3d82309527882ebeb9553eb66b7b4f40c6876c672ae3620288e51",
       "externalCallCount": 30,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1543,8 +1543,8 @@
       ]
     },
     "eacl.datahike.core/datahike-delete-object!": {
-      "internalDefinitionCount": 448,
-      "internalDefinitionIdsSha256": "2e5128ba5bafd18bd17338ca954820e35c089ddb7b1154363de7f2ead10836de",
+      "internalDefinitionCount": 447,
+      "internalDefinitionIdsSha256": "69ba2c35db1e29ae7eb438fc7134d8562ce7fc5f95512545c266c37055bbf2a9",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1579,7 +1579,7 @@
     },
     "eacl.datahike.core/datahike-can?": {
       "internalDefinitionCount": 637,
-      "internalDefinitionIdsSha256": "56b7e3e9d55ee6539bb1207660cdc79ce359db2d18acbaa5bd73498ab3176c95",
+      "internalDefinitionIdsSha256": "4a674f959a0f0eedab23444d9cfc2a784b4eee387f8089df7f533b07dd5d9f45",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1614,7 +1614,7 @@
     },
     "eacl.datahike.core/datahike-lookup-resources": {
       "internalDefinitionCount": 843,
-      "internalDefinitionIdsSha256": "0f8e7c143cb05b1929415bb6f542e2881a3c7f74a5bad73007fe1f64ea311b9b",
+      "internalDefinitionIdsSha256": "7d07e66b35da8fa2f4115a2e64fa3dfe45169fc855cf6e30a04447812269bedd",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1650,7 +1650,7 @@
     },
     "eacl.datahike.core/datahike-count-resources": {
       "internalDefinitionCount": 662,
-      "internalDefinitionIdsSha256": "5756d8c212625c0e7ad18cd01c9c94f5ead4a87350159d130ee1f5e16fe48df9",
+      "internalDefinitionIdsSha256": "9461aed0221cf06245969d217ec0f91e71d24267e4a9f24a6aad543c899da9cd",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1685,7 +1685,7 @@
     },
     "eacl.datahike.core/datahike-lookup-subjects": {
       "internalDefinitionCount": 843,
-      "internalDefinitionIdsSha256": "734fd87fb7951854cc2df1d30128f0956bd08c3eac7f9094f75813ccabfdb971",
+      "internalDefinitionIdsSha256": "134dc77881586f7a215e6c7cab14d2629c1377966bbc122bf6325b7067521c08",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1721,7 +1721,7 @@
     },
     "eacl.datahike.core/datahike-count-subjects": {
       "internalDefinitionCount": 662,
-      "internalDefinitionIdsSha256": "3fee4c2f9db0116e248038f1224bb9cfa600daf2a6b2048fdee8d67175a43f87",
+      "internalDefinitionIdsSha256": "95bcd50144d7f3bee54ba9f2b09d0edc8e8f8444b85df1a6ed57a5c0f50b76e5",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1755,8 +1755,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 404,
-      "internalDefinitionIdsSha256": "cb3bf01b3f7bf36d0ad499acd57f62ec1e2a8b922b63deaeef2ee43d48df938d",
+      "internalDefinitionCount": 403,
+      "internalDefinitionIdsSha256": "9dbe0158609b9e08792e60ac94f1848e0b3897bc785c0a53ea6b95fc80741d11",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1787,7 +1787,7 @@
     },
     "eacl.datascript.core/datascript-read-relationships": {
       "internalDefinitionCount": 641,
-      "internalDefinitionIdsSha256": "1ced6c3db9aac40320b7ef84eff44e5e62cb76af3d1264c306367b6dcb4c415d",
+      "internalDefinitionIdsSha256": "85745590f4d7fe264fc5005f6a81f50450204df345291ea76dbe4046f4497bff",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1821,8 +1821,8 @@
       ]
     },
     "eacl.datascript.core/datascript-write-relationships!": {
-      "internalDefinitionCount": 442,
-      "internalDefinitionIdsSha256": "d99fad086ddeb7c9e43677942f0184de5e618f1694e074cc307f93206b58861a",
+      "internalDefinitionCount": 441,
+      "internalDefinitionIdsSha256": "7fc236bb8626f48ab447570cd7b7eeb14ccbf942d673e416906dc83a478775b0",
       "externalCallCount": 29,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1857,8 +1857,8 @@
       ]
     },
     "eacl.datascript.core/datascript-delete-object!": {
-      "internalDefinitionCount": 433,
-      "internalDefinitionIdsSha256": "a07f9f337faff76e950771737bd2dd4e2585559101bc1a2ae1a944cfecb7024a",
+      "internalDefinitionCount": 432,
+      "internalDefinitionIdsSha256": "2e1f11dc6348b5f0b5184688d298821c6a9132d7501efdf6f1d8aba935359ac0",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1892,7 +1892,7 @@
     },
     "eacl.datascript.core/datascript-can?": {
       "internalDefinitionCount": 622,
-      "internalDefinitionIdsSha256": "bdf4f4db708aa6a63f1549f398a9951a18961ea96a9d58cfc97998c20c493900",
+      "internalDefinitionIdsSha256": "939e477ffff49352be39b25c054e85322f6a9d335d5892bf0037c53dada492f4",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1926,7 +1926,7 @@
     },
     "eacl.datascript.core/datascript-lookup-resources": {
       "internalDefinitionCount": 828,
-      "internalDefinitionIdsSha256": "dfeee3cf422913f7859f7789e867e44a80e757e4b52b357b54c1a64144b3a41c",
+      "internalDefinitionIdsSha256": "80f9a1ff23313411565af63292018927932d84081c70de74f7c6b1a9f6603f5c",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1961,7 +1961,7 @@
     },
     "eacl.datascript.core/datascript-count-resources": {
       "internalDefinitionCount": 647,
-      "internalDefinitionIdsSha256": "15c9bc1f62a95a27da38426c39aad8f3eb80201b95d2c9d965254799317132af",
+      "internalDefinitionIdsSha256": "1e0368d205422b53f72ad00ce8abe93bb9f6ca99e200fc3959be4589b3859b35",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1995,7 +1995,7 @@
     },
     "eacl.datascript.core/datascript-lookup-subjects": {
       "internalDefinitionCount": 828,
-      "internalDefinitionIdsSha256": "3a24e77c5a3dbef4513e9466d36a7bdf1ab807295ca90f9cdb9aa53accbb18da",
+      "internalDefinitionIdsSha256": "a416d5465ef3bab1d7a29df357a708b1998c7a7f3694e60febd5d0914d7102d0",
       "externalCallCount": 28,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2030,7 +2030,7 @@
     },
     "eacl.datascript.core/datascript-count-subjects": {
       "internalDefinitionCount": 647,
-      "internalDefinitionIdsSha256": "accea5ec18df6f89328a70a2185705821c6288063539006421f4489de89d56d1",
+      "internalDefinitionIdsSha256": "f18863cf92687a9d23eaf8bf2d80db33c88c024d69685df37b8fa9526ba74be3",
       "externalCallCount": 27,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2063,8 +2063,8 @@
       ]
     },
     "eacl.datascript.core/make-client": {
-      "internalDefinitionCount": 389,
-      "internalDefinitionIdsSha256": "545743d8190cfd7dd413eccf6c872c44882dab4366a1472d6e730dc668cfb604",
+      "internalDefinitionCount": 388,
+      "internalDefinitionIdsSha256": "a7a337e157a7b08f7baf9df6f342995172aec8554b86751293c45d9faeb620b5",
       "externalCallCount": 23,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2093,8 +2093,8 @@
       ]
     },
     "eacl.datalevin.core/datalevin-read-relationships": {
-      "internalDefinitionCount": 663,
-      "internalDefinitionIdsSha256": "dee23f25d74fa0ec3b0e9a8ae86bf757f96ddc266a210a50a5b8533fbdc2ce59",
+      "internalDefinitionCount": 664,
+      "internalDefinitionIdsSha256": "ac039271ecac5fcf87cf5e51e7ea0acc31973111b235422a6eb0b8170b29dca9",
       "externalCallCount": 33,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2112,7 +2112,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2134,7 +2134,7 @@
     },
     "eacl.datalevin.core/datalevin-write-relationships!": {
       "internalDefinitionCount": 465,
-      "internalDefinitionIdsSha256": "342109f38b867ba32e3f43f2f2c8fbc988bd8af7d4f9114b6679b528ba1ccb95",
+      "internalDefinitionIdsSha256": "31905241dbb45e749570d25b9c07ca161c10c7fbe2037f3fef8112cf24669e83",
       "externalCallCount": 34,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2153,7 +2153,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2175,7 +2175,7 @@
     },
     "eacl.datalevin.core/datalevin-delete-object!": {
       "internalDefinitionCount": 456,
-      "internalDefinitionIdsSha256": "6b2ccf395a6e3d35b2ef5695a1016b8f8c10468a2e6537b92a7659371283d1ff",
+      "internalDefinitionIdsSha256": "b86e83c84a9b38ded8794d83df9935d855255d2b83567b746a94fbaac6eda16d",
       "externalCallCount": 32,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2192,7 +2192,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2213,8 +2213,8 @@
       ]
     },
     "eacl.datalevin.core/datalevin-can?": {
-      "internalDefinitionCount": 646,
-      "internalDefinitionIdsSha256": "4c3cf5fa9970d111074bbbdcc1925765942ff1243a0ce2c70ee72ec11ddcdbde",
+      "internalDefinitionCount": 647,
+      "internalDefinitionIdsSha256": "8ddefae61024d05fabbae52179071980449e99ace1cbb11183657e13bebf17ec",
       "externalCallCount": 32,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2231,7 +2231,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2252,8 +2252,8 @@
       ]
     },
     "eacl.datalevin.core/datalevin-lookup-resources": {
-      "internalDefinitionCount": 850,
-      "internalDefinitionIdsSha256": "5e3ff19fd4fd8182305560e0aab0ce99b2e602f8c836f5b4d7d723c70264de71",
+      "internalDefinitionCount": 851,
+      "internalDefinitionIdsSha256": "ef0c2ca493b5a98cc48f31ca15d5528eef71116ed70981b288d4d2b85bcff227",
       "externalCallCount": 33,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2271,7 +2271,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2292,8 +2292,8 @@
       ]
     },
     "eacl.datalevin.core/datalevin-count-resources": {
-      "internalDefinitionCount": 671,
-      "internalDefinitionIdsSha256": "8f8d7ad93fac75456a692d3a9afd1963aaa29459f9e8ed60880f3f6847d15df2",
+      "internalDefinitionCount": 672,
+      "internalDefinitionIdsSha256": "697bf1809d60daf9f36fc56a64296c2321bdfdcedb8ca462fa3caca90931f945",
       "externalCallCount": 32,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2310,7 +2310,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2331,8 +2331,8 @@
       ]
     },
     "eacl.datalevin.core/datalevin-lookup-subjects": {
-      "internalDefinitionCount": 850,
-      "internalDefinitionIdsSha256": "a0d4a430df6c0b4c963cf328c525113103ff8414fddb86a71fb2baa764f27b70",
+      "internalDefinitionCount": 851,
+      "internalDefinitionIdsSha256": "f0561527a4bb83dd0615a463b37f903ff0013cf54236d2419f7cc82928c9526f",
       "externalCallCount": 33,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2350,7 +2350,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2371,8 +2371,8 @@
       ]
     },
     "eacl.datalevin.core/datalevin-count-subjects": {
-      "internalDefinitionCount": 671,
-      "internalDefinitionIdsSha256": "099b8d59d34e95f079756cf1d15fd83453f1f158b700fda246fdfdd9e2ccfe7f",
+      "internalDefinitionCount": 672,
+      "internalDefinitionIdsSha256": "822df5bebc2e6710c6a92b035f4c82a74102d1a761653b50c81ec63dfd82a098",
       "externalCallCount": 32,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2389,7 +2389,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",
@@ -2410,8 +2410,8 @@
       ]
     },
     "eacl.datalevin.core/make-client": {
-      "internalDefinitionCount": 398,
-      "internalDefinitionIdsSha256": "1d7eaf37fc0b41fbd9ab4fc54b1d579a9a1876bdec07ea3fa8b86731e8bfb691",
+      "internalDefinitionCount": 399,
+      "internalDefinitionIdsSha256": "c813a7d50724f38952e6d4bcc52aa5021197f63b9f26f7609efa0f0668c2d21c",
       "externalCallCount": 32,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -2428,7 +2428,7 @@
         "datalevin.core/entid",
         "datalevin.core/entity",
         "datalevin.core/open-read-snapshot",
-        "datalevin.core/pull",
+        "datalevin.core/pull-many",
         "datalevin.core/read-snapshot-capabilities",
         "datalevin.core/read-snapshot-info",
         "datalevin.core/read-snapshot?",

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -1,6 +1,7 @@
 (ns eacl.datahike.backend
   "Datahike storage operations for the shared v8 authorization engine."
   (:require [datahike.api :as d]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.backend.v8 :as backend]
             [eacl.datahike.db :as ddb]
             [eacl.datahike.impl :as impl]
@@ -367,3 +368,40 @@
        :proof-frame
        (fn [relation-ids]
          (ordered-generation-frame db relation-ids))}})))
+
+(defn provider
+  "Builds the borrowed immutable-snapshot provider for one Datahike conn."
+  [conn opts]
+  (let [current-adapter
+        (fn [] (snapshot-adapter (d/db conn) opts))
+        static-adapter (current-adapter)
+        source-scope (backend/invoke static-adapter :source-scope)
+        source-lifecycle
+        (fn []
+          (or (some-> (:source-lifecycle-state opts) deref)
+              (:source-lifecycle opts)))
+        select!
+        (fn [operation-key & args]
+          (let [selected
+                (apply backend/invoke
+                       (current-adapter) operation-key args)]
+            (or selected
+                (throw
+                 (ex-info
+                  "The requested Datahike snapshot is unavailable."
+                  {:type :eacl.consistency/exact-snapshot-unavailable
+                   :eacl/error :eacl.consistency/exact-snapshot-unavailable
+                   :backend :datahike})))))]
+    (snapshot-provider/borrowed-adapter-provider
+     {:static-adapter static-adapter
+      :topology {:deployment :embedded
+                 :snapshot-values :immutable}
+      :source-scope-fn (constantly source-scope)
+      :source-lifecycle-fn source-lifecycle
+      :acquire-current! current-adapter
+      :acquire-authoritative!
+      #(select! :select-authoritative %)
+      :acquire-at-least!
+      #(select! :select-at-least %1 %2)
+      :acquire-exact!
+      #(select! :select-exact %1 %2)})))

--- a/modules/eacl-datahike/src/eacl/datahike/core.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/core.clj
@@ -62,6 +62,12 @@
    :entid ddb/entid
    :default-entid->object-id (fn [db eid] (:eacl/id (d/entity db eid)))
    :snapshot-adapter datahike-backend/snapshot-adapter
+   :snapshot-provider datahike-backend/provider
+   :db-native-revision
+   (fn [db]
+     {:revision (:max-tx db)
+      :exact-locator
+      (some-> (get-in db [:meta :datahike/commit-id]) str)})
    :relationship-retraction-count relationship-retraction-count
    :transact! transact-native!
    ;; Vars, not values: late binding keeps instrumentation (with-redefs in

--- a/modules/eacl-datalevin/PORTING.md
+++ b/modules/eacl-datalevin/PORTING.md
@@ -1,0 +1,52 @@
+# Porting and operational contract
+
+`eacl-datalevin` is not a mechanical namespace substitution for DataScript or
+Datahike. An ordinary Datalevin DB object is live. Every EACL read therefore
+enters the shared snapshot-provider lifecycle, owns one public explicit
+Datalevin reader, eagerly externalizes its result, and releases the reader on
+the acquiring platform thread.
+
+The certified declaration is
+`eacl.datalevin.backend/certified-topology-declaration`. Client construction
+requires that exact map and independently checks the native connection profile.
+The module rejects remote stores, WAL, HA, unsafe LMDB durability flags,
+multiple connections or writers, external writer ownership, virtual request
+threads, mutable physical schema, and any undeclared topology variation.
+
+Supported consistency modes are minimize latency, fully consistent, and at
+least as fresh. On the sole-writer local topology, a fresh explicit snapshot is
+the local head linearization point. At-least retries fresh candidates until the
+authenticated revision floor is reached, the original request deadline
+expires, or cancellation is observed. Exact historical selection is rejected;
+the module advertises no exact, historical, durable-history, or ordered
+generation capability.
+
+Physical EACL schema and a random source UUID are installed before readiness.
+Every existing physical attribute is compared after Datalevin tuple-type
+inference; missing, renamed, retyped, recardinalized, reindexed, or wrong-arity
+attributes fail startup. Physical schema is frozen after bootstrap. Logical
+SpiceDB schema changes remain ordinary fenced EACL transactions.
+
+Relationship writes maintain forward and reverse tuple halves atomically and
+stamp relation versions with `:db/current-tx`. Create conflicts are rechecked
+inside the serialized writer. Schema and relationship mutations cross-check
+write fences. Object cleanup rescans inside a Datalevin transaction function,
+so an intervening relationship commit cannot escape a later-linearized delete.
+
+All revisions, entity IDs, relation/permission IDs, cursor bounds, and returned
+scan IDs are restricted to the portable exact-integer domain
+`0..9007199254740991`. Exceeding it fails closed without conversion.
+
+Third-party adapters must not call private Datalevin reader functions. Depend
+on the explicitly named maintained snapshot-API artifact, retain owned reader
+handles only inside EACL's selected-snapshot scope, declare execution
+constraints statically, and provide a complete semantic identity containing
+backend, source UUID, lifecycle, revision, exact locator (nil here), and the
+physical-schema fingerprint.
+
+Signing material, source lifecycle, and the monotonic revision watermark are
+external durability inputs. The module rejects the shared default signing key,
+nil/implicit lifecycle generation, and process-local `expire-cache!` rotation.
+Restore tooling must durably rotate lifecycle and establish its new watermark
+before recreating the client; old tokens then fail source-lifecycle
+authentication.

--- a/modules/eacl-datalevin/README.md
+++ b/modules/eacl-datalevin/README.md
@@ -1,0 +1,87 @@
+# EACL Datalevin
+
+`dev.eacl/eacl-datalevin` is the CLJ-only EACL v8 adapter for a qualified
+embedded Datalevin database. The initial contract is deliberately narrow:
+
+- one local embedded database, JVM, connection, and synchronous writer;
+- platform-thread request execution with acquiring-thread snapshot ownership;
+- fresh explicit snapshots for minimize-latency, fully-consistent, and
+  at-least-as-fresh reads;
+- no exact historical snapshot selection, remote/server, HA, replica,
+  multiple-writer, or WAL qualification;
+- physical schema frozen after bootstrap; and
+- revision-bound cache and cursor reuse with no ordered-generation proofs.
+
+Every request snapshot owns a public Datalevin read handle and closes it after
+the complete EACL response is realized. The module never treats Datalevin's
+ordinary live DB handle as an immutable snapshot.
+
+Development uses the sibling maintained-fork checkout containing the public
+read-snapshot API. Publication is blocked until that fork is released as the
+explicit `dev.eacl/datalevin-embedded-eacl` coordinate and its packaged native
+runtime passes certification.
+
+For a source checkout with the expected sibling layout, use:
+
+```clojure
+{:deps
+ {dev.eacl/eacl-datalevin
+  {:local/root "/absolute/path/to/eacl/core/modules/eacl-datalevin"}}}
+```
+
+The reserved release coordinate is
+`dev.eacl/eacl-datalevin:8.0.0-SNAPSHOT`, depending on
+`dev.eacl/datalevin-embedded-eacl:1.0.2-eacl.1`. Neither is a usable published
+dependency until the release and clean remote-consumer gates pass.
+
+Construction requires an exact topology declaration plus externally retained
+lifecycle, signing material, and revision state. Omitting a signing key/keyring
+or supplying a nil lifecycle fails construction; the shared development key is
+never used by this module:
+
+```clojure
+(require '[eacl.datalevin.backend :as datalevin-backend]
+         '[eacl.datalevin.core :as datalevin])
+
+(def conn (datalevin/create-conn "/var/lib/my-app/eacl"))
+(def watermark (atom (load-watermark-from-durable-storage)))
+
+(def client
+  (datalevin/make-client
+   conn
+   {:security-key signing-key
+    :source-lifecycle (load-source-lifecycle)
+    :revision-watermark watermark
+    :advance-revision-watermark!
+    (fn [revision]
+      (persist-watermark-durably! revision)
+      (swap! watermark max revision))
+    :datalevin-topology
+    datalevin-backend/certified-topology-declaration}))
+```
+
+`minimize-latency` and `fully-consistent` each acquire a fresh explicit reader
+at the qualified local sole-writer head. `at-least-as-fresh` retries fresh
+readers until the authenticated revision floor is visible or the original
+deadline/cancellation terminates the request. `at-exact-snapshot` always
+throws `:eacl.consistency/exact-snapshot-unavailable`. The module never
+advertises ordered generations and never supplies a `:proof-frame`, so cached
+answers cannot lift across revisions.
+
+The advance callback is synchronous and release-critical: EACL does not
+acknowledge a bootstrap or authorization commit until the callback returns and
+the dereferenced watermark is at least the committed Datalevin revision. The
+callback must implement monotonic max semantics when requests commit
+concurrently. A process-local atom is suitable only for tests; production must
+load and atomically persist the value outside the Datalevin database so a
+restored or rolled-back store cannot erase its own rollback detector.
+
+Client construction rejects a persisted Datalevin revision below the external
+watermark while the lifecycle is unchanged. An operator-authorized restore
+must rotate `:source-lifecycle`, invalidate old tokens/caches, and establish a
+new matching watermark before readiness. `expire-cache!` deliberately rejects
+process-local lifecycle rotation. Persist the replacement lifecycle and
+watermark first, close the old client/connection, and construct a new client.
+
+See [PORTING.md](PORTING.md) for the adapter boundary and unsupported
+configurations.

--- a/modules/eacl-datalevin/build.clj
+++ b/modules/eacl-datalevin/build.clj
@@ -1,0 +1,11 @@
+(ns build
+  (:require [eacl.build.module :as module]))
+
+(defn clean [options]
+  (module/clean! :eacl-datalevin options))
+
+(defn jar [options]
+  (module/jar! :eacl-datalevin options))
+
+(defn install [options]
+  (module/install! :eacl-datalevin options))

--- a/modules/eacl-datalevin/deps.edn
+++ b/modules/eacl-datalevin/deps.edn
@@ -1,0 +1,36 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
+        dev.eacl/eacl {:local/root "../eacl"}
+        com.rpl/specter {:mvn/version "1.1.4"}
+        ;; Development resolves the maintained snapshot-API fork checkout.
+        ;; Release metadata replaces this local root with the published
+        ;; dev.eacl/datalevin-embedded-eacl coordinate pinned by the change.
+        dev.eacl/datalevin-embedded-eacl
+        {:local/root "../../../datalevin"}}
+ :aliases
+ {:build {:extra-paths ["."]
+          :ns-default build
+          :extra-deps {eacl/build-tools {:local/root "../../src-build"}}}
+  :test {:extra-paths ["test" "../eacl/test"]
+         :jvm-opts ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+                    "--add-opens=java.base/java.nio=ALL-UNNAMED"
+                    "--add-opens=java.base/java.util=ALL-UNNAMED"
+                    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+                    "--enable-native-access=ALL-UNNAMED"]
+         :extra-deps
+         {dev.eacl/eacl-datahike {:local/root "../eacl-datahike"}
+          dev.eacl/eacl-datascript {:local/root "../eacl-datascript"}
+         io.github.cognitect-labs/test-runner
+          {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :exec-fn cognitect.test-runner.api/test
+         :exec-args {:dirs ["test" "../eacl/test"]
+                     :patterns ["^(?!eacl[.]bench[.])(?!eacl[.]characterization-fixture-test$)(?!eacl[.]formal[.]).*-test$"]
+                     :excludes [:benchmark]}}
+  :nrepl {:extra-paths ["test" "../eacl/test"]
+          :jvm-opts ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+                     "--add-opens=java.base/java.nio=ALL-UNNAMED"
+                     "--add-opens=java.base/java.util=ALL-UNNAMED"
+                     "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+                     "--enable-native-access=ALL-UNNAMED"]
+          :extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
+          :main-opts ["-m" "nrepl.cmdline"]}}}

--- a/modules/eacl-datalevin/src/eacl/datalevin/backend.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/backend.cljc
@@ -1,0 +1,387 @@
+(ns eacl.datalevin.backend
+  "Owned explicit-snapshot storage operations for the EACL v8 engine."
+  (:require [clojure.set :as set]
+            [datalevin.core :as d]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.backend.v8 :as backend]
+            [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.impl :as impl]
+            [eacl.secure-format :as secure-format]))
+
+(def capabilities
+  {:consistency #{:minimize-latency
+                  :fully-consistent
+                  :at-least-as-fresh}
+   :snapshots #{:current :authoritative :causal}
+   :source #{:stable-scope :source-lifecycle :native-revision :order-hint}
+   :cursor #{:forward :reverse :opaque}
+   :transactions #{:schema :relationships :object-deletion}
+   ;; Datalevin persistent datoms do not expose their original transaction.
+   ;; No ordered-generation proof is claimed by the initial adapter.
+   :cache-proofs #{:snapshot-bound :database-visible}
+   :runtime #{:clj}})
+
+(def execution-constraints
+  {:virtual-threads :rejected
+   :snapshot-thread :acquiring-thread
+   :release-thread :acquiring-thread})
+
+(def certified-topology-declaration
+  {:deployment :embedded
+   :jvms 1
+   :connections 1
+   :writers 1
+   :writer-ownership :application-exclusive
+   :commit-mode :direct-synchronous
+   :physical-schema :frozen
+   :request-threads :platform
+   :wal false})
+
+(def topology
+  (assoc certified-topology-declaration
+         :snapshot-values :owned-explicit))
+
+(defn exact-natural!
+  [field value]
+  (when-not (and (integer? value)
+                 (not (neg? value))
+                 (<= value backend/maximum-exact-integer))
+    (throw
+     (ex-info
+      "Datalevin snapshot metadata exceeds EACL's exact integer domain."
+      {:type :eacl/numeric-domain-error
+       :eacl/error :eacl/numeric-domain-error
+       :backend :datalevin
+       :field field
+       :value value
+       :maximum backend/maximum-exact-integer})))
+  value)
+
+(defn- normalized-permission
+  [permission]
+  {:permission-id (exact-natural! :permission-id (:db/id permission))
+   :resource-type (:eacl.permission/resource-type permission)
+   :permission-name (:eacl.permission/permission-name permission)
+   :source-relation-name
+   (:eacl.permission/source-relation-name permission)
+   :target-type (:eacl.permission/target-type permission)
+   :target-name (:eacl.permission/target-name permission)})
+
+(defn- snapshot-info
+  [snapshot]
+  (when-not (d/read-snapshot? snapshot)
+    (throw
+     (ex-info
+      "Datalevin EACL adapters require a public explicit read snapshot."
+      {:type :eacl/invalid-selected-snapshot
+       :eacl/error :eacl/invalid-selected-snapshot
+       :backend :datalevin})))
+  (let [info (d/read-snapshot-info snapshot)]
+    (exact-natural! :revision (:max-tx info))
+    (exact-natural! :max-eid (:max-eid info))
+    info))
+
+(defn- physical-schema-fingerprint
+  [info fingerprint-cache]
+  (let [schema (:schema info)
+        cached (when fingerprint-cache @fingerprint-cache)]
+    (if (= schema (:schema cached))
+      (:fingerprint cached)
+      (let [fingerprint
+            (secure-format/canonical-digest
+             "eacl.datalevin.physical-schema.v1"
+             schema)]
+        (if-not fingerprint-cache
+          fingerprint
+          (:fingerprint
+           (swap! fingerprint-cache
+                  (fn [current]
+                    ;; Structural equality, rather than a hash-only lookup,
+                    ;; makes this memo safe across a physical schema change.
+                    ;; Concurrent readers may compute the digest twice but can
+                    ;; never receive a digest for a different schema value.
+                    (if (= schema (:schema current))
+                      current
+                      {:schema schema :fingerprint fingerprint})))))))))
+
+(defn snapshot-adapter
+  "Creates an immutable v8 adapter around one open Datalevin read snapshot.
+  The provider retains ownership; every operation binds the snapshot's one
+  explicit native reader and eagerly realizes its result before returning."
+  [snapshot {:keys [object-id->entid entid->object-id] :as opts}]
+  (let [info (snapshot-info snapshot)
+        revision (:max-tx info)
+        schema-identity
+        (physical-schema-fingerprint
+         info (:physical-schema-fingerprint-cache opts))
+        source-lifecycle
+        (or (some-> (:source-lifecycle-state opts) deref)
+            (:source-lifecycle opts))
+        source-scope
+        (or (:source-scope opts)
+            {:source-id (:native-source-id opts)
+             :branch nil})
+        adapter-opts
+        (-> opts
+            (dissoc :source-lifecycle-state)
+            (assoc :source-lifecycle source-lifecycle
+                   :source-scope source-scope))]
+    (when-not (some? (:source-id source-scope))
+      (throw
+       (ex-info
+        "Datalevin requires a persisted stable source identity."
+        {:type :eacl/invalid-source-identity
+         :eacl/error :eacl/invalid-source-identity
+         :backend :datalevin})))
+    (backend/make-adapter
+     {:id :datalevin
+      :traversal-execution backend/strict-sequential-traversal-execution
+      :fingerprint (:adapter-fingerprint opts)
+      :deterministic? (:adapter-deterministic? opts)
+      :identity-contract
+      (:identity-contract opts
+                          :selected-internal/current-external-injective-v2)
+      :capabilities capabilities
+      :runtime-guards? true
+      :state {:db snapshot
+              :revision revision
+              :max-eid (:max-eid info)
+              :schema-identity schema-identity}
+      :operations
+      {:snapshot-id
+       (fn []
+         {:database-id :datalevin
+          :basis-t revision
+          :schema-identity schema-identity})
+
+       :source-scope (constantly source-scope)
+       :source-lifecycle (constantly source-lifecycle)
+       :native-revision
+       (fn [] {:revision revision :exact-locator nil})
+       :order-hint (constantly revision)
+
+       ;; These adapter-level operations exist for the closed v8 contract.
+       ;; Provider-based public orchestration owns cross-request acquisition.
+       :select-current
+       (fn [] (snapshot-adapter snapshot adapter-opts))
+       :select-authoritative
+       (fn [_timeout-ms] (snapshot-adapter snapshot adapter-opts))
+       :select-at-least
+       (fn [token-data _timeout-ms]
+         (if (>= revision (exact-natural! :token-revision
+                                          (:revision token-data)))
+           (snapshot-adapter snapshot adapter-opts)
+           nil))
+       :exact-locator (constantly nil)
+       :select-exact (fn [_token-data _timeout-ms] nil)
+
+       :object-id->internal
+       (fn [object-id]
+         (ddb/with-db
+           snapshot
+           (fn [db]
+             (let [internal-id
+                   (if (number? object-id)
+                     object-id
+                     (object-id->entid db object-id))]
+               (when (some? internal-id)
+                 (exact-natural! :entity-id internal-id))))))
+
+       :internal-id->object
+       (fn [internal-id]
+         (exact-natural! :entity-id internal-id)
+         (ddb/with-db snapshot #(entid->object-id % internal-id)))
+
+       :relation-defs
+       (fn [resource-type relation-name]
+         (ddb/with-db
+           snapshot
+           (fn [db]
+             (mapv
+              (fn [{:keys [e v]}]
+                (exact-natural! :relation-id e)
+                {:relation-id e
+                 :resource-type resource-type
+                 :relation-name relation-name
+                 :subject-type (nth v 2)})
+              (impl/relation-datoms db resource-type relation-name)))))
+
+       :permission-defs
+       (fn [resource-type permission-name]
+         (ddb/with-db
+           snapshot
+           #(mapv normalized-permission
+                  (impl/find-permission-defs
+                   % resource-type permission-name))))
+
+       :subject->resources
+       (fn [subject-type subject-id relation-id resource-type options]
+         (exact-natural! :subject-id subject-id)
+         (exact-natural! :relation-id relation-id)
+         (when-some [bound-eid (:bound-eid options)]
+           (exact-natural! :cursor-bound bound-eid))
+         (ddb/with-db
+           snapshot
+           #(mapv (fn [resource-id]
+                    (exact-natural! :resource-id resource-id))
+                  (impl/subject->resources
+                   % subject-type subject-id relation-id resource-type
+                   options))))
+
+       :resource->subjects
+       (fn [resource-type resource-id relation-id subject-type options]
+         (exact-natural! :resource-id resource-id)
+         (exact-natural! :relation-id relation-id)
+         (when-some [bound-eid (:bound-eid options)]
+           (exact-natural! :cursor-bound bound-eid))
+         (ddb/with-db
+           snapshot
+           #(mapv (fn [subject-id]
+                    (exact-natural! :subject-id subject-id))
+                  (impl/resource->subjects
+                   % resource-type resource-id relation-id subject-type
+                   options))))
+
+       :direct-match?
+       (fn [subject-type subject-id relation-id resource-type resource-id]
+         (exact-natural! :subject-id subject-id)
+         (exact-natural! :relation-id relation-id)
+         (exact-natural! :resource-id resource-id)
+         (ddb/with-db
+           snapshot
+           #(boolean
+             (impl/direct-match?
+              % subject-type subject-id relation-id
+              resource-type resource-id))))
+
+       :all-permission-nodes
+       (fn []
+         (ddb/with-db
+           snapshot
+           impl/all-permission-nodes))}})))
+
+(defn connection-source-id
+  "Reads the bounded source UUID installed in Datalevin module metadata.
+  Called once during client construction, never on a request path."
+  [conn]
+  (let [source-id
+        (:eacl.datalevin/source-id
+         (d/entity (d/db conn) [:eacl/id "datalevin-metadata"]))]
+    (when-not (uuid? source-id)
+      (throw
+       (ex-info
+        "Datalevin module metadata has no stable source UUID."
+        {:type :eacl/invalid-source-identity
+         :eacl/error :eacl/invalid-source-identity
+         :backend :datalevin
+         :value source-id})))
+    (str source-id)))
+
+(defn- acquire-owned!
+  [conn opts]
+  (let [snapshot (d/open-read-snapshot conn)]
+    (try
+      {:adapter (snapshot-adapter snapshot opts)
+       :ownership :owned
+       :release-token snapshot}
+      (catch #?(:clj Throwable :cljs :default) error
+        (d/close-read-snapshot! snapshot)
+        (throw error)))))
+
+(defn validate-topology!
+  "Rejects any connection/runtime/declaration outside the certified embedded
+  Datalevin profile before module bootstrap is allowed to mutate the store."
+  [conn opts]
+  (let [snapshot-capabilities (d/read-snapshot-capabilities conn)
+        _
+        (when-not (:supported? snapshot-capabilities)
+          (throw
+           (ex-info
+            "Datalevin topology has no supported embedded snapshot session."
+            {:type :eacl/unsupported-topology
+             :eacl/error :eacl/unsupported-topology
+             :backend :datalevin
+             :reason (:reason snapshot-capabilities)})))
+        declared-topology (:datalevin-topology opts)
+        _
+        (when-not (= certified-topology-declaration declared-topology)
+          (throw
+           (ex-info
+            "Datalevin requires the exact certified sole-writer topology declaration."
+            {:type :eacl/unsupported-topology
+             :eacl/error :eacl/unsupported-topology
+             :backend :datalevin
+             :expected certified-topology-declaration
+             :actual declared-topology})))
+        _
+        (when (or (:wal? snapshot-capabilities)
+                  (some? (:ha-mode snapshot-capabilities)))
+          (throw
+           (ex-info
+            "Datalevin WAL and HA modes are not certified for this adapter."
+            {:type :eacl/unsupported-topology
+             :eacl/error :eacl/unsupported-topology
+             :backend :datalevin
+             :wal? (:wal? snapshot-capabilities)
+             :ha-mode (:ha-mode snapshot-capabilities)})))
+        unsafe-flags
+        (set/intersection #{:nosync :nometasync :mapasync :writemap}
+                          (:env-flags snapshot-capabilities))
+        _
+        (when (seq unsafe-flags)
+          (throw
+           (ex-info
+            "Datalevin LMDB durability flags are outside the certified profile."
+            {:type :eacl/unsupported-topology
+             :eacl/error :eacl/unsupported-topology
+             :backend :datalevin
+             :unsafe-env-flags unsafe-flags})))]
+    snapshot-capabilities))
+
+(defn provider
+  "Builds the owned, platform-thread-affine snapshot provider for one
+  qualified local embedded Datalevin connection."
+  [conn opts]
+  (let [_ (validate-topology! conn opts)
+        source-scope {:source-id (:native-source-id opts) :branch nil}
+        opts (assoc opts
+                    :source-scope source-scope
+                    :physical-schema-fingerprint-cache (atom nil))
+        source-lifecycle
+        (fn []
+          (or (some-> (:source-lifecycle-state opts) deref)
+              (:source-lifecycle opts)))]
+    (snapshot-provider/make-provider
+     {:id :datalevin
+      :capabilities capabilities
+      :traversal-execution backend/strict-sequential-traversal-execution
+      :topology topology
+      :execution-constraints execution-constraints
+      :snapshot-ownership :owned
+      :fingerprint
+      (or (:adapter-fingerprint opts)
+          {:backend :datalevin
+           :adapter-version backend/adapter-version
+           :snapshot-api :dev.eacl/read-snapshot-v1})
+      :deterministic? (:adapter-deterministic? opts)
+      :operations
+      {:source-scope (constantly source-scope)
+       :source-lifecycle source-lifecycle
+       :acquire-current! (fn [] (acquire-owned! conn opts))
+       :acquire-authoritative!
+       (fn [_timeout-ms] (acquire-owned! conn opts))
+       ;; Shared consistency orchestration compares the revision, closes an
+       ;; insufficient candidate, preserves the original deadline, and retries.
+       :acquire-at-least!
+       (fn [_token-data _remaining-ms] (acquire-owned! conn opts))
+       :acquire-exact!
+       (fn [_token-data _timeout-ms]
+         (throw
+          (ex-info
+           "Datalevin does not retain exact historical snapshots."
+           {:type :eacl/unsupported-capability
+            :eacl/error :eacl/unsupported-capability
+            :backend :datalevin
+            :capability :consistency
+            :requested :at-exact-snapshot})))
+       :release! d/close-read-snapshot!}})))

--- a/modules/eacl-datalevin/src/eacl/datalevin/core.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/core.cljc
@@ -1,0 +1,348 @@
+(ns eacl.datalevin.core
+  "Datalevin construction shim over the shared client orchestration
+  (backend-unification, D-7). Everything here is genuinely
+  Datalevin-specific: index access for managed stamps, the snapshot
+  adapter, schema installation, and transaction submission. The
+  nine public operations, snapshot-context assembly, cursor plumbing, and
+  cache wiring live once in eacl.client.orchestration."
+  (:require [datalevin.core :as ds]
+            [eacl.client.orchestration :as orchestration]
+            [eacl.cursor :as cursor]
+            [eacl.datalevin.backend :as datalevin-backend]
+            [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.impl :as impl]
+            [eacl.datalevin.schema :as schema]
+            [eacl.relationships.storage :as relationship-storage]))
+
+(def cursor->token cursor/cursor->token)
+(def token->cursor cursor/token->cursor)
+
+(def default-internal-cursor->spice orchestration/default-internal-cursor->spice)
+(def default-spice-cursor->internal orchestration/default-spice-cursor->internal)
+
+(def ^:private prepared-native-source-id-key
+  ::prepared-native-source-id)
+
+(defn- relationship-retraction-count
+  [_db tx-data]
+  (count
+   (filter
+    (fn [{:keys [a added]}]
+      (and (false? added)
+           (contains? relationship-storage/attributes a)))
+    tx-data)))
+
+(defn- cas-failure-data
+  [throwable]
+  (loop [cause throwable]
+    (when cause
+      (let [data (ex-data cause)]
+        (if (= :transact/cas (:error data))
+          data
+          (recur #?(:clj (.getCause ^Throwable cause)
+                    :cljs (ex-cause cause))))))))
+
+(defn- transact-native!
+  [conn {:keys [tx-data]}]
+  (try
+    (ds/transact! conn (vec tx-data))
+    (catch #?(:clj Throwable :cljs :default) throwable
+      (if-let [cause-data (cas-failure-data throwable)]
+        (throw
+         (ex-info
+          "A Datalevin relationship mutation lost a commit-time fence."
+          {:type :eacl/relationship-concurrent-write
+           :eacl/error :eacl/relationship-concurrent-write
+           :backend :datalevin
+           :datalevin-error cause-data}
+          throwable))
+        (throw throwable)))))
+
+(defn- derefable?
+  [value]
+  #?(:clj (instance? clojure.lang.IDeref value)
+     :cljs (satisfies? IDeref value)))
+
+(defn- advance-revision-watermark!
+  [{:keys [revision] :as native-revision} opts]
+  (datalevin-backend/exact-natural! :committed-revision revision)
+  (let [watermark-state (:revision-watermark opts)
+        advance! (:advance-revision-watermark! opts)]
+    (try
+      (advance! revision)
+      (catch #?(:clj Throwable :cljs :default) error
+        (throw
+         (ex-info
+          "Datalevin committed, but external revision-watermark persistence failed."
+          {:type :eacl.datalevin/revision-watermark-persistence-failed
+           :eacl/error :eacl.datalevin/revision-watermark-persistence-failed
+           :committed-revision native-revision}
+          error))))
+    (let [persisted @watermark-state]
+      (when-not (and (integer? persisted)
+                     (<= revision persisted 9007199254740991))
+        (throw
+         (ex-info
+          "Datalevin committed, but the external revision watermark did not advance."
+          {:type :eacl.datalevin/revision-watermark-not-persisted
+           :eacl/error :eacl.datalevin/revision-watermark-not-persisted
+           :committed-revision native-revision
+           :observed-watermark persisted})))))
+  native-revision)
+
+(defn- snapshot-entid
+  [snapshot-or-db eid-or-ref]
+  (ddb/with-db snapshot-or-db #(ds/entid % eid-or-ref)))
+
+(defn- snapshot-object-id
+  [snapshot-or-db eid]
+  (ddb/with-db
+   snapshot-or-db
+   #(some-> (ddb/eavt-datoms % eid :eacl/id) first :v)))
+
+(defn- snapshot-relationship-relation-id
+  [snapshot-or-db relationship]
+  (ddb/with-db
+   snapshot-or-db
+   #(impl/relationship-relation-id % relationship)))
+
+(defn- snapshot-tx-update-relationship
+  [snapshot-or-db update]
+  (ddb/with-db snapshot-or-db #(impl/tx-update-relationship % update)))
+
+(defn- snapshot-tx-delete-object
+  [snapshot-or-db object-eid]
+  (ddb/with-db snapshot-or-db #(impl/tx-delete-object % object-eid)))
+
+(defn- snapshot-read-relationships
+  [snapshot-or-db query kernel]
+  (ddb/with-db snapshot-or-db #(impl/read-relationships % query kernel)))
+
+(def ^:private api
+  {:backend-id :datalevin
+   :db ds/db
+   :entid snapshot-entid
+   :default-entid->object-id snapshot-object-id
+   :snapshot-adapter datalevin-backend/snapshot-adapter
+   :snapshot-provider datalevin-backend/provider
+   :db-native-revision
+   (fn [db]
+     {:revision (datalevin-backend/exact-natural!
+                 :committed-revision (:max-tx db))
+      :exact-locator nil})
+   :after-commit! advance-revision-watermark!
+   :native-source-id datalevin-backend/connection-source-id
+   :prepared-native-source-id-key prepared-native-source-id-key
+   :relationship-retraction-count relationship-retraction-count
+   :transact! transact-native!
+   ;; Vars, not values: late binding keeps instrumentation (with-redefs in
+   ;; the impl suites) and REPL redefinition visible through the shared
+   ;; orchestration.
+   :schema {:read-schema #'schema/read-schema
+            :write-schema! #'schema/write-schema!}
+   :impl {:validate-relationship-operation!
+          #'impl/validate-relationship-operation!
+          :relationship-relation-id snapshot-relationship-relation-id
+          :tx-update-relationship snapshot-tx-update-relationship
+          :tx-delete-object snapshot-tx-delete-object
+          :affected-relation-ids #'impl/affected-relation-ids
+          :read-relationships snapshot-read-relationships}
+   :extra-client-opt-keys
+   #{:datalevin-topology
+     :revision-watermark
+     :advance-revision-watermark!
+     prepared-native-source-id-key}})
+
+(defn datalevin-read-relationships
+  [db opts filters]
+  (orchestration/read-relationships api db opts filters))
+
+(defn datalevin-write-relationships!
+  [conn opts updates]
+  (orchestration/write-relationships! api conn opts updates))
+
+(defn datalevin-delete-object!
+  [conn opts object]
+  (orchestration/delete-object! api conn opts object))
+
+(defn datalevin-check-permission
+  [db opts subject permission resource consistency]
+  (orchestration/check-permission
+   api db opts subject permission resource consistency))
+
+(defn datalevin-can?
+  [db opts subject permission resource consistency]
+  (orchestration/can? api db opts subject permission resource consistency))
+
+(defn datalevin-lookup-resources
+  [db opts query]
+  (orchestration/lookup-resources api db opts query))
+
+(defn datalevin-count-resources
+  [db opts query]
+  (orchestration/count-resources api db opts query))
+
+(defn datalevin-lookup-subjects
+  [db opts query]
+  (orchestration/lookup-subjects api db opts query))
+
+(defn datalevin-count-subjects
+  [db opts query]
+  (orchestration/count-subjects api db opts query))
+
+(defn- require-datalevin-client!
+  [client fn-name]
+  (when-not (orchestration/client? client :datalevin)
+    (throw (ex-info (str fn-name " requires a Datalevin EACL client.")
+                    {:type :eacl/invalid-client}))))
+
+(defn expire-cache!
+  "Datalevin lifecycle rotation is an external durability operation.
+
+  A process-local cache rotation would claim a new source lifecycle without
+  proving it was retained across restart. Recreate the client only after the
+  operator has durably stored the new lifecycle and coordinated any restored
+  revision watermark."
+  ([client]
+   (require-datalevin-client! client "expire-cache!")
+   (throw
+    (ex-info
+     "Datalevin lifecycle rotation must be persisted before client recreation."
+     {:type :eacl.datalevin/source-lifecycle-persistence-required
+      :eacl/error :eacl.datalevin/source-lifecycle-persistence-required
+      :operation :expire-cache!})))
+  ([client source-lifecycle]
+   (require-datalevin-client! client "expire-cache!")
+   (throw
+    (ex-info
+     "Datalevin lifecycle rotation must be persisted before client recreation."
+     {:type :eacl.datalevin/source-lifecycle-persistence-required
+      :eacl/error :eacl.datalevin/source-lifecycle-persistence-required
+      :operation :expire-cache!
+      :requested-source-lifecycle source-lifecycle}))))
+
+(def prepare-cache-coherence!
+  "Initializes missing native cache generations on a quiesced connection.
+
+  This does not detect or repair earlier unsupported unstamped mutations and
+  is not a cache flush."
+  schema/prepare-cache-coherence!)
+
+(defn cache-stats
+  "Returns private completed-cache counters for one Datalevin EACL client."
+  [client]
+  (require-datalevin-client! client "cache-stats")
+  (orchestration/cache-stats client))
+
+(defn make-client
+  "Builds an IAuthorization client over a Datalevin conn.
+
+  Options (unknown keys throw :eacl/invalid-config - a silently ignored key
+  means silently wrong ID coercion, audit 5):
+  - :entid->object-id  (fn [db eid] external-id) - canonical.
+  - :object-id->lookup-ref (fn [external-id] lookup-ref). Default: [:eacl/id id].
+  - :cache - omitted creates a bounded client-private current-generation
+    cache; eacl.cache/no-cache disables it; a config map bounds it.
+    Exact hits are snapshot-local; complete native generation proofs let
+    unchanged answers survive unrelated forward transactions. Authorization
+    mutations must use EACL APIs or intact EACL-produced transaction data.
+  - :cursor-ttl-seconds - optional cursor token expiry; default nil (tokens never expire).
+  - :internal-cursor->spice / :spice-cursor->internal - advanced cursor coercion overrides.
+
+  Datalevin is current-basis-only across requests. It does not retain old DB
+  values and rejects :at-exact-snapshot before cache access."
+  [conn config-opts]
+  (when (contains? config-opts prepared-native-source-id-key)
+    (throw
+     (ex-info
+      "Datalevin prepared source identity is module-internal."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key prepared-native-source-id-key})))
+  (when-not (contains? config-opts :source-lifecycle)
+    (throw
+     (ex-info
+      "Datalevin requires an externally retained :source-lifecycle."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key :source-lifecycle})))
+  (when-not (some? (:source-lifecycle config-opts))
+    (throw
+     (ex-info
+      "Datalevin requires a non-nil externally retained :source-lifecycle."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key :source-lifecycle
+       :value nil})))
+  (when-not (or (contains? config-opts :security-key)
+                (contains? config-opts :security-keyring))
+    (throw
+     (ex-info
+      "Datalevin requires an externally retained token-signing key or keyring."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key :security-key})))
+  (when-not (contains? config-opts :revision-watermark)
+    (throw
+     (ex-info
+      "Datalevin requires an externally retained :revision-watermark."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key :revision-watermark})))
+  (when-not (derefable? (:revision-watermark config-opts))
+    (throw
+     (ex-info
+      "Datalevin :revision-watermark must be an externally retained dereferenceable state."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key :revision-watermark
+       :value (:revision-watermark config-opts)})))
+  (when-not (fn? (:advance-revision-watermark! config-opts))
+    (throw
+     (ex-info
+      "Datalevin requires synchronous external revision-watermark persistence."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key :advance-revision-watermark!})))
+  (let [watermark-value (:revision-watermark config-opts)
+        watermark @watermark-value]
+    (when-not (and (integer? watermark)
+                   (not (neg? watermark))
+                   (<= watermark 9007199254740991))
+      (throw
+       (ex-info
+        "Datalevin :revision-watermark must be an exact nonnegative integer."
+        {:type :eacl/invalid-config
+         :eacl/error :eacl/invalid-config
+         :key :revision-watermark
+         :value watermark})))
+    (datalevin-backend/validate-topology! conn config-opts)
+    (let [revision (:max-tx (ds/db conn))]
+      (when (< revision watermark)
+        (throw
+         (ex-info
+          "Datalevin revision regressed below the external watermark."
+          {:type :eacl.datalevin/revision-regression
+           :eacl/error :eacl.datalevin/revision-regression
+           :revision revision
+           :revision-watermark watermark})))))
+  (let [source-id (schema/ensure-physical-schema! conn)
+        native-revision
+        {:revision (datalevin-backend/exact-natural!
+                    :startup-revision (:max-tx (ds/db conn)))
+         :exact-locator nil}]
+    ;; Readiness is not acknowledged until the externally retained watermark
+    ;; covers every bootstrap transaction visible at this lifecycle.
+    (advance-revision-watermark! native-revision config-opts)
+    (orchestration/make-client
+     api conn (assoc config-opts prepared-native-source-id-key
+                     (str source-id)))))
+
+(defn create-conn
+  "A Datalevin connection carrying EACL's schema. See
+  `eacl.datalevin.schema/create-conn` for the config options."
+  ([] (schema/create-conn))
+  ([dir] (schema/create-conn dir))
+  ([dir extra-schema] (schema/create-conn dir extra-schema))
+  ([dir extra-schema store-options]
+   (schema/create-conn dir extra-schema store-options)))

--- a/modules/eacl-datalevin/src/eacl/datalevin/db.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/db.cljc
@@ -1,0 +1,116 @@
+(ns eacl.datalevin.db
+  "Guarded native Datalevin index access for endpoint-pair relationship
+  values. Every seek starts from a complete four-element tuple and is eagerly
+  realized inside the explicit Datalevin read-snapshot scope."
+  (:require [datalevin.core :as ds]
+            [eacl.backend.v8 :as backend]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]))
+
+(def min-eid 0)
+
+(def max-eid backend/maximum-exact-integer)
+
+(def maximum-unpaged-scan-results 100000)
+
+(defn with-db
+  "Runs `f` with a raw Datalevin DB. Public request paths pass an explicit
+  read snapshot; raw compatibility helpers may pass a DB directly."
+  [snapshot-or-db f]
+  (if (ds/read-snapshot? snapshot-or-db)
+    (ds/with-read-snapshot snapshot-or-db f)
+    (f snapshot-or-db)))
+
+(defn entid
+  [db eid-or-ref]
+  (ds/entid db eid-or-ref))
+
+(defn entity-exists?
+  [db eid]
+  (boolean (seq (ds/datoms db :eav eid))))
+
+(defn avet-datoms
+  ([db attr]
+   (ds/datoms db :ave attr))
+  ([db attr value]
+   (ds/datoms db :ave attr value)))
+
+(defn eavt-datoms
+  ([db entity attr]
+   (ds/datoms db :eav entity attr))
+  ([db entity attr value]
+   (ds/datoms db :eav entity attr value)))
+
+(defn- valid-prefix?
+  [prefix]
+  (and (vector? prefix)
+       (= 3 (count prefix))
+       (keyword? (nth prefix 0))
+       (nat-int? (nth prefix 1))
+       (keyword? (nth prefix 2))))
+
+(defn- matches-prefix?
+  [prefix {:keys [v]}]
+  (endpoint-pair/value-prefix? v prefix))
+
+(defn eavt-endpoint-prefix
+  "Endpoint datoms for an exact three-component value prefix.
+
+  `cursor-eid` is an inclusive lower/upper seek bound; portable cursor logic
+  decides whether to drop the boundary row. Direction is `:asc` or `:desc`."
+  ([db entity attr prefix]
+   (eavt-endpoint-prefix db entity attr prefix nil :asc
+                         maximum-unpaged-scan-results))
+  ([db entity attr prefix cursor-eid direction]
+   (eavt-endpoint-prefix db entity attr prefix cursor-eid direction
+                         maximum-unpaged-scan-results))
+  ([db entity attr prefix cursor-eid direction native-limit]
+   (if-not (and (nat-int? entity)
+                (valid-prefix? prefix)
+                (#{:asc :desc} direction)
+                (pos-int? native-limit))
+     []
+     (let [tail  (or cursor-eid
+                     (if (= :desc direction) max-eid min-eid))
+           bound (conj prefix tail)
+           scan  (if (= :desc direction)
+                   (ds/rseek-datoms db :eav entity attr bound native-limit)
+                   (ds/seek-datoms db :eav entity attr bound native-limit))]
+       (into []
+             (take-while
+              (fn [{:keys [e a] :as datom}]
+                (and (= entity e)
+                     (= attr a)
+                     (matches-prefix? prefix datom))))
+             scan)))))
+
+(defn avet-endpoint-prefix
+  "Endpoint datoms across entities for an exact three-component value prefix,
+  using a complete four-component AVET seek bound."
+  ([db attr prefix]
+   (avet-endpoint-prefix db attr prefix nil :asc
+                         maximum-unpaged-scan-results))
+  ([db attr prefix cursor-eid direction]
+   (avet-endpoint-prefix db attr prefix cursor-eid direction
+                         maximum-unpaged-scan-results))
+  ([db attr prefix cursor-eid direction native-limit]
+   (avet-endpoint-prefix db attr prefix cursor-eid nil direction native-limit))
+  ([db attr prefix cursor-eid cursor-entity direction native-limit]
+   (if-not (and (valid-prefix? prefix)
+                (#{:asc :desc} direction)
+                (or (nil? cursor-entity) (nat-int? cursor-entity))
+                (pos-int? native-limit))
+     []
+     (let [tail  (or cursor-eid
+                     (if (= :desc direction) max-eid min-eid))
+           bound (conj prefix tail)
+           scan  (if (= :desc direction)
+                   (ds/rseek-datoms
+                    db :ave attr bound cursor-entity native-limit)
+                   (ds/seek-datoms
+                    db :ave attr bound cursor-entity native-limit))]
+       (into []
+             (take-while
+              (fn [{:keys [a] :as datom}]
+                (and (= attr a)
+                     (matches-prefix? prefix datom))))
+             scan)))))

--- a/modules/eacl-datalevin/src/eacl/datalevin/impl.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/impl.cljc
@@ -1,0 +1,834 @@
+(ns eacl.datalevin.impl
+  (:require [datalevin.core :as ds]
+            [eacl.core :as eacl :refer [spice-object]]
+            [eacl.datalevin.db :as ddb]
+            [eacl.engine.relationships :as relationship-engine]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
+            [eacl.relationships.filters :as relationship-filters]
+            [eacl.relationships.storage :as relationship-storage]
+            [eacl.schema.model :as model]))
+
+(def Relation model/Relation)
+(def Permission model/Permission)
+
+(defn Relationship
+  [subject relation resource]
+  (eacl/->Relationship subject relation resource))
+
+(def permission-def-pull
+  '[:db/id
+    :eacl.permission/resource-type
+    :eacl.permission/permission-name
+    :eacl.permission/source-relation-name
+    :eacl.permission/target-type
+    :eacl.permission/target-name])
+
+(defn- bounded-realize!
+  [operation values]
+  (let [result (into []
+                     (take (inc ddb/maximum-unpaged-scan-results))
+                     values)]
+    (when (> (count result) ddb/maximum-unpaged-scan-results)
+      (throw
+       (ex-info
+        "Datalevin metadata scan exceeded its certified eager bound."
+        {:type :eacl/scan-limit-exceeded
+         :eacl/error :eacl/scan-limit-exceeded
+         :operation operation
+         :maximum ddb/maximum-unpaged-scan-results})))
+    result))
+
+(defn relation-datoms
+  "Returns relation datoms for the exact resource/relation name pair, for ANY
+  subject-type keyword. Implemented as a seek + prefix take-while rather than a
+  bounded index-range: a keyword-sentinel range like [.. :a]..[.. :z] silently
+  misses subject types that collate outside it (uppercase-initial, z-prefixed,
+  and namespaced keywords), making those relations invisible to permission
+  evaluation (audit 2)."
+  [db resource-type relation-name]
+  (if (and resource-type relation-name)
+    ;; Datalevin sorts vectors by LENGTH FIRST, so a short seek-start would
+    ;; land at the head of the whole attribute; pad to full tuple arity with
+    ;; nil (nil sorts lowest) to position at the exact prefix.
+    (bounded-realize!
+     :relation-definitions
+     (take-while
+      (fn [datom]
+        (and
+         (= :eacl.relation/resource-type+relation-name+subject-type
+            (:a datom))
+         (let [v (:v datom)]
+           (and (= resource-type (nth v 0))
+                (= relation-name (nth v 1))))))
+      (ds/seek-datoms
+       db :ave
+       :eacl.relation/resource-type+relation-name+subject-type
+       [resource-type relation-name nil]
+       nil
+       (inc ddb/maximum-unpaged-scan-results))))
+    []))
+
+(defn find-permission-defs
+  [db resource-type permission-name]
+  (let [definition-datoms
+        (bounded-realize!
+         :permission-definitions
+         (ds/datoms
+          db :ave :eacl.permission/resource-type+permission-name
+          [resource-type permission-name]))]
+    ;; Parse the pull pattern once and resolve the bounded entity set as one
+    ;; operation. `map` of `pull` reparsed the same pattern for every union arm.
+    (ds/pull-many db permission-def-pull (mapv :e definition-datoms))))
+
+(defn all-relation-defs
+  [db]
+  (mapv (fn [{:keys [e v]}]
+          {:relation-id e
+           :resource-type (nth v 0)
+           :relation-name (nth v 1)
+           :subject-type (nth v 2)})
+        (bounded-realize!
+         :all-relation-definitions
+         (ds/datoms
+          db :ave
+          :eacl.relation/resource-type+relation-name+subject-type))))
+
+(defn- matching-relation-defs
+  [db filters]
+  (if (and (:resource/type filters) (:resource/relation filters))
+    (mapv
+     (fn [{:keys [e v]}]
+       {:relation-id e
+        :resource-type (nth v 0)
+        :relation-name (nth v 1)
+        :subject-type (nth v 2)})
+     (relation-datoms
+      db (:resource/type filters) (:resource/relation filters)))
+    (all-relation-defs db)))
+
+(defn all-permission-nodes
+  [db]
+  (into #{}
+        (map :v)
+        (bounded-realize!
+         :all-permission-nodes
+         (ds/datoms
+          db :ave
+          :eacl.permission/resource-type+permission-name))))
+
+(defn- eager-scan-values
+  [datoms {:keys [direction bound-eid inclusive-bound? limit]}]
+  (let [within-bound?
+        (case direction
+          :asc
+          (if bound-eid
+            (if inclusive-bound?
+              #(<= bound-eid %)
+              #(< bound-eid %))
+            (constantly true))
+
+          :desc
+          (if bound-eid
+            (if inclusive-bound?
+              #(>= bound-eid %)
+              #(> bound-eid %))
+            (constantly true)))
+        values (into []
+                     (comp (map (comp #(nth % 3) :v))
+                           (filter within-bound?)
+                           (distinct)
+                           (if limit (take limit) identity))
+                     datoms)]
+    (when (and (nil? limit)
+               (> (count values) ddb/maximum-unpaged-scan-results))
+      (throw
+       (ex-info
+        "Datalevin relationship scan exceeded its certified eager bound."
+        {:type :eacl/scan-limit-exceeded
+         :eacl/error :eacl/scan-limit-exceeded
+         :maximum ddb/maximum-unpaged-scan-results})))
+    values))
+
+(defn subject->resources
+  [db subject-type subject-id relation-id resource-type cursor-or-options]
+  (let [{:keys [direction bound-eid limit] :as options}
+        (if (map? cursor-or-options)
+          (merge {:direction :asc} cursor-or-options)
+          {:direction :asc
+           :bound-eid cursor-or-options
+           :inclusive-bound? false})
+        native-limit (inc (or limit ddb/maximum-unpaged-scan-results))]
+    (eager-scan-values
+     (ddb/eavt-endpoint-prefix
+      db subject-id relationship-storage/forward-attribute
+      [subject-type relation-id resource-type]
+      bound-eid direction native-limit)
+     options)))
+
+(defn resource->subjects
+  [db resource-type resource-id relation-id subject-type cursor-or-options]
+  (let [{:keys [direction bound-eid limit] :as options}
+        (if (map? cursor-or-options)
+          (merge {:direction :asc} cursor-or-options)
+          {:direction :asc
+           :bound-eid cursor-or-options
+           :inclusive-bound? false})
+        native-limit (inc (or limit ddb/maximum-unpaged-scan-results))]
+    (eager-scan-values
+     (ddb/eavt-endpoint-prefix
+      db resource-id relationship-storage/reverse-attribute
+      [resource-type relation-id subject-type]
+      bound-eid direction native-limit)
+     options)))
+
+(defn- relationship-tuple
+  [{:keys [subject-type relation-id resource-type resource-id]}]
+  (endpoint-pair/forward-value
+   subject-type relation-id resource-type resource-id))
+
+(defn- reverse-relationship-tuple
+  [{:keys [resource-type relation-id subject-type subject-id]}]
+  (endpoint-pair/reverse-value
+   resource-type relation-id subject-type subject-id))
+
+(defn- internal-id
+  [db value]
+  (when value
+    (ds/entid db value)))
+
+(defn- existing-internal-id
+  "Resolves to an eid and verifies the entity exists (datom presence - entid
+  passes unallocated numeric ids through unchanged). Throws :eacl/unknown-object
+  otherwise: nil ids reaching tx-data raised raw transact errors, and silent
+  no-ops hid typos (audit 11/12)."
+  [db {:keys [type id]}]
+  (let [eid (internal-id db id)]
+    (if (and eid (seq (ds/datoms db :eav eid)))
+      eid
+      (throw (ex-info (str "Unknown object: " (pr-str type) " with id " (pr-str id) " does not exist.")
+               {:type :eacl/unknown-object
+                :eacl/error :eacl/unknown-object
+                :object {:type type :id id}})))))
+
+(defn- relation-id
+  [resource-type relation-name subject-type]
+  [:eacl/id (model/->relation-id resource-type relation-name subject-type)])
+
+(defn- endpoint-identity-guard
+  [db role eid object]
+  (let [candidate (or (:eacl.relationship/identity-guard object)
+                      (when (and (vector? (:id object))
+                                 (= 2 (count (:id object))))
+                        (:id object))
+                      (when-let [value (:eacl/id (ds/entity db eid))]
+                        [:eacl/id value]))]
+    (when-not (and (vector? candidate)
+                   (= 2 (count candidate))
+                   (keyword? (first candidate))
+                   (some? (second candidate)))
+      (throw
+       (ex-info
+        "A relationship endpoint has no commit-time identity guard."
+        {:type :eacl/endpoint-identity-unavailable
+         :role role
+         :endpoint-eid eid
+         :object object})))
+    (let [[attribute value] candidate]
+      [:db.fn/cas eid attribute value value])))
+
+(defn tx-relation-version-stamp
+  [relation-id]
+  [:db/add relation-id :eacl/relation-version :db/current-tx])
+
+(defn- guard-schema-write-fence
+  "Fences client-planned relationship data against concurrent schema writes.
+
+  The dedicated fence is intentionally distinct from the cache generation:
+  an implementation may reassert an old==new CAS datom with a new physical
+  assertion tx. Such predicate bookkeeping must not invalidate managed schema
+  entries."
+  [db tx-data]
+  (if (seq tx-data)
+    (let [schema-eid (ds/entid db [:eacl/id "schema-string"])
+          write-fence
+          (when schema-eid
+            (some-> (ds/datoms db :eav schema-eid
+                               :eacl/schema-write-fence)
+                    first
+                    :v))]
+      (when-not write-fence
+        (throw
+         (ex-info
+          "Relationship writes require a prepared EACL schema write fence."
+          {:type :eacl.cache/generation-unprepared
+           :backend :datalevin})))
+      (into
+       [[:db.fn/cas schema-eid :eacl/schema-write-fence
+         write-fence write-fence]]
+       tx-data))
+    []))
+
+(defn- resolve-relationship
+  [db {:keys [subject relation resource]}]
+  (let [subject-type  (:type subject)
+        subject-id    (existing-internal-id db subject)
+        resource-type (:type resource)
+        resource-id   (existing-internal-id db resource)
+        relation-eid  (ds/entid db (relation-id resource-type relation subject-type))]
+    (when-not relation-eid
+      (throw
+       (ex-info
+        (str "Missing Relation: " relation
+             " on resource type " resource-type
+             " for subject type " subject-type ".")
+        {:type :eacl/unknown-relation-or-permission
+         :eacl/error :eacl/unknown-relation-or-permission
+         :operation :write-relationships
+         :definition resource-type
+         :relation relation
+         :relation-or-permission relation
+         :schema-kind :relation
+         :resource/type resource-type
+         :relation/name relation
+         :subject/type subject-type})))
+    {:subject subject
+     :subject-type subject-type
+     :subject-id subject-id
+     :subject-identity-guard
+     (endpoint-identity-guard db :subject subject-id subject)
+     :relation relation
+     :relation-id relation-eid
+     :resource resource
+     :resource-type resource-type
+     :resource-id resource-id
+     :resource-identity-guard
+     (endpoint-identity-guard db :resource resource-id resource)}))
+
+(defn find-one-relationship-id
+  "Returns the resolved tuple identity for an existing relationship, or nil.
+  A read: unresolvable endpoints mean no such relationship can exist -> nil."
+  [db relationship]
+  (let [resolved (try
+                   (resolve-relationship db relationship)
+                   (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e
+                     (when-not (= :eacl/unknown-object (:type (ex-data e)))
+                       (throw e))))
+        existing? (and resolved
+                       (seq
+                        (ddb/eavt-datoms
+                         db
+                         (:subject-id resolved)
+                         relationship-storage/forward-attribute
+                         (relationship-tuple resolved)))
+                       (seq
+                        (ddb/eavt-datoms
+                         db
+                         (:resource-id resolved)
+                         relationship-storage/reverse-attribute
+                         (reverse-relationship-tuple resolved))))]
+    (when existing?
+      resolved)))
+
+(defn relationship-relation-id
+  [db relationship]
+  (:relation-id (resolve-relationship db relationship)))
+
+(defn- add-relationship-txes
+  [resolved]
+  [(:subject-identity-guard resolved)
+   (:resource-identity-guard resolved)
+   [:db/add
+    (:subject-id resolved)
+    relationship-storage/forward-attribute
+    (relationship-tuple resolved)]
+   [:db/add
+    (:resource-id resolved)
+    relationship-storage/reverse-attribute
+    (reverse-relationship-tuple resolved)]
+   (tx-relation-version-stamp (:relation-id resolved))])
+
+(defn- retract-relationship-txes
+  [resolved]
+  [[:db/retract
+    (:subject-id resolved)
+    relationship-storage/forward-attribute
+    (relationship-tuple resolved)]
+   [:db/retract
+    (:resource-id resolved)
+    relationship-storage/reverse-attribute
+    (reverse-relationship-tuple resolved)]
+   (tx-relation-version-stamp (:relation-id resolved))])
+
+(defn direct-match?
+  [db subject-type subject-id relation-id resource-type resource-id]
+  (boolean
+   (seq
+    (ddb/eavt-datoms
+     db subject-id relationship-storage/forward-attribute
+     (endpoint-pair/forward-value
+      subject-type relation-id resource-type resource-id)))))
+
+(defn- reverse-match?
+  [db resource-type resource-id relation-id subject-type subject-id]
+  (boolean
+   (seq
+    (ddb/eavt-datoms
+     db resource-id relationship-storage/reverse-attribute
+     (endpoint-pair/reverse-value
+      resource-type relation-id subject-type subject-id)))))
+
+(defn- relationship-exists?
+  [db {:keys [subject-type subject-id relation-id
+              resource-type resource-id]}]
+  (and (direct-match? db subject-type subject-id relation-id
+                      resource-type resource-id)
+       (reverse-match? db resource-type resource-id relation-id
+                       subject-type subject-id)))
+
+(def ^:private supported-relationship-operations
+  #{:create :touch :delete})
+
+(defn validate-relationship-operation!
+  [operation]
+  (when-not (contains? supported-relationship-operations operation)
+    (throw
+     (ex-info
+      (str (pr-str operation)
+           " relationship update is not supported. Use :create, :touch or :delete.")
+      {:type :eacl/unsupported-operation
+       :operation operation})))
+  true)
+
+(defn- relationship-conflict!
+  [relationship]
+  (throw
+   (ex-info
+    ":create conflicts with an existing relationship. Use :touch for idempotent writes."
+    {:type :eacl/relationship-conflict
+     :eacl/error :eacl/relationship-conflict
+     :relationship relationship})))
+
+(defn create-relationship-at-commit
+  "Commit-time precondition behind `:create`. It re-checks the relationship
+  against the transaction-time database, so two writers that both planned a
+  `:create` against the same pre-write value are serialized by the connection:
+  the first commits and the second observes the winner and fails with
+  `:eacl/relationship-conflict`.
+
+  The planned adds remain adjacent to their update in the outer transaction;
+  the shared writer runs every create precondition before those mutations so
+  all updates in one batch retain the calculation-snapshot semantics shared
+  with Datomic."
+  [db resolved relationship]
+  (if (relationship-exists? db resolved)
+    (relationship-conflict! relationship)
+    []))
+
+(defn tx-update-relationship
+  [db {:keys [operation relationship]}]
+  (validate-relationship-operation! operation)
+  (let [resolved (resolve-relationship db relationship)
+        exists?  (relationship-exists? db resolved)
+        tx-data
+        (case operation
+          :touch
+          (when-not exists?
+            (add-relationship-txes resolved))
+
+          :create
+          (if exists?
+            (relationship-conflict! relationship)
+            (into
+             [[:db.fn/call create-relationship-at-commit
+               resolved relationship]]
+             (add-relationship-txes resolved)))
+
+          :delete
+          ;; Retraction of an absent Datalevin datom is harmless. Always
+          ;; retract both halves so an out-of-band half pair is repairable.
+          (retract-relationship-txes resolved))]
+    (when tx-data
+      (guard-schema-write-fence db tx-data))))
+
+(defn read-relationships
+  ([db filters]
+   (read-relationships db filters nil))
+  ([db filters decision-kernel]
+  ;; The unified filter contract shared by every backend
+  ;; (backend-unification 9.1).
+  (relationship-filters/validate! filters)
+  (let [subject-id'  (when (contains? filters :subject/id)
+                       (internal-id db (:subject/id filters)))
+        resource-id' (when (contains? filters :resource/id)
+                       (internal-id db (:resource/id filters)))
+        filters'     (cond-> filters
+                       (contains? filters :subject/id) (assoc :subject/id subject-id')
+                       (contains? filters :resource/id) (assoc :resource/id resource-id'))]
+    (if (or (and (contains? filters :subject/id) (nil? subject-id'))
+            (and (contains? filters :resource/id) (nil? resource-id')))
+      {:data [] :cursor nil}
+      (letfn [(relationship-row [spec subject-id resource-id]
+                {:spec-idx    (:idx spec)
+                 :subject-id  subject-id
+                 :resource-id resource-id
+                 :relationship
+                 (eacl/->Relationship
+                  (spice-object (:subject-type spec) subject-id)
+                  (:relation-name spec)
+                  (spice-object (:resource-type spec) resource-id))})
+              (normalized-cursor [cursor]
+                (when cursor
+                  {:subject-id (or (:subject-id cursor)
+                                   (:subject cursor))
+                   :resource-id (or (:resource-id cursor)
+                                    (:resource cursor))}))
+              (drop-until-beyond-cursor [spec cursor direction rows]
+                (drop-while
+                 #(not
+                   (relationship-engine/beyond-cursor?
+                    (:scan-kind spec)
+                    direction
+                    (normalized-cursor cursor)
+                    %))
+                 rows))
+              (native-page-limit [spec cursor]
+                (when-let [remaining (:physical-limit spec)]
+                  ;; Native seeks are inclusive. A continued page therefore
+                  ;; needs one extra row for the authenticated boundary that
+                  ;; `drop-until-beyond-cursor` removes.
+                  (+ remaining (if cursor 1 0))))
+              (exact-match-row [spec cursor direction]
+                (let [row
+                      (when (and (:subject-id spec) (:resource-id spec))
+                        (when
+                         (direct-match?
+                          db
+                          (:subject-type spec)
+                          (:subject-id spec)
+                          (:relation-id spec)
+                          (:resource-type spec)
+                          (:resource-id spec))
+                          (relationship-row
+                           spec (:subject-id spec) (:resource-id spec))))]
+                  (if row
+                    (drop-until-beyond-cursor
+                     spec cursor direction [row])
+                    [])))
+              (scan-forward-anchored [spec cursor direction]
+                (if (:resource-id spec)
+                  (exact-match-row spec cursor direction)
+                  (let [args
+                        [db
+                         (:subject-id spec)
+                         relationship-storage/forward-attribute
+                         [(:subject-type spec)
+                          (:relation-id spec)
+                          (:resource-type spec)]
+                         (or (:resource-id cursor)
+                             (:resource cursor))
+                         direction]
+                        rows
+                        (if-let [limit (native-page-limit spec cursor)]
+                          (apply ddb/eavt-endpoint-prefix
+                                 (conj args limit))
+                          (apply ddb/eavt-endpoint-prefix args))]
+                    (->> rows
+                       (map
+                        (fn [{:keys [v]}]
+                          (relationship-row
+                           spec (:subject-id spec) (nth v 3))))
+                       (drop-until-beyond-cursor
+                        spec cursor direction)))))
+              (scan-reverse-anchored [spec cursor direction]
+                (if (:subject-id spec)
+                  (exact-match-row spec cursor direction)
+                  (let [args
+                        [db
+                         (:resource-id spec)
+                         relationship-storage/reverse-attribute
+                         [(:resource-type spec)
+                          (:relation-id spec)
+                          (:subject-type spec)]
+                         (or (:subject-id cursor)
+                             (:subject cursor))
+                         direction]
+                        rows
+                        (if-let [limit (native-page-limit spec cursor)]
+                          (apply ddb/eavt-endpoint-prefix
+                                 (conj args limit))
+                          (apply ddb/eavt-endpoint-prefix args))]
+                    (->> rows
+                       (map
+                        (fn [{:keys [v]}]
+                          (relationship-row
+                           spec (nth v 3) (:resource-id spec))))
+                       (drop-until-beyond-cursor
+                        spec cursor direction)))))
+              (scan-forward-partial [spec cursor direction]
+                (let [args
+                      [db
+                       relationship-storage/forward-attribute
+                       [(:subject-type spec)
+                        (:relation-id spec)
+                        (:resource-type spec)]
+                       (or (:resource-id cursor)
+                           (:resource cursor))
+                       (or (:subject-id cursor)
+                           (:subject cursor))
+                       direction]
+                      rows
+                      (if-let [limit (native-page-limit spec cursor)]
+                        (apply ddb/avet-endpoint-prefix (conj args limit))
+                        (ddb/avet-endpoint-prefix
+                         db
+                         relationship-storage/forward-attribute
+                         [(:subject-type spec)
+                          (:relation-id spec)
+                          (:resource-type spec)]
+                         (or (:resource-id cursor)
+                             (:resource cursor))
+                         direction))]
+                  (->> rows
+                     (map
+                      (fn [{:keys [e v]}]
+                        (relationship-row spec e (nth v 3))))
+                     (drop-until-beyond-cursor
+                      spec cursor direction))))
+              (scan-reverse-partial [spec cursor direction]
+                (let [args
+                      [db
+                       relationship-storage/reverse-attribute
+                       [(:resource-type spec)
+                        (:relation-id spec)
+                        (:subject-type spec)]
+                       (or (:subject-id cursor)
+                           (:subject cursor))
+                       (or (:resource-id cursor)
+                           (:resource cursor))
+                       direction]
+                      rows
+                      (if-let [limit (native-page-limit spec cursor)]
+                        (apply ddb/avet-endpoint-prefix (conj args limit))
+                        (ddb/avet-endpoint-prefix
+                         db
+                         relationship-storage/reverse-attribute
+                         [(:resource-type spec)
+                          (:relation-id spec)
+                          (:subject-type spec)]
+                         (or (:subject-id cursor)
+                             (:subject cursor))
+                         direction))]
+                  (->> rows
+                     (map
+                      (fn [{:keys [e v]}]
+                        (relationship-row spec (nth v 3) e)))
+                     (drop-until-beyond-cursor
+                      spec cursor direction))))
+              (scan-spec
+                ([spec cursor]
+                 (scan-spec spec cursor :asc))
+                ([spec cursor direction]
+                (case (:scan-kind spec)
+                  :forward-anchored
+                  (scan-forward-anchored spec cursor direction)
+
+                  :reverse-anchored
+                  (scan-reverse-anchored spec cursor direction)
+
+                  :forward-partial
+                  (scan-forward-partial spec cursor direction)
+
+                  (scan-reverse-partial
+                   spec cursor direction))))]
+        (let [scan-specs
+              (relationship-engine/plan-scans
+               (matching-relation-defs db filters') filters')]
+          (if-not (or (contains? filters' :limit)
+                      (contains? filters' :cursor))
+            (relationship-engine/execute-page
+             scan-specs filters' decision-kernel scan-spec)
+            (relationship-engine/execute-plan
+             scan-specs filters' scan-spec))))))))
+
+(defn- relation-triples
+  [db]
+  (mapv (fn [{:keys [e v]}]
+          [(nth v 0) e (nth v 2)])
+        (ddb/avet-datoms
+         db :eacl.relation/resource-type+relation-name+subject-type)))
+
+(defn- relationship-pair-retractions
+  [subject-type subject-id relation-id resource-type resource-id]
+  [[:db/retract
+    subject-id
+    relationship-storage/forward-attribute
+    (endpoint-pair/forward-value
+     subject-type relation-id resource-type resource-id)]
+   [:db/retract
+    resource-id
+    relationship-storage/reverse-attribute
+    (endpoint-pair/reverse-value
+     resource-type relation-id subject-type subject-id)]])
+
+(defn- relationship-op-relation-id
+  [op]
+  (when (and (vector? op)
+             (contains? #{:db/add :db/retract} (first op))
+             (contains? #{relationship-storage/forward-attribute
+                          relationship-storage/reverse-attribute}
+                        (nth op 2 nil))
+             (vector? (nth op 3 nil)))
+    (nth (nth op 3) 1 nil)))
+
+(defn stamp-relation-versions
+  "Adds one idempotent native generation stamp per affected relation."
+  [tx-data]
+  (let [ops (vec tx-data)
+        relation-ids (into #{} (keep relationship-op-relation-id) ops)
+        stamped (into #{}
+                      (keep (fn [op]
+                              (when (and (vector? op)
+                                         (= :db/add (first op))
+                                         (= :eacl/relation-version
+                                            (nth op 2 nil)))
+                                (nth op 1))))
+                      ops)]
+    (into ops
+          (map tx-relation-version-stamp)
+          (sort (remove stamped relation-ids)))))
+
+(defn- object-relationship-retractions
+  [db object-eid]
+  (let [triples (relation-triples db)]
+    (->>
+     (concat
+        (mapcat
+         (fn [{:keys [v]}]
+           (when-let [{:keys [subject-type relation-eid
+                             resource-type resource-eid]}
+                      (endpoint-pair/decode-forward object-eid v)]
+             (relationship-pair-retractions
+              subject-type object-eid relation-eid
+              resource-type resource-eid)))
+         (ddb/eavt-datoms
+          db object-eid relationship-storage/forward-attribute))
+
+        (mapcat
+         (fn [{:keys [v]}]
+           (when-let [{:keys [subject-type subject-eid relation-eid
+                             resource-type]}
+                      (endpoint-pair/decode-reverse object-eid v)]
+             (relationship-pair-retractions
+              subject-type subject-eid relation-eid
+              resource-type object-eid)))
+         (ddb/eavt-datoms
+          db object-eid relationship-storage/reverse-attribute))
+
+        (mapcat
+         (fn [[resource-type relation-id subject-type]]
+           (mapcat
+            (fn [{resource-id :e}]
+              (relationship-pair-retractions
+               subject-type object-eid relation-id
+               resource-type resource-id))
+            (ddb/avet-datoms
+             db relationship-storage/reverse-attribute
+             (endpoint-pair/reverse-value
+              resource-type relation-id subject-type object-eid))))
+         triples)
+
+        (mapcat
+         (fn [[resource-type relation-id subject-type]]
+           (mapcat
+            (fn [{subject-id :e}]
+              (relationship-pair-retractions
+               subject-type subject-id relation-id
+               resource-type object-eid))
+            (ddb/avet-datoms
+             db relationship-storage/forward-attribute
+             (endpoint-pair/forward-value
+              subject-type relation-id resource-type object-eid))))
+         triples))
+     (remove nil?)
+     distinct
+     vec
+     stamp-relation-versions)))
+
+(defn delete-object-at-commit
+  "Datalevin transaction function that rescans the writer's serialized DB.
+  A relationship committed after planning but before this transaction is
+  therefore removed; a relationship committed afterward linearizes later."
+  [db object-eid]
+  (object-relationship-retractions db object-eid))
+
+(defn tx-delete-object
+  "Returns a commit-time transaction function removing both physical halves
+  of every relationship touching `object-id`. The object entity itself is
+  retained. Cross-entity AVET probes repair one-sided out-of-band ghosts."
+  [db object-id]
+  (if-let [object-eid (internal-id db object-id)]
+    (guard-schema-write-fence
+     db [[:db.fn/call delete-object-at-commit object-eid]])
+    []))
+
+(defn affected-relation-ids
+  "Every relation named by endpoint-pair retraction operations."
+  [tx-data]
+  (->> tx-data
+       (keep
+        (fn [op]
+          (when (and (vector? op)
+                     (= :db/retract (first op))
+                     (contains?
+                      #{relationship-storage/forward-attribute
+                        relationship-storage/reverse-attribute}
+                      (nth op 2 nil)))
+            (nth (nth op 3) 1))))
+       distinct
+       sort
+       vec))
+
+(defn orphaned-relationship-halves
+  "Lazy deterministic scan of physical relationship halves whose exact peer
+  half is absent. Malformed values are reported as dangling rather than
+  throwing from the diagnostic."
+  [db]
+  (concat
+   (for [{subject-id :e value :v}
+         (ddb/avet-datoms db relationship-storage/forward-attribute)
+         :let [decoded (endpoint-pair/decode-forward subject-id value)
+               peer (endpoint-pair/peer-half :forward subject-id value)]
+         :when
+         (or (nil? decoded)
+             (empty?
+              (ddb/eavt-datoms
+               db (:endpoint-eid peer)
+               relationship-storage/reverse-attribute
+               (:value peer))))]
+     {:half :forward
+      :e subject-id
+      :attr relationship-storage/forward-attribute
+      :v (if (sequential? value) (vec value) value)
+      :subject-eid subject-id
+      :resource-eid (:resource-eid decoded)
+      :relation-eid (:relation-eid decoded)
+      :value-arity (when (counted? value) (count value))})
+   (for [{resource-id :e value :v}
+         (ddb/avet-datoms db relationship-storage/reverse-attribute)
+         :let [decoded (endpoint-pair/decode-reverse resource-id value)
+               peer (endpoint-pair/peer-half :reverse resource-id value)]
+         :when
+         (or (nil? decoded)
+             (empty?
+              (ddb/eavt-datoms
+               db (:endpoint-eid peer)
+               relationship-storage/forward-attribute
+               (:value peer))))]
+     {:half :reverse
+      :e resource-id
+      :attr relationship-storage/reverse-attribute
+      :v (if (sequential? value) (vec value) value)
+      :subject-eid (:subject-eid decoded)
+      :resource-eid resource-id
+      :relation-eid (:relation-eid decoded)
+      :value-arity (when (counted? value) (count value))})))

--- a/modules/eacl-datalevin/src/eacl/datalevin/integrity.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/integrity.cljc
@@ -1,0 +1,40 @@
+(ns eacl.datalevin.integrity
+  "Read-only, offline endpoint-pair integrity diagnostics."
+  (:require [eacl.datalevin.impl :as impl]))
+
+(defn dangling-relationship-halves
+  "Returns a lazy sequence of relationship halves whose exact peer is absent."
+  [db]
+  (impl/orphaned-relationship-halves db))
+
+(defn dangling-relationship-report
+  "Returns deterministic total/per-half dangling counts and a bounded sample.
+  This scan never mutates the database."
+  ([db]
+   (dangling-relationship-report db {}))
+  ([db {:keys [sample-size] :or {sample-size 20}}]
+   (when-not (and (integer? sample-size)
+                  (not (neg? sample-size)))
+     (throw
+      (ex-info
+       ":sample-size must be a non-negative integer."
+       {:type :eacl.integrity/invalid-options
+        :sample-size sample-size})))
+   (let [{:keys [count by-half sample]}
+         (reduce
+          (fn [{:keys [count] :as report} half]
+            (cond-> (-> report
+                        (assoc :count (inc count))
+                        (update-in
+                         [:by-half (:half half)]
+                         (fnil inc 0)))
+              (< count sample-size)
+              (update :sample conj half)))
+          {:count 0
+           :by-half {:forward 0 :reverse 0}
+           :sample []}
+          (dangling-relationship-halves db))]
+     {:valid? (zero? count)
+      :dangling-count count
+      :by-half by-half
+      :sample sample})))

--- a/modules/eacl-datalevin/src/eacl/datalevin/safe_retraction.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/safe_retraction.cljc
@@ -1,0 +1,162 @@
+(ns eacl.datalevin.safe-retraction
+  "Optional in-process Datalevin transaction function for safe entity
+  retraction. Datalevin cannot persist arbitrary Clojure function values, so
+  this adapter deliberately supports only direct `:db.fn/call` invocation."
+  (:require [datalevin.core :as ds]
+            [eacl.datalevin.db :as ddb]
+            [eacl.relationships.safe-retraction :as safe]
+            [eacl.relationships.storage :as storage]))
+
+(def support
+  (safe/support-descriptor
+   {:backend :datalevin
+    :mode :direct
+    :reason :in-process-db-fn-call
+    :requires-installation? false
+    :transport-safe? false}))
+
+(defn support-descriptor
+  []
+  support)
+
+(defn- component-attributes
+  [db]
+  (into #{}
+        (keep (fn [[attribute options]]
+                (when (true? (:db/isComponent options))
+                  attribute)))
+        (ds/schema db)))
+
+(defn- control-entity-data
+  [db eid]
+  (let [entity (ds/entity db eid)]
+    {:db-ident (:db/ident entity)
+     :eacl-id (:eacl/id entity)
+     :schema-string (:eacl/schema-string entity)
+     :relation-name (:eacl.relation/relation-name entity)
+     :permission-name (:eacl.permission/permission-name entity)}))
+
+(defn- relation-triples
+  [db]
+  (mapv (fn [{:keys [e v]}]
+          [(nth v 0) e (nth v 2)])
+        (ddb/avet-datoms
+         db :eacl.relation/resource-type+relation-name+subject-type)))
+
+(defn- known-ghost-plan
+  [db target-eid]
+  (safe/combine-plans
+   (mapcat
+    (fn [[resource-type relation-eid subject-type]]
+      (let [reverse-value
+            [resource-type relation-eid subject-type target-eid]
+            forward-value
+            [subject-type relation-eid resource-type target-eid]]
+        (concat
+         (for [{peer-eid :e}
+               (ddb/avet-datoms db storage/reverse-attribute reverse-value)]
+           {:peer-retractions
+            [[:db/retract peer-eid storage/reverse-attribute reverse-value]]
+            :relation-ids [relation-eid]
+            :local-half-count 0})
+         (for [{peer-eid :e}
+               (ddb/avet-datoms db storage/forward-attribute forward-value)]
+           {:peer-retractions
+            [[:db/retract peer-eid storage/forward-attribute forward-value]]
+            :relation-ids [relation-eid]
+            :local-half-count 0}))))
+    (relation-triples db))))
+
+(defn retract-entity-function
+  "Datalevin target-only transaction function implementation."
+  [db target]
+  (safe/validate-target! target)
+  (let [target-eid (ds/entid db target)
+        lookup-ref? (vector? target)]
+    (if (and lookup-ref? (nil? target-eid))
+      []
+      (let [live? (and target-eid
+                       (seq (ds/datoms db :eav target-eid)))
+            closure
+            (when live?
+              (let [component-attrs (component-attributes db)]
+                (safe/component-closure
+                 target-eid
+                 (fn [eid]
+                   (into []
+                         (comp
+                          (filter #(contains? component-attrs (:a %)))
+                          (map :v))
+                         (ds/datoms db :eav eid))))))
+            protected-eid
+            (some (fn [eid]
+                    (when (safe/protected-control-entity?
+                           (control-entity-data db eid))
+                      eid))
+                  closure)]
+        (when protected-eid
+          (throw
+           (ex-info
+            "EACL safe retraction cannot delete schema/control entities."
+            {:type :eacl.safe-retraction/invalid
+             :eacl/error :eacl.safe-retraction/invalid
+             :reason :protected-control-entity
+             :target-eid target-eid
+             :protected-eid protected-eid})))
+        (let [plan
+              (if live?
+                (safe/combine-plans
+                 (map (fn [eid]
+                        (safe/plan-local-halves
+                         eid
+                         (mapv :v (ds/datoms db :eav eid
+                                            storage/forward-attribute))
+                         (mapv :v (ds/datoms db :eav eid
+                                            storage/reverse-attribute))))
+                      closure))
+                (if target-eid
+                  (known-ghost-plan db target-eid)
+                  {:peer-retractions []
+                   :relation-ids []
+                   :local-half-count 0}))]
+          (into []
+                (concat
+                 (:peer-retractions plan)
+                 (safe/relation-stamps (:relation-ids plan))
+                 (when live?
+                   [[:db.fn/retractEntity target-eid]]))))))))
+
+(defn prepare!
+  "Returns the direct invocation capability; no installation is needed."
+  [_conn]
+  {:installed? false :state :direct :support support})
+
+(defn install!
+  "Always rejects named installation. Datalevin's value encoding does not
+  round-trip arbitrary Clojure functions; use `prepare!` and direct tx data."
+  [_conn]
+  (throw
+   (ex-info
+    "Datalevin cannot persist the EACL Clojure transaction function; use direct prepared invocation."
+    {:type :eacl.safe-retraction/installation-unavailable
+     :eacl/error :eacl.safe-retraction/installation-unavailable
+     :backend :datalevin
+     :support support
+     :alternative
+     {:prepare 'eacl.datalevin.safe-retraction/prepare!
+      :tx-data 'eacl.datalevin.safe-retraction/retract-entity-tx-data}})))
+
+(defn retract-entity-tx-data
+  "Builds one in-process invocation. Call `prepare!` before use."
+  [target]
+  (safe/validate-target! target)
+  [[:db.fn/call (fn [db wrapped-target]
+                  (retract-entity-function db (first wrapped-target)))
+    [target]]])
+
+(defn direct-retract-entity-tx-data
+  "Builds one in-process `:db.fn/call` invocation without installation.
+
+  Call `prepare!` once for a new connection before submitting this data."
+  [target]
+  (retract-entity-tx-data target))

--- a/modules/eacl-datalevin/src/eacl/datalevin/schema.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/schema.cljc
@@ -1,0 +1,463 @@
+(ns eacl.datalevin.schema
+  (:require [datalevin.core :as ds]
+            [eacl.datalevin.db :as ddb]
+            [eacl.relationships.storage :as relationship-storage]
+            [eacl.schema.model :as model]
+            [eacl.spicedb.parser :as parser]))
+
+(def datalevin-schema
+  {:eacl/id {:db/valueType :db.type/string
+             :db/unique :db.unique/identity}
+   :eacl/schema-string {:db/valueType :db.type/string}
+   :eacl/schema-generation {:db/valueType :db.type/ref}
+   :eacl/schema-write-fence {:db/valueType :db.type/ref}
+   :eacl/relation-version {:db/valueType :db.type/ref}
+   :eacl.datalevin/source-id {:db/valueType :db.type/uuid
+                              :db/unique :db.unique/identity}
+   :eacl.relation/resource-type {:db/valueType :db.type/keyword
+                                 :db/index true}
+   :eacl.relation/relation-name {:db/valueType :db.type/keyword
+                                 :db/index true}
+   :eacl.relation/subject-type {:db/valueType :db.type/keyword
+                                :db/index true}
+   :eacl.relation/resource-type+relation-name+subject-type
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [:eacl.relation/resource-type
+                    :eacl.relation/relation-name
+                    :eacl.relation/subject-type]
+    :db/unique :db.unique/identity}
+
+   :eacl.permission/resource-type {:db/valueType :db.type/keyword
+                                   :db/index true}
+   :eacl.permission/permission-name {:db/valueType :db.type/keyword
+                                     :db/index true}
+   :eacl.permission/source-relation-name
+   {:db/valueType :db.type/keyword :db/index true}
+   :eacl.permission/target-type {:db/valueType :db.type/keyword
+                                 :db/index true}
+   :eacl.permission/target-name {:db/valueType :db.type/keyword
+                                 :db/index true}
+   :eacl.permission/resource-type+permission-name
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [:eacl.permission/resource-type
+                    :eacl.permission/permission-name]
+    :db/index true}
+   :eacl.permission/full-key
+   {:db/valueType :db.type/tuple
+    :db/tupleAttrs [:eacl.permission/resource-type
+                    :eacl.permission/source-relation-name
+                    :eacl.permission/target-type
+                    :eacl.permission/target-name
+                    :eacl.permission/permission-name]
+    :db/unique :db.unique/identity}
+
+   relationship-storage/forward-attribute
+   {:db/valueType :db.type/tuple
+    :db/tupleTypes [:db.type/keyword :db.type/ref
+                    :db.type/keyword :db.type/ref]
+    :db/cardinality :db.cardinality/many
+    :db/index true}
+   relationship-storage/reverse-attribute
+   {:db/valueType :db.type/tuple
+    :db/tupleTypes [:db.type/keyword :db.type/ref
+                    :db.type/keyword :db.type/ref]
+    :db/cardinality :db.cardinality/many
+    :db/index true}})
+
+(defn merge-schema
+  ([] datalevin-schema)
+  ([extra-schema]
+   (merge datalevin-schema extra-schema)))
+
+(defn create-conn
+  ([] (create-conn nil nil nil))
+  ([dir] (create-conn dir nil nil))
+  ([dir extra-schema] (create-conn dir extra-schema nil))
+  ([dir extra-schema store-options]
+   (let [conn (ds/get-conn dir (merge-schema extra-schema) store-options)]
+     (when-not
+      (ds/entid (ds/db conn) [:eacl/id "datalevin-metadata"])
+       (ds/transact!
+        conn
+        [{:eacl/id "datalevin-metadata"
+          :eacl.datalevin/source-id (random-uuid)}]))
+     conn)))
+
+(def ^:private physical-schema-keys
+  #{:db/valueType :db/cardinality :db/unique :db/index
+    :db/tupleAttrs :db/tupleTypes :db/tupleType})
+
+(defn- normalized-attribute
+  [schema attribute]
+  (let [normalized (select-keys attribute physical-schema-keys)]
+    (if (and (:db/tupleAttrs normalized)
+             (not (:db/tupleTypes normalized)))
+      (assoc normalized
+             :db/tupleTypes
+             (mapv #(get-in schema [% :db/valueType])
+                   (:db/tupleAttrs normalized)))
+      normalized)))
+
+(defn ensure-physical-schema!
+  "Installs missing EACL attributes on a quiesced embedded connection and
+  rejects any incompatible definition. Returns the persisted source UUID."
+  [conn]
+  (let [db (ds/db conn)
+        actual (ds/schema conn)
+        drift
+        (into {}
+              (keep
+               (fn [[attribute expected]]
+                 (when-let [present (get actual attribute)]
+                   (when-not (= (normalized-attribute datalevin-schema expected)
+                                (normalized-attribute actual present))
+                     [attribute
+                      {:expected (normalized-attribute datalevin-schema expected)
+                       :actual (normalized-attribute actual present)}]))))
+              datalevin-schema)]
+    (when (seq drift)
+      (throw
+       (ex-info
+        "Datalevin physical EACL schema has drifted."
+        {:type :eacl.datalevin/physical-schema-drift
+         :eacl/error :eacl.datalevin/physical-schema-drift
+         :backend :datalevin
+         :drift drift})))
+    (let [missing (into {}
+                        (remove #(contains? actual (key %)))
+                        datalevin-schema)]
+      (when (seq missing)
+        (ds/update-schema conn missing)))
+    (let [db (ds/db conn)
+          metadata (ds/entity db [:eacl/id "datalevin-metadata"])
+          existing (:eacl.datalevin/source-id metadata)]
+      (cond
+        (uuid? existing) existing
+        (some? existing)
+        (throw
+         (ex-info
+          "Datalevin source identity is not a UUID."
+          {:type :eacl/invalid-source-identity
+           :eacl/error :eacl/invalid-source-identity
+           :backend :datalevin
+           :value existing}))
+        :else
+        (let [source-id (random-uuid)]
+          (ds/transact!
+           conn
+           [{:eacl/id "datalevin-metadata"
+             :eacl.datalevin/source-id source-id}])
+          source-id)))))
+
+(def relation-pull
+  [:eacl/id :eacl.relation/subject-type
+   :eacl.relation/resource-type :eacl.relation/relation-name])
+
+(def permission-pull
+  [:eacl/id :eacl.permission/resource-type
+   :eacl.permission/permission-name
+   :eacl.permission/source-relation-name
+   :eacl.permission/target-type :eacl.permission/target-name])
+
+(defn- eager-entity
+  [db eid attributes]
+  (let [entity (ds/entity db eid)]
+    (into (if (some #{:db/id} attributes) {:db/id eid} {})
+          (keep (fn [attribute]
+                  (when-some [value (get entity attribute)]
+                    [attribute value])))
+          (remove #{:db/id} attributes))))
+
+(defn read-relations
+  [db]
+  (mapv #(eager-entity db (:e %) relation-pull)
+        (ddb/avet-datoms
+         db :eacl.relation/resource-type+relation-name+subject-type)))
+
+(defn read-permissions
+  [db]
+  (mapv #(eager-entity db (:e %) permission-pull)
+        (ddb/avet-datoms
+         db :eacl.permission/resource-type+permission-name)))
+
+(defn read-schema
+  [snapshot-or-db & [_format]]
+  (ddb/with-db
+   snapshot-or-db
+   (fn [db]
+     {:relations (read-relations db)
+      :permissions (read-permissions db)})))
+
+(defn prepare-cache-coherence!
+  "Initializes missing physical schema/relation generations and the schema
+  write fence additively."
+  [conn]
+  (let [db (ds/db conn)
+        physical-schema (ds/schema conn)
+        _ (when-not (and (contains? physical-schema :eacl/schema-generation)
+                         (contains? physical-schema :eacl/schema-write-fence)
+                         (contains? physical-schema :eacl/relation-version))
+            (throw
+             (ex-info
+              "Datalevin connection schema lacks native EACL generation attributes."
+              {:type :eacl.cache/generation-schema-missing
+               :eacl/error :eacl.cache/generation-schema-missing
+               :backend :datalevin})))
+        schema-eid (ds/entid db [:eacl/id "schema-string"])
+        relation-eids
+        (into [] (map :e)
+              (ddb/avet-datoms
+               db :eacl.relation/resource-type+relation-name+subject-type))
+        missing-schema?
+        (and schema-eid
+             (empty? (ds/datoms db :eav schema-eid
+                                :eacl/schema-generation)))
+        missing-schema-fence?
+        (and schema-eid
+             (empty? (ds/datoms db :eav schema-eid
+                                :eacl/schema-write-fence)))
+        missing-relations
+        (filterv #(empty? (ds/datoms db :eav %
+                                    :eacl/relation-version))
+                 relation-eids)
+        tx-data
+        (into (cond-> []
+                missing-schema?
+                (conj [:db/add schema-eid
+                       :eacl/schema-generation :db/current-tx])
+
+                missing-schema-fence?
+                (conj [:db/add schema-eid
+                       :eacl/schema-write-fence :db/current-tx]))
+              (map #(vector :db/add % :eacl/relation-version :db/current-tx))
+              missing-relations)
+        report (when (seq tx-data) (ds/transact! conn tx-data))
+        db-after (if report (:db-after report) db)
+        schema-missing-after?
+        (and schema-eid
+             (empty? (ds/datoms db-after :eav schema-eid
+                                :eacl/schema-generation)))
+        schema-fence-missing-after?
+        (and schema-eid
+             (empty? (ds/datoms db-after :eav schema-eid
+                                :eacl/schema-write-fence)))
+        relation-missing-after
+        (filterv #(empty? (ds/datoms db-after :eav %
+                                    :eacl/relation-version))
+                 relation-eids)]
+    {:prepared? true
+     :changed? (boolean report)
+     :schema-generation-initialized? missing-schema?
+     :schema-write-fence-initialized? missing-schema-fence?
+     :relation-generations-initialized (count missing-relations)
+     :missing-after
+     (cond-> relation-missing-after
+       schema-missing-after? (conj :eacl/schema-generation)
+       schema-fence-missing-after? (conj :eacl/schema-write-fence))
+     :db-after db-after}))
+
+(def validate-schema-references model/validate-schema-references)
+(def compare-schema model/compare-schema)
+
+(defn count-relationships-using-relation
+  "Counts relationships that reference the given relation.
+
+  The maximum of the two endpoint-index cardinalities is exact for healthy
+  pairs and remains positive for either one-sided ghost, so corruption cannot
+  make a relation definition appear unused."
+  [db {:eacl.relation/keys [resource-type relation-name subject-type]}]
+  (let [relation-id  (str "eacl.relation:" resource-type ":" relation-name ":" subject-type)
+        relation-eid (ds/entid db [:eacl/id relation-id])]
+    (if-not relation-eid
+      0
+      (max
+       (count
+        (ddb/avet-endpoint-prefix
+         db relationship-storage/forward-attribute
+         [subject-type relation-eid resource-type]))
+       (count
+        (ddb/avet-endpoint-prefix
+         db relationship-storage/reverse-attribute
+         [resource-type relation-eid subject-type]))))))
+
+(defn- current-schema-generation
+  [db]
+  (when-let [schema-eid (ds/entid db [:eacl/id "schema-string"])]
+    (some-> (ds/datoms db :eav schema-eid :eacl/schema-generation)
+            first
+            :v)))
+
+(defn- current-schema-write-fence
+  [db]
+  (when-let [schema-eid (ds/entid db [:eacl/id "schema-string"])]
+    (some-> (ds/datoms db :eav schema-eid :eacl/schema-write-fence)
+            first
+            :v)))
+
+(defn- ensure-schema-coherence!
+  "Bootstraps the schema singleton before its first guarded replacement.
+
+  Datalevin does not allow a tempid or :db/current-tx as a :db.fn/cas value,
+  so the first physical generation and fence must exist before the replacement
+  CAS. The parser, reference checks, and empty-schema guard run first."
+  [conn]
+  (loop []
+    (let [db (ds/db conn)]
+      (if (and (current-schema-generation db)
+               (current-schema-write-fence db))
+        db
+        (do
+          (ds/transact!
+           conn
+           [(cond-> {:eacl/id "schema-string"}
+              (nil? (current-schema-generation db))
+              (assoc :eacl/schema-generation :db/current-tx)
+
+              (nil? (current-schema-write-fence db))
+              (assoc :eacl/schema-write-fence :db/current-tx))])
+          (recur))))))
+
+(defn- cas-failure-data
+  [throwable]
+  (loop [cause throwable]
+    (when cause
+      (let [data (ex-data cause)]
+        (if (= :transact/cas (:error data))
+          data
+          (recur #?(:clj (.getCause ^Throwable cause)
+                    :cljs (ex-cause cause))))))))
+
+(defn- transact-schema!
+  [conn tx-data expected-generation]
+  (try
+    (ds/transact! conn tx-data)
+    (catch #?(:clj Throwable :cljs :default) throwable
+      (if-let [cause-data (cas-failure-data throwable)]
+        (throw
+         (ex-info
+          "The EACL schema changed concurrently; retry from the new database value."
+          {:type :eacl.schema/concurrent-write
+           :eacl/error :eacl.schema/concurrent-write
+           :expected-generation expected-generation
+           :actual-generation (current-schema-generation (ds/db conn))
+           :backend-error cause-data
+           :datalevin-error cause-data}
+          throwable))
+        (throw throwable)))))
+
+(defn write-schema!
+  "Parses, validates, diffs and transacts a SpiceDB schema string.
+  Throws :eacl.schema/parse-error on unparseable input (a failed parse must
+  never retract the stored schema) and :eacl.schema/empty-schema-guard when the
+  new schema has zero definitions while a non-empty schema is stored; pass
+  {:allow-empty-schema? true} to wipe intentionally."
+  ([conn schema-string]
+   (write-schema! conn schema-string {}))
+  ([conn schema-string
+    {:keys [allow-empty-schema?]}]
+   (let [new-schema-map  (parser/->eacl-schema (parser/parse-schema schema-string))
+         _               (validate-schema-references new-schema-map)
+         initial-db      (ds/db conn)
+         initial-schema  (read-schema initial-db)
+         _               (when (and (empty? (:definitions new-schema-map))
+                                    (not allow-empty-schema?)
+                                    (or (seq (:relations initial-schema))
+                                        (seq (:permissions initial-schema))))
+                           (throw (ex-info (str "Refusing to replace a non-empty schema with zero definitions."
+                                                " Pass {:allow-empty-schema? true} to write-schema! if this is intentional.")
+                                           {:type :eacl.schema/empty-schema-guard
+                                            :existing {:relations (count (:relations initial-schema))
+                                                       :permissions (count (:permissions initial-schema))}})))
+         db              (ensure-schema-coherence! conn)
+         existing-schema (read-schema db)
+         _               (when (and (empty? (:definitions new-schema-map))
+                                    (not allow-empty-schema?)
+                                    (or (seq (:relations existing-schema))
+                                        (seq (:permissions existing-schema))))
+                           (throw (ex-info (str "Refusing to replace a non-empty schema with zero definitions."
+                                                " Pass {:allow-empty-schema? true} to write-schema! if this is intentional.")
+                                           {:type :eacl.schema/empty-schema-guard
+                                            :existing {:relations (count (:relations existing-schema))
+                                                       :permissions (count (:permissions existing-schema))}})))
+         deltas          (compare-schema existing-schema new-schema-map)
+         {:keys [relations permissions]} deltas
+         relation-retractions   (:retractions relations)
+         permission-retractions (:retractions permissions)]
+     (doseq [rel relation-retractions]
+       (let [cnt (count-relationships-using-relation db rel)]
+         (when (pos? cnt)
+           (throw (ex-info (str "Cannot delete relation " (:eacl.relation/relation-name rel)
+                                " because it is used by " cnt " relationships.")
+                           {:type :eacl.schema/relation-in-use
+                            :eacl/error :eacl.schema/relation-in-use
+                            :relation rel
+                            :count cnt})))))
+     (let [relation-additions
+           (mapv #(assoc % :eacl/relation-version :db/current-tx)
+                 (:additions relations))
+           schema-eid (ds/entid db [:eacl/id "schema-string"])
+           schema-generation (current-schema-generation db)
+           schema-write-fence (current-schema-write-fence db)
+           relation-commit-guards
+           (mapv
+            (fn [relation]
+              (let [relation-eid
+                    (ds/entid db [:eacl/id (:eacl/id relation)])
+                    relation-generation
+                    (some-> (ds/datoms db :eav relation-eid
+                                       :eacl/relation-version)
+                            first
+                            :v)]
+                (when-not relation-generation
+                  (throw
+                   (ex-info
+                    "Relation removal requires prepared native generations."
+                    {:type :eacl.cache/generation-unprepared
+                     :backend :datalevin
+                     :relation-id (:eacl/id relation)})))
+                [:db.fn/cas relation-eid :eacl/relation-version
+                 relation-generation relation-generation]))
+            relation-retractions)
+           tx-data
+           (vec
+            (concat
+             [[:db.fn/cas schema-eid :eacl/schema-write-fence
+               schema-write-fence schema-write-fence]]
+             relation-commit-guards
+             relation-additions
+             (:additions permissions)
+             (for [rel relation-retractions
+                   :let [eid (ds/entid db [:eacl/id (:eacl/id rel)])]
+                   :when eid]
+               [:db/retractEntity eid])
+             (for [perm permission-retractions
+                   :let [eid (ds/entid db [:eacl/id (:eacl/id perm)])]
+                   :when eid]
+               [:db/retractEntity eid])
+             [{:db/id schema-eid
+               :eacl/id "schema-string"
+               :eacl/schema-string schema-string}
+              [:db/add schema-eid :eacl/schema-generation
+               :db/current-tx]
+              [:db/add schema-eid :eacl/schema-write-fence
+               :db/current-tx]]))
+           stored-string
+           (some-> (ds/entity db [:eacl/id "schema-string"])
+                   :eacl/schema-string)
+           changed?
+           (or (not= stored-string schema-string)
+               (some seq
+                     [(:additions relations)
+                      (:retractions relations)
+                      (:additions permissions)
+                      (:retractions permissions)]))
+           report
+           (if changed?
+             (transact-schema! conn tx-data schema-generation)
+             {:db-before db
+              :db-after db
+              :tx-data []
+              :no-op? true})]
+       (assoc deltas
+              :eacl.schema/db-after (:db-after report)
+              :eacl.schema/no-op? (boolean (:no-op? report)))))))

--- a/modules/eacl-datalevin/test/eacl/bench/datalevin_test.clj
+++ b/modules/eacl-datalevin/test/eacl/bench/datalevin_test.clj
@@ -1,0 +1,269 @@
+(ns eacl.bench.datalevin-test
+  "Explicit local Datalevin latency, allocation, and reader-pressure fixture.
+  Tagged out of normal correctness suites; invoke `run-benchmark!` through the
+  module nREPL and retain the complete returned report."
+  (:require [clojure.test :refer [deftest is]]
+            [datalevin.constants :as constants]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.backend.v8 :as backend]
+            [eacl.core :as eacl]
+            [eacl.datalevin.backend :as datalevin-backend]
+            [eacl.datalevin.core :as datalevin])
+  (:import [com.sun.management ThreadMXBean]
+           [java.io File]
+           [java.lang.management ManagementFactory]))
+
+(def ^:private test-key "01234567890123456789012345678901")
+(def ^:private warmup-samples 25)
+(def ^:private measurement-samples 51)
+(def ^:private write-warmup-samples 5)
+(def ^:private write-measurement-samples 21)
+(def ^:private document-count 256)
+(def ^:private held-reader-count 32)
+
+(def ^:private schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     permission view = viewer
+   }")
+
+(defn- percentile
+  [samples p]
+  (let [ordered (vec (sort samples))
+        index (min (dec (count ordered))
+                   (long (Math/floor (* p (dec (count ordered))))))]
+    (nth ordered index)))
+
+(defn- allocation-bean
+  []
+  (let [bean (ManagementFactory/getThreadMXBean)]
+    (when (instance? ThreadMXBean bean)
+      (let [bean ^ThreadMXBean bean]
+        (when (.isThreadAllocatedMemorySupported bean)
+          (when-not (.isThreadAllocatedMemoryEnabled bean)
+            (.setThreadAllocatedMemoryEnabled bean true))
+          bean)))))
+
+(def ^:private allocated-memory-bean (delay (allocation-bean)))
+
+(defn- allocated-bytes
+  []
+  (when-let [bean @allocated-memory-bean]
+    (.getThreadAllocatedBytes
+     ^ThreadMXBean bean (.getId (Thread/currentThread)))))
+
+(defn- distribution
+  [warmups samples f]
+  (let [latencies (transient [])
+        allocations (transient [])
+        checksum (volatile! 0)]
+    (dotimes [iteration (+ warmups samples)]
+      (let [allocated-before (allocated-bytes)
+            started (System/nanoTime)
+            value (f iteration)
+            elapsed (- (System/nanoTime) started)
+            allocated-after (allocated-bytes)]
+        (vswap! checksum unchecked-add-int (hash value))
+        (when (>= iteration warmups)
+          (conj! latencies (/ (double elapsed) 1000.0))
+          (when (and allocated-before allocated-after)
+            (conj! allocations (- allocated-after allocated-before))))))
+    (let [latencies (persistent! latencies)
+          allocations (persistent! allocations)]
+      {:unit :microseconds
+       :samples samples
+       :min (apply min latencies)
+       :p50 (percentile latencies 0.50)
+       :p95 (percentile latencies 0.95)
+       :p99 (percentile latencies 0.99)
+       :max (apply max latencies)
+       :mean (/ (reduce + latencies) (double samples))
+       :allocated-bytes
+       (when (seq allocations)
+         {:p50 (percentile allocations 0.50)
+          :p95 (percentile allocations 0.95)})
+       :checksum @checksum})))
+
+(defn- used-heap-bytes
+  []
+  (let [runtime (Runtime/getRuntime)]
+    (- (.totalMemory runtime) (.freeMemory runtime))))
+
+(defn- directory-bytes
+  [dir]
+  (reduce
+   + 0
+   (keep (fn [^File file]
+           (when (.isFile file) (.length file)))
+         (file-seq (File. (str dir))))))
+
+(defn- with-system
+  [f]
+  (let [dir (u/tmp-dir (str "eacl-datalevin-benchmark-" (random-uuid)))
+        conn (datalevin/create-conn dir)
+        watermark (atom 0)
+        client
+        (datalevin/make-client
+         conn
+         {:source-lifecycle "benchmark-lifecycle"
+          :revision-watermark watermark
+          :advance-revision-watermark! #(swap! watermark max %)
+          :datalevin-topology
+          datalevin-backend/certified-topology-declaration
+          :security-key test-key})]
+    (try
+      (eacl/write-schema! client schema)
+      (d/transact!
+       conn
+       (into [{:eacl/id "alice"} {:eacl/id "bob"}]
+             (map (fn [index]
+                    {:eacl/id (str "document-" index)})
+                  (range document-count))))
+      (let [alice (eacl/spice-object :user "alice")
+            bob (eacl/spice-object :user "bob")
+            documents
+            (mapv #(eacl/spice-object :document (str "document-" %))
+                  (range document-count))]
+        (eacl/create-relationships!
+         client
+         (mapv #(eacl/->Relationship alice :viewer %) documents))
+        (f {:dir dir :conn conn :client client
+            :alice alice :bob bob :documents documents}))
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(defn run-benchmark!
+  []
+  (with-system
+    (fn [{:keys [dir conn client alice bob documents]}]
+      (let [document (first documents)
+            heap-before (used-heap-bytes)
+            disk-before (directory-bytes dir)
+            provider (get-in client [:opts :snapshot-provider])
+            selected (snapshot-provider/acquire! provider :current)
+            adapter (snapshot-provider/adapter selected)
+            subject-id (backend/invoke adapter :object-id->internal "alice")
+            relation-id
+            (:relation-id
+             (first (backend/invoke adapter :relation-defs :document :viewer)))
+            scan-result
+            (try
+              (distribution
+               warmup-samples measurement-samples
+               (fn [_]
+                 (backend/invoke
+                  adapter :subject->resources
+                  :user subject-id relation-id :document
+                  {:direction :asc :limit 25})))
+              (finally
+                (snapshot-provider/release! selected)))
+            permission-result
+            (distribution
+             warmup-samples measurement-samples
+             (fn [_] (eacl/can? client alice :view document)))
+            pagination-result
+            (distribution
+             warmup-samples measurement-samples
+             (fn [_]
+               (eacl/lookup-resources
+                client {:subject alice :permission :view
+                        :resource/type :document :first 25})))
+            count-result
+            (distribution
+             warmup-samples measurement-samples
+             (fn [_]
+               (eacl/count-resources
+                client {:subject alice :permission :view
+                        :resource/type :document})))
+            acquisition-result
+            (distribution
+             warmup-samples measurement-samples
+             (fn [_]
+               (with-open [snapshot (d/open-read-snapshot conn)]
+                 (:max-tx (d/read-snapshot-info snapshot)))))
+            provider-acquisition-result
+            (distribution
+             warmup-samples measurement-samples
+             (fn [_]
+               (let [selected
+                     (snapshot-provider/acquire! provider :current)]
+                 (try
+                   (get-in
+                    (snapshot-provider/semantic-identity selected)
+                    [:backend-snapshot-id :basis-t])
+                   (finally
+                     (snapshot-provider/release! selected))))))
+            cache-bypass-result
+            (distribution
+             warmup-samples measurement-samples
+             (fn [_]
+               (with-open [snapshot (d/open-read-snapshot conn)]
+                 (d/with-read-snapshot
+                  snapshot
+                  #(count (d/datoms % :ave :eacl/id))))))
+            relationship-present? (atom false)
+            write-result
+            (distribution
+             write-warmup-samples write-measurement-samples
+             (fn [_]
+               (if (swap! relationship-present? not)
+                 (eacl/write-relationship!
+                  client :touch bob :viewer document)
+                 (eacl/delete-relationship!
+                  client (eacl/->Relationship bob :viewer document)))))
+            held (mapv (fn [_] (d/open-read-snapshot conn))
+                       (range held-reader-count))
+            reader-pressure
+            (try
+              {:held-readers held-reader-count
+               :active-while-held (d/active-read-snapshot-info)
+               :additional-acquire-close
+               (distribution
+                warmup-samples measurement-samples
+                (fn [_]
+                  (with-open [snapshot (d/open-read-snapshot conn)]
+                    (:max-tx (d/read-snapshot-info snapshot)))))}
+              (finally
+                (doseq [snapshot (reverse held)]
+                  (d/close-read-snapshot! snapshot))))]
+        {:environment
+         {:os (System/getProperty "os.name")
+          :architecture (System/getProperty "os.arch")
+          :java-version (System/getProperty "java.version")
+          :java-vendor (System/getProperty "java.vendor")
+          :datalevin-version constants/version
+          :documents document-count}
+         :latency
+         {:bounded-forward-scan-25 scan-result
+          :warm-permission-check permission-result
+          :first-page-25 pagination-result
+          :exact-count count-result
+          :snapshot-acquire-close acquisition-result
+          :provider-acquire-adapt-release provider-acquisition-result
+          :snapshot-cache-bypass-read cache-bypass-result
+          :relationship-write write-result
+          :long-reader-pressure reader-pressure}
+         :resources
+         {:heap-before-bytes heap-before
+          :heap-after-bytes (used-heap-bytes)
+          :database-before-bytes disk-before
+          :database-after-bytes (directory-bytes dir)
+          :active-readers-after (d/active-read-snapshot-info)}}))))
+
+(deftest ^:benchmark datalevin-local-benchmark-test
+  (let [report (run-benchmark!)]
+    (is (= {:active 0 :oldest-age-ms nil}
+           (get-in report [:resources :active-readers-after])))
+    (is (= held-reader-count
+           (get-in report
+                   [:latency :long-reader-pressure
+                    :active-while-held :active])))
+    (is (every?
+         pos?
+         (map :samples
+              (vals
+               (dissoc (:latency report) :long-reader-pressure)))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/adapter_certification_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/adapter_certification_test.clj
@@ -1,0 +1,70 @@
+(ns eacl.datalevin.adapter-certification-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.adapter-certification :as certification]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.backend.v8 :as v8]
+            [eacl.core :as eacl]
+            [eacl.datalevin.backend :as backend]
+            [eacl.datalevin.core :as datalevin]))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(deftest datalevin-owned-snapshot-adapter-certification-test
+  (doseq [fixture (certification/coherent-fixtures [820084])]
+    (testing (str "seed " (:seed fixture))
+      (let [dir (u/tmp-dir (str "eacl-datalevin-cert-" (random-uuid)))
+            conn (datalevin/create-conn dir)]
+        (try
+          (let [watermark (atom 0)
+                client
+                (datalevin/make-client
+                 conn
+                 {:source-lifecycle "certification-lifecycle"
+                  :revision-watermark watermark
+                  :advance-revision-watermark!
+                  #(swap! watermark max %)
+                  :datalevin-topology backend/certified-topology-declaration
+                  :security-key "01234567890123456789012345678901"})]
+            (eacl/write-schema! client (:schema fixture))
+            (d/transact!
+             conn
+             (map-indexed
+              (fn [index {:keys [id]}]
+                {:db/id (- (inc index)) :eacl/id id})
+              (:objects fixture)))
+            (eacl/create-relationships! client (:relationships fixture))
+            (let [provider (get-in client [:opts :snapshot-provider])
+                  selected (snapshot-provider/acquire! provider :current)]
+              (try
+                (let [adapter (snapshot-provider/adapter selected)
+                      report
+                      (certification/certify
+                       {:adapter adapter
+                        :fixture fixture
+                        :runtime :clj})]
+                  (is (:passed? report) (pr-str (:checks report)))
+                  (testing "persistent Datalevin transaction IDs are not exposed as proof generations"
+                    (is (= #{:snapshot-bound :database-visible}
+                           (:cache-proofs (v8/capabilities adapter))))
+                    (is (not (v8/supports? adapter
+                                           :cache-proofs
+                                           :ordered-generations)))
+                    (is (= {:type :eacl/unsupported-capability
+                            :capability :operation
+                            :requested :proof-frame}
+                           (select-keys
+                            (error-data #(v8/operation adapter :proof-frame))
+                            [:type :capability :requested])))))
+                (finally
+                  (snapshot-provider/release! selected)))))
+          (finally
+            (d/close conn)
+            (u/delete-files dir)))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/contract_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/contract_test.clj
@@ -1,0 +1,1250 @@
+(ns eacl.datalevin.contract-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datalevin.constants :as datalevin-constants]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.backend.v8 :as backend]
+            [eacl.cache :as cache]
+            [eacl.causal-token :as causal-token]
+            [eacl.contract-support :as contract]
+            [eacl.core :as eacl]
+            [eacl.datalevin.backend :as datalevin-backend]
+            [eacl.datalevin.core :as datalevin]
+            [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.schema :as datalevin-schema]
+            [eacl.secure-format :as secure-format]
+            [eacl.spicedb.consistency :as consistency])
+  (:import [java.util.concurrent TimeUnit]))
+
+(def ^:private test-key "01234567890123456789012345678901")
+
+(def ^:private schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     permission view = viewer
+   }")
+
+(def ^:private scan-schema
+  "definition user {}
+   definition group {}
+   definition folder {
+     relation viewer: user
+   }
+   definition document {
+     relation viewer: user
+     relation editor: user
+     relation reviewer: group
+     permission view = viewer + editor
+   }")
+
+(def ^:private schema-with-editor
+  "definition user {}
+   definition document {
+     relation viewer: user
+     relation editor: user
+     permission view = viewer + editor
+   }")
+
+(defn- watermark-options
+  ([] (watermark-options 0))
+  ([initial]
+   (let [state (atom initial)]
+     {:revision-watermark state
+      :advance-revision-watermark!
+      (fn [revision]
+        (swap! state max revision))})))
+
+(defn- with-system
+  [f]
+  (let [dir (u/tmp-dir (str "eacl-datalevin-module-" (random-uuid)))
+        conn (datalevin/create-conn dir)]
+    (try
+      (let [client
+            (datalevin/make-client
+             conn
+             (merge
+              (watermark-options)
+              {:source-lifecycle "test-lifecycle"
+               :datalevin-topology
+               datalevin-backend/certified-topology-declaration
+               :security-key test-key}))]
+        (f {:dir dir :conn conn :client client}))
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(defn- seed!
+  [conn client]
+  (eacl/write-schema! client schema)
+  (d/transact! conn [{:eacl/id "alice"}
+                     {:eacl/id "bob"}
+                     {:eacl/id "document-1"}]))
+
+(defn- with-connection
+  [f]
+  (let [dir (u/tmp-dir (str "eacl-datalevin-contract-" (random-uuid)))
+        conn (datalevin/create-conn dir)]
+    (try
+      (f conn)
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(defn- error-record
+  [f]
+  (try
+    (f)
+    nil
+    (catch Throwable error
+      {:message (ex-message error)
+       :data (ex-data error)
+       :class (str (class error))})))
+
+(defn- halted-writer-process
+  [dir watermark-file]
+  (let [expression
+        (str
+         "(do "
+         "(require '[eacl.core :as eacl] "
+         "         '[eacl.datalevin.backend :as backend] "
+         "         '[eacl.datalevin.core :as datalevin]) "
+         "(let [watermark (atom 0) "
+         "      conn (datalevin/create-conn " (pr-str dir) ") "
+         "      client (datalevin/make-client "
+         "              conn "
+         "              {:source-lifecycle \"process-kill-lifecycle\" "
+         "               :revision-watermark watermark "
+         "               :advance-revision-watermark! "
+         "               (fn [revision] "
+         "                 (spit " (pr-str watermark-file) " (str revision)) "
+         "                 (swap! watermark max revision)) "
+         "               :datalevin-topology "
+         "               backend/certified-topology-declaration "
+         "               :security-key " (pr-str test-key) "})] "
+         "  (eacl/write-schema! client " (pr-str schema) ") "
+         "  (.halt (Runtime/getRuntime) 23)))")
+        java (str (System/getProperty "java.home") "/bin/java")
+        command
+        [java
+         "--add-opens=java.base/java.lang=ALL-UNNAMED"
+         "--add-opens=java.base/java.nio=ALL-UNNAMED"
+         "--add-opens=java.base/java.util=ALL-UNNAMED"
+         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+         "--enable-native-access=ALL-UNNAMED"
+         "-cp" (System/getProperty "java.class.path")
+         "clojure.main" "-e" expression]
+        process (-> (ProcessBuilder. ^java.util.List command)
+                    (.redirectErrorStream true)
+                    (.start))]
+    (when-not (.waitFor process 30 TimeUnit/SECONDS)
+      (.destroyForcibly process)
+      (throw (ex-info "Datalevin process-kill fixture timed out."
+                      {:type :test/process-timeout})))
+    {:exit (.exitValue process)
+     :output (slurp (.getInputStream process))}))
+
+(defn- client-config
+  ([] (client-config {}))
+  ([overrides]
+   (merge
+    (watermark-options)
+    {:source-lifecycle "test-lifecycle"
+     :datalevin-topology
+     datalevin-backend/certified-topology-declaration
+     :security-key test-key}
+    overrides)))
+
+(defn- issue-token
+  [client revision overrides]
+  (let [provider (get-in client [:opts :snapshot-provider])]
+    (causal-token/issue
+     (get-in client [:opts :format-options])
+     (merge
+      {:backend :datalevin
+       :source-lifecycle (snapshot-provider/source-lifecycle provider)
+       :revision revision
+       :exact-locator nil}
+      (snapshot-provider/source-scope provider)
+      overrides))))
+
+(defn- collect-exclusive-pages
+  [adapter operation prefix direction page-size]
+  (loop [bound nil
+         values []
+         calls 0]
+    (let [options (cond-> {:direction direction
+                           :inclusive-bound? false
+                           :limit page-size}
+                    bound (assoc :bound-eid bound))
+          page (apply backend/invoke adapter operation
+                      (conj prefix options))]
+      (if (empty? page)
+        {:values values :calls (inc calls)}
+        (recur (peek page)
+               (into values page)
+               (inc calls))))))
+
+(defn- normalize-schema
+  [value]
+  {:relations
+   (into #{}
+         (map #(select-keys %
+                           [:eacl.relation/resource-type
+                            :eacl.relation/relation-name
+                            :eacl.relation/subject-type]))
+         (:relations value))
+   :permissions
+   (into #{}
+         (map #(select-keys %
+                           [:eacl.permission/resource-type
+                            :eacl.permission/permission-name
+                            :eacl.permission/source-relation-name
+                            :eacl.permission/target-type
+                            :eacl.permission/target-name]))
+         (:permissions value))})
+
+(defn- with-observation-system
+  [f]
+  (with-system
+    (fn [{:keys [conn client] :as system}]
+      (seed! conn client)
+      (d/transact! conn [{:eacl/id "document-2"}])
+      (let [bob (eacl/spice-object :user "bob")
+            document-1 (eacl/spice-object :document "document-1")
+            document-2 (eacl/spice-object :document "document-2")]
+        (eacl/create-relationship! client bob :viewer document-1)
+        (f (assoc system
+                  :bob bob
+                  :document-1 document-1
+                  :document-2 document-2))))))
+
+(defn- observation-schedule
+  [kind {:keys [client bob document-2]}]
+  (let [add-second! #(eacl/create-relationship!
+                      client bob :viewer document-2)
+        normalize-page
+        (fn [value]
+          {:ids (mapv :id (:data value))
+           :has-next-page? (get-in value [:page-info :has-next-page?])})]
+    (case kind
+      :permission
+      {:prepare! (constantly nil)
+       :invoke #(eacl/can? client bob :view document-2)
+       :mutate! add-second!
+       :normalize identity}
+
+      :lookup
+      {:prepare! (constantly nil)
+       :invoke #(eacl/lookup-resources
+                 client
+                 {:subject bob
+                  :permission :view
+                  :resource/type :document
+                  :first 100})
+       :mutate! add-second!
+       :normalize normalize-page}
+
+      :count
+      {:prepare! (constantly nil)
+       :invoke #(eacl/count-resources
+                 client
+                 {:subject bob
+                  :permission :view
+                  :resource/type :document})
+       :mutate! add-second!
+       :normalize #(select-keys % [:count :limit])}
+
+      :schema
+      {:prepare! (constantly nil)
+       :invoke #(eacl/read-schema client)
+       :mutate! #(eacl/write-schema! client schema-with-editor)
+       :normalize normalize-schema}
+
+      :proof
+      {:prepare! #(eacl/can? client bob :view document-2)
+       :invoke #(eacl/can? client bob :view document-2)
+       :mutate! add-second!
+       :normalize identity}
+
+      :cursor
+      {:prepare! (constantly nil)
+       :invoke #(eacl/lookup-resources
+                 client
+                 {:subject bob
+                  :permission :view
+                  :resource/type :document
+                  :first 1})
+       :mutate! add-second!
+       :normalize normalize-page})))
+
+(defn- capture-observation-schedule
+  [kind]
+  (with-observation-system
+    (fn [system]
+      (let [{:keys [prepare! invoke mutate! normalize]}
+            (observation-schedule kind system)
+            observations (atom [])]
+        (prepare!)
+        (let [before
+              (binding [backend/*invoke-observer*
+                        (fn [{:keys [phase operation]}]
+                          (when (= :after phase)
+                            (swap! observations conj operation)))]
+                (normalize (invoke)))]
+          (mutate!)
+          {:before before
+           :after (normalize (invoke))
+           :observations @observations})))))
+
+(defn- run-observation-boundary
+  [kind boundary]
+  (with-observation-system
+    (fn [system]
+      (let [{:keys [prepare! invoke mutate! normalize]}
+            (observation-schedule kind system)
+            observations (atom [])
+            mutated? (atom false)]
+        (prepare!)
+        (let [captured
+              (binding [backend/*invoke-observer*
+                        (fn [{:keys [phase operation]}]
+                          (when (= :after phase)
+                            (let [index (count @observations)]
+                              (swap! observations conj operation)
+                              (when (and (= boundary index)
+                                         (compare-and-set!
+                                          mutated? false true))
+                                (binding [backend/*invoke-observer* nil]
+                                  (mutate!))))))]
+                (normalize (invoke)))]
+          {:captured captured
+           :after (normalize (invoke))
+           :mutated? @mutated?
+           :observations @observations})))))
+
+(deftest construction-requires-certified-topology-and-monotonic-state-test
+  (with-connection
+    (fn [conn]
+      (let [before (d/active-read-snapshot-info)]
+        (testing "every unsupported declared topology fails closed"
+          (doseq [topology
+                  [(assoc datalevin-backend/certified-topology-declaration
+                          :deployment :remote)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :jvms 2)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :connections 2)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :writers 2)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :writer-ownership :external)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :commit-mode :wal)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :physical-schema :mutable)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :request-threads :virtual)
+                   (assoc datalevin-backend/certified-topology-declaration
+                          :wal true)]]
+            (is (= :eacl/unsupported-topology
+                   (:type
+                    (error-data
+                     #(datalevin/make-client
+                       conn (client-config {:datalevin-topology topology}))))))))
+        (testing "watermark is mandatory, bounded, exact, and monotonic"
+          (is (= :eacl/invalid-config
+                 (:type
+                  (error-data
+                   #(datalevin/make-client
+                     conn (dissoc (client-config) :revision-watermark))))))
+          (is (= :eacl/invalid-config
+                 (:type
+                  (error-data
+                   #(datalevin/make-client
+                     conn (dissoc (client-config)
+                                  :advance-revision-watermark!))))))
+          (is (= :eacl/invalid-config
+                 (:type
+                  (error-data
+                   #(datalevin/make-client
+                     conn (client-config {:revision-watermark 0}))))))
+          (doseq [watermark [nil -1 1.5 9007199254740992]]
+            (is (= :eacl/invalid-config
+                   (:type
+                    (error-data
+                     #(datalevin/make-client
+                       conn (client-config
+                             {:revision-watermark (atom watermark)})))))))
+          (is (= :eacl.datalevin/revision-regression
+                 (:type
+                  (error-data
+                   #(datalevin/make-client
+                     conn (client-config
+                           {:revision-watermark
+                            (atom 9007199254740991)}))))))
+          (is (map? (datalevin/make-client conn (client-config)))))
+        (testing "lifecycle and signing material must be externally supplied"
+          (doseq [config [(dissoc (client-config) :source-lifecycle)
+                          (client-config {:source-lifecycle nil})
+                          (dissoc (client-config) :security-key)]]
+            (is (= :eacl/invalid-config
+                   (:type
+                    (error-data
+                     #(datalevin/make-client conn config)))))))
+        (is (= before (d/active-read-snapshot-info)))))))
+
+(deftest process-local-lifecycle-rotation-is-rejected-test
+  (with-system
+    (fn [{:keys [client]}]
+      (doseq [invoke [#(datalevin/expire-cache! client)
+                      #(datalevin/expire-cache! client "new-life")]]
+        (is (= :eacl.datalevin/source-lifecycle-persistence-required
+               (:type (error-data invoke))))))))
+
+(deftest revision-watermark-advances-before-success-and-fails-closed-test
+  (testing "every acknowledged bootstrap and EACL commit advances the watermark"
+    (with-system
+      (fn [{:keys [conn client]}]
+        (let [watermark (get-in client [:opts :revision-watermark])]
+          (is (= (:max-tx (d/db conn)) @watermark))
+          (eacl/write-schema! client schema)
+          (is (= (:max-tx (d/db conn)) @watermark))
+          (d/transact! conn [{:eacl/id "alice"}
+                             {:eacl/id "document-1"}])
+          ;; Out-of-band object fixture writes are deliberately outside EACL's
+          ;; authorization mutation acknowledgement contract.
+          (let [before @watermark]
+            (eacl/create-relationship!
+             client
+             (eacl/->Relationship
+              (eacl/spice-object :user "alice")
+              :viewer
+              (eacl/spice-object :document "document-1")))
+            (is (> @watermark before))
+            (is (= (:max-tx (d/db conn)) @watermark)))))))
+  (doseq [failure-mode [:no-op :throw]]
+    (testing (name failure-mode)
+      (let [dir (u/tmp-dir (str "eacl-watermark-failure-" (random-uuid)))
+            conn (datalevin/create-conn dir)
+            watermark (atom 0)
+            mode (atom :ok)
+            client
+            (datalevin/make-client
+             conn
+             {:source-lifecycle "watermark-failure"
+              :revision-watermark watermark
+              :advance-revision-watermark!
+              (fn [revision]
+                (case @mode
+                  :ok (swap! watermark max revision)
+                  :no-op nil
+                  :throw (throw (ex-info "injected" {:mode :throw}))))
+              :datalevin-topology
+              datalevin-backend/certified-topology-declaration
+              :security-key test-key})]
+        (try
+          (reset! mode failure-mode)
+          (let [before @watermark
+                error (error-data #(eacl/write-schema! client schema))]
+            (is (= (if (= :throw failure-mode)
+                     :eacl.datalevin/revision-watermark-persistence-failed
+                     :eacl.datalevin/revision-watermark-not-persisted)
+                   (:type error)))
+            (is (= before @watermark))
+            (is (> (:max-tx (d/db conn)) @watermark))
+            (is (= {:active 0 :oldest-age-ms nil}
+                   (d/active-read-snapshot-info))))
+          (finally
+            (d/close conn)
+            (u/delete-files dir)))))))
+
+(deftest restart-and-backup-restore-enforce-lifecycle-continuity-test
+  (let [dir (u/tmp-dir (str "eacl-datalevin-restart-" (random-uuid)))
+        backup (u/tmp-dir (str "eacl-datalevin-backup-" (random-uuid)))
+        watermark (atom 0)
+        lifecycle "continuity-life-1"
+        options
+        {:source-lifecycle lifecycle
+         :revision-watermark watermark
+         :advance-revision-watermark! #(swap! watermark max %)
+         :datalevin-topology
+         datalevin-backend/certified-topology-declaration
+         :security-key test-key}
+        conn (datalevin/create-conn dir)]
+    (try
+      (let [client (datalevin/make-client conn options)]
+        (eacl/write-schema! client schema)
+        (d/transact! conn [{:eacl/id "alice"}
+                           {:eacl/id "document-1"}])
+        (d/copy (d/db conn) backup true)
+        (let [old-token
+              (:zed/token
+               (eacl/create-relationship!
+                client
+                (eacl/->Relationship
+                 (eacl/spice-object :user "alice")
+                 :viewer
+                 (eacl/spice-object :document "document-1"))))
+              live-watermark @watermark]
+          (d/close conn)
+          (testing "ordinary restart preserves identity and monotonic state"
+            (let [reopened (datalevin/create-conn dir)]
+              (try
+                (is (map? (datalevin/make-client reopened options)))
+                (is (<= live-watermark @watermark))
+                (finally
+                  (d/close reopened)))))
+          (testing "restoring an older backup under the old lifecycle fails"
+            (let [restored (datalevin/create-conn backup)]
+              (try
+                (is (= :eacl.datalevin/revision-regression
+                       (:type
+                        (error-data
+                         #(datalevin/make-client restored options)))))
+                (testing "authorized lifecycle rotation with a new watermark succeeds"
+                  (let [rotated-watermark (atom 0)
+                        rotated
+                        (datalevin/make-client
+                         restored
+                         (assoc options
+                                :source-lifecycle "continuity-life-2"
+                                :revision-watermark rotated-watermark
+                                :advance-revision-watermark!
+                                #(swap! rotated-watermark max %)))]
+                    (is (map? rotated))
+                    (is (= :eacl.consistency/incomparable-scope
+                           (:type
+                            (error-data
+                             #(eacl/can?
+                               rotated
+                               (eacl/spice-object :user "alice")
+                               :view
+                               (eacl/spice-object :document "document-1")
+                               (consistency/at-least-as-fresh
+                                old-token))))))))
+                (finally
+                  (d/close restored)))))))
+      (finally
+        (d/close conn)
+        (u/delete-files dir)
+        (u/delete-files backup)))))
+
+(deftest abrupt-process-kill-recovers-committed-schema-and-watermark-test
+  (let [dir (u/tmp-dir (str "eacl-datalevin-process-kill-"
+                            (random-uuid)))
+        watermark-file (str dir "-watermark")]
+    (try
+      (let [{:keys [exit output]}
+            (halted-writer-process dir watermark-file)]
+        (is (= 23 exit) output)
+        (is (.exists (java.io.File. watermark-file)))
+        (let [persisted (parse-long (slurp watermark-file))
+              watermark (atom persisted)
+              conn (datalevin/create-conn dir)]
+          (try
+            (let [client
+                  (datalevin/make-client
+                   conn
+                   {:source-lifecycle "process-kill-lifecycle"
+                    :revision-watermark watermark
+                    :advance-revision-watermark!
+                    (fn [revision]
+                      (spit watermark-file (str revision))
+                      (swap! watermark max revision))
+                    :datalevin-topology
+                    datalevin-backend/certified-topology-declaration
+                    :security-key test-key})]
+              (is (pos? persisted))
+              (is (<= persisted @watermark))
+              (is (= #{[:document :viewer :user]}
+                     (into #{}
+                           (map (juxt :eacl.relation/resource-type
+                                      :eacl.relation/relation-name
+                                      :eacl.relation/subject-type))
+                           (:relations (eacl/read-schema client)))))
+              (is (= {:active 0 :oldest-age-ms nil}
+                     (d/active-read-snapshot-info))))
+            (finally
+              (d/close conn)))))
+      (finally
+        (u/delete-files dir)
+        (u/delete-files watermark-file)))))
+
+(deftest corrupt-and-incompatible-backup-version-metadata-fail-closed-test
+  (doseq [[label version expected-message expected-data]
+          [[:corrupt "not-a-version" #"Corrupt VERSION file"
+            {:input "not-a-version"}]
+           [:newer "999.0.0" #"newer Datalevin version"
+            {:database-version "999.0.0"
+             :current-version datalevin-constants/version}]]]
+    (testing (name label)
+      (let [dir (u/tmp-dir (str "eacl-datalevin-backup-source-"
+                                (random-uuid)))
+            backup (u/tmp-dir (str "eacl-datalevin-backup-invalid-"
+                                   (random-uuid)))
+            conn (datalevin/create-conn dir)]
+        (try
+          (let [client (datalevin/make-client conn (client-config))]
+            (eacl/write-schema! client schema)
+            (d/copy (d/db conn) backup true))
+          (d/close conn)
+          (spit (str backup java.io.File/separator "VERSION") version)
+          (let [{:keys [message data]}
+                (error-record #(datalevin/create-conn backup))]
+            (is (re-find expected-message message))
+            (is (= expected-data (select-keys data (keys expected-data)))))
+          (finally
+            (d/close conn)
+            (u/delete-files dir)
+            (u/delete-files backup)))))))
+
+(deftest actual-wal-and-unsafe-lmdb-flags-are-rejected-test
+  (doseq [[label store-options]
+          [[:wal {:wal? true :wal-durability-profile :strict}]
+           [:unsafe-flags {:kv-opts {:flags #{:nosync}}}]]]
+    (testing (name label)
+      (let [dir (u/tmp-dir (str "eacl-datalevin-unsafe-" (random-uuid)))
+            conn (datalevin/create-conn dir nil store-options)]
+        (try
+          (let [error (error-data
+                       #(datalevin/make-client conn (client-config)))]
+            (is (= :eacl/unsupported-topology (:type error)))
+            (when (= label :unsafe-flags)
+              (is (= #{:nosync} (:unsafe-env-flags error)))))
+          (finally
+            (d/close conn)
+            (u/delete-files dir)))))))
+
+(deftest physical-schema-drift-is-rejected-test
+  (let [dir (u/tmp-dir (str "eacl-datalevin-drift-" (random-uuid)))
+        conn (d/get-conn
+              dir
+              {:eacl/id {:db/valueType :db.type/long
+                         :db/unique :db.unique/identity}})]
+    (try
+      (is (= :eacl.datalevin/physical-schema-drift
+             (:type
+              (error-data
+               #(datalevin/make-client conn (client-config))))))
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(deftest exact-integer-domain-is-enforced-at-every-adapter-boundary-test
+  (with-connection
+    (fn [conn]
+      (let [too-large 9007199254740992
+            snapshot (d/open-read-snapshot conn)
+            info (d/read-snapshot-info snapshot)
+            adapter-opts {:native-source-id "source"
+                          :source-lifecycle "lifecycle"}]
+        (try
+          (doseq [field [:max-tx :max-eid]]
+            (is (= :eacl/numeric-domain-error
+                   (:type
+                    (with-redefs [d/read-snapshot-info
+                                  (fn [_] (assoc info field too-large))]
+                      (error-data
+                       #(datalevin-backend/snapshot-adapter
+                         snapshot adapter-opts)))))))
+          (let [adapter
+                (datalevin-backend/snapshot-adapter snapshot adapter-opts)]
+            (doseq [[operation args]
+                    [[:object-id->internal [too-large]]
+                     [:internal-id->object [too-large]]
+                     [:subject->resources
+                      [:user too-large 1 :document {:direction :asc}]]
+                     [:subject->resources
+                      [:user 1 too-large :document {:direction :asc}]]
+                     [:subject->resources
+                      [:user 1 1 :document
+                       {:direction :asc :bound-eid too-large}]]
+                     [:resource->subjects
+                      [:document too-large 1 :user {:direction :asc}]]
+                     [:resource->subjects
+                      [:document 1 too-large :user {:direction :asc}]]
+                     [:resource->subjects
+                      [:document 1 1 :user
+                       {:direction :asc :bound-eid too-large}]]
+                     [:direct-match?
+                      [:user too-large 1 :document 1]]
+                     [:direct-match?
+                      [:user 1 too-large :document 1]]
+                     [:direct-match?
+                      [:user 1 1 :document too-large]]]]
+              (is (= :eacl/numeric-domain-error
+                     (:type
+                      (error-data
+                       #(apply backend/invoke adapter operation args)))))))
+          (finally
+            (d/close-read-snapshot! snapshot)))))))
+
+(deftest provider-owns-and-closes-explicit-snapshots-test
+  (with-system
+    (fn [{:keys [client]}]
+      (let [provider (get-in client [:opts :snapshot-provider])
+            before (d/active-read-snapshot-info)
+            selected (snapshot-provider/acquire! provider :current)]
+        (is (= :owned (snapshot-provider/ownership selected)))
+        (is (= :datalevin
+               (:backend (snapshot-provider/semantic-identity selected))))
+        (is (= (inc (:active before))
+               (:active (d/active-read-snapshot-info))))
+        (is (true? (snapshot-provider/release! selected)))
+        (is (false? (snapshot-provider/release! selected)))
+        (is (= before (d/active-read-snapshot-info)))))))
+
+(deftest provider-memoizes-schema-digests-with-structural-drift-detection-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (let [provider (get-in client [:opts :snapshot-provider])
+            digest secure-format/canonical-digest
+            calls (atom 0)
+            acquire-identity
+            (fn []
+              (let [selected (snapshot-provider/acquire! provider :current)]
+                (try
+                  (:schema-identity
+                   (backend/invoke
+                    (snapshot-provider/adapter selected) :snapshot-id))
+                  (finally
+                    (snapshot-provider/release! selected)))))]
+        (with-redefs [secure-format/canonical-digest
+                      (fn [& args]
+                        (swap! calls inc)
+                        (apply digest args))]
+          (let [first-identity (acquire-identity)
+                second-identity (acquire-identity)]
+            (is (= first-identity second-identity))
+            (is (= 1 @calls))
+            ;; This mutation violates the certified frozen-schema topology, but
+            ;; the memo must still fail safe if an owner does it between reads.
+            (d/update-schema
+             conn {:test/physical-drift {:db/valueType :db.type/string}})
+            (let [drifted-identity (acquire-identity)]
+              (is (not= first-identity drifted-identity))
+              (is (= 2 @calls)))))))))
+
+(deftest partial-relationship-pagination-is-native-bounded-and-lossless-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (eacl/write-schema! client schema)
+      (let [user-ids (mapv #(str "user-" %) (range 7))
+            document (eacl/spice-object :document "document-1")]
+        (d/transact!
+         conn
+         (into [{:eacl/id "document-1"}]
+               (map (fn [id] {:eacl/id id}) user-ids)))
+        (eacl/create-relationships!
+         client
+         (mapv
+          #(eacl/->Relationship
+            (eacl/spice-object :user %) :viewer document)
+          user-ids))
+        (let [native-limits (atom [])
+              scan ddb/avet-endpoint-prefix]
+          (with-redefs [ddb/avet-endpoint-prefix
+                        (fn [& args]
+                          (when (number? (last args))
+                            (swap! native-limits conj (last args)))
+                          (apply scan args))]
+            (let [relationships
+                  (loop [after nil
+                         acc []]
+                    (let [page
+                          (eacl/read-relationships
+                           client
+                           (cond->
+                            {:subject/type :user
+                             :resource/type :document
+                             :resource/relation :viewer
+                             :first 2
+                             :cache? false}
+                             after (assoc :after after)))
+                          acc' (into acc (:data page))]
+                      (if (get-in page [:page-info :has-next-page?])
+                        (recur (get-in page [:page-info :end-cursor]) acc')
+                        acc')))]
+              (is (= (set user-ids)
+                     (into #{} (map (comp :id :subject)) relationships)))
+              (is (= (count user-ids) (count relationships)))
+              (is (seq @native-limits))
+              (is (every? #(<= % 4) @native-limits)))))))))
+
+(deftest public-reads-writes-and-consistency-release-all-readers-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (seed! conn client)
+      (let [alice (eacl/spice-object :user "alice")
+            document (eacl/spice-object :document "document-1")
+            write-response
+            (eacl/create-relationship! client alice :viewer document)
+            token (:zed/token write-response)]
+        (is (true? (eacl/can? client alice :view document)))
+        (is (true?
+             (eacl/can? client alice :view document
+                        consistency/fully-consistent)))
+        (is (true?
+             (eacl/can?
+              client alice :view document
+              (consistency/at-least-as-fresh token))))
+        (is (= ["document-1"]
+               (mapv (comp :id :resource)
+                     (:data
+                      (eacl/read-relationships
+                       client {:subject/type :user
+                               :subject/id "alice"})))))
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))
+        (let [error
+              (try
+                (eacl/can?
+                 client alice :view document
+                 (consistency/at-exact-snapshot token))
+                nil
+                (catch clojure.lang.ExceptionInfo error error))]
+          (is (= :eacl.consistency/exact-snapshot-unavailable
+                 (:type (ex-data error))))
+          (is (= {:active 0 :oldest-age-ms nil}
+                 (d/active-read-snapshot-info))))))))
+
+(deftest composed-snapshot-view-is-single-snapshot-read-only-and-non-escaping-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (seed! conn client)
+      (let [alice (eacl/spice-object :user "alice")
+            document (eacl/spice-object :document "document-1")]
+        (eacl/create-relationship! client alice :viewer document)
+        (let [opens (atom 0)
+              schema-reads (atom 0)
+              open-read-snapshot d/open-read-snapshot
+              read-schema datalevin-schema/read-schema
+              escaped (atom nil)]
+          (with-redefs [d/open-read-snapshot
+                        (fn [connection]
+                          (swap! opens inc)
+                          (open-read-snapshot connection))
+                        datalevin-schema/read-schema
+                        (fn [db]
+                          (swap! schema-reads inc)
+                          (read-schema db))]
+            (eacl/with-snapshot
+             client
+             (fn [view]
+               (reset! escaped view)
+               (is (= 1 (count (:relations (eacl/read-schema view)))))
+               (is (= 1
+                      (count
+                       (:data
+                        (eacl/read-relationships
+                         view {:subject/type :user
+                               :subject/id "alice"
+                               :resource/type :document
+                               :resource/relation :viewer
+                               :first 10
+                               :cache? false})))))
+               (dotimes [_ 4]
+                 (is (:allowed?
+                      (eacl/check-permission
+                       view {:subject alice
+                             :permission :view
+                             :resource document
+                             :cache? false}))))
+               (is (= :eacl/read-only-snapshot-view
+                      (:type
+                       (error-data
+                        #(eacl/delete-relationship!
+                          view alice :viewer document)))))
+               (is (= :eacl/snapshot-view-thread-violation
+                      (:type
+                       @(future
+                          (error-data
+                           #(eacl/can? view alice :view document))))))))
+            (is (= 1 @opens))
+            (is (= 2 @schema-reads)
+                "one public schema read plus one shared request-local parse"))
+          (is (= :eacl/snapshot-view-closed
+                 (:type
+                  (error-data
+                   #(eacl/can? @escaped alice :view document)))))
+          (is (= {:active 0 :oldest-age-ms nil}
+                 (d/active-read-snapshot-info))))))))
+
+(deftest composed-snapshot-view-does-not-mix-a-concurrent-commit-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (seed! conn client)
+      (let [alice (eacl/spice-object :user "alice")
+            document (eacl/spice-object :document "document-1")]
+        (eacl/with-snapshot
+         client consistency/fully-consistent
+         (fn [view]
+           (is (false? (eacl/can? view alice :view document)))
+           @(future
+              (eacl/create-relationship! client alice :viewer document))
+           (is (false? (eacl/can? view alice :view document)))))
+        (is (true? (eacl/can? client alice :view document)))
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))))))
+
+(deftest composed-snapshot-request-budget-covers-selection-and-nested-reads-test
+  (with-system
+    (fn [{:keys [client]}]
+      (let [token (eacl/cancellation-token)
+            opens (atom 0)
+            open-read-snapshot d/open-read-snapshot]
+        (eacl/cancel! token)
+        (with-redefs [d/open-read-snapshot
+                      (fn [connection]
+                        (swap! opens inc)
+                        (open-read-snapshot connection))]
+          (is (= :eacl.execution/cancelled
+                 (:type
+                  (error-data
+                   #(eacl/with-snapshot
+                     client nil {:cancellation-token token}
+                     (fn [_] :unreachable)))))))
+        (is (zero? @opens)
+            "cancellation is enforced before native snapshot acquisition")
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))))))
+
+(deftest at-least-timeout-cancellation-and-scope-validation-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (seed! conn client)
+      (let [alice (eacl/spice-object :user "alice")
+            document (eacl/spice-object :document "document-1")
+            revision (:max-tx (d/db conn))
+            demand
+            (fn [consistency-value request-options]
+              (eacl/can?
+               client
+               (merge
+                {:subject alice
+                 :permission :view
+                 :resource document
+                 :consistency consistency-value}
+                request-options)))]
+        (testing "authenticated incomparable scope and lifecycle fail before acquisition"
+          (doseq [[label overrides]
+                  [[:source {:source-id "another-source"}]
+                   [:lifecycle {:source-lifecycle "another-lifecycle"}]]]
+            (let [before (d/active-read-snapshot-info)
+                  error
+                  (error-data
+                   #(demand
+                     (consistency/at-least-as-fresh
+                      (issue-token client revision overrides))
+                     {:timeout-ms 100}))]
+              (is (= :eacl.consistency/incomparable-scope (:type error))
+                  (name label))
+              (is (= before (d/active-read-snapshot-info))))))
+        (testing "a future revision becomes selectable after a concurrent commit"
+          (let [target (inc revision)
+                result
+                (future
+                  (error-data
+                   #(demand
+                     (consistency/at-least-as-fresh
+                      (issue-token client target {}))
+                     {:timeout-ms 2000})))]
+            (Thread/sleep 10)
+            (d/transact! conn [{:eacl/id "future-object"}])
+            (is (nil? (deref result 3000 ::timed-out)))
+            (is (= {:active 0 :oldest-age-ms nil}
+                   (d/active-read-snapshot-info)))))
+        (testing "an unreachable future revision times out and releases candidates"
+          (is (= :eacl.execution/deadline-exceeded
+                 (:type
+                  (error-data
+                   #(demand
+                     (consistency/at-least-as-fresh
+                      (issue-token client (+ revision 1000) {}))
+                     {:timeout-ms 10})))))
+          (is (= {:active 0 :oldest-age-ms nil}
+                 (d/active-read-snapshot-info))))
+        (testing "cooperative cancellation stops an at-least retry loop"
+          (let [cancellation (eacl/cancellation-token)
+                result
+                (future
+                  (error-data
+                   #(demand
+                     (consistency/at-least-as-fresh
+                      (issue-token client (+ revision 2000) {}))
+                     {:timeout-ms 2000
+                      :cancellation-token cancellation})))]
+            (Thread/sleep 10)
+            (eacl/cancel! cancellation)
+            (is (= :eacl.execution/cancelled
+                   (:type (deref result 3000 ::timed-out))))
+            (is (= {:active 0 :oldest-age-ms nil}
+                   (d/active-read-snapshot-info)))))))))
+
+(deftest one-request-remains-on-one-snapshot-across-concurrent-commit-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (seed! conn client)
+      (let [alice (eacl/spice-object :user "alice")
+            bob (eacl/spice-object :user "bob")
+            document (eacl/spice-object :document "document-1")
+            mutated? (atom false)
+            captured
+            (binding [backend/*invoke-observer*
+                      (fn [{:keys [phase operation]}]
+                        (when (and (= :before phase)
+                                   (= :relation-defs operation)
+                                   (compare-and-set! mutated? false true))
+                          (eacl/create-relationship!
+                           client bob :viewer document)))]
+              (eacl/can? client bob :view document))]
+        (testing "the in-flight request cannot see the later commit"
+          (is (false? captured)))
+        (testing "a later request obtains a fresh explicit snapshot"
+          (is (true? (eacl/can? client bob :view document))))
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))))))
+
+(deftest every-backend-observation-boundary-retains-one-request-snapshot-test
+  (doseq [kind [:permission :lookup :count :schema :proof :cursor]]
+    (testing (name kind)
+      (let [{:keys [before after observations]}
+            (capture-observation-schedule kind)]
+        (is (<= 2 (count observations))
+            (str kind " exposes at least one inter-observation boundary"))
+        (is (not= before after)
+            (str kind " fixture mutation changes the next request"))
+        (doseq [boundary (range (dec (count observations)))]
+          (let [result (run-observation-boundary kind boundary)]
+            (is (:mutated? result)
+                (str kind " mutation ran at boundary " boundary))
+            (is (= (subvec observations 0 (inc boundary))
+                   (subvec (:observations result) 0 (inc boundary)))
+                (str kind " reached the certified boundary " boundary))
+            (is (= before (:captured result))
+                (str kind " mixed snapshots at boundary " boundary))
+            (is (= after (:after result))
+                (str kind " later request missed commit at boundary " boundary))))))))
+
+(deftest exhaustive-bounded-forward-and-reverse-scan-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (eacl/write-schema! client scan-schema)
+      (let [large-safe-id 2147483659]
+      (d/transact!
+       conn
+       (conj
+        (mapv (fn [id] {:eacl/id id})
+              ["alice" "bob" "carol" "dave" "eve" "group-one"
+               "document-1" "document-2" "document-3"
+               "document-4" "document-5" "folder-1"])
+        {:db/id large-safe-id :eacl/id "document-large"}))
+      (let [users (mapv #(eacl/spice-object :user %)
+                        ["alice" "bob" "carol" "dave" "eve"])
+            alice (first users)
+            document-1 (eacl/spice-object :document "document-1")
+            documents
+            (conj
+             (mapv #(eacl/spice-object :document (str "document-" %))
+                   (range 1 6))
+             (eacl/spice-object :document "document-large"))]
+        (eacl/create-relationships!
+         client
+         (into
+          (mapv #(eacl/->Relationship alice :viewer %) documents)
+          (concat
+           (map #(eacl/->Relationship % :viewer document-1)
+                (rest users))
+           ;; Adjacent prefixes that must never escape into viewer/user/document
+           ;; scans in either direction.
+           [(eacl/->Relationship
+             alice :editor (eacl/spice-object :document "document-2"))
+            (eacl/->Relationship
+             alice :viewer (eacl/spice-object :folder "folder-1"))
+            (eacl/->Relationship
+             (eacl/spice-object :group "group-one")
+             :reviewer document-1)])))
+        ;; Reassertions exercise storage-level set semantics and adapter-level
+        ;; duplicate suppression without creating another logical tuple.
+        (dotimes [_ 2]
+          (eacl/write-relationship!
+           client :touch alice :viewer document-1))
+        (let [provider (get-in client [:opts :snapshot-provider])
+              selected (snapshot-provider/acquire! provider :current)
+              adapter (snapshot-provider/adapter selected)]
+          (try
+            (let [subject-id
+                  (backend/invoke adapter :object-id->internal "alice")
+                  relation-id
+                  (:relation-id
+                   (first
+                    (backend/invoke
+                     adapter :relation-defs :document :viewer)))
+                  resource-ids (->> ["document-1" "document-2" "document-3"
+                                     "document-4" "document-5" "document-large"]
+                                    (mapv #(backend/invoke
+                                            adapter :object-id->internal %))
+                                    sort
+                                    vec)
+                  document-id
+                  (backend/invoke adapter :object-id->internal "document-1")
+                  subject-ids (->> ["alice" "bob" "carol" "dave" "eve"]
+                                   (mapv #(backend/invoke
+                                           adapter :object-id->internal %))
+                                   sort
+                                   vec)
+                  forward-prefix [:user subject-id relation-id :document]
+                  reverse-prefix [:document document-id relation-id :user]
+                  scan (fn [operation prefix options]
+                         (apply backend/invoke adapter operation
+                                (conj prefix options)))]
+              (testing "complete ordering, uniqueness, large safe IDs, and replay"
+                (doseq [[operation prefix expected]
+                        [[:subject->resources forward-prefix resource-ids]
+                         [:resource->subjects reverse-prefix subject-ids]]]
+                  (let [ascending (scan operation prefix {:direction :asc})
+                        descending (scan operation prefix {:direction :desc})]
+                    (is (= expected ascending))
+                    (is (= (vec (reverse expected)) descending))
+                    (is (= ascending (scan operation prefix {:direction :asc})))
+                    (is (= (count ascending) (count (distinct ascending))))))
+                (is (= large-safe-id (peek resource-ids))))
+
+              (testing "inclusive and exclusive bounds in both directions"
+                (doseq [[operation prefix expected]
+                        [[:subject->resources forward-prefix resource-ids]
+                         [:resource->subjects reverse-prefix subject-ids]]
+                        bound expected]
+                  (is (= (filterv #(<= bound %) expected)
+                         (scan operation prefix
+                               {:direction :asc :bound-eid bound
+                                :inclusive-bound? true})))
+                  (is (= (filterv #(< bound %) expected)
+                         (scan operation prefix
+                               {:direction :asc :bound-eid bound
+                                :inclusive-bound? false})))
+                  (is (= (->> expected (filterv #(>= bound %)) reverse vec)
+                         (scan operation prefix
+                               {:direction :desc :bound-eid bound
+                                :inclusive-bound? true})))
+                  (is (= (->> expected (filterv #(> bound %)) reverse vec)
+                         (scan operation prefix
+                               {:direction :desc :bound-eid bound
+                                :inclusive-bound? false})))))
+
+              (testing "all page sizes use an exclusive sentinel step without skips"
+                (doseq [[operation prefix expected]
+                        [[:subject->resources forward-prefix resource-ids]
+                         [:resource->subjects reverse-prefix subject-ids]]
+                        direction [:asc :desc]
+                        page-size [1 2 3 5 20]]
+                  (let [expected (if (= :desc direction)
+                                   (vec (reverse expected))
+                                   expected)
+                        result (collect-exclusive-pages
+                                adapter operation prefix direction page-size)]
+                    (is (= expected (:values result)))
+                    (is (= (inc (long (Math/ceil
+                                      (/ (double (count expected)) page-size))))
+                           (:calls result))))))
+
+              (testing "zero and oversized limits are exact"
+                (is (= [] (scan :subject->resources forward-prefix
+                                {:direction :asc :limit 0})))
+                (is (= resource-ids
+                       (scan :subject->resources forward-prefix
+                             {:direction :asc :limit 1000}))))
+
+              (testing "missing and adjacent prefixes never leak"
+                (is (= []
+                       (scan :subject->resources
+                             [:user subject-id relation-id :missing]
+                             {:direction :asc :limit 100})))
+                (is (= []
+                       (scan :resource->subjects
+                             [:document document-id relation-id :missing]
+                             {:direction :desc :limit 100}))))
+
+              (is (true?
+                   (backend/invoke
+                    adapter :direct-match?
+                    :user subject-id relation-id :document
+                    (first resource-ids))))
+              (snapshot-provider/release! selected)
+              (is (= {:active 0 :oldest-age-ms nil}
+                     (d/active-read-snapshot-info))))
+            (finally
+              (snapshot-provider/release! selected)))))))))
+
+(deftest shared-v8-backend-contract-test
+  (with-connection
+    (fn [conn]
+      (let [store (contract/portable-store)
+            client
+            (datalevin/make-client
+             conn
+             (merge
+              (watermark-options)
+              {:cache store
+               :security-key test-key
+               :datalevin-topology
+               datalevin-backend/certified-topology-declaration
+               :source-lifecycle "shared-contract"}))]
+        (eacl/write-schema! client contract/smoke-schema)
+        (d/transact!
+         conn
+         (map-indexed
+          (fn [index {:keys [id]}]
+            {:db/id (- (inc index)) :eacl/id id})
+          contract/smoke-objects))
+        (eacl/create-relationships! client contract/smoke-relationships)
+        (contract/assert-v8-seeded-contracts! client)
+        (contract/assert-v8-permission-tree-contract! client)
+        (contract/assert-unified-filter-validation! client)
+        (contract/assert-v8-request-cache-controls! client store)
+        (contract/assert-v8-cache-disabled!
+         (datalevin/make-client
+          conn
+          (merge
+           (watermark-options)
+           {:cache cache/no-cache
+            :security-key test-key
+            :datalevin-topology
+            datalevin-backend/certified-topology-declaration
+            :source-lifecycle "shared-contract"})))
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))))))
+
+(deftest shared-v8-recursive-contract-test
+  (with-connection
+    (fn [conn]
+      (let [client
+            (datalevin/make-client
+             conn
+             (merge
+              (watermark-options)
+              {:security-key test-key
+               :datalevin-topology
+               datalevin-backend/certified-topology-declaration
+               :source-lifecycle "recursive-contract"}))]
+        (eacl/write-schema! client contract/recursive-schema)
+        (d/transact!
+         conn
+         (map-indexed
+          (fn [index {:keys [id]}]
+            {:db/id (- (inc index)) :eacl/id id})
+          contract/recursive-objects))
+        (eacl/create-relationships! client contract/recursive-relationships)
+        (contract/assert-v8-recursive-contracts! client)
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/differential_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/differential_test.clj
@@ -1,0 +1,223 @@
+(ns eacl.datalevin.differential-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as datahike]
+            [datascript.core :as datascript]
+            [datalevin.core :as datalevin-native]
+            [datalevin.util :as u]
+            [eacl.core :as eacl]
+            [eacl.datahike.core :as datahike-eacl]
+            [eacl.datascript.core :as datascript-eacl]
+            [eacl.datalevin.backend :as datalevin-backend]
+            [eacl.datalevin.core :as datalevin-eacl]))
+
+(def ^:private schema
+  "definition user {}
+   definition folder {
+     relation reader: user
+     relation parent: folder
+     permission view = reader + parent->view
+   }")
+
+(def ^:private schema-with-inspect
+  "definition user {}
+   definition folder {
+     relation reader: user
+     relation parent: folder
+     permission view = reader + parent->view
+     permission inspect = reader + parent->inspect
+   }")
+
+(def ^:private key "01234567890123456789012345678901")
+
+(defn- random-relationships
+  [seed]
+  (let [random (java.util.Random. seed)
+        users (mapv #(eacl/spice-object :user (str "u" %)) (range 5))
+        folders (mapv #(eacl/spice-object :folder (str "f" %)) (range 12))
+        readers
+        (for [folder folders
+              user users
+              :when (< (.nextDouble random) 0.32)]
+          (eacl/->Relationship user :reader folder))
+        parents
+        (for [index (range 1 (count folders))
+              :let [parent-index (.nextInt random index)]]
+          (eacl/->Relationship
+           (nth folders parent-index) :parent (nth folders index)))]
+    {:users users
+     :folders folders
+     :relationships (vec (concat readers parents))}))
+
+(defn- create-systems
+  [seed]
+  (let [dir (u/tmp-dir (str "eacl-differential-" seed "-" (random-uuid)))
+        datalevin-conn (datalevin-eacl/create-conn dir)
+        watermark (atom 0)
+        datahike-conn (datahike-eacl/create-conn)
+        datascript-conn (datascript-eacl/create-conn)]
+    {:dir dir
+     :systems
+     [{:backend :datalevin
+       :conn datalevin-conn
+       :client
+       (datalevin-eacl/make-client
+        datalevin-conn
+        {:source-lifecycle (str "differential-" seed)
+         :revision-watermark watermark
+         :advance-revision-watermark! #(swap! watermark max %)
+         :datalevin-topology
+         datalevin-backend/certified-topology-declaration
+         :security-key key})
+       :transact! #(datalevin-native/transact! datalevin-conn %)}
+      {:backend :datahike
+       :conn datahike-conn
+       :client (datahike-eacl/make-client datahike-conn {:security-key key})
+       :transact! #(datahike/transact datahike-conn %)}
+      {:backend :datascript
+       :conn datascript-conn
+       :client (datascript-eacl/make-client datascript-conn {:security-key key})
+       :transact! #(datascript/transact! datascript-conn %)}]}))
+
+(defn- close-systems!
+  [{:keys [dir systems]}]
+  (doseq [{:keys [backend conn]} systems]
+    (case backend
+      :datalevin (datalevin-native/close conn)
+      :datahike (datahike/release conn)
+      :datascript nil))
+  (u/delete-files dir))
+
+(defn- page-walk
+  [client query]
+  (loop [after nil
+         seen []]
+    (let [page (eacl/lookup-resources
+                client
+                (cond-> (assoc query :first 3)
+                  after (assoc :after after)))
+          seen (into seen (map :id) (:data page))]
+      (if (get-in page [:page-info :has-next-page?])
+        (recur (get-in page [:page-info :end-cursor]) seen)
+        seen))))
+
+(defn- normalize-relationships
+  [relationships]
+  (into #{}
+        (map (fn [{:keys [subject relation resource]}]
+               [[(:type subject) (:id subject)]
+                relation
+                [(:type resource) (:id resource)]]))
+        relationships))
+
+(defn- observations
+  [{:keys [client]} users folders permissions]
+  {:checks
+   (into {}
+         (for [permission permissions]
+           [permission
+            (mapv (fn [user]
+                    (mapv #(boolean (eacl/can?
+                                     client user permission %))
+                          folders))
+                  users)]))
+   :resource-pages
+   (into {}
+         (for [permission permissions]
+           [permission
+            (mapv (fn [user]
+                    (page-walk client
+                               {:subject user
+                                :permission permission
+                                :resource/type :folder}))
+                  users)]))
+   :resource-counts
+   (into {}
+         (for [permission permissions]
+           [permission
+            (mapv (fn [user]
+                    ;; Backend-specific cache identities are deliberately
+                    ;; opaque across independent databases. Compare only the
+                    ;; public count, limit, and cache-hit semantics.
+                    (select-keys
+                     (eacl/count-resources
+                      client
+                      {:subject user
+                       :permission permission
+                       :resource/type :folder})
+                     [:count :limit :cached?]))
+                  users)]))
+   :subject-sets
+   (into {}
+         (for [permission permissions]
+           [permission
+            (mapv (fn [folder]
+                    (into #{}
+                          (map :id)
+                          (:data
+                           (eacl/lookup-subjects
+                            client
+                            {:resource folder
+                             :permission permission
+                             :subject/type :user
+                             :first 100}))))
+                  folders)]))
+   :relationships
+   (normalize-relationships
+    (:data
+     (eacl/read-relationships
+      client {:resource/type :folder :first 1000})))})
+
+(defn- assert-equal-observations!
+  ([seed phase systems users folders]
+   (assert-equal-observations!
+    seed phase systems users folders [:view]))
+  ([seed phase systems users folders permissions]
+  (let [by-backend
+        (into {}
+              (map (juxt :backend
+                         #(observations % users folders permissions)))
+              systems)
+        expected (:datascript by-backend)]
+    (doseq [[backend actual] by-backend]
+      (is (= expected actual)
+          (str "seed=" seed " phase=" phase " backend=" backend))))))
+
+(deftest randomized-public-api-differential-test
+  (doseq [seed [41 820084 20260822]]
+    (testing (str "seed " seed)
+      (let [{:keys [users folders relationships]}
+            (random-relationships seed)
+            fixture (create-systems seed)
+            systems (:systems fixture)
+            objects
+            (mapv (fn [{:keys [id]}] {:eacl/id id})
+                  (concat users folders))]
+        (try
+          (doseq [{:keys [client transact!]} systems]
+            (eacl/write-schema! client schema)
+            (transact! objects)
+            (eacl/create-relationships! client relationships))
+          (assert-equal-observations!
+           seed :initial systems users folders)
+
+          (let [deletions (vec (take-nth 3 relationships))
+                touches (vec (take-nth 4 (drop 1 relationships)))]
+            (doseq [{:keys [client]} systems]
+              (eacl/delete-relationships! client deletions)
+              (eacl/write-relationships!
+               client
+               (mapv #(eacl/->RelationshipUpdate :touch %) touches)))
+            (assert-equal-observations!
+             seed :mutated systems users folders))
+
+          (doseq [{:keys [client]} systems]
+            (eacl/write-schema! client schema-with-inspect))
+          (assert-equal-observations!
+           seed :schema-changed systems users folders [:view :inspect])
+
+          (doseq [{:keys [client]} systems]
+            (eacl/delete-object! client (first folders)))
+          (assert-equal-observations!
+           seed :object-deleted systems users folders [:view :inspect])
+          (finally
+            (close-systems! fixture)))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/mutation_race_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/mutation_race_test.clj
@@ -1,0 +1,291 @@
+(ns eacl.datalevin.mutation-race-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.core :as eacl]
+            [eacl.datalevin.backend :as backend]
+            [eacl.datalevin.core :as datalevin]
+            [eacl.relationships.storage :as storage]
+            [eacl.schema.model :as model])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(def ^:private test-key "01234567890123456789012345678901")
+
+(def ^:private schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     permission view = viewer
+   }")
+
+(def ^:private schema-with-editor
+  "definition user {}
+   definition document {
+     relation viewer: user
+     relation editor: user
+     permission view = viewer + editor
+   }")
+
+(def ^:private schema-with-owner
+  "definition user {}
+   definition document {
+     relation viewer: user
+     relation owner: user
+     permission view = viewer + owner
+   }")
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(defn- with-system
+  [f]
+  (let [dir (u/tmp-dir (str "eacl-datalevin-race-" (random-uuid)))
+        conn (datalevin/create-conn dir)
+        watermark (atom 0)
+        client
+        (datalevin/make-client
+         conn
+         {:source-lifecycle "race-lifecycle"
+          :revision-watermark watermark
+          :advance-revision-watermark! #(swap! watermark max %)
+          :datalevin-topology backend/certified-topology-declaration
+          :security-key test-key})]
+    (try
+      (eacl/write-schema! client schema)
+      (d/transact! conn [{:eacl/id "alice"}
+                         {:eacl/id "document-1"}])
+      (f {:conn conn
+          :client client
+          :alice (eacl/spice-object :user "alice")
+          :document (eacl/spice-object :document "document-1")})
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(defn- relationship
+  [{:keys [alice document]}]
+  (eacl/->Relationship alice :viewer document))
+
+(defn- relationship-state
+  [conn]
+  (let [db (d/db conn)
+        forward
+        (into #{}
+              (map (fn [{subject :e [_ relation _ resource] :v}]
+                     [subject relation resource]))
+              (d/datoms db :ave storage/forward-attribute))
+        reverse
+        (into #{}
+              (map (fn [{resource :e [_ relation _ subject] :v}]
+                     [subject relation resource]))
+              (d/datoms db :ave storage/reverse-attribute))]
+    {:forward forward :reverse reverse}))
+
+(defn- assert-paired!
+  [conn]
+  (let [{:keys [forward reverse]} (relationship-state conn)]
+    (is (= forward reverse))
+    (is (<= (count forward) 1))))
+
+(defn- ref-value
+  [db lookup-ref attribute]
+  (when-let [eid (d/entid db lookup-ref)]
+    (some-> (d/datoms db :eav eid attribute)
+            first
+            :v)))
+
+(defn- coherence-state
+  [conn]
+  (let [db (d/db conn)]
+    {:schema-generation
+     (ref-value db [:eacl/id "schema-string"] :eacl/schema-generation)
+     :schema-write-fence
+     (ref-value db [:eacl/id "schema-string"] :eacl/schema-write-fence)
+     :viewer-version
+     (ref-value db
+                [:eacl/id (model/->relation-id :document :viewer :user)]
+                :eacl/relation-version)
+     :editor-version
+     (ref-value db
+                [:eacl/id (model/->relation-id :document :editor :user)]
+                :eacl/relation-version)}))
+
+(defn- assert-advanced!
+  [before after key]
+  (let [before-value (get before key)
+        after-value (get after key)]
+    (is (integer? before-value) (str key " has a baseline value"))
+    (is (integer? after-value) (str key " has a committed value"))
+    (when (and (integer? before-value) (integer? after-value))
+      (is (< before-value after-value) (str key " advances")))))
+
+(defn- run-at-same-commit-boundary
+  [intercept? left right]
+  (let [ready (CountDownLatch. 2)
+        intercepted (atom 0)
+        original d/transact!
+        transact
+        (fn [& args]
+          (let [tx-data (second args)
+                slot (when (intercept? tx-data)
+                       (swap! intercepted inc))]
+            (when (and slot (<= slot 2))
+              (.countDown ready)
+              (when-not (.await ready 5 TimeUnit/SECONDS)
+                (throw (ex-info "race barrier timed out"
+                                {:type :test/barrier-timeout}))))
+            (apply original args)))]
+    (with-redefs [d/transact! transact]
+      (let [left-result (future (error-data left))
+            right-result (future (error-data right))]
+        [(deref left-result 10000 {:type :test/future-timeout})
+         (deref right-result 10000 {:type :test/future-timeout})]))))
+
+(defn- relationship-transaction?
+  [tx-data]
+  (boolean
+   (some (fn [op]
+           (and (vector? op)
+                (contains? storage/attributes (nth op 2 nil))))
+         tx-data)))
+
+(deftest create-create-create-delete-and-touch-delete-are-serializable-test
+  (testing "create/create has exactly one winner"
+    (with-system
+      (fn [{:keys [conn client] :as system}]
+        (let [rel (relationship system)
+              results
+              (run-at-same-commit-boundary
+               relationship-transaction?
+               #(eacl/create-relationship! client rel)
+               #(eacl/create-relationship! client rel))]
+          (is (= 1 (count (filter nil? results))))
+          (is (= [:eacl/relationship-conflict]
+                 (keep :type results)))
+          (assert-paired! conn)))))
+  (doseq [left-operation [:create :touch]]
+    (testing (str (name left-operation) "/delete")
+      (with-system
+        (fn [{:keys [conn client] :as system}]
+          (let [rel (relationship system)
+                left #(case left-operation
+                        :create (eacl/create-relationship! client rel)
+                        :touch (eacl/write-relationship!
+                                client :touch
+                                (:subject rel) (:relation rel) (:resource rel)))
+                results
+                (run-at-same-commit-boundary
+                 relationship-transaction?
+                 left
+                 #(eacl/delete-relationship! client rel))]
+            (is (= [nil nil] results))
+            (assert-paired! conn)))))))
+
+(deftest relation-removal-create-and-schema-schema-races-are-fenced-test
+  (testing "relation removal and relationship creation cannot both commit"
+    (with-system
+      (fn [{:keys [conn client] :as system}]
+        (let [rel (relationship system)
+              results
+              (run-at-same-commit-boundary
+               (constantly true)
+               #(eacl/write-schema!
+                 client "definition user {} definition document {}")
+               #(eacl/create-relationship! client rel))]
+          (is (= 1 (count (filter nil? results))))
+          (is (= 1 (count (keep :type results))))
+          (is (contains? #{:eacl.schema/concurrent-write
+                           :eacl/relationship-concurrent-write}
+                         (:type (first (remove nil? results)))))
+          (assert-paired! conn)))))
+  (testing "two schema writers serialize through the schema generation CAS"
+    (with-system
+      (fn [{:keys [client]}]
+        (let [results
+              (run-at-same-commit-boundary
+               (constantly true)
+               #(eacl/write-schema! client schema-with-editor)
+               #(eacl/write-schema! client schema-with-owner))]
+          (is (= 1 (count (filter nil? results))))
+          (is (= [:eacl.schema/concurrent-write]
+                 (keep :type results))))))))
+
+(deftest object-delete-rescans-at-commit-after-intervening-create-test
+  (with-system
+    (fn [{:keys [conn client alice] :as system}]
+      (let [rel (relationship system)
+            injected? (atom false)
+            original d/transact!
+            delete-function-call?
+            (fn [tx-data]
+              (some (fn [op]
+                      (and (vector? op)
+                           (= :db.fn/call (first op))))
+                    tx-data))]
+        (with-redefs
+         [d/transact!
+         (fn [& args]
+            (when (and (delete-function-call? (second args))
+                       (compare-and-set! injected? false true))
+              (eacl/create-relationship! client rel))
+            (apply original args))]
+          (is (nil? (error-data #(eacl/delete-object! client alice)))))
+        (is (true? @injected?))
+        (is (= {:forward #{} :reverse #{}}
+               (relationship-state conn)))
+        (is (= {:active 0 :oldest-age-ms nil}
+               (d/active-read-snapshot-info)))))))
+
+(deftest successful-state-changing-mutations-advance-coherence-metadata-test
+  (with-system
+    (fn [{:keys [conn client alice] :as system}]
+      (let [rel (relationship system)
+            initial (coherence-state conn)]
+        (testing "create atomically writes both tuple directions and advances the relation"
+          (eacl/create-relationship! client rel)
+          (assert-paired! conn)
+          (is (= 1 (count (:forward (relationship-state conn)))))
+          (let [after-create (coherence-state conn)]
+            (assert-advanced! initial after-create :viewer-version)
+
+            (testing "delete atomically removes both tuple directions and advances the relation"
+              (eacl/delete-relationship! client rel)
+              (assert-paired! conn)
+              (is (= {:forward #{} :reverse #{}}
+                     (relationship-state conn)))
+              (let [after-delete (coherence-state conn)]
+                (assert-advanced! after-create after-delete :viewer-version)
+
+                (testing "touch of an absent tuple creates both halves and advances the relation"
+                  (eacl/write-relationship!
+                   client :touch (:subject rel) (:relation rel) (:resource rel))
+                  (assert-paired! conn)
+                  (is (= 1 (count (:forward (relationship-state conn)))))
+                  (let [after-touch (coherence-state conn)]
+                    (assert-advanced! after-delete after-touch :viewer-version)
+
+                    (testing "object deletion removes both halves and advances every affected relation"
+                      (eacl/delete-object! client alice)
+                      (assert-paired! conn)
+                      (is (= {:forward #{} :reverse #{}}
+                             (relationship-state conn)))
+                      (let [after-object-delete (coherence-state conn)]
+                        (assert-advanced! after-touch after-object-delete
+                                          :viewer-version)
+
+                        (testing "schema replacement advances both schema values in its commit"
+                          (eacl/write-schema! client schema-with-editor)
+                          (assert-paired! conn)
+                          (let [after-schema (coherence-state conn)]
+                            (assert-advanced! after-object-delete after-schema
+                                              :schema-generation)
+                            (assert-advanced! after-object-delete after-schema
+                                              :schema-write-fence)
+                            (is (integer? (:editor-version after-schema)))
+                            (is (< (:schema-write-fence after-object-delete)
+                                   (:editor-version after-schema)))))))))))))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/safe_retraction_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/safe_retraction_test.clj
@@ -1,0 +1,108 @@
+(ns eacl.datalevin.safe-retraction-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.core :as eacl]
+            [eacl.datalevin.backend :as backend]
+            [eacl.datalevin.core :as datalevin]
+            [eacl.datalevin.safe-retraction :as safe-retraction]
+            [eacl.relationships.safe-retraction :as safe]
+            [eacl.relationships.storage :as storage]))
+
+(def ^:private test-key "01234567890123456789012345678901")
+
+(def ^:private logical-schema
+  "definition user {}
+   definition folder {
+     relation viewer: user
+     permission view = viewer
+   }")
+
+(defn- with-system
+  [extra-schema f]
+  (let [dir (u/tmp-dir (str "eacl-datalevin-safe-retraction-"
+                            (random-uuid)))
+        conn (datalevin/create-conn dir extra-schema)
+        watermark (atom 0)]
+    (try
+      (let [client
+            (datalevin/make-client
+             conn
+             {:security-key test-key
+              :source-lifecycle "safe-retraction-test"
+              :revision-watermark watermark
+              :advance-revision-watermark! #(swap! watermark max %)
+              :datalevin-topology
+              backend/certified-topology-declaration})]
+        (eacl/write-schema! client logical-schema)
+        (f conn client))
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(defn- halves
+  [db eid]
+  {:forward (mapv :v (d/datoms db :eav eid storage/forward-attribute))
+   :reverse (mapv :v (d/datoms db :eav eid storage/reverse-attribute))})
+
+(deftest direct-safe-retraction-uses-the-transaction-database-schema-test
+  (with-system
+    {:test/component {:db/valueType :db.type/ref
+                      :db/cardinality :db.cardinality/one
+                      :db/isComponent true}}
+    (fn [conn client]
+      (d/transact! conn [{:eacl/id "alice"}
+                         {:eacl/id "child"}
+                         {:eacl/id "parent"
+                          :test/component [:eacl/id "child"]}
+                         {:eacl/id "other-folder"}])
+      (eacl/create-relationships!
+       client
+       [(eacl/->Relationship
+         (eacl/spice-object :user "alice")
+         :viewer
+         (eacl/spice-object :folder "child"))
+        (eacl/->Relationship
+         (eacl/spice-object :user "alice")
+         :viewer
+         (eacl/spice-object :folder "other-folder"))])
+      (let [before (d/db conn)
+            parent (d/entid before [:eacl/id "parent"])
+            child (d/entid before [:eacl/id "child"])
+            alice (d/entid before [:eacl/id "alice"])
+            unrelated (d/entid before [:eacl/id "other-folder"])]
+        (is (seq (:reverse (halves before child))))
+        (is (seq (:forward (halves before alice))))
+        (d/transact!
+         conn
+         (safe-retraction/direct-retract-entity-tx-data parent))
+        (let [after (d/db conn)]
+          (is (empty? (d/datoms after :eav parent)))
+          (is (empty? (d/datoms after :eav child)))
+          (is (empty? (:reverse (halves after child))))
+          (is (= 1 (count (:forward (halves after alice)))))
+          (is (seq (:reverse (halves after unrelated)))))))))
+
+(deftest only-direct-in-process-invocation-is-advertised-test
+  (with-system
+    nil
+    (fn [conn _]
+      (is (nil? (d/entid (d/db conn) safe/function-ident)))
+      (is (= :direct (:mode (safe-retraction/support-descriptor))))
+      (is (= {:installed? false :state :direct}
+             (select-keys (safe-retraction/prepare! conn)
+                          [:installed? :state])))
+      (is (= :eacl.safe-retraction/installation-unavailable
+             (:type
+              (try
+                (safe-retraction/install! conn)
+                nil
+                (catch clojure.lang.ExceptionInfo error
+                  (ex-data error))))))
+      (testing "the direct function executes against the serialized writer DB"
+        (d/transact! conn [{:eacl/id "victim"}])
+        (let [eid (d/entid (d/db conn) [:eacl/id "victim"])]
+          (d/transact!
+           conn
+           (safe-retraction/retract-entity-tx-data [:eacl/id "victim"]))
+          (is (empty? (d/datoms (d/db conn) :eav eid))))))))

--- a/modules/eacl-datascript/src/eacl/datascript/backend.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/backend.cljc
@@ -1,6 +1,7 @@
 (ns eacl.datascript.backend
   "DataScript storage operations for the shared v8 authorization engine."
   (:require [datascript.core :as ds]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.backend.v8 :as backend]
             [eacl.datascript.impl :as impl])
   #?(:clj (:import [java.util WeakHashMap])))
@@ -228,3 +229,40 @@
        :proof-frame
        (fn [relation-ids]
          (ordered-generation-frame db relation-ids))}})))
+
+(defn provider
+  "Builds the borrowed immutable-snapshot provider for one DataScript conn."
+  [conn opts]
+  (let [current-adapter
+        (fn [] (snapshot-adapter (ds/db conn) opts))
+        static-adapter (current-adapter)
+        source-scope (backend/invoke static-adapter :source-scope)
+        source-lifecycle
+        (fn []
+          (or (some-> (:source-lifecycle-state opts) deref)
+              (:source-lifecycle opts)))]
+    (snapshot-provider/borrowed-adapter-provider
+     {:static-adapter static-adapter
+      :topology {:deployment :embedded
+                 :snapshot-values :immutable}
+      :source-scope-fn (constantly source-scope)
+      :source-lifecycle-fn source-lifecycle
+      :acquire-current! current-adapter
+      :acquire-authoritative!
+      (fn [timeout-ms]
+        (backend/invoke
+         (current-adapter) :select-authoritative timeout-ms))
+      :acquire-at-least!
+      (fn [token-data timeout-ms]
+        (backend/invoke
+         (current-adapter) :select-at-least token-data timeout-ms))
+      :acquire-exact!
+      (fn [_token-data _timeout-ms]
+        (throw
+         (ex-info
+          "DataScript does not retain exact historical snapshots."
+          {:type :eacl/unsupported-capability
+           :eacl/error :eacl/unsupported-capability
+           :backend :datascript
+           :capability :consistency
+           :requested :at-exact-snapshot})))})))

--- a/modules/eacl-datascript/src/eacl/datascript/core.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/core.cljc
@@ -38,6 +38,11 @@
    :entid ds/entid
    :default-entid->object-id (fn [db eid] (:eacl/id (ds/entity db eid)))
    :snapshot-adapter datascript-backend/snapshot-adapter
+   :snapshot-provider datascript-backend/provider
+   :db-native-revision
+   (fn [db]
+     {:revision (:max-tx db)
+      :exact-locator nil})
    :native-source-id datascript-backend/connection-source-id
    :relationship-retraction-count relationship-retraction-count
    :transact! transact-native!

--- a/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
+++ b/modules/eacl-datascript/test/eacl/datascript/cljs_test_runner.cljs
@@ -25,6 +25,7 @@
             [eacl.datascript.contract-test]
             [eacl.datascript.impl-test]
             [eacl.datascript.safe-retraction-test]
+            [eacl.datascript.snapshot-lifecycle-test]
             [eacl.datascript.storage-test]))
 
 (nodejs/enable-util-print!)
@@ -63,6 +64,7 @@
                'eacl.datascript.contract-test
                'eacl.datascript.impl-test
                'eacl.datascript.safe-retraction-test
+               'eacl.datascript.snapshot-lifecycle-test
                'eacl.datascript.storage-test))
 
 (set! *main-cli-fn* -main)

--- a/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
@@ -354,9 +354,9 @@
     (is (= :eacl/invalid-config (:type removed-option-error)))
     (is (= [:exact-snapshot-registry-size]
            (:unknown-keys removed-option-error)))
-    (is (= :eacl/unsupported-capability (:type exact-error)))
-    (is (= :consistency (:capability exact-error)))
-    (is (= :at-exact-snapshot (:requested exact-error)))
+    (is (= :eacl.consistency/exact-snapshot-unavailable
+           (:type exact-error)))
+    (is (= :exact-snapshot-unavailable (:reason exact-error)))
     (is (= before after)
         "unsupported exact selection must fail before cache access")))
 
@@ -464,7 +464,7 @@
          (:cached?
           (eacl/lookup-resources authorization query))))
     (eacl/delete-relationship! authorization relationship)
-    (is (= :eacl/unsupported-capability
+    (is (= :eacl.consistency/exact-snapshot-unavailable
            (:type
             (error-data
              #(eacl/can?

--- a/modules/eacl-datascript/test/eacl/datascript/snapshot_lifecycle_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/snapshot_lifecycle_test.cljc
@@ -1,0 +1,255 @@
+(ns eacl.datascript.snapshot-lifecycle-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [datascript.core :as ds]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.cache :as cache]
+            [eacl.core :as eacl]
+            [eacl.cursor :as cursor]
+            [eacl.datascript.core :as datascript]
+            [eacl.execution :as execution]
+            [eacl.proof-frame :as proof-frame]))
+
+(def schema
+  "definition user {}
+   definition account {
+     relation owner: user
+     permission admin = owner
+   }")
+
+(defn- fixture
+  []
+  (let [conn (datascript/create-conn)
+        client (datascript/make-client conn {:cache cache/no-cache})
+        user (eacl/spice-object :user "user")
+        account (eacl/spice-object :account "account")]
+    (eacl/write-schema! client schema)
+    (ds/transact! conn [{:eacl/id "user"}
+                        {:eacl/id "account"}])
+    (eacl/create-relationship!
+     client (eacl/->Relationship user :owner account))
+    {:conn conn :client client :user user :account account}))
+
+(defn- observed-call
+  [conn f]
+  (let [provider-calls (atom {})
+        db-calls (atom 0)
+        original-db ds/db
+        value
+        (with-redefs [ds/db (fn [candidate]
+                             (when (identical? conn candidate)
+                               (swap! db-calls inc))
+                             (original-db candidate))]
+          (binding [snapshot-provider/*provider-op-stats* provider-calls]
+            (f)))]
+    {:value value
+     :provider-calls @provider-calls
+     :db-calls @db-calls}))
+
+(deftest every-public-read-has-one-current-snapshot-scope-test
+  (let [{:keys [conn client user account]} (fixture)
+        operations
+        [[:can? #(eacl/can? client user :admin account)]
+         [:check-permission
+          #(eacl/check-permission client user :admin account)]
+         [:read-schema #(eacl/read-schema client)]
+         [:read-relationships
+          #(eacl/read-relationships
+            client {:subject/type :user :first 10})]
+         [:lookup-resources
+          #(eacl/lookup-resources
+            client
+            {:subject user
+             :resource/type :account
+             :permission :admin
+             :first 10})]
+         [:count-resources
+          #(eacl/count-resources
+            client
+            {:subject user
+             :resource/type :account
+             :permission :admin})]
+         [:lookup-subjects
+          #(eacl/lookup-subjects
+            client
+            {:resource account
+             :subject/type :user
+             :permission :admin
+             :first 10})]
+         [:count-subjects
+          #(eacl/count-subjects
+            client
+            {:resource account
+             :subject/type :user
+             :permission :admin})]
+         [:expand-permission-tree
+          #(eacl/expand-permission-tree
+            client {:resource account :permission :admin})]]]
+    (doseq [[operation f] operations]
+      (testing (name operation)
+        (let [{:keys [value provider-calls db-calls]}
+              (observed-call conn f)]
+          (is (some? value))
+          (is (= 1 (:acquire-current! provider-calls 0)))
+          (is (= 1 (:release! provider-calls 0)))
+          (is (= 1 db-calls)))))))
+
+(deftest selected-snapshot-releases-on-public-validation-error-test
+  (let [{:keys [conn client user account]} (fixture)
+        error (atom nil)
+        {:keys [provider-calls db-calls]}
+        (observed-call
+         conn
+         #(try
+            (eacl/can? client user :missing-permission account)
+            (catch #?(:clj clojure.lang.ExceptionInfo
+                      :cljs cljs.core.ExceptionInfo)
+                   failure
+              (reset! error (ex-data failure)))))]
+    (is (keyword? (:type @error)))
+    (is (= 1 (:acquire-current! provider-calls 0)))
+    (is (= 1 (:release! provider-calls 0)))
+    (is (= 1 db-calls))))
+
+(deftest selected-snapshot-releases-when-context-construction-fails-test
+  (let [{:keys [conn client user account]} (fixture)
+        error (atom nil)
+        {:keys [provider-calls db-calls]}
+        (with-redefs
+         [execution/check!
+          (fn
+            ([stage]
+             (when (= :consistency-selected stage)
+               (throw
+                (ex-info "injected context failure"
+                         {:type :test/context-construction}))))
+            ([contract stage]
+             (if (= :consistency-selected stage)
+               (throw
+                (ex-info "injected context failure"
+                         {:type :test/context-construction}))
+               nil))
+            ([contract stage consumed-work]
+             (if (= :consistency-selected stage)
+               (throw
+                (ex-info "injected context failure"
+                         {:type :test/context-construction}))
+               nil)))]
+         (observed-call
+          conn
+          #(try
+             (eacl/can? client user :admin account)
+             (catch #?(:clj clojure.lang.ExceptionInfo
+                       :cljs cljs.core.ExceptionInfo)
+                    failure
+               (reset! error (ex-data failure))))))]
+    (is (= :test/context-construction (:type @error)))
+    (is (= 1 (:acquire-current! provider-calls 0)))
+    (is (= 1 (:release! provider-calls 0)))
+    (is (= 1 db-calls))))
+
+#?(:clj
+   (defn- observed-failure
+     [conn f]
+     (let [failure (atom nil)
+           observation
+           (observed-call
+            conn
+            #(try
+               (f)
+               (catch Throwable error
+                 (reset! failure error))))]
+       (assoc observation :failure @failure))))
+
+#?(:clj
+   (defn- fail-execution-stage
+     [original target-stage error]
+     (fn
+       ([stage]
+        (if (= target-stage stage)
+          (throw error)
+          (original stage)))
+       ([contract stage]
+        (if (= target-stage stage)
+          (throw error)
+          (original contract stage)))
+       ([contract stage consumed-work]
+        (if (= target-stage stage)
+          (throw error)
+          (original contract stage consumed-work))))))
+
+#?(:clj
+   (deftest selected-snapshot-releases-across-post-selection-fault-boundaries-test
+     (let [{:keys [conn client user account]} (fixture)
+           assert-one-release!
+           (fn [{:keys [failure provider-calls db-calls]} expected-message]
+             (is (= expected-message (.getMessage ^Throwable failure)))
+             (is (= 1 (:acquire-current! provider-calls 0)))
+             (is (= 1 (:release! provider-calls 0)))
+             (is (= 1 db-calls)))]
+       (testing "foreign runtime failures release the selected snapshot"
+         (let [original execution/check!
+               error (RuntimeException. "injected foreign failure")]
+           (with-redefs
+            [execution/check!
+             (fail-execution-stage original :semantic-evaluation error)]
+             (assert-one-release!
+              (observed-failure
+               conn #(eacl/can? client user :admin account))
+              "injected foreign failure"))))
+       (testing "proof failures release the selected snapshot"
+         (with-redefs
+          [proof-frame/resolve!
+           (fn [& _]
+             (throw (ex-info "injected proof failure"
+                             {:type :test/proof-failure})))]
+           (assert-one-release!
+            (observed-failure
+             conn #(eacl/can? client user :admin account))
+            "injected proof failure")))
+       (testing "cache-publication failures release the selected snapshot"
+         (let [cached-client
+               (datascript/make-client conn {:cache {}})
+               original execution/check!]
+           (with-redefs
+            [execution/check!
+             (fail-execution-stage
+              original
+              :cache-publication
+              (ex-info "injected cache publication failure"
+                       {:type :test/cache-publication-failure}))]
+             (assert-one-release!
+              (observed-failure
+               conn #(eacl/can? cached-client user :admin account))
+              "injected cache publication failure"))))
+       (testing "cursor-construction failures release the selected snapshot"
+         (with-redefs
+          [cursor/cursor->token
+           (fn [& _]
+             (throw (ex-info "injected cursor construction failure"
+                             {:type :test/cursor-construction-failure})))]
+           (assert-one-release!
+            (observed-failure
+             conn
+             #(eacl/read-relationships
+               client {:subject/type :user :first 1}))
+            "injected cursor construction failure"))))))
+
+(deftest write-planning-snapshot-releases-before-commit-test
+  (let [{:keys [conn client user account]} (fixture)
+        provider-calls (atom {})
+        release-count-at-commit (atom nil)
+        original-transact! ds/transact!
+        response
+        (with-redefs [ds/transact!
+                      (fn [candidate tx]
+                        (reset! release-count-at-commit
+                                (:release! @provider-calls 0))
+                        (original-transact! candidate tx))]
+          (binding [snapshot-provider/*provider-op-stats* provider-calls]
+            (eacl/delete-relationship!
+             client (eacl/->Relationship user :owner account))))]
+    (is (= 1 @release-count-at-commit))
+    (is (= 1 (:acquire-current! @provider-calls 0)))
+    (is (= 1 (:release! @provider-calls 0)))
+    (is (string? (:zed/token response)))))

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -2,6 +2,7 @@
   "Datomic's storage-specific implementation of the shared v8 snapshot
   adapter. Authorization graph algorithms remain outside this namespace."
   (:require [datomic.api :as d]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.backend.v8 :as backend]
             [eacl.datomic.db :as ddb])
   (:import [java.util UUID]
@@ -514,3 +515,43 @@
         :proof-frame
         (fn [relation-ids]
           (ordered-generation-frame db relation-ids))}}))))
+
+(defn provider
+  "Builds the borrowed immutable-snapshot provider for one Datomic conn."
+  [conn opts]
+  (let [adapter-fn
+        (or (:backend-adapter-fn opts)
+            #(snapshot-adapter % (assoc opts :conn conn)))
+        current-adapter
+        (fn [] (adapter-fn (d/db conn)))
+        static-adapter (current-adapter)
+        source-scope (backend/invoke static-adapter :source-scope)
+        source-lifecycle
+        (fn []
+          (or (some-> (:source-lifecycle-state opts) deref)
+              (:source-lifecycle opts)))
+        select!
+        (fn [operation-key & args]
+          (let [selected
+                (apply backend/invoke
+                       (current-adapter) operation-key args)]
+            (or selected
+                (throw
+                 (ex-info
+                  "The requested Datomic snapshot is unavailable."
+                  {:type :eacl.consistency/exact-snapshot-unavailable
+                   :eacl/error :eacl.consistency/exact-snapshot-unavailable
+                   :backend :datomic})))))]
+    (snapshot-provider/borrowed-adapter-provider
+     {:static-adapter static-adapter
+      :topology {:deployment :embedded-or-peer
+                 :snapshot-values :immutable}
+      :source-scope-fn (constantly source-scope)
+      :source-lifecycle-fn source-lifecycle
+      :acquire-current! current-adapter
+      :acquire-authoritative!
+      #(select! :select-authoritative %)
+      :acquire-at-least!
+      #(select! :select-at-least %1 %2)
+      :acquire-exact!
+      #(select! :select-exact %1 %2)})))

--- a/modules/eacl-datomic/src/eacl/datomic/core.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/core.clj
@@ -2,6 +2,7 @@
   "Reifies eacl.core/IAuthorization for Datomic-backed EACL in eacl.datomic.impl."
   (:require [com.rpl.specter :as S]
             [datomic.api :as d]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.backend.v8 :as backend]
             [eacl.cache :as shared-cache]
             [eacl.causal-token :as causal-token]
@@ -474,13 +475,15 @@
          (execution/remaining-millis contract))
     (:consistency-sync-timeout-ms opts)))
 
+(declare select-current-request-db)
+
 (defn- await-revision-db
   "Returns a local DB that has observed `requested-t`, waiting only when needed."
   [conn opts requested-t]
   (let [timeout-ms (cursor-selection-timeout-ms opts)
         local-db
         (try
-          (d/db conn)
+          (select-current-request-db conn opts)
           (catch Exception failure
             (historical-selection-failure!
              "Failed reading the local Datomic database."
@@ -1228,7 +1231,7 @@
   (let [updates (vec updates)]
     (doseq [{:keys [operation]} updates]
       (impl/validate-relationship-operation! operation))
-    (let [schema (schema/read-schema (d/db conn))]
+    (let [schema (schema/read-schema (select-current-request-db conn opts))]
       (doseq [{:keys [relationship]} updates]
         (schema-errors/validate-relationship-write!
          schema :write-relationships
@@ -1236,7 +1239,7 @@
           :subject-type (:type (:subject relationship))
           :relation (:relation relationship)})))
     (loop [attempt 1]
-      (let [db (d/db conn)
+      (let [db (select-current-request-db conn opts)
             internal-updates
             (S/transform [S/ALL :relationship]
                          #(spice-relationship->internal db opts %)
@@ -1519,27 +1522,41 @@
   [conn opts consistency-value]
   (let [contract (:execution-contract opts)
         _ (execution/check! contract :consistency-selection)
-        descriptor (consistency/descriptor consistency-value)
-        source-adapter ((:backend-adapter-fn opts) (d/db conn))
+        provider (:snapshot-provider opts)
         selection-options
         {:format-options (:format-options opts)
          :decision-kernel (:decision-kernel opts)
          :issue-token? false
+         :selection-check!
+         (when contract
+           (fn [phase]
+             (execution/check! contract phase)))
          :timeout-ms
          (if contract
            (min (:consistency-sync-timeout-ms opts)
                 (execution/remaining-millis contract))
            (:consistency-sync-timeout-ms opts))}
         selection
-        (if (= :minimize-latency (:mode descriptor))
-          (consistency-v3/captured-current-selection
-           source-adapter consistency-value selection-options)
-          (consistency-v3/select
-           source-adapter
-           consistency-value
-           selection-options))]
-    (execution/check! contract :consistency-selected)
-    selection))
+        (consistency-v3/select
+         provider consistency-value selection-options)
+        selected (:selected-snapshot selection)]
+    (try
+      (execution/check! contract :consistency-selected)
+      ;; Datomic DB values are immutable and the compatibility provider owns
+      ;; no native resource. Closing its borrowed selection here still makes
+      ;; every acquisition/release observable and balanced while the adapter
+      ;; remains valid for the full request.
+      (dissoc selection :selected-snapshot)
+      (finally
+        (when selected
+          (snapshot-provider/release! selected))))))
+
+(defn- select-current-request-db
+  [conn opts]
+  (-> (select-request-snapshot conn opts consistency/minimize-latency)
+      :adapter
+      backend/state
+      :db))
 
 (defn- capture-result-context
   "Selects one immutable request snapshot. Exact-snapshot requests reconstruct
@@ -1651,7 +1668,7 @@
                  :kernel-decision initial})))))]
     (when (:revision-checkpoints opts)
       (revision/observe! (:revision-checkpoints opts)
-                         (d/basis-t (d/db conn))))
+                         (backend/invoke selected-adapter :order-hint)))
     (let [snapshot-exact?
           (or (= :at-exact-snapshot
                  (or (:mode selected-context) mode))
@@ -1682,7 +1699,7 @@
         request-token (:request-token selection)]
     (when (:revision-checkpoints opts)
       (revision/observe! (:revision-checkpoints opts)
-                         (d/basis-t (d/db conn))))
+                         (backend/invoke adapter :order-hint)))
     {:adapter adapter
      :db db
      :basis-t basis-t
@@ -1836,10 +1853,10 @@
 (def ^:private delete-object-batch-size 1000)
 
 (defn- transact-delete-object-batch!
-  [conn batch]
+  [conn opts batch]
   (let [batch (vec batch)]
     (loop [attempt 1]
-      (let [db (d/db conn)
+      (let [db (select-current-request-db conn opts)
           stamped (impl/stamp-relation-versions batch)
           guarded (impl/optimistic-relationship-tx-data db stamped)
           submission
@@ -1877,7 +1894,7 @@
   far worse against a real transactor). No barrier is taken now."
   [conn {:keys [object-id->entid] :as opts} object]
   (let [object-id (if (map? object) (:id object) object)
-        db        (d/db conn)
+        db        (select-current-request-db conn opts)
         eid       (or (try (object-id->entid db object-id)
                            (catch Exception _ nil))
                       ;; A retracted entity no longer resolves through the
@@ -1896,7 +1913,7 @@
           ;; without this a later batch retracts relationships while announcing
           ;; nothing.
           (let [{:keys [db-after tx-data]}
-                (transact-delete-object-batch! conn batch)]
+                (transact-delete-object-batch! conn opts batch)]
             (recur (next batches)
                    (+ retracted
                       (relationship-retraction-count db-after tx-data))
@@ -2299,10 +2316,10 @@
                      consistency)))
 
   (read-schema [_]
-    (schema/read-schema (d/db conn)))
+    (schema/read-schema (select-current-request-db conn opts)))
 
   (write-schema! [_ schema-string]
-    (let [base-db     (d/db conn)
+    (let [base-db     (select-current-request-db conn opts)
           expected-version (impl.indexed/schema-version base-db)
           deltas      (schema/write-schema!
                        conn schema-string
@@ -3037,7 +3054,7 @@
                             :token-ttl-seconds
                             (or token-ttl-seconds
                                 causal-token/default-token-ttl-seconds)}
-        opts               {:object-id->ident object-id->ident
+        opts-base          {:object-id->ident object-id->ident
                             :execution-timeout-ms
                             (or execution-timeout-ms
                                 execution/default-execution-timeout-ms)
@@ -3142,10 +3159,13 @@
                             (some-> (physical/normalize-service-admission
                                      service-admission)
                                     physical/make-service-admission)}
-        ;; The stable engine runs only on a qualified topology; the adapter's
-        ;; declared execution profile is checked once here.
-        _ (physical/require-qualified-topology!
-           ((:backend-adapter-fn opts) (d/db conn)))]
+        provider           (datomic-backend/provider conn opts-base)
+        opts               (assoc opts-base :snapshot-provider provider)
+        ;; Construction qualification is provider-static and retains no
+        ;; request DB value. The provider remains the sole selection seam for
+        ;; Datomic request reads, allowing head-observation optimization to be
+        ;; implemented without changing the public client.
+        _ (physical/require-qualified-provider-topology! provider)]
     (->Spiceomic conn opts)))
 
 (defn current-zed-token

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_v3_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_v3_test.clj
@@ -1,6 +1,7 @@
 (ns eacl.datomic.consistency-v3-test
   (:require [clojure.test :refer [deftest is testing]]
             [datomic.api :as d]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.causal-token :as causal-token]
             [eacl.core :as eacl]
             [eacl.datomic.core :as datomic]
@@ -65,6 +66,31 @@
               :consistency false}))]
       (is (= :eacl/unsupported-consistency (:type error)))
       (is (false? (:consistency error))))))
+
+(deftest public-datomic-reads-use-balanced-borrowed-provider-selections-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [authorization (client conn)
+          _ (seed! conn authorization)
+          _ (eacl/create-relationship! authorization relationship)
+          operations
+          [[:can? #(eacl/can? authorization user :view document)]
+           [:read-schema #(eacl/read-schema authorization)]
+           [:read-relationships
+            #(eacl/read-relationships
+              authorization {:subject/type :user :first 10})]
+           [:lookup-resources
+            #(eacl/lookup-resources
+              authorization {:subject user
+                             :permission :view
+                             :resource/type :document
+                             :first 10})]]]
+      (doseq [[label operation] operations]
+        (testing (name label)
+          (let [calls (atom {})]
+            (binding [snapshot-provider/*provider-op-stats* calls]
+              (is (some? (operation))))
+            (is (= 1 (:acquire-current! @calls 0)))
+            (is (= 1 (:release! @calls 0)))))))))
 
 (deftest minimize-authoritative-and-targeted-sync-arities-test
   (with-mem-conn [conn schema/v7-schema]
@@ -245,7 +271,10 @@
             (is (= :eacl.consistency/freshness-unavailable
                    (:type data)))
             (is (= :freshness-timeout (:reason data)))
-            (is (= 5 (:timeout-ms data)))))))))
+            ;; The provider receives the remaining duration from one original
+            ;; deadline; authentication and setup may consume part of the
+            ;; configured five milliseconds before Datomic starts waiting.
+            (is (<= 1 (:timeout-ms data) 5))))))))
 
 (deftest authenticated-cache-lifts-only-across-equal-proofs-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl/README.md
+++ b/modules/eacl/README.md
@@ -43,12 +43,14 @@ remains a correct exact-current adapter.
 The contract uses logical types and identifiers. Datoms, attribute ids,
 database values, and raw index tuples stay inside each adapter. See the
 [v8 adapter boundary](../../docs/v8-backend-adapter-boundary.md) for the full
-inventory.
+inventory and the
+[snapshot-provider migration guide](../../docs/v8-snapshot-provider-migration.md)
+for owned/borrowed lifecycle and third-party adapter requirements.
 
 The shared contract fixture is
 `modules/eacl/test/eacl/contract_support.cljc`. It exercises the same v8 public
-API and recursive/cache behavior for Datomic, DataScript, and Datahike and
-compares authorization sets with independent semantic oracles. Those oracles
+API and recursive/cache behavior for Datomic, DataScript, Datahike, and
+Datalevin, and compares authorization sets with independent semantic oracles. Those oracles
 are test code, not selectable production engines.
 
 ## Permission-tree expansion

--- a/modules/eacl/src/eacl/backend/snapshot_provider.cljc
+++ b/modules/eacl/src/eacl/backend/snapshot_provider.cljc
@@ -1,0 +1,662 @@
+(ns eacl.backend.snapshot-provider
+  "Closed lifecycle contract between a long-lived backend source and one
+  selected immutable request snapshot.
+
+  Providers own freshness acquisition. Selected snapshots own, or explicitly
+  borrow, exactly one adapter and carry an idempotent release boundary. Native
+  handles and release tokens remain private to this namespace."
+  (:require [eacl.backend.v8 :as backend]))
+
+(def provider-version 1)
+(def selected-snapshot-version 1)
+
+(def ownership-policies
+  #{:borrowed :owned :mixed})
+
+(def snapshot-ownerships
+  #{:borrowed :owned})
+
+(def required-provider-operations
+  #{:source-scope
+    :source-lifecycle
+    :acquire-current!
+    :acquire-authoritative!
+    :acquire-at-least!
+    :acquire-exact!
+    :release!})
+
+(def acquisition-operations
+  {:current :acquire-current!
+   :authoritative :acquire-authoritative!
+   :at-least :acquire-at-least!
+   :exact :acquire-exact!})
+
+(def default-execution-constraints
+  "Portable providers have no thread affinity. A native provider can reject
+  virtual threads and bind use/release to the acquiring thread."
+  {:virtual-threads :supported
+   :snapshot-thread :any
+   :release-thread :any})
+
+(def ^:private execution-constraint-values
+  {:virtual-threads #{:supported :rejected}
+   :snapshot-thread #{:any :acquiring-thread}
+   :release-thread #{:any :acquiring-thread}})
+
+(def ^:private provider-input-keys
+  #{:id
+    :capabilities
+    :traversal-execution
+    :topology
+    :execution-constraints
+    :snapshot-ownership
+    :fingerprint
+    :deterministic?
+    :operations})
+
+(def ^:private raw-acquisition-keys
+  #{:adapter :ownership :release-token})
+
+(def semantic-identity-keys
+  "Closed equality identity for all EACL-visible state of one selected
+  snapshot. `:schema-identity` is nil unless the backend certifies a schema
+  dimension independent of its revision."
+  #{:backend
+    :source-id
+    :branch
+    :source-lifecycle
+    :revision
+    :exact-locator
+    :schema-identity
+    :backend-snapshot-id})
+
+(def ^:dynamic *provider-op-stats*
+  "Optional atom counting provider operation invocations by keyword."
+  nil)
+
+(defn- invalid-provider!
+  [message data]
+  (throw
+   (ex-info
+    message
+    (assoc data
+           :type :eacl/invalid-snapshot-provider
+           :eacl/error :eacl/invalid-snapshot-provider))))
+
+(defn- invalid-selected-snapshot!
+  [message data]
+  (throw
+   (ex-info
+    message
+    (assoc data
+           :type :eacl/invalid-selected-snapshot
+           :eacl/error :eacl/invalid-selected-snapshot))))
+
+(defn- normalize-execution-constraints
+  [backend-id constraints]
+  (let [constraints (or constraints default-execution-constraints)
+        expected (set (keys execution-constraint-values))]
+    (when-not (and (map? constraints)
+                   (= expected (set (keys constraints))))
+      (invalid-provider!
+       "Snapshot provider execution constraints have unknown or missing fields."
+       {:backend backend-id
+        :expected-keys expected
+        :actual-keys (when (map? constraints) (set (keys constraints)))}))
+    (doseq [[field supported] execution-constraint-values]
+      (when-not (contains? supported (get constraints field))
+        (invalid-provider!
+         "Snapshot provider declares an unknown execution constraint."
+         {:backend backend-id
+          :field field
+          :value (get constraints field)
+          :supported supported})))
+    constraints))
+
+(defn make-provider
+  "Constructs a validated long-lived snapshot provider.
+
+  Acquisition operations return exactly
+  `{:adapter v8-adapter :ownership :borrowed-or-owned :release-token x}`.
+  `:release!` accepts the opaque release token and must tolerate one call for
+  every successful acquisition. This namespace makes repeated core release
+  calls idempotent."
+  [{:keys [id capabilities traversal-execution topology execution-constraints
+           snapshot-ownership fingerprint deterministic? operations]
+    :or {traversal-execution backend/default-traversal-execution
+         topology {}
+         execution-constraints default-execution-constraints
+         deterministic? true}
+    :as provider-input}]
+  (let [unknown-keys (seq (remove provider-input-keys (keys provider-input)))]
+    (when unknown-keys
+      (invalid-provider!
+       "Snapshot provider has unknown fields."
+       {:backend id
+        :unknown-keys (vec unknown-keys)
+        :known-keys provider-input-keys})))
+  (when-not (keyword? id)
+    (invalid-provider! "Snapshot provider :id must be a keyword."
+                       {:backend id}))
+  (when-not (map? topology)
+    (invalid-provider! "Snapshot provider :topology must be a map."
+                       {:backend id :topology topology}))
+  (when-not (contains? ownership-policies snapshot-ownership)
+    (invalid-provider!
+     "Snapshot provider must declare borrowed, owned, or mixed ownership."
+     {:backend id
+      :snapshot-ownership snapshot-ownership
+      :supported ownership-policies}))
+  (when-not (map? operations)
+    (invalid-provider! "Snapshot provider :operations must be a map."
+                       {:backend id :operations operations}))
+  (let [missing
+        (seq
+         (remove #(fn? (get operations %))
+                 required-provider-operations))]
+    (when missing
+      (invalid-provider!
+       "Snapshot provider is missing required operations."
+       {:backend id
+        :missing-operations (vec missing)
+        :required-operations required-provider-operations})))
+  {::provider true
+   ::version provider-version
+   ::id id
+   ::capabilities (backend/normalize-capabilities id capabilities)
+   ::traversal-execution
+   (backend/normalize-traversal-execution id traversal-execution)
+   ::topology topology
+   ::execution-constraints
+   (normalize-execution-constraints id execution-constraints)
+   ::snapshot-ownership snapshot-ownership
+   ::fingerprint
+   (or fingerprint
+       {:backend id
+        :provider-version provider-version
+        :adapter-version backend/adapter-version})
+   ::deterministic? (boolean deterministic?)
+   ::operations operations})
+
+(defn provider?
+  [candidate]
+  (and (map? candidate)
+       (true? (::provider candidate))
+       (= provider-version (::version candidate))
+       (keyword? (::id candidate))
+       (map? (::capabilities candidate))
+       (map? (::traversal-execution candidate))
+       (map? (::topology candidate))
+       (map? (::execution-constraints candidate))
+       (contains? ownership-policies (::snapshot-ownership candidate))
+       (map? (::operations candidate))))
+
+(defn- require-provider
+  [provider]
+  (if (provider? provider)
+    provider
+    (invalid-provider! "Value is not a snapshot provider."
+                       {:value provider})))
+
+(defn backend-id
+  [provider]
+  (::id (require-provider provider)))
+
+(defn capabilities
+  [provider]
+  (::capabilities (require-provider provider)))
+
+(defn traversal-execution
+  [provider]
+  (::traversal-execution (require-provider provider)))
+
+(defn topology
+  [provider]
+  (::topology (require-provider provider)))
+
+(defn execution-constraints
+  [provider]
+  (::execution-constraints (require-provider provider)))
+
+(defn snapshot-ownership
+  [provider]
+  (::snapshot-ownership (require-provider provider)))
+
+(defn fingerprint
+  [provider]
+  (::fingerprint (require-provider provider)))
+
+(defn deterministic?
+  [provider]
+  (::deterministic? (require-provider provider)))
+
+(defn static-profile
+  "Returns the snapshot-free provider metadata used at client construction."
+  [provider]
+  {:backend-id (backend-id provider)
+   :capabilities (capabilities provider)
+   :traversal-execution (traversal-execution provider)
+   :topology (topology provider)
+   :execution-constraints (execution-constraints provider)
+   :snapshot-ownership (snapshot-ownership provider)
+   :fingerprint (fingerprint provider)
+   :deterministic? (deterministic? provider)})
+
+(defn supports?
+  ([provider capability]
+   (boolean (seq (get (capabilities provider) capability))))
+  ([provider capability requested]
+   (contains? (get (capabilities provider) capability #{}) requested)))
+
+(defn operation
+  [provider operation-key]
+  (let [provider (require-provider provider)]
+    (if-let [implementation (get (::operations provider) operation-key)]
+      implementation
+      (invalid-provider!
+       "Snapshot provider operation is unavailable."
+       {:backend (::id provider)
+        :operation operation-key
+        :supported (set (keys (::operations provider)))}))))
+
+(defn invoke
+  [provider operation-key & args]
+  (when *provider-op-stats*
+    (swap! *provider-op-stats* update operation-key (fnil inc 0)))
+  (apply (operation provider operation-key) args))
+
+(defn- virtual-thread?
+  []
+  #?(:clj
+     (try
+       (boolean
+        (clojure.lang.Reflector/invokeInstanceMethod
+         (Thread/currentThread) "isVirtual" (object-array 0)))
+       ;; Java runtimes before virtual threads have no `Thread.isVirtual`.
+       (catch Throwable _
+         false))
+     :cljs false))
+
+(defn- require-acquisition-runtime!
+  [provider]
+  (let [constraints (execution-constraints provider)]
+    (when (and (= :rejected (:virtual-threads constraints))
+               (virtual-thread?))
+      (throw
+       (ex-info
+        "Snapshot acquisition is unsupported on a virtual thread."
+        {:type :eacl/unsupported-runtime
+         :eacl/error :eacl/unsupported-runtime
+         :backend (backend-id provider)
+         :runtime :virtual-thread
+         :phase :snapshot-acquisition}))))
+  nil)
+
+(defn- require-owner-thread!
+  [selected constraint phase]
+  #?(:clj
+     (when (and (= :acquiring-thread constraint)
+                (not (identical? (::owner-thread selected)
+                                 (Thread/currentThread))))
+       (throw
+        (ex-info
+         "Selected snapshot operation escaped its acquiring thread."
+         {:type :eacl/snapshot-thread-violation
+          :eacl/error :eacl/snapshot-thread-violation
+          :backend (backend-id (::provider selected))
+          :phase phase
+          :constraint constraint})))
+     :cljs nil)
+  nil)
+
+(defn source-scope
+  "Returns provider-static source and branch identity without acquiring a DB."
+  [provider]
+  (let [scope (invoke provider :source-scope)]
+    (when-not (and (map? scope)
+                   (contains? scope :source-id)
+                   (contains? scope :branch))
+      (invalid-provider!
+       "Snapshot provider returned an invalid source scope."
+       {:backend (backend-id provider)
+        :source-scope scope}))
+    (select-keys scope [:source-id :branch])))
+
+(defn source-lifecycle
+  "Returns current provider continuity identity without acquiring a DB."
+  [provider]
+  (invoke provider :source-lifecycle))
+
+(defn selected-snapshot?
+  [candidate]
+  (and (map? candidate)
+       (true? (::selected-snapshot candidate))
+       (= selected-snapshot-version (::version candidate))
+       (provider? (::provider candidate))
+       (backend/adapter? (::adapter candidate))
+       (map? (::semantic-identity candidate))
+       (= semantic-identity-keys
+          (set (keys (::semantic-identity candidate))))
+       (contains? snapshot-ownerships (::ownership candidate))
+       #?(:clj (instance? clojure.lang.Atom (::release-state candidate))
+          :cljs (satisfies? IDeref (::release-state candidate)))
+       (contains? #{:open :releasing :released}
+                  @(::release-state candidate))))
+
+(defn- ownership-compatible?
+  [policy ownership]
+  (or (= :mixed policy)
+      (= policy ownership)))
+
+(defn- exact-natural?
+  [value]
+  (and (integer? value)
+       (not (neg? value))
+       (<= value backend/maximum-exact-integer)))
+
+(defn- adapter-semantic-identity
+  [adapter]
+  (let [backend-id (backend/backend-id adapter)
+        scope (backend/invoke adapter :source-scope)
+        lifecycle (backend/invoke adapter :source-lifecycle)
+        native-revision (backend/invoke adapter :native-revision)
+        snapshot-id (backend/invoke adapter :snapshot-id)
+        revision (:revision native-revision)
+        order-hint (backend/invoke adapter :order-hint)
+        exact-locator (backend/invoke adapter :exact-locator)]
+    (when-not (and (map? scope)
+                   (contains? scope :source-id)
+                   (contains? scope :branch))
+      (invalid-selected-snapshot!
+       "Selected adapter returned an invalid source scope."
+       {:backend backend-id :source-scope scope}))
+    (when-not (and (map? native-revision)
+                   (contains? native-revision :exact-locator)
+                   (exact-natural? revision)
+                   (= revision order-hint)
+                   (= (:exact-locator native-revision) exact-locator))
+      (invalid-selected-snapshot!
+       "Selected adapter returned an invalid native revision."
+       {:backend backend-id
+        :native-revision native-revision
+        :order-hint order-hint
+        :exact-locator exact-locator}))
+    (when-not (map? snapshot-id)
+      (invalid-selected-snapshot!
+       "Selected adapter returned an invalid snapshot identity."
+       {:backend backend-id :snapshot-id snapshot-id}))
+    {:backend backend-id
+     :source-id (:source-id scope)
+     :branch (:branch scope)
+     :source-lifecycle lifecycle
+     :revision revision
+     :exact-locator (:exact-locator native-revision)
+     :schema-identity (:schema-identity snapshot-id)
+     :backend-snapshot-id snapshot-id}))
+
+(defn- selected-snapshot
+  [provider {:keys [adapter ownership release-token] :as acquisition}]
+  (when-not (and (map? acquisition)
+                 (= raw-acquisition-keys (set (keys acquisition))))
+    (invalid-selected-snapshot!
+     "Provider acquisition must return the closed selected-snapshot map."
+     {:backend (backend-id provider)
+      :expected-keys raw-acquisition-keys
+      :actual-keys (when (map? acquisition) (set (keys acquisition)))}))
+  (when-not (backend/adapter? adapter)
+    (invalid-selected-snapshot!
+     "Provider acquisition did not return a v8 adapter."
+     {:backend (backend-id provider)
+      :adapter adapter}))
+  (when-not (= (backend-id provider) (backend/backend-id adapter))
+    (invalid-selected-snapshot!
+     "Provider acquisition crossed backend identity."
+     {:provider-backend (backend-id provider)
+      :adapter-backend (backend/backend-id adapter)}))
+  (when-not (contains? snapshot-ownerships ownership)
+    (invalid-selected-snapshot!
+     "Provider acquisition declared invalid ownership."
+     {:backend (backend-id provider)
+      :ownership ownership
+      :supported snapshot-ownerships}))
+  (when-not (ownership-compatible?
+             (snapshot-ownership provider)
+             ownership)
+    (invalid-selected-snapshot!
+     "Provider acquisition violated its static ownership policy."
+     {:backend (backend-id provider)
+      :provider-ownership (snapshot-ownership provider)
+      :acquisition-ownership ownership}))
+  (when-not (= (traversal-execution provider)
+               (backend/traversal-execution adapter))
+    (invalid-selected-snapshot!
+     "Selected adapter traversal profile differs from provider-static metadata."
+     {:backend (backend-id provider)}))
+  {::selected-snapshot true
+   ::version selected-snapshot-version
+   ::provider provider
+   ::adapter adapter
+   ::semantic-identity (adapter-semantic-identity adapter)
+   ::ownership ownership
+   ::release-token release-token
+   ::owner-thread #?(:clj (Thread/currentThread) :cljs nil)
+   ::release-state (atom :open)})
+
+(defn acquire!
+  "Acquires and validates one candidate selected snapshot.
+
+  `kind` is one of `:current`, `:authoritative`, `:at-least`, or `:exact`.
+  Remaining arguments are forwarded to that acquisition operation."
+  [provider kind & args]
+  (let [provider (require-provider provider)
+        operation-key (get acquisition-operations kind)]
+    (require-acquisition-runtime! provider)
+    (when-not operation-key
+      (invalid-provider!
+       "Unknown snapshot acquisition kind."
+       {:backend (backend-id provider)
+        :kind kind
+        :supported (set (keys acquisition-operations))}))
+    (let [acquisition (apply invoke provider operation-key args)]
+      (try
+        (selected-snapshot provider acquisition)
+        (catch #?(:clj Throwable :cljs :default) selection-error
+          ;; Any map returned from an acquisition operation represents a
+          ;; completed acquisition. Core therefore invokes cleanup even when
+          ;; the provider omitted the mandatory token; passing nil is the only
+          ;; fail-closed cleanup opportunity available for that malformed
+          ;; result. A conforming provider must accept exactly the token it
+          ;; returned, including nil when nil is its opaque token.
+          (when (map? acquisition)
+            (try
+              (invoke provider :release! (:release-token acquisition))
+              (catch #?(:clj Throwable :cljs :default) release-error
+                (throw
+                 (ex-info
+                  "Invalid snapshot acquisition also failed cleanup."
+                  {:type :eacl/snapshot-release-failed
+                   :eacl/error :eacl/snapshot-release-failed
+                   :backend (backend-id provider)
+                   :acquisition-error (ex-data selection-error)}
+                  release-error)))))
+          (throw selection-error))))))
+
+(defn released?
+  [selected]
+  (if (selected-snapshot? selected)
+    (= :released @(::release-state selected))
+    (invalid-selected-snapshot!
+     "Value is not a selected snapshot."
+     {:value selected})))
+
+(defn ownership
+  [selected]
+  (if (selected-snapshot? selected)
+    (::ownership selected)
+    (invalid-selected-snapshot!
+     "Value is not a selected snapshot."
+     {:value selected})))
+
+(defn semantic-identity
+  "Returns the immutable semantic equality identity captured at acquisition."
+  [selected]
+  (if (selected-snapshot? selected)
+    (::semantic-identity selected)
+    (invalid-selected-snapshot!
+     "Value is not a selected snapshot."
+     {:value selected})))
+
+(defn assert-open!
+  [selected]
+  (when-not (selected-snapshot? selected)
+    (invalid-selected-snapshot!
+     "Value is not a selected snapshot."
+     {:value selected}))
+  (case @(::release-state selected)
+    :open nil
+    :releasing
+    (throw
+     (ex-info
+      "Selected snapshot release is already in progress."
+      {:type :eacl/snapshot-release-in-progress
+       :eacl/error :eacl/snapshot-release-in-progress
+       :backend (backend-id (::provider selected))}))
+    :released
+    (throw
+     (ex-info
+      "Selected snapshot has already been released."
+      {:type :eacl/snapshot-released
+       :eacl/error :eacl/snapshot-released
+       :backend (backend-id (::provider selected))})))
+  (require-owner-thread!
+   selected
+   (:snapshot-thread
+    (execution-constraints (::provider selected)))
+   :snapshot-access)
+  selected)
+
+(defn adapter
+  "Returns the selected adapter while the selected snapshot is open."
+  [selected]
+  (::adapter (assert-open! selected)))
+
+(defn owner-thread
+  "Returns the acquiring thread on CLJ and nil on CLJS."
+  [selected]
+  (if (selected-snapshot? selected)
+    (::owner-thread selected)
+    (invalid-selected-snapshot!
+     "Value is not a selected snapshot."
+     {:value selected})))
+
+(defn release!
+  "Releases a selected snapshot at most once.
+
+  Returns true for the call that performs provider release and false after the
+  snapshot has already been released."
+  [selected]
+  (when-not (selected-snapshot? selected)
+    (invalid-selected-snapshot!
+     "Value is not a selected snapshot."
+     {:value selected}))
+  (require-owner-thread!
+   selected
+   (:release-thread
+    (execution-constraints (::provider selected)))
+   :snapshot-release)
+  (let [release-state (::release-state selected)]
+    (loop []
+      (case @release-state
+        :released false
+
+        :releasing
+        (throw
+         (ex-info
+          "Selected snapshot release is already in progress."
+          {:type :eacl/snapshot-release-in-progress
+           :eacl/error :eacl/snapshot-release-in-progress
+           :backend (backend-id (::provider selected))}))
+
+        :open
+        (if (compare-and-set! release-state :open :releasing)
+          (try
+            (invoke (::provider selected)
+                    :release!
+                    (::release-token selected))
+            (reset! release-state :released)
+            true
+            (catch #?(:clj Throwable :cljs :default) error
+              ;; A failed native release is not equivalent to a closed
+              ;; resource. Restore retryability and classify the boundary.
+              (reset! release-state :open)
+              (throw
+               (ex-info
+                "Snapshot provider failed to release an owned candidate."
+                {:type :eacl/snapshot-release-failed
+                 :eacl/error :eacl/snapshot-release-failed
+                 :backend (backend-id (::provider selected))}
+                error))))
+          (recur))))))
+
+(defn borrowed-adapter-provider
+  "Compatibility provider for backends whose selected DB values are immutable
+  and require no close.
+
+  `static-adapter` is inspected during construction only and is not retained.
+  Each acquisition callback must return a newly selected adapter (or throw).
+  This compatibility path must never be used for a mutable or closeable native
+  value."
+  [{:keys [static-adapter topology execution-constraints source-scope-fn
+           source-lifecycle-fn acquire-current! acquire-authoritative!
+           acquire-at-least! acquire-exact!]}]
+  (when-not (backend/adapter? static-adapter)
+    (invalid-provider!
+     "Borrowed compatibility provider requires a static v8 adapter."
+     {:adapter static-adapter}))
+  (doseq [[operation-key f]
+          [[:source-scope source-scope-fn]
+           [:source-lifecycle source-lifecycle-fn]
+           [:acquire-current! acquire-current!]
+           [:acquire-authoritative! acquire-authoritative!]
+           [:acquire-at-least! acquire-at-least!]
+           [:acquire-exact! acquire-exact!]]]
+    (when-not (fn? f)
+      (invalid-provider!
+       "Borrowed compatibility provider requires every callback."
+       {:backend (backend/backend-id static-adapter)
+        :operation operation-key})))
+  (let [backend-id (backend/backend-id static-adapter)
+        capabilities (backend/capabilities static-adapter)
+        traversal-execution (backend/traversal-execution static-adapter)
+        fingerprint (backend/fingerprint static-adapter)
+        deterministic? (backend/deterministic? static-adapter)
+        acquired
+        (fn [candidate]
+          (when-not (backend/adapter? candidate)
+            (invalid-selected-snapshot!
+             "Borrowed provider acquisition returned no immutable adapter."
+             {:backend backend-id :adapter candidate}))
+          {:adapter candidate
+           :ownership :borrowed
+           :release-token nil})]
+    (make-provider
+     {:id backend-id
+      :capabilities capabilities
+      :traversal-execution traversal-execution
+      :topology (or topology {:snapshot-values :immutable})
+      :execution-constraints
+      (or execution-constraints default-execution-constraints)
+      :snapshot-ownership :borrowed
+      :fingerprint fingerprint
+      :deterministic? deterministic?
+      :operations
+      {:source-scope source-scope-fn
+       :source-lifecycle source-lifecycle-fn
+       :acquire-current! #(acquired (acquire-current!))
+       :acquire-authoritative!
+       #(acquired (acquire-authoritative! %))
+       :acquire-at-least!
+       #(acquired (acquire-at-least! %1 %2))
+       :acquire-exact!
+       #(acquired (acquire-exact! %1 %2))
+       :release! (constantly nil)}})))

--- a/modules/eacl/src/eacl/backend/v8.cljc
+++ b/modules/eacl/src/eacl/backend/v8.cljc
@@ -475,14 +475,6 @@
   (and (exact-integer? value)
        (not (neg? value))))
 
-(defn- strictly-ordered?
-  [direction values]
-  (or (< (count values) 2)
-      (every?
-       (fn [[left right]]
-         ((if (= :desc direction) > <) left right))
-       (partition 2 1 values))))
-
 (defn- within-bound?
   [direction bound inclusive? value]
   (if (= :desc direction)
@@ -499,33 +491,36 @@
     (when-not (sequential? value)
       (contract-violation!
        backend-id operation-key :finite-sequential-result value))
-    (let [values (vec value)]
-      (when-not (every? exact-integer? values)
-        (contract-violation!
-         backend-id operation-key :exact-integer values))
-      (when-not (every? exact-natural? values)
-        (contract-violation!
-         backend-id operation-key :nonnegative values))
-      (when-not (= (count values) (count (distinct values)))
-        (contract-violation!
-         backend-id operation-key :unique values))
-      (when-not (contains? #{:asc :desc} direction)
-        (contract-violation!
-         backend-id operation-key :known-direction direction))
-      (when-not (strictly-ordered? direction values)
-        (contract-violation!
-         backend-id operation-key :strict-order values))
-      (when (and (some? bound)
-                 (not
-                  (every?
-                   #(within-bound?
-                     direction bound inclusive? %)
-                   values)))
-        (contract-violation!
-         backend-id operation-key
-         :inclusive-exclusive-bound
-         {:options options :values values}))
-      value)))
+    (when-not (contains? #{:asc :desc} direction)
+      (contract-violation!
+       backend-id operation-key :known-direction direction))
+    (loop [remaining (seq value)
+           previous nil
+           first? true]
+      (if-not remaining
+        value
+        (let [item (first remaining)]
+          (when-not (exact-integer? item)
+            (contract-violation!
+             backend-id operation-key :exact-integer value))
+          (when-not (exact-natural? item)
+            (contract-violation!
+             backend-id operation-key :nonnegative value))
+          (when-not first?
+            (if (= previous item)
+              (contract-violation!
+               backend-id operation-key :unique value)
+              (when-not ((if (= :desc direction) > <) previous item)
+                (contract-violation!
+                 backend-id operation-key :strict-order value))))
+          (when (and (some? bound)
+                     (not (within-bound?
+                           direction bound inclusive? item)))
+            (contract-violation!
+             backend-id operation-key
+             :inclusive-exclusive-bound
+             {:options options :values value}))
+          (recur (next remaining) item false))))))
 
 (defn- guard-output!
   [adapter operation-key args value]

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -11,8 +11,12 @@
     :db                         (fn [conn] db) - current immutable value
     :entid                      (fn [db lookup-ref-or-eid] eid-or-nil)
     :default-entid->object-id   (fn [db eid] external-id-or-nil)
-    :snapshot-adapter           (fn [db opts] v8-adapter)
+    :snapshot-adapter           (fn [db opts] v8-adapter), for raw DB helpers
+    :snapshot-provider          (fn [conn opts] long-lived provider)
+    :db-native-revision         (fn [db] committed native revision map)
     :native-source-id           optional (fn [conn] stable source identity)
+    :prepared-native-source-id-key optional private config key populated by
+                                  a backend bootstrap wrapper
     :relationship-retraction-count (fn [db tx-data] n)
     :schema  {:read-schema    (fn [db] ...)
               :write-schema!  (fn [conn schema-string opts] ...)}
@@ -26,6 +30,7 @@
     :extra-client-opt-keys      set of documented per-backend extension
                                 option keys accepted by make-client"
   (:require [com.rpl.specter :as S]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.backend.v8 :as backend]
             [eacl.cache :as cache]
             [eacl.causal-token :as causal-token]
@@ -34,6 +39,7 @@
             [eacl.cursor :as cursor]
             [eacl.core :as eacl :refer [IAuthorization
                                         IDetailedAuthorization
+                                        ISnapshotAuthorization
                                         spice-object
                                         ->Relationship
                                         ->RelationshipUpdate]]
@@ -122,19 +128,55 @@
         (:resource cursor) (S/transform [:resource :id] #(object-id->entid db %) cursor)
         (:subject cursor) (S/transform [:subject :id] #(object-id->entid db %) cursor)))))
 
+(defn- adapter-semantic-identity
+  [adapter]
+  (let [scope (consistency-v3/source-scope adapter)
+        revision (consistency-v3/native-revision adapter)
+        snapshot-id (backend/invoke adapter :snapshot-id)]
+    {:backend (backend/backend-id adapter)
+     :source-id (:source-id scope)
+     :branch (:branch scope)
+     :source-lifecycle (:source-lifecycle scope)
+     :revision (:revision revision)
+     :exact-locator (:exact-locator revision)
+     :schema-identity (:schema-identity snapshot-id)
+     :backend-snapshot-id snapshot-id}))
+
+(defn- release-selected-after-error!
+  "Closes ownership that was transferred into orchestration before propagating
+  a context-construction failure. A failed cleanup is classified explicitly
+  and retains the original failure as data."
+  [selected error]
+  (when selected
+    (try
+      (snapshot-provider/release! selected)
+      (catch #?(:clj Throwable :cljs :default) release-error
+        (throw
+         (ex-info
+          "Request context construction failed and snapshot cleanup also failed."
+          {:type :eacl/snapshot-release-failed
+           :eacl/error :eacl/snapshot-release-failed
+           :context-error (ex-data error)}
+          release-error)))))
+  (throw error))
+
 (defn- selected-context
-  [api db opts consistency-value]
+  [api source opts consistency-value]
   (let [contract (:execution-contract opts)
         _ (execution/check! contract :consistency-selection)
         descriptor (consistency/descriptor consistency-value)
-        source-adapter ((:snapshot-adapter api) db opts)
-        _ (when (and (= :datascript (backend/backend-id source-adapter))
+        provider? (snapshot-provider/provider? source)
+        source-adapter (when-not provider?
+                         ((:snapshot-adapter api) source opts))
+        _ (when (and (not provider?)
+                     (= :datascript (backend/backend-id source-adapter))
                      (= :at-exact-snapshot (:mode descriptor)))
             (throw
              (ex-info
               "DataScript is current-basis-only and does not retain exact historical snapshots."
-              {:type :eacl/unsupported-capability
-               :eacl/error :eacl/unsupported-capability
+              {:type :eacl.consistency/exact-snapshot-unavailable
+               :eacl/error :eacl.consistency/exact-snapshot-unavailable
+               :reason :exact-snapshot-unavailable
                :backend :datascript
                :capability :consistency
                :requested :at-exact-snapshot
@@ -147,32 +189,63 @@
         {:format-options (:format-options opts)
          :decision-kernel (:decision-kernel opts)
          :issue-token? false
+         :selection-check!
+         (when contract
+           (fn [phase]
+             (execution/check! contract phase)))
          :timeout-ms
          (if contract
            (min (:consistency-sync-timeout-ms opts)
                 (execution/remaining-millis contract))
            (:consistency-sync-timeout-ms opts))}
         selection
-        (if (= :minimize-latency (:mode descriptor))
-          (consistency-v3/captured-current-selection
-           source-adapter consistency-value selection-options)
+        (if provider?
           (consistency-v3/select
-           source-adapter
-           consistency-value
-           selection-options))
-        adapter (:adapter selection)]
-    (execution/check! contract :consistency-selected)
-    {:adapter adapter
-     :db (:db (backend/state adapter))
-     :selection selection
-     :snapshot-exact?
-     (= :at-exact-snapshot
-        (get-in selection [:descriptor :mode]))
-     :completed-cache?
-     (and (:completed-cache-request? opts)
-          (or (not= :at-exact-snapshot
-                    (get-in selection [:descriptor :mode]))
-              (backend/deterministic? adapter)))}))
+           source consistency-value selection-options)
+          (if (= :minimize-latency (:mode descriptor))
+            (consistency-v3/captured-current-selection
+             source-adapter consistency-value selection-options)
+            (consistency-v3/select
+             source-adapter consistency-value selection-options)))
+        adapter (:adapter selection)
+        selected (:selected-snapshot selection)]
+    (try
+      (execution/check! contract :consistency-selected)
+      {:adapter adapter
+       :db (:db (backend/state adapter))
+       :selection selection
+       :selected-snapshot selected
+       :snapshot-semantic-identity
+       (if selected
+         (snapshot-provider/semantic-identity selected)
+         (adapter-semantic-identity adapter))
+       :snapshot-exact?
+       (= :at-exact-snapshot
+          (get-in selection [:descriptor :mode]))
+       :completed-cache?
+       (and (:completed-cache-request? opts)
+            (or (not= :at-exact-snapshot
+                      (get-in selection [:descriptor :mode]))
+                (backend/deterministic? adapter)))}
+      (catch #?(:clj Throwable :cljs :default) error
+        (release-selected-after-error! selected error)))))
+
+(defn- with-selected-context
+  [api source opts consistency-value f]
+  (let [context (selected-context api source opts consistency-value)]
+    (try
+      (f context)
+      (finally
+        (when-let [selected (:selected-snapshot context)]
+          (snapshot-provider/release! selected))))))
+
+(defn- selected-cache-options
+  [opts context]
+  (assoc opts
+         :completed-cache? (:completed-cache? context)
+         :snapshot-exact? (:snapshot-exact? context)
+         :snapshot-semantic-identity
+         (:snapshot-semantic-identity context)))
 
 (defn- permission-dependencies
   [adapter resource-type permission]
@@ -206,15 +279,22 @@
   is actually minted or resumed."
   [adapter opts selection resource-type permission]
   (let [contract (:execution-contract opts)
+        candidate-proof-frame (:request-proof-frame opts)
+        reuse-request-context?
+        (and candidate-proof-frame
+             (identical? adapter (:adapter candidate-proof-frame)))
         request-proof-frame
-        (or (:request-proof-frame opts)
-            (new-request-proof-frame adapter opts))
+        (if reuse-request-context?
+          candidate-proof-frame
+          (new-request-proof-frame adapter opts))
         schema-cache
-        (delay
-          (binding [engine/*proof-frame* request-proof-frame]
-            (engine/schema-cache-for!
-             (:derived-schema-caches opts)
-             adapter)))]
+        (or (when reuse-request-context?
+              (:request-schema-cache opts))
+            (delay
+              (binding [engine/*proof-frame* request-proof-frame]
+                (engine/schema-cache-for!
+                 (:derived-schema-caches opts)
+                 adapter))))]
     (assoc opts
            :request-proof-frame request-proof-frame
            :cursor-consistency-mode
@@ -250,7 +330,13 @@
 
 (defn- page-context
   [opts selection operation query resource-type permission]
-  (let [adapter (:adapter selection)
+  (let [;; Low-level raw-DB entry points may receive a client's opts map. They
+        ;; must remain bound to that caller-owned DB and must not reach through
+        ;; the client's live provider during cursor recovery.
+        opts (if (:selected-snapshot selection)
+               opts
+               (dissoc opts :snapshot-provider))
+        adapter (:adapter selection)
         current-opts
         (cursor-options
          adapter opts selection resource-type permission)
@@ -259,30 +345,53 @@
          adapter current-opts operation query)
         page-adapter
         (:adapter prepared)
-        snapshot-exact?
-        (or (= :at-exact-snapshot
-               (get-in selection [:descriptor :mode]))
-            (not
-             (identical?
-              (:db (backend/state adapter))
-              (:db (backend/state page-adapter)))))
-        page-opts
-        (assoc
-         (cursor-options
-          page-adapter opts selection resource-type permission)
-         :snapshot-exact? snapshot-exact?
-         :completed-cache?
-         (and
-          (:completed-cache-request? opts)
-          ;; Historical completed-answer reuse additionally requires a stable
-          ;; adapter/identity contract. Cursor authentication and exact
-          ;; selection have already happened before this decision.
-          (or (not snapshot-exact?)
-              (backend/deterministic? page-adapter))))]
-    {:adapter page-adapter
-     :db (:db (backend/state page-adapter))
-     :opts page-opts
-     :query (:query prepared)}))
+        page-selected-snapshot (:selected-snapshot prepared)]
+    (try
+      (let [initial-semantic-identity
+            (if-let [selected (:selected-snapshot selection)]
+              (snapshot-provider/semantic-identity selected)
+              (adapter-semantic-identity adapter))
+            page-semantic-identity
+            (if page-selected-snapshot
+              (snapshot-provider/semantic-identity page-selected-snapshot)
+              (adapter-semantic-identity page-adapter))
+            snapshot-exact?
+            (or (= :at-exact-snapshot
+                   (get-in selection [:descriptor :mode]))
+                (not= initial-semantic-identity page-semantic-identity))
+            page-opts
+            (assoc
+             (cursor-options
+              page-adapter opts selection resource-type permission)
+             :snapshot-semantic-identity page-semantic-identity
+             :snapshot-exact? snapshot-exact?
+             :completed-cache?
+             (and
+              (:completed-cache-request? opts)
+              ;; Historical completed-answer reuse additionally requires a stable
+              ;; adapter/identity contract. Cursor authentication and exact
+              ;; selection have already happened before this decision.
+              (or (not snapshot-exact?)
+                  (backend/deterministic? page-adapter))))]
+        {:adapter page-adapter
+         :selected-snapshot page-selected-snapshot
+         :snapshot-semantic-identity page-semantic-identity
+         :db (:db (backend/state page-adapter))
+         :opts page-opts
+         :query (:query prepared)})
+      (catch #?(:clj Throwable :cljs :default) error
+        (release-selected-after-error! page-selected-snapshot error)))))
+
+(defn- with-page-context
+  [opts selection operation query resource-type permission f]
+  (let [context
+        (page-context
+         opts selection operation query resource-type permission)]
+    (try
+      (f context)
+      (finally
+        (when-let [selected (:selected-snapshot context)]
+          (snapshot-provider/release! selected))))))
 
 (defn- cached-engine-result
   [adapter opts operation query resource-type permission
@@ -343,7 +452,7 @@
               (proof-frame/resolve!
                request-proof-frame
                (:relation-ids @dependencies)))
-            db (:db (backend/state adapter))
+            semantic-snapshot (:snapshot-semantic-identity opts)
             semantic-key
             {:operation operation
              :query query
@@ -377,10 +486,10 @@
                    semantic-key operation valid-value? evaluate)
                   (cache/resolve-current!
                    (:current-cache-store opts)
-                   {:snapshot db
+                   {:snapshot semantic-snapshot
                     :cache-lifecycle (:cache-lifecycle opts)
-                    :snapshot-order (:max-tx db)
-                    :same-snapshot? identical?
+                    :snapshot-order (:revision semantic-snapshot)
+                    :same-snapshot? =
                     :snapshot-exact-key (cache/snapshot-exact-key adapter)
                     :cache-basis (backend/invoke adapter :snapshot-id)
                     :decision-kernel (:decision-kernel opts)
@@ -457,78 +566,88 @@
   (let [cache engine/*schema-cache*
         slot (:parsed-schema cache)
         read-schema (get-in api [:schema :read-schema])]
-    (if (and slot (some? (:schema-version cache)))
+    (if (and slot
+             (or (some? (:schema-version cache))
+                 (true? (:request-local? cache))))
       (or @slot
           (reset! slot (read-schema db)))
       (read-schema db))))
 
 (defn read-relationships
-  [api db
+  [api source
    {:as opts
    :keys [object-id->entid]}
    filters]
   ;; The unified filter contract validates the complete public query before
   ;; any snapshot selection or cursor work (backend-unification 9.1).
   (relationship-filters/validate! filters)
-  (let [opts (ensure-execution-contract opts :read-relationships filters)
-        {selection :selection}
-        (selected-context api db opts (:consistency filters))
-        {adapter :adapter page-db :db cursor-opts :opts
-         page-query :query}
-        (page-context
-         opts selection :read-relationships filters nil nil)
-        ;; Schema validation runs on the miss path (inside the bound schema
-        ;; generation) and on the unknown-object short-circuit; a cache hit
-        ;; implies the request validated under an equal schema generation.
-        validate!
-        (fn []
-          (schema-errors/validate-relationship-read!
-           (request-schema api page-db)
-           filters))
-        base-filters
-        (apply dissoc filters
-               [:first :last :after :before :consistency :cache?
-                :timeout-ms :cancellation-token])
-        subject-id (:subject/id base-filters)
-        resource-id (:resource/id base-filters)
-        subject-eid (when subject-id
-                      (object-id->entid page-db subject-id))
-        resource-eid (when resource-id
-                       (object-id->entid page-db resource-id))
-        internal-query
-        (-> page-query
-            (dissoc :consistency :timeout-ms :cancellation-token)
-            (cond->
-              subject-id (assoc :subject/id subject-eid)
-              resource-id (assoc :resource/id resource-eid)))]
-    (if (or (and subject-id (nil? subject-eid))
-            (and resource-id (nil? resource-eid)))
-      (do
-        (validate!)
-        (if (cursor-request? filters)
-          (stale-cursor-anchor! :read-relationships)
-          (assoc relay/empty-page :cached? false :cache-basis nil)))
-      (or
-       (relay/lookup-visited-page
-        adapter cursor-opts :read-relationships filters)
-       (let [answer
-             (cached-engine-result
-              adapter cursor-opts :read-relationships
-              (cache/lookup-page-query-identity filters internal-query)
-              nil nil
-              #(and (map? %) (vector? (:data %)) (map? (:page-info %)))
-              #(do
-                 (validate!)
-                 ((get-in api [:impl :read-relationships])
-                  page-db internal-query (:decision-kernel cursor-opts))))
-             page
-             (with-cache-info
-               (relay/externalize-relationship-page
-                adapter cursor-opts :read-relationships filters
-                (:value answer))
-               answer)]
-         (relay/remember-visited-page!
-          adapter cursor-opts :read-relationships filters page))))))
+  (let [opts (ensure-execution-contract opts :read-relationships filters)]
+    (with-selected-context
+     api source opts (:consistency filters)
+     (fn [{selection :selection}]
+       (with-page-context
+        opts selection :read-relationships filters nil nil
+        (fn [{adapter :adapter page-db :db cursor-opts :opts
+              page-query :query}]
+          (let [;; Schema validation runs on the miss path (inside the bound
+                ;; schema generation) and on the unknown-object short-circuit.
+                validate!
+                (fn []
+                  (schema-errors/validate-relationship-read!
+                   (request-schema api page-db)
+                   filters))
+                base-filters
+                (apply dissoc filters
+                       [:first :last :after :before :consistency :cache?
+                        :timeout-ms :cancellation-token])
+                subject-id (:subject/id base-filters)
+                resource-id (:resource/id base-filters)
+                subject-eid
+                (when subject-id
+                  (object-id->entid page-db subject-id))
+                resource-eid
+                (when resource-id
+                  (object-id->entid page-db resource-id))
+                internal-query
+                (-> page-query
+                    (dissoc :consistency :timeout-ms :cancellation-token)
+                    (cond->
+                      subject-id (assoc :subject/id subject-eid)
+                      resource-id (assoc :resource/id resource-eid)))]
+            (if (or (and subject-id (nil? subject-eid))
+                    (and resource-id (nil? resource-eid)))
+              (do
+                (validate!)
+                (if (cursor-request? filters)
+                  (stale-cursor-anchor! :read-relationships)
+                  (assoc relay/empty-page
+                         :cached? false :cache-basis nil)))
+              (or
+               (relay/lookup-visited-page
+                adapter cursor-opts :read-relationships filters)
+               (let [answer
+                     (cached-engine-result
+                      adapter cursor-opts :read-relationships
+                      (cache/lookup-page-query-identity
+                       filters internal-query)
+                      nil nil
+                      #(and (map? %)
+                            (vector? (:data %))
+                            (map? (:page-info %)))
+                      #(do
+                         (validate!)
+                         ((get-in api [:impl :read-relationships])
+                          page-db internal-query
+                          (:decision-kernel cursor-opts))))
+                     page
+                     (with-cache-info
+                       (relay/externalize-relationship-page
+                        adapter cursor-opts :read-relationships filters
+                        (:value answer))
+                       answer)]
+                 (relay/remember-visited-page!
+                  adapter cursor-opts :read-relationships filters
+                  page)))))))))))
 
 (defn spice-relationship->internal
   [db {:keys [spice-object->internal object-id->lookup-ref]}
@@ -542,20 +661,68 @@
      :relation relation
      :resource (internalize resource)}))
 
+(defn- response-token-for-revision
+  [api native-revision opts]
+  (let [provider (:snapshot-provider opts)]
+    (if (snapshot-provider/provider? provider)
+      (causal-token/issue
+       (:format-options opts)
+       (merge
+        {:backend (snapshot-provider/backend-id provider)
+         :source-lifecycle
+         (snapshot-provider/source-lifecycle provider)}
+        (snapshot-provider/source-scope provider)
+        native-revision))
+      nil)))
+
 (defn- response-token
   [api db opts]
-  (let [adapter ((:snapshot-adapter api) db opts)]
-    (causal-token/issue
-     (:format-options opts)
-     (merge
-      (consistency-v3/source-scope adapter)
-      (consistency-v3/native-revision adapter)))))
+  (if-let [native-revision-fn (:db-native-revision api)]
+    (response-token-for-revision api (native-revision-fn db) opts)
+    (let [adapter ((:snapshot-adapter api) db opts)]
+      (causal-token/issue
+       (:format-options opts)
+       (merge
+        (consistency-v3/source-scope adapter)
+        (consistency-v3/native-revision adapter))))))
 
 (defn- write-response
   [api db opts]
   (if-let [token (response-token api db opts)]
     {:zed/token token}
     {}))
+
+(defn- write-response-for-revision
+  [api native-revision opts]
+  (if-let [token
+           (response-token-for-revision api native-revision opts)]
+    {:zed/token token}
+    {}))
+
+(defn- committed-write-response
+  "Acknowledges one committed backend revision only after any backend-specific
+  monotonic durability hook has completed."
+  [api db opts]
+  (if-let [native-revision-fn (:db-native-revision api)]
+    (let [native-revision (native-revision-fn db)]
+      (when-let [after-commit! (:after-commit! api)]
+        (after-commit! native-revision opts))
+      (write-response-for-revision api native-revision opts))
+    (write-response api db opts)))
+
+(defn- with-write-planning-context
+  [api conn opts f]
+  (if-let [provider (:snapshot-provider opts)]
+    (with-selected-context
+     api provider opts consistency/minimize-latency
+     (fn [{:keys [db selection]}]
+       {:plan (f db)
+        :native-revision (:native-revision selection)}))
+    (let [db ((:db api) conn)
+          adapter ((:snapshot-adapter api) db opts)]
+      {:plan (f db)
+       :native-revision (consistency-v3/native-revision adapter)
+       :raw-db db})))
 
 (defn- relationship-commit-preconditions-first
   "Moves relationship transaction functions ahead of the mutations they
@@ -587,56 +754,71 @@
         updates (vec updates)
         _ (doseq [{:keys [operation]} updates]
             (validate-operation! operation))
-        db      ((:db api) conn)
-        schema  ((get-in api [:schema :read-schema]) db)
-        _ (doseq [{:keys [relationship]} updates]
-            (schema-errors/validate-relationship-write!
-             schema :write-relationships
-             {:resource-type (:type (:resource relationship))
-              :subject-type (:type (:subject relationship))
-              :relation (:relation relationship)}))
-        internal-updates
-        (S/transform [S/ALL :relationship]
-                     #(spice-relationship->internal db opts %)
-                     updates)
-        _ (relationship-mutations/validate-batch! internal-updates)
-        tx-data (->> internal-updates
-                     (mapcat #(tx-update-relationship db %))
-                     (remove nil?)
-                     distinct
-                     vec
-                     relationship-commit-preconditions-first)]
+        {tx-data :plan planning-revision :native-revision raw-db :raw-db}
+        (with-write-planning-context
+         api conn opts
+         (fn [db]
+           (let [schema ((get-in api [:schema :read-schema]) db)
+                 _ (doseq [{:keys [relationship]} updates]
+                     (schema-errors/validate-relationship-write!
+                      schema :write-relationships
+                      {:resource-type
+                       (:type (:resource relationship))
+                       :subject-type
+                       (:type (:subject relationship))
+                       :relation (:relation relationship)}))
+                 internal-updates
+                 (S/transform
+                  [S/ALL :relationship]
+                  #(spice-relationship->internal db opts %)
+                  updates)
+                 _ (relationship-mutations/validate-batch!
+                    internal-updates)]
+             (->> internal-updates
+                  (mapcat #(tx-update-relationship db %))
+                  (remove nil?)
+                  distinct
+                  vec
+                  relationship-commit-preconditions-first))))]
     (if (seq tx-data)
       (let [report
             ((:transact! api)
              conn
              {:tx-data tx-data})]
-        (write-response api (:db-after report) opts))
-      (write-response api ((:db api) conn) opts))))
+        (committed-write-response api (:db-after report) opts))
+      (if raw-db
+        (write-response api raw-db opts)
+        (write-response-for-revision api planning-revision opts)))))
 
 (defn delete-object!
   "Removes every relationship that references `object`, without retracting the
   object entity itself."
   [api conn {:keys [object->entid] :as opts} object]
-  (let [db ((:db api) conn)
-        object-eid
-        (or (try
-              (object->entid db object)
-              (catch #?(:clj Exception :cljs :default) _
-                nil))
-            (when (number? (:id object))
-              (:id object)))
-        tx-data ((get-in api [:impl :tx-delete-object]) db object-eid)]
+  (let [{tx-data :plan planning-revision :native-revision raw-db :raw-db}
+        (with-write-planning-context
+         api conn opts
+         (fn [db]
+           (let [object-eid
+                 (or (try
+                       (object->entid db object)
+                       (catch #?(:clj Exception :cljs :default) _
+                         nil))
+                     (when (number? (:id object))
+                       (:id object)))]
+             ((get-in api [:impl :tx-delete-object]) db object-eid))))]
     (if (seq tx-data)
       (let [report
             ((:transact! api)
              conn
              {:tx-data tx-data})]
-        (assoc (write-response api (:db-after report) opts)
+        (assoc (committed-write-response api (:db-after report) opts)
                :retracted-datoms
                ((:relationship-retraction-count api)
                 (:db-after report) (:tx-data report))))
-      (assoc (write-response api ((:db api) conn) opts)
+      (assoc (if raw-db
+               (write-response api raw-db opts)
+               (write-response-for-revision
+                api planning-revision opts))
              :retracted-datoms 0))))
 
 (defn- relationship-seq
@@ -646,7 +828,7 @@
     relationships))
 
 (defn check-permission
-  [api db {:keys [spice-object->internal] :as opts}
+  [api source {:keys [spice-object->internal] :as opts}
    subject permission resource consistency]
   (let [request
         (merge {:subject subject
@@ -655,349 +837,506 @@
                 :consistency consistency}
                (:execution-request opts))
         opts (ensure-execution-contract
-              opts (or (:request-operation opts) :can?) request)
-        {selected-db :db adapter :adapter
-         completed-cache? :completed-cache?
-         snapshot-exact? :snapshot-exact?}
-        (selected-context api db opts consistency)
-        opts (assoc opts
-                    :completed-cache? completed-cache?
-                    :snapshot-exact? snapshot-exact?)
-        validate!
-        (fn []
-          (schema-errors/validate-permission-request!
-           (request-schema api selected-db)
-           (or (:request-operation opts) :can?)
-           {:resource-type (:type resource)
-            :subject-type (:type subject)
-            :permission permission}))
-        internal-subject (spice-object->internal selected-db subject)
-        internal-resource (spice-object->internal selected-db resource)]
-    (if-not (and (:id internal-subject) (:id internal-resource))
-      (do
-        (validate!)
-        {:allowed? false
-         :cached? false
-         :cache-basis nil
-         :evaluation (get-in opts [:execution-contract :evaluation])})
-      (let [answer
-            (cached-engine-result
-             adapter opts :can?
-             {:public [subject permission resource]
-              :internal
-              [internal-subject permission internal-resource]}
-             (:type internal-resource)
-             permission
-             boolean?
-             #(do
-                (validate!)
-                (engine/can?
-                 adapter internal-subject permission internal-resource)))]
-        {:allowed? (:value answer)
-         :cached? (:cached? answer)
-         :cache-basis (:cache-basis answer)
-         :evaluation (get-in opts [:execution-contract :evaluation])}))))
+              opts (or (:request-operation opts) :can?) request)]
+    (with-selected-context
+     api source opts consistency
+     (fn [{selected-db :db adapter :adapter
+           completed-cache? :completed-cache?
+           snapshot-exact? :snapshot-exact?
+           semantic-identity :snapshot-semantic-identity}]
+       (let [opts (assoc opts
+                         :completed-cache? completed-cache?
+                         :snapshot-exact? snapshot-exact?
+                         :snapshot-semantic-identity semantic-identity)
+             validate!
+             (fn []
+               (schema-errors/validate-permission-request!
+                (request-schema api selected-db)
+                (or (:request-operation opts) :can?)
+                {:resource-type (:type resource)
+                 :subject-type (:type subject)
+                 :permission permission}))
+             internal-subject
+             (spice-object->internal selected-db subject)
+             internal-resource
+             (spice-object->internal selected-db resource)]
+         (if-not (and (:id internal-subject) (:id internal-resource))
+           (do
+             (validate!)
+             {:allowed? false
+              :cached? false
+              :cache-basis nil
+              :evaluation
+              (get-in opts [:execution-contract :evaluation])})
+           (let [answer
+                 (cached-engine-result
+                  adapter opts :can?
+                  {:public [subject permission resource]
+                   :internal
+                   [internal-subject permission internal-resource]}
+                  (:type internal-resource)
+                  permission
+                  boolean?
+                  #(do
+                     (validate!)
+                     (engine/can?
+                      adapter internal-subject permission
+                      internal-resource)))]
+             {:allowed? (:value answer)
+              :cached? (:cached? answer)
+              :cache-basis (:cache-basis answer)
+              :evaluation
+              (get-in opts [:execution-contract :evaluation])})))))))
 
 (defn can?
-  [api db opts subject permission resource consistency]
+  [api source opts subject permission resource consistency]
   (:allowed?
    (check-permission
-    api db opts subject permission resource consistency)))
+    api source opts subject permission resource consistency)))
 
 (defn lookup-resources
-  [api db
+  [api source
    {:as opts :keys [spice-object->internal]}
    {:as query :keys [subject]}]
-  (let [opts (ensure-execution-contract opts :lookup-resources query)
-        {selection :selection}
-        (selected-context api db opts (:consistency query))
-        {adapter :adapter selected-db :db cursor-opts :opts
-         page-query :query}
-        (page-context
-         opts selection :lookup-resources query
-         (:resource/type query) (:permission query))
-        validate!
-        (fn []
-          (schema-errors/validate-permission-request!
-           (request-schema api selected-db)
-           :lookup-resources
-           {:resource-type (:resource/type query)
-            :subject-type (:type subject)
-            :permission (:permission query)}))
-        internal-subject (spice-object->internal selected-db subject)]
-    (if (nil? (:id internal-subject))
-      (do
-        (validate!)
-        (if (cursor-request? query)
-          (stale-cursor-anchor! :lookup-resources)
-          (assoc relay/empty-page :cached? false :cache-basis nil)))
-      (or
-       (relay/lookup-visited-page
-        adapter cursor-opts :lookup-resources query)
-       (let [internal-query
-             (-> page-query
-                 (dissoc :consistency :evaluation :timeout-ms
-                         :cancellation-token)
-                 (assoc :subject internal-subject))
-             answer
-             (cached-engine-result
-              adapter cursor-opts :lookup-resources
-              (cache/lookup-page-query-identity query internal-query)
-              (:resource/type internal-query)
-              (:permission internal-query)
-              #(and (map? %) (vector? (:data %))
-                    (map? (:page-info %)))
-              #(do
-                 (validate!)
-                 (engine/lookup-resources
-                  adapter
-                  internal-query
-                  ;; Thunked: the engine forces this only on the
-                  ;; first-discovery route — an acyclic keyset page
-                  ;; never pays for context it cannot use.
-                  {:continuation-cache-fn
-                   (fn []
-                     (continuation-context
-                      adapter cursor-opts :lookup-resources query))})))
-             page
-             (with-cache-info
-               (binding [subproblem/*store*
-                         (:subproblem-store answer)
-                         subproblem/*decision-kernel*
-                         (:decision-kernel cursor-opts)]
-                 (relay/externalize-page
+  (let [opts (ensure-execution-contract opts :lookup-resources query)]
+    (with-selected-context
+     api source opts (:consistency query)
+     (fn [{selection :selection}]
+       (with-page-context
+        opts selection :lookup-resources query
+        (:resource/type query) (:permission query)
+        (fn [{adapter :adapter selected-db :db cursor-opts :opts
+              page-query :query}]
+          (let [validate!
+                (fn []
+                  (schema-errors/validate-permission-request!
+                   (request-schema api selected-db)
+                   :lookup-resources
+                   {:resource-type (:resource/type query)
+                    :subject-type (:type subject)
+                    :permission (:permission query)}))
+                internal-subject
+                (spice-object->internal selected-db subject)]
+            (if (nil? (:id internal-subject))
+              (do
+                (validate!)
+                (if (cursor-request? query)
+                  (stale-cursor-anchor! :lookup-resources)
+                  (assoc relay/empty-page
+                         :cached? false :cache-basis nil)))
+              (or
+               (relay/lookup-visited-page
+                adapter cursor-opts :lookup-resources query)
+               (let [internal-query
+                     (-> page-query
+                         (dissoc :consistency :evaluation :timeout-ms
+                                 :cancellation-token)
+                         (assoc :subject internal-subject))
+                     answer
+                     (cached-engine-result
+                      adapter cursor-opts :lookup-resources
+                      (cache/lookup-page-query-identity
+                       query internal-query)
+                      (:resource/type internal-query)
+                      (:permission internal-query)
+                      #(and (map? %)
+                            (vector? (:data %))
+                            (map? (:page-info %)))
+                      #(do
+                         (validate!)
+                         (engine/lookup-resources
+                          adapter
+                          internal-query
+                          {:continuation-cache-fn
+                           (fn []
+                             (continuation-context
+                              adapter cursor-opts
+                              :lookup-resources query))})))
+                     page
+                     (with-cache-info
+                       (binding [subproblem/*store*
+                                 (:subproblem-store answer)
+                                 subproblem/*decision-kernel*
+                                 (:decision-kernel cursor-opts)]
+                         (relay/externalize-page
+                          adapter cursor-opts :lookup-resources query
+                          (:value answer)))
+                       answer)]
+                 (relay/remember-visited-page!
                   adapter cursor-opts :lookup-resources query
-                  (:value answer)))
-               answer)]
-         (relay/remember-visited-page!
-          adapter cursor-opts :lookup-resources query page))))))
+                  page)))))))))))
 
 (defn count-resources
-  [api db
+  [api source
    {:as opts :keys [spice-object->internal]}
    {:as query :keys [subject]}]
-  (let [opts (ensure-execution-contract opts :count-resources query)
-        {selected-db :db adapter :adapter
-         completed-cache? :completed-cache?
-         snapshot-exact? :snapshot-exact?}
-        (selected-context api db opts (:consistency query))
-        opts (assoc opts
-                    :completed-cache? completed-cache?
-                    :snapshot-exact? snapshot-exact?)
-        validate!
-        (fn []
-          (schema-errors/validate-permission-request!
-           (request-schema api selected-db)
-           :count-resources
-           {:resource-type (:resource/type query)
-            :subject-type (:type subject)
-            :permission (:permission query)}))
-        internal-subject (spice-object->internal selected-db subject)]
-    (if-not (:id internal-subject)
-      (do
-        (validate!)
-        (assoc
-         (cond-> {:count 0 :limit (or (:count-limit query) -1)}
-           (contains? query :count-limit) (assoc :truncated? false))
-         :cached? false :cache-basis nil))
-      (let [internal-query
-            (-> query
-                (assoc :subject internal-subject)
-                (dissoc :consistency :cache? :evaluation :timeout-ms
-                        :cancellation-token))
-            answer
-            (cached-engine-result
-             adapter opts :count-resources
-             {:public (dissoc query :consistency :cache?
-                              :cancellation-token)
-              :internal internal-query}
-             (:resource/type internal-query)
-             (:permission internal-query)
-             #(and (map? %) (integer? (:count %)))
-             #(do (validate!)
-                  (engine/count-resources adapter internal-query)))]
-        (with-cache-info (:value answer) answer)))))
+  (let [opts (ensure-execution-contract opts :count-resources query)]
+    (with-selected-context
+     api source opts (:consistency query)
+     (fn [{selected-db :db adapter :adapter :as context}]
+       (let [opts (selected-cache-options opts context)
+             validate!
+             (fn []
+               (schema-errors/validate-permission-request!
+                (request-schema api selected-db)
+                :count-resources
+                {:resource-type (:resource/type query)
+                 :subject-type (:type subject)
+                 :permission (:permission query)}))
+             internal-subject
+             (spice-object->internal selected-db subject)]
+         (if-not (:id internal-subject)
+           (do
+             (validate!)
+             (assoc
+              (cond-> {:count 0 :limit (or (:count-limit query) -1)}
+                (contains? query :count-limit)
+                (assoc :truncated? false))
+              :cached? false :cache-basis nil))
+           (let [internal-query
+                 (-> query
+                     (assoc :subject internal-subject)
+                     (dissoc :consistency :cache? :evaluation :timeout-ms
+                             :cancellation-token))
+                 answer
+                 (cached-engine-result
+                  adapter opts :count-resources
+                  {:public (dissoc query :consistency :cache?
+                                   :cancellation-token)
+                   :internal internal-query}
+                  (:resource/type internal-query)
+                  (:permission internal-query)
+                  #(and (map? %) (integer? (:count %)))
+                  #(do
+                     (validate!)
+                     (engine/count-resources adapter internal-query)))]
+             (with-cache-info (:value answer) answer))))))))
 
 (defn lookup-subjects
-  [api db
+  [api source
    {:as opts :keys [spice-object->internal]}
    query]
-  (let [opts (ensure-execution-contract opts :lookup-subjects query)
-        {selection :selection}
-        (selected-context api db opts (:consistency query))
-        {adapter :adapter selected-db :db cursor-opts :opts
-         page-query :query}
-        (page-context
-         opts selection :lookup-subjects query
-         (:type (:resource query)) (:permission query))
-        validate!
-        (fn []
-          (schema-errors/validate-permission-request!
-           (request-schema api selected-db)
-           :lookup-subjects
-           {:resource-type (:type (:resource query))
-            :subject-type (:subject/type query)
-            :permission (:permission query)}))
-        internal-resource
-        (spice-object->internal selected-db (:resource query))]
-    (when (contains? query :subject/relation)
-      (throw (ex-info ":subject/relation is not supported by lookup-subjects."
-                      {:eacl/error :eacl.pagination/unsupported-filter
-                       :filter :subject/relation})))
-    (if-not (:id internal-resource)
-      (do
-        (validate!)
-        (if (cursor-request? query)
-          (stale-cursor-anchor! :lookup-subjects)
-          (assoc relay/empty-page :cached? false :cache-basis nil)))
-      (or
-       (relay/lookup-visited-page
-        adapter cursor-opts :lookup-subjects query)
-       (let [internal-query
-             (-> page-query
-                 (dissoc :consistency :evaluation :timeout-ms
-                         :cancellation-token)
-                 (assoc :resource internal-resource))
-             answer
-             (cached-engine-result
-              adapter cursor-opts :lookup-subjects
-              (cache/lookup-page-query-identity query internal-query)
-              (:type (:resource internal-query))
-              (:permission internal-query)
-              #(and (map? %) (vector? (:data %))
-                    (map? (:page-info %)))
-              #(do
-                 (validate!)
-                 (engine/lookup-subjects
-                  adapter
-                  internal-query
-                  {:continuation-cache-fn
-                   (fn []
-                     (continuation-context
-                      adapter cursor-opts :lookup-subjects query))})))
-             page
-             (with-cache-info
-               (binding [subproblem/*store*
-                         (:subproblem-store answer)
-                         subproblem/*decision-kernel*
-                         (:decision-kernel cursor-opts)]
-                 (relay/externalize-page
+  (when (contains? query :subject/relation)
+    (throw (ex-info ":subject/relation is not supported by lookup-subjects."
+                    {:eacl/error :eacl.pagination/unsupported-filter
+                     :filter :subject/relation})))
+  (let [opts (ensure-execution-contract opts :lookup-subjects query)]
+    (with-selected-context
+     api source opts (:consistency query)
+     (fn [{selection :selection}]
+       (with-page-context
+        opts selection :lookup-subjects query
+        (:type (:resource query)) (:permission query)
+        (fn [{adapter :adapter selected-db :db cursor-opts :opts
+              page-query :query}]
+          (let [validate!
+                (fn []
+                  (schema-errors/validate-permission-request!
+                   (request-schema api selected-db)
+                   :lookup-subjects
+                   {:resource-type (:type (:resource query))
+                    :subject-type (:subject/type query)
+                    :permission (:permission query)}))
+                internal-resource
+                (spice-object->internal selected-db (:resource query))]
+            (if-not (:id internal-resource)
+              (do
+                (validate!)
+                (if (cursor-request? query)
+                  (stale-cursor-anchor! :lookup-subjects)
+                  (assoc relay/empty-page
+                         :cached? false :cache-basis nil)))
+              (or
+               (relay/lookup-visited-page
+                adapter cursor-opts :lookup-subjects query)
+               (let [internal-query
+                     (-> page-query
+                         (dissoc :consistency :evaluation :timeout-ms
+                                 :cancellation-token)
+                         (assoc :resource internal-resource))
+                     answer
+                     (cached-engine-result
+                      adapter cursor-opts :lookup-subjects
+                      (cache/lookup-page-query-identity
+                       query internal-query)
+                      (:type (:resource internal-query))
+                      (:permission internal-query)
+                      #(and (map? %)
+                            (vector? (:data %))
+                            (map? (:page-info %)))
+                      #(do
+                         (validate!)
+                         (engine/lookup-subjects
+                          adapter
+                          internal-query
+                          {:continuation-cache-fn
+                           (fn []
+                             (continuation-context
+                              adapter cursor-opts
+                              :lookup-subjects query))})))
+                     page
+                     (with-cache-info
+                       (binding [subproblem/*store*
+                                 (:subproblem-store answer)
+                                 subproblem/*decision-kernel*
+                                 (:decision-kernel cursor-opts)]
+                         (relay/externalize-page
+                          adapter cursor-opts :lookup-subjects query
+                          (:value answer)))
+                       answer)]
+                 (relay/remember-visited-page!
                   adapter cursor-opts :lookup-subjects query
-                  (:value answer)))
-               answer)]
-         (relay/remember-visited-page!
-          adapter cursor-opts :lookup-subjects query page))))))
+                  page)))))))))))
 
 (defn count-subjects
-  [api db
+  [api source
    {:as opts :keys [spice-object->internal]}
    query]
-  (let [opts (ensure-execution-contract opts :count-subjects query)
-        {selected-db :db adapter :adapter
-         completed-cache? :completed-cache?
-         snapshot-exact? :snapshot-exact?}
-        (selected-context api db opts (:consistency query))
-        opts (assoc opts
-                    :completed-cache? completed-cache?
-                    :snapshot-exact? snapshot-exact?)
-        validate!
-        (fn []
-          (schema-errors/validate-permission-request!
-           (request-schema api selected-db)
-           :count-subjects
-           {:resource-type (:type (:resource query))
-            :subject-type (:subject/type query)
-            :permission (:permission query)}))
-        internal-resource
-        (spice-object->internal selected-db (:resource query))]
-    (if-not (:id internal-resource)
-      (do
-        (validate!)
-        (assoc
-         (cond-> {:count 0 :limit (or (:count-limit query) -1)}
-           (contains? query :count-limit) (assoc :truncated? false))
-         :cached? false :cache-basis nil))
-      (let [internal-query
-            (-> query
-                (assoc :resource internal-resource)
-                (dissoc :consistency :cache? :evaluation :timeout-ms
-                        :cancellation-token))
-            answer
-            (cached-engine-result
-             adapter opts :count-subjects
-             {:public (dissoc query :consistency :cache?
-                              :cancellation-token)
-              :internal internal-query}
-             (:type (:resource internal-query))
-             (:permission internal-query)
-             #(and (map? %) (integer? (:count %)))
-             #(do (validate!)
-                  (engine/count-subjects adapter internal-query)))]
-        (with-cache-info (:value answer) answer)))))
+  (let [opts (ensure-execution-contract opts :count-subjects query)]
+    (with-selected-context
+     api source opts (:consistency query)
+     (fn [{selected-db :db adapter :adapter :as context}]
+       (let [opts (selected-cache-options opts context)
+             validate!
+             (fn []
+               (schema-errors/validate-permission-request!
+                (request-schema api selected-db)
+                :count-subjects
+                {:resource-type (:type (:resource query))
+                 :subject-type (:subject/type query)
+                 :permission (:permission query)}))
+             internal-resource
+             (spice-object->internal selected-db (:resource query))]
+         (if-not (:id internal-resource)
+           (do
+             (validate!)
+             (assoc
+              (cond-> {:count 0 :limit (or (:count-limit query) -1)}
+                (contains? query :count-limit)
+                (assoc :truncated? false))
+              :cached? false :cache-basis nil))
+           (let [internal-query
+                 (-> query
+                     (assoc :resource internal-resource)
+                     (dissoc :consistency :cache? :evaluation :timeout-ms
+                             :cancellation-token))
+                 answer
+                 (cached-engine-result
+                  adapter opts :count-subjects
+                  {:public (dissoc query :consistency :cache?
+                                   :cancellation-token)
+                   :internal internal-query}
+                  (:type (:resource internal-query))
+                  (:permission internal-query)
+                  #(and (map? %) (integer? (:count %)))
+                  #(do
+                     (validate!)
+                     (engine/count-subjects adapter internal-query)))]
+             (with-cache-info (:value answer) answer))))))))
 
 (defn expand-permission-tree
-  [api db opts query]
+  [api source opts query]
   (permission-tree/validate-request! query)
   (let [opts (ensure-execution-contract
               opts :expand-permission-tree query)
-        contract (:execution-contract opts)
-        {adapter :adapter db :db
-         completed-cache? :completed-cache?
-         snapshot-exact? :snapshot-exact?}
-        (selected-context api db opts (:consistency query))
-        opts (assoc opts
-                    :completed-cache? completed-cache?
-                    :snapshot-exact? snapshot-exact?)
-        validate!
-        (fn []
-          (schema-errors/validate-expansion-request!
-           (request-schema api db)
-           :expand-permission-tree
-           (:type (:resource query))
-           (:permission query)))
-        answer
-        (cached-engine-result
-         adapter opts :expand-permission-tree
-         (dissoc query :consistency :cache? :timeout-ms :cancellation-token)
-         (:type (:resource query))
-         (:permission query)
-         map?
-         #(do
-            (validate!)
-            (permission-tree/expand
-             adapter
-             {:limits (:permission-tree-limits opts)
-              :execution-contract contract}
-             (:resource query)
-             (:permission query))))
-        tree (:value answer)]
-    (execution/check! contract :permission-tree-token-issuance)
-    (let [token
-          (permission-tree/selected-adapter-token adapter opts)]
-      (execution/check! contract :permission-tree-token-issued)
-      {:expanded-at token
-       :tree-root tree})))
+        contract (:execution-contract opts)]
+    (with-selected-context
+     api source opts (:consistency query)
+     (fn [{adapter :adapter db :db :as context}]
+       (let [opts (selected-cache-options opts context)
+             validate!
+             (fn []
+               (schema-errors/validate-expansion-request!
+                (request-schema api db)
+                :expand-permission-tree
+                (:type (:resource query))
+                (:permission query)))
+             answer
+             (cached-engine-result
+              adapter opts :expand-permission-tree
+              (dissoc query :consistency :cache? :timeout-ms
+                      :cancellation-token)
+              (:type (:resource query))
+              (:permission query)
+              map?
+              #(do
+                 (validate!)
+                 (permission-tree/expand
+                  adapter
+                  {:limits (:permission-tree-limits opts)
+                   :execution-contract contract}
+                  (:resource query)
+                  (:permission query))))
+             tree (:value answer)]
+         (execution/check! contract :permission-tree-token-issuance)
+         (let [token
+               (permission-tree/selected-adapter-token adapter opts)]
+           (execution/check! contract :permission-tree-token-issued)
+           {:expanded-at token
+            :tree-root tree}))))))
 
 (defn- request-cache-enabled?
   [cache-option]
   (cache/validate-request-cache-option! cache-option)
   (not (false? cache-option)))
 
+(defn- fixed-snapshot-provider
+  [adapter]
+  (snapshot-provider/borrowed-adapter-provider
+   {:static-adapter adapter
+    :topology {:snapshot-values :fixed-borrowed-view}
+    :source-scope-fn #(backend/invoke adapter :source-scope)
+    :source-lifecycle-fn #(backend/invoke adapter :source-lifecycle)
+    :acquire-current! (constantly adapter)
+    :acquire-authoritative! (fn [_timeout-ms] adapter)
+    :acquire-at-least! (fn [_token-data _timeout-ms] adapter)
+    :acquire-exact! (fn [_token-data _timeout-ms] adapter)}))
+
+(defn- snapshot-view-closed!
+  []
+  (throw
+   (ex-info
+    "The snapshot authorization view escaped its synchronous scope."
+    {:type :eacl/snapshot-view-closed
+     :eacl/error :eacl/snapshot-view-closed})))
+
+(defn- snapshot-view-thread-violation!
+  []
+  (throw
+   (ex-info
+    "The snapshot authorization view escaped its owning thread."
+    {:type :eacl/snapshot-view-thread-violation
+     :eacl/error :eacl/snapshot-view-thread-violation})))
+
+(defn- snapshot-view-write!
+  []
+  (throw
+   (ex-info
+    "A composed snapshot view is read-only."
+    {:type :eacl/read-only-snapshot-view
+     :eacl/error :eacl/read-only-snapshot-view})))
+
+(defn- require-snapshot-view!
+  [open? owner-thread]
+  (when-not @open?
+    (snapshot-view-closed!))
+  #?(:clj
+     (when-not (identical? owner-thread (Thread/currentThread))
+       (snapshot-view-thread-violation!))
+     :cljs nil)
+  nil)
+
+(defn- fixed-snapshot-demand
+  [demand]
+  (when (some? (:consistency demand))
+    (throw
+     (ex-info
+      "Consistency is fixed by the enclosing with-snapshot selection."
+      {:type :eacl/snapshot-view-consistency-fixed
+       :eacl/error :eacl/snapshot-view-consistency-fixed
+       :requested (:consistency demand)})))
+  (dissoc demand :consistency))
+
+(declare ->ClientAuthorization)
+
+(defrecord SnapshotAuthorization [delegate open? owner-thread]
+  IAuthorization
+  (can? [_ subject permission resource]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/can? delegate subject permission resource))
+  (can? [_ subject permission resource consistency-value]
+    (require-snapshot-view! open? owner-thread)
+    (fixed-snapshot-demand {:consistency consistency-value})
+    (eacl/can? delegate subject permission resource))
+  (can? [_ demand]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/can? delegate (fixed-snapshot-demand demand)))
+
+  (read-schema [_]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/read-schema delegate))
+  (write-schema! [_ _schema]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+
+  (read-relationships [_ query]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/read-relationships delegate (fixed-snapshot-demand query)))
+  (write-relationships! [_ _updates]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (write-relationship! [_ _operation _subject _relation _resource]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (write-relationship! [_ _demand]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (create-relationships! [_ _relationships]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (create-relationship! [_ _subject _relation _resource]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (create-relationship! [_ _relationship]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (delete-relationships! [_ _relationships]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (delete-object! [_ _object]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (delete-relationship! [_ _subject _relation _resource]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+  (delete-relationship! [_ _relationship]
+    (require-snapshot-view! open? owner-thread)
+    (snapshot-view-write!))
+
+  (lookup-resources [_ query]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/lookup-resources delegate (fixed-snapshot-demand query)))
+  (count-resources [_ query]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/count-resources delegate (fixed-snapshot-demand query)))
+  (lookup-subjects [_ query]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/lookup-subjects delegate (fixed-snapshot-demand query)))
+  (count-subjects [_ query]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/count-subjects delegate (fixed-snapshot-demand query)))
+  (expand-permission-tree [_ query]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/expand-permission-tree delegate (fixed-snapshot-demand query)))
+
+  IDetailedAuthorization
+  (-check-permission [_ demand]
+    (require-snapshot-view! open? owner-thread)
+    (eacl/check-permission delegate (fixed-snapshot-demand demand))))
+
+(defn- read-current-schema
+  [api source opts]
+  (let [opts (ensure-execution-contract opts :read-schema {})]
+    (with-selected-context
+     api source opts consistency/minimize-latency
+     (fn [{:keys [db]}]
+       ((get-in api [:schema :read-schema]) db)))))
+
 (defrecord ClientAuthorization [conn opts api]
   IAuthorization
   (can? [_ subject permission resource]
-    (can? api ((:db api) conn) (assoc opts
-                                     :request-operation :can?
-                                     :completed-cache-request? true)
+    (can? api (:snapshot-provider opts) (assoc opts
+                                              :request-operation :can?
+                                              :completed-cache-request? true)
           subject permission resource consistency/minimize-latency))
   (can? [_ subject permission resource consistency]
-    (can? api ((:db api) conn) (assoc opts
-                                     :request-operation :can?
-                                     :completed-cache-request? true)
+    (can? api (:snapshot-provider opts) (assoc opts
+                                              :request-operation :can?
+                                              :completed-cache-request? true)
           subject permission resource consistency))
   (can? [_ {:keys [subject permission resource consistency]
             cache? :cache? :as demand}]
-    (can? api ((:db api) conn)
+    (can? api (:snapshot-provider opts)
           (assoc opts
                  :request-operation :can?
                  :execution-request demand
@@ -1007,7 +1346,7 @@
           consistency))
 
   (read-schema [_]
-    ((get-in api [:schema :read-schema]) ((:db api) conn)))
+    (read-current-schema api (:snapshot-provider opts) opts))
   (write-schema! [_ schema-string]
     (let [result
           ((get-in api [:schema :write-schema!])
@@ -1018,12 +1357,15 @@
         (when-let [store (:current-cache-store opts)]
           (cache/expire-current! store)))
       (merge result
-             (write-response api (:eacl.schema/db-after result) opts))))
+             (if (:eacl.schema/no-op? result)
+               (write-response api (:eacl.schema/db-after result) opts)
+               (committed-write-response
+                api (:eacl.schema/db-after result) opts)))))
 
   (read-relationships [_ filters]
     (read-relationships
      api
-     ((:db api) conn)
+     (:snapshot-provider opts)
      (assoc opts
             :completed-cache-request?
             (request-cache-enabled? (:cache? filters)))
@@ -1068,7 +1410,7 @@
           (request-cache-enabled? (:cache? query))]
       (lookup-resources
        api
-       ((:db api) conn)
+       (:snapshot-provider opts)
        (assoc opts
               :completed-cache-request? cache-enabled?
               :continuation-cache-request? cache-enabled?)
@@ -1076,7 +1418,7 @@
   (count-resources [_ query]
     (count-resources
      api
-     ((:db api) conn)
+     (:snapshot-provider opts)
      (assoc opts :completed-cache-request?
             (request-cache-enabled? (:cache? query)))
      (dissoc query :cache?)))
@@ -1085,7 +1427,7 @@
           (request-cache-enabled? (:cache? query))]
       (lookup-subjects
        api
-       ((:db api) conn)
+       (:snapshot-provider opts)
        (assoc opts
               :completed-cache-request? cache-enabled?
               :continuation-cache-request? cache-enabled?)
@@ -1093,7 +1435,7 @@
   (count-subjects [_ query]
     (count-subjects
      api
-     ((:db api) conn)
+     (:snapshot-provider opts)
      (assoc opts :completed-cache-request?
             (request-cache-enabled? (:cache? query)))
      (dissoc query :cache?)))
@@ -1101,7 +1443,7 @@
   (expand-permission-tree [_ query]
     (expand-permission-tree
      api
-     ((:db api) conn)
+     (:snapshot-provider opts)
      (assoc opts :completed-cache-request? true)
      query))
 
@@ -1111,14 +1453,48 @@
         cache? :cache? :as demand}]
     (check-permission
      api
-     ((:db api) conn)
+     (:snapshot-provider opts)
      (assoc opts
             :request-operation :check-permission
             :execution-request demand
             :completed-cache-request?
             (request-cache-enabled? cache?))
      subject permission resource
-     (or consistency consistency/minimize-latency))))
+     (or consistency consistency/minimize-latency)))
+
+  ISnapshotAuthorization
+  (-with-snapshot
+    [_ consistency-value request-options f]
+    (let [opts
+          (ensure-execution-contract
+           opts :with-snapshot request-options)]
+      (with-selected-context
+       api (:snapshot-provider opts) opts consistency-value
+       (fn [{:keys [adapter]}]
+         (let [open? (atom true)
+               fixed-provider (fixed-snapshot-provider adapter)
+               request-proof-frame (new-request-proof-frame adapter opts)
+               request-schema-cache
+               (delay
+                 (binding [engine/*proof-frame* request-proof-frame]
+                   (engine/schema-cache-for!
+                    (:derived-schema-caches opts) adapter)))
+               delegate
+               (->ClientAuthorization
+                conn
+                (assoc opts
+                       :snapshot-provider fixed-provider
+                       :request-proof-frame request-proof-frame
+                       :request-schema-cache request-schema-cache)
+                api)
+               view
+               (->SnapshotAuthorization
+                delegate open?
+                #?(:clj (Thread/currentThread) :cljs nil))]
+           (try
+             (f view)
+             (finally
+               (reset! open? false)))))))))
 
 (defn client?
   "True when `client` is a shared-orchestration client for `backend-id`."
@@ -1290,10 +1666,15 @@
   (let [source-lifecycle (or source-lifecycle (str (random-uuid)))
         source-lifecycle-state (atom source-lifecycle)
         codec-instance-id (str (random-uuid))
+        prepared-native-source-id-key
+        (:prepared-native-source-id-key api)
         native-source-id
-        (if-let [native-source-id-fn (:native-source-id api)]
-          (native-source-id-fn conn)
-          (str (random-uuid)))
+        (if (and prepared-native-source-id-key
+                 (contains? config-opts prepared-native-source-id-key))
+          (get config-opts prepared-native-source-id-key)
+          (if-let [native-source-id-fn (:native-source-id api)]
+            (native-source-id-fn conn)
+            (str (random-uuid))))
         current-kid (or security-kid :default)
         root-keyring
         (cond
@@ -1349,7 +1730,10 @@
               2048)}))
         entid->object-id (or entid->object-id
                              (:default-entid->object-id api))
-        opts             {:object-id->lookup-ref object-id->lookup-ref
+        base-opts        (merge
+                          (select-keys config-opts
+                                       (:extra-client-opt-keys api))
+                         {:object-id->lookup-ref object-id->lookup-ref
                           :conn conn
                           :derived-schema-caches (atom {})
                           :adapter-fingerprint
@@ -1418,9 +1802,19 @@
                           :service-admission
                           (some-> (physical/normalize-service-admission
                                    service-admission)
-                                  physical/make-service-admission)}
-        ;; The stable engine runs only on a qualified topology; the adapter's
-        ;; declared execution profile is checked once here.
-        _ (physical/require-qualified-topology!
-           ((:snapshot-adapter api) ((:db api) conn) opts))]
+                                  physical/make-service-admission)})
+        provider-constructor (:snapshot-provider api)
+        _ (when-not (fn? provider-constructor)
+            (throw
+             (ex-info
+              "Backend api must provide a snapshot-provider constructor."
+              {:type :eacl/invalid-backend-api
+               :eacl/error :eacl/invalid-backend-api
+               :backend (:backend-id api)
+               :missing :snapshot-provider})))
+        provider (provider-constructor conn base-opts)
+        opts (assoc base-opts :snapshot-provider provider)
+        ;; Stable-engine qualification uses only long-lived provider metadata;
+        ;; client construction does not retain or own a request snapshot.
+        _ (physical/require-qualified-provider-topology! provider)]
     (->ClientAuthorization conn opts api)))

--- a/modules/eacl/src/eacl/consistency.cljc
+++ b/modules/eacl/src/eacl/consistency.cljc
@@ -1,6 +1,7 @@
 (ns eacl.consistency
   "Shared v4 backend-native revision selection over validated adapters."
   (:require [eacl.backend.v8 :as backend]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.causal-token :as causal-token]
             [eacl.spicedb.consistency :as public-consistency]
             [eacl.subproblem-cache :as subproblem]
@@ -76,8 +77,15 @@
     revision))
 
 (defn- expected-scope
-  [adapter]
-  (source-scope adapter))
+  [source]
+  (if (snapshot-provider/provider? source)
+    (let [scope (snapshot-provider/source-scope source)
+          lifecycle (snapshot-provider/source-lifecycle source)]
+      (causal-token/validate-source-lifecycle! lifecycle)
+      (assoc scope
+             :source-lifecycle lifecycle
+             :backend (snapshot-provider/backend-id source)))
+    (source-scope source)))
 
 (defn- authenticate
   [adapter {:keys [format-options]} token]
@@ -114,7 +122,13 @@
 (defn- capability-error
   [source mode]
   (try
-    (backend/require-capability! source :consistency mode)
+    (if (snapshot-provider/provider? source)
+      (backend/require-supported!
+       (snapshot-provider/backend-id source)
+       (snapshot-provider/capabilities source)
+       :consistency
+       mode)
+      (backend/require-capability! source :consistency mode))
     nil
     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
       error
@@ -137,6 +151,11 @@
            :mode mode})))
 
       :exact-snapshot-unavailable
+      ;; Exact selection has a stable public failure regardless of whether the
+      ;; backend omitted the exact capability or advertised it but cannot
+      ;; reconstruct the requested locator.  Preserve the capability failure
+      ;; only as the cause; leaking :eacl/unsupported-capability here would
+      ;; contradict the verified consistency boundary.
       (fail! :exact-snapshot-unavailable
              "The backend cannot reconstruct exact snapshots."
              {}
@@ -168,7 +187,9 @@
   decision over that fact is made by the generated kernel."
   [source {:keys [mode]} options]
   (let [capability-supported?
-        (backend/supports? source :consistency mode)
+        (if (snapshot-provider/provider? source)
+          (snapshot-provider/supports? source :consistency mode)
+          (backend/supports? source :consistency mode))
         input
         {:mode mode
          :capability-supported? capability-supported?}
@@ -358,6 +379,257 @@
       {:adapter selected
        :request-token payload})))
 
+(defn- selection-check!
+  [options phase]
+  (when-let [check! (:selection-check! options)]
+    (check! phase))
+  nil)
+
+(defn- monotonic-millis
+  []
+  #?(:clj (/ (double (System/nanoTime)) 1000000.0)
+     :cljs (.now js/Date)))
+
+(defn- selection-deadline
+  [options]
+  (+ (monotonic-millis)
+     (double (or (:timeout-ms options) 30000))))
+
+(defn- remaining-millis
+  [deadline]
+  (let [remaining (- deadline (monotonic-millis))]
+    (if (pos? remaining)
+      (max 1 (long remaining))
+      0)))
+
+(defn- release-after-selection-error!
+  [selected selection-error]
+  (try
+    (snapshot-provider/release! selected)
+    (catch #?(:clj Throwable :cljs :default) release-error
+      (throw
+       (ex-info
+        "Snapshot selection failed and candidate cleanup also failed."
+        {:type :eacl/snapshot-release-failed
+         :eacl/error :eacl/snapshot-release-failed
+         :backend (:backend (snapshot-provider/semantic-identity selected))
+         :selection-error (ex-data selection-error)}
+        release-error))))
+  (throw selection-error))
+
+(defn- acquire-provider-candidate!
+  [source kind options & args]
+  (selection-check! options :before-snapshot-acquisition)
+  (let [selected (apply snapshot-provider/acquire! source kind args)]
+    (try
+      (selection-check! options :after-snapshot-acquisition)
+      selected
+      (catch #?(:clj Throwable :cljs :default) error
+        (release-after-selection-error! selected error)))))
+
+(defn- provider-selected-adapter!
+  [source selected kind revision-check options required-scope]
+  (let [adapter (snapshot-provider/adapter selected)
+        provider-scope-value (or required-scope (expected-scope source))
+        selected-scope-value (source-scope adapter)
+        same-source-scope? (= provider-scope-value selected-scope-value)
+        revision-observation
+        (if (and same-source-scope? revision-check)
+          (revision-check adapter)
+          {:satisfied? (nil? revision-check)})
+        input
+        {:kind kind
+         :selection-present? true
+         :selected-adapter? true
+         :same-source-scope? same-source-scope?
+         :revision-satisfied? (boolean (:satisfied? revision-observation))}
+        decision
+        (decide options :consistency-validation input)]
+    (case decision
+      :accept selected
+
+      :exact-snapshot-unavailable
+      (fail! :exact-snapshot-unavailable
+             "The requested exact snapshot is unavailable.")
+
+      :invalid-selected-adapter
+      (throw
+       (ex-info
+        "A provider acquisition did not return an immutable adapter."
+        {:type :eacl/invalid-backend-adapter
+         :eacl/error :eacl/invalid-backend-adapter
+         :backend (snapshot-provider/backend-id source)}))
+
+      :incomparable-scope
+      (fail! :incomparable-scope
+             "Backend selection crossed source, branch, or lifecycle scope."
+             {:source provider-scope-value
+              :selected selected-scope-value})
+
+      :history-divergence
+      (fail! :history-divergence
+             (:message revision-observation)
+             (:data revision-observation)))))
+
+(defn- validate-provider-candidate!
+  [source selected kind revision-check options required-scope]
+  (try
+    (provider-selected-adapter!
+     source selected kind revision-check options required-scope)
+    (catch #?(:clj Throwable :cljs :default) error
+      (release-after-selection-error! selected error))))
+
+(defn- freshness-timeout!
+  [payload timeout-ms]
+  (fail! :freshness-timeout
+         "Timed out waiting for the requested native revision."
+         {:requested-revision (:revision payload)
+          :timeout-ms timeout-ms}))
+
+(defn- select-provider-at-least!
+  [source payload options deadline]
+  (let [timeout-ms (or (:timeout-ms options) 30000)]
+    (loop []
+      (selection-check! options :at-least-candidate)
+      (let [remaining (remaining-millis deadline)]
+        (when (zero? remaining)
+          (freshness-timeout! payload timeout-ms))
+        (let [selected
+              (acquire-provider-candidate!
+               source :at-least options payload remaining)
+              _
+              (when (zero? (remaining-millis deadline))
+                (try
+                  (freshness-timeout! payload timeout-ms)
+                  (catch #?(:clj Throwable :cljs :default) error
+                    (release-after-selection-error! selected error))))
+              ;; Acquisition already captured and validated native revision in
+              ;; the selected snapshot's semantic identity. Re-observing the
+              ;; adapter here is unnecessary and, for owned native snapshots,
+              ;; would create a post-validation failure point that could leak
+              ;; the candidate before ownership transfer.
+              actual
+              (:revision (snapshot-provider/semantic-identity selected))]
+          (if (>= actual (:revision payload))
+            (validate-provider-candidate!
+             source
+             selected
+             :at-least
+             (fn [_]
+               {:satisfied? true
+                :message
+                "The selected snapshot did not reach the requested native revision."
+                :data {:requested-revision (:revision payload)
+                       :actual-revision actual}})
+             options
+             (select-keys
+              payload
+              [:backend :source-id :branch :source-lifecycle]))
+            (do
+              (snapshot-provider/release! selected)
+              (selection-check! options :at-least-retry)
+              (recur))))))))
+
+(defn- select-provider-snapshot
+  [source {:keys [mode token]} options]
+  (case (selection-plan source {:mode mode} options)
+      :select-current
+      {:selected-snapshot
+       (let [selected
+             (acquire-provider-candidate! source :current options)]
+         (validate-provider-candidate!
+          source selected :current nil options nil))}
+
+      :select-authoritative
+      {:selected-snapshot
+       (let [selected
+             (acquire-provider-candidate!
+              source
+              :authoritative
+              options
+              (:timeout-ms options))]
+         (validate-provider-candidate!
+          source selected :authoritative nil options nil))}
+
+      :authenticate-and-select-at-least
+      (let [payload (authenticate source options token)
+            deadline (selection-deadline options)]
+        {:selected-snapshot
+         (select-provider-at-least! source payload options deadline)
+         :request-token payload})
+
+      :authenticate-and-select-exact
+      (let [payload (authenticate source options token)
+            deadline (selection-deadline options)
+            selected
+            (acquire-provider-candidate!
+             source :exact options payload (remaining-millis deadline))]
+        {:selected-snapshot
+         (validate-provider-candidate!
+          source
+          selected
+          :exact
+          (fn [_selected-adapter]
+            (let [actual
+                  (select-keys
+                   (snapshot-provider/semantic-identity selected)
+                   [:revision :exact-locator])]
+              {:satisfied?
+               (and (= (:revision payload) (:revision actual))
+                    (= (:exact-locator payload)
+                       (:exact-locator actual)))
+               :message
+               "The exact locator resolved to a different native revision."
+               :data
+               {:expected-revision
+                (select-keys payload [:revision :exact-locator])
+                :actual-revision actual}}))
+          options
+          (select-keys
+           payload
+           [:backend :source-id :branch :source-lifecycle]))
+         :request-token payload})))
+
+(defn select-from-provider
+  "Authenticates and acquires exactly one provider-owned selected snapshot.
+
+  The caller owns `:selected-snapshot` on return and must release it in a
+  `finally` scope after completely realizing the public response. Every error
+  before ownership transfer releases the candidate here."
+  [source consistency-value
+   {:keys [format-options issue-token?]
+    :as options}]
+  (when-not (snapshot-provider/provider? source)
+    (throw
+     (ex-info
+      "Provider selection requires a snapshot provider."
+      {:type :eacl/invalid-snapshot-provider
+       :eacl/error :eacl/invalid-snapshot-provider})))
+  (let [descriptor (public-consistency/descriptor consistency-value)
+        selection (select-provider-snapshot source descriptor options)
+        selected (:selected-snapshot selection)]
+    (try
+      (let [selected-adapter (snapshot-provider/adapter selected)
+            request-token (:request-token selection)
+            identity (snapshot-provider/semantic-identity selected)
+            revision (select-keys identity [:revision :exact-locator])
+            response-token
+            (when issue-token?
+              (causal-token/issue
+               format-options
+               (select-keys
+                identity
+                [:backend :source-id :branch :source-lifecycle
+                 :revision :exact-locator])))]
+        {:selected-snapshot selected
+         :adapter selected-adapter
+         :descriptor descriptor
+         :request-token request-token
+         :response-token response-token
+         :native-revision revision})
+      (catch #?(:clj Throwable :cljs :default) error
+        (release-after-selection-error! selected error)))))
+
 (defn select
   "Authenticates and selects exactly one immutable snapshot adapter.
 
@@ -367,22 +639,24 @@
   [source consistency-value
    {:keys [format-options issue-token?]
     :as options}]
-  (let [descriptor (public-consistency/descriptor consistency-value)
-        selection (select-adapter source descriptor options)
-        selected (:adapter selection)
-        request-token (:request-token selection)
-        revision (native-revision selected)
-        response-token
-        (when issue-token?
-          (causal-token/issue
-           format-options
-           (merge (source-scope selected)
-                  revision)))]
-    {:adapter selected
-     :descriptor descriptor
-     :request-token request-token
-     :response-token response-token
-     :native-revision revision}))
+  (if (snapshot-provider/provider? source)
+    (select-from-provider source consistency-value options)
+    (let [descriptor (public-consistency/descriptor consistency-value)
+          selection (select-adapter source descriptor options)
+          selected (:adapter selection)
+          request-token (:request-token selection)
+          revision (native-revision selected)
+          response-token
+          (when issue-token?
+            (causal-token/issue
+             format-options
+             (merge (source-scope selected)
+                    revision)))]
+      {:adapter selected
+       :descriptor descriptor
+       :request-token request-token
+       :response-token response-token
+       :native-revision revision})))
 
 (defn selected-adapter-token
   "Issues a causal token from an already selected immutable adapter.

--- a/modules/eacl/src/eacl/core.cljc
+++ b/modules/eacl/src/eacl/core.cljc
@@ -149,6 +149,50 @@
   Omitted or nil consistency defaults to :minimize-latency."
   (-check-permission [this demand]))
 
+(defprotocol ISnapshotAuthorization
+  "Optional synchronous composition boundary for multiple read operations that
+  must observe one selected immutable backend snapshot."
+  (-with-snapshot [this consistency request-options f]))
+
+(defn with-snapshot
+  "Runs `f` synchronously with a read-only authorization view fixed to one
+  selected immutable snapshot.
+
+  The view must not escape `f`, rejects writes and cross-thread use, and fails
+  deterministically after scope exit. Omitted consistency uses
+  :minimize-latency. Backends that do not implement the lifecycle boundary fail
+  with a typed unsupported-capability error.
+
+  The four-argument form accepts one request-options map (for example
+  :timeout-ms and :cancellation-token) whose execution budget covers snapshot
+  selection and every nested read."
+  ([authorization f]
+   (with-snapshot authorization nil {} f))
+  ([authorization consistency f]
+   (with-snapshot authorization consistency {} f))
+  ([authorization consistency request-options f]
+   (when-not (map? request-options)
+     (throw
+      (ex-info
+       "with-snapshot request options must be a map."
+       {:type :eacl/invalid-snapshot-request-options
+        :eacl/error :eacl/invalid-snapshot-request-options
+        :value request-options})))
+   (when-not (fn? f)
+     (throw
+      (ex-info
+       "with-snapshot requires a synchronous callback."
+       {:type :eacl/invalid-snapshot-callback
+        :eacl/error :eacl/invalid-snapshot-callback})))
+   (if (satisfies? ISnapshotAuthorization authorization)
+     (-with-snapshot authorization consistency request-options f)
+     (throw
+      (ex-info
+       "This authorization implementation has no composable snapshot lifecycle."
+       {:type :eacl/unsupported-capability
+        :eacl/error :eacl/unsupported-capability
+        :capability :snapshot-composition})))))
+
 (defn check-permission
   "Returns an authorization decision with cache provenance.
 

--- a/modules/eacl/src/eacl/engine/physical.cljc
+++ b/modules/eacl/src/eacl/engine/physical.cljc
@@ -11,6 +11,7 @@
   inside the classification boundary), or throws CANCELLED. Nil is never
   an outcome."
   (:require [clojure.string]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.backend.v8 :as backend]
             [eacl.execution :as execution]))
 
@@ -285,19 +286,10 @@
                         :strict-progress? :atomic-response?
                         :failure-classification?]))
 
-(defn adapter-topology-capabilities
-  "The closed capability record of one adapter's topology, derived from the
-  execution profile the adapter declares (`eacl.backend.v8/traversal-execution`:
-  immutable basis reads and the strict/unique/replayable/progress/atomic scan
-  contract), its snapshot capabilities (exact selection), and the engine's
-  read boundary, which classifies every adapter failure
-  (`classified-fetch-fn`) so `:failure-classification?` holds for any adapter
-  read through it. Semantic concurrent-read safety and physical
-  cancellability stay conservative until the concurrency change certifies
-  them; deployment width is one."
-  [adapter]
+(defn- declared-topology-capabilities
+  [traversal-execution exact-basis-selection?]
   (let [{:keys [immutable-basis-reads? scan-contract concurrent-snapshot-reads]}
-        (backend/traversal-execution adapter)]
+        traversal-execution]
     (topology-capabilities
      {:immutable-basis? (boolean immutable-basis-reads?)
       :strict-scan-order? (boolean (:strict-order? scan-contract))
@@ -318,8 +310,31 @@
         :unknown)
       :semantic-concurrent-read-safe? false
       :deployment-width 1
-      :exact-basis-selection?
-      (boolean (backend/supports? adapter :snapshots :exact))})))
+      :exact-basis-selection? (boolean exact-basis-selection?)})))
+
+(defn adapter-topology-capabilities
+  "The closed capability record of one adapter's topology, derived from the
+  execution profile the adapter declares (`eacl.backend.v8/traversal-execution`:
+  immutable basis reads and the strict/unique/replayable/progress/atomic scan
+  contract), its snapshot capabilities (exact selection), and the engine's
+  read boundary, which classifies every adapter failure
+  (`classified-fetch-fn`) so `:failure-classification?` holds for any adapter
+  read through it. Semantic concurrent-read safety and physical
+  cancellability stay conservative until the concurrency change certifies
+  them; deployment width is one."
+  [adapter]
+  (declared-topology-capabilities
+   (backend/traversal-execution adapter)
+   (backend/supports? adapter :snapshots :exact)))
+
+(defn provider-topology-capabilities
+  "Derives stable-discovery qualifications from provider-static metadata.
+
+  This function never acquires or retains a request snapshot."
+  [provider]
+  (declared-topology-capabilities
+   (snapshot-provider/traversal-execution provider)
+   (snapshot-provider/supports? provider :snapshots :exact)))
 
 (defn require-qualified-topology!
   "Fails closed with `:eacl.topology/unqualified` when the adapter's derived
@@ -335,6 +350,23 @@
                        :eacl/error :eacl.topology/unqualified
                        :backend (backend/backend-id adapter)
                        :capabilities capabilities})))
+    capabilities))
+
+(defn require-qualified-provider-topology!
+  "Provider-static counterpart of `require-qualified-topology!`.
+
+  Client construction uses this boundary so topology validation cannot leak
+  or accidentally pin a request snapshot."
+  [provider]
+  (let [capabilities (provider-topology-capabilities provider)]
+    (when-not (stable-discovery-qualified? capabilities)
+      (throw
+       (ex-info
+        "This backend topology is not qualified for stable-discovery enumeration: its provider does not declare the strict, unique, replayable, strict-progress, atomic scan contract over an immutable basis."
+        {:type :eacl.topology/unqualified
+         :eacl/error :eacl.topology/unqualified
+         :backend (snapshot-provider/backend-id provider)
+         :capabilities capabilities})))
     capabilities))
 
 ;; ---------------------------------------------------------------------------

--- a/modules/eacl/src/eacl/engine/relationships.cljc
+++ b/modules/eacl/src/eacl/engine/relationships.cljc
@@ -135,9 +135,9 @@
       (if (or (empty? pending)
               (= target (count rows)))
         rows
-        (let [spec (first pending)
+        (let [remaining (- target (count rows))
+              spec (assoc (first pending) :physical-limit remaining)
               resume-edge (when (= (:idx spec) start-index) edge)
-              remaining (- target (count rows))
               scanned (take remaining
                             (scan-fn spec resume-edge direction))]
           (recur (rest pending) (into rows scanned)))))))
@@ -251,7 +251,9 @@
               (and remaining (zero? remaining)))
         {:data (mapv :relationship acc)
          :cursor (build-cursor cursor last-row)}
-        (let [spec          (first pending)
+        (let [spec          (cond-> (first pending)
+                              remaining
+                              (assoc :physical-limit remaining))
               resume-cursor (when (= (:idx spec) start-idx) cursor)
               rows          (seq (scan-fn spec resume-cursor))]
           (if (empty? rows)

--- a/modules/eacl/src/eacl/engine/stable_reducer.cljc
+++ b/modules/eacl/src/eacl/engine/stable_reducer.cljc
@@ -287,6 +287,8 @@
   [adapter]
   (fn [{:keys [operation bound-eid] :as descriptor}]
     (let [options (cond-> {:direction :asc}
+                    (:limit descriptor)
+                    (assoc :limit (:limit descriptor))
                     bound-eid (assoc :bound-eid bound-eid
                                      :inclusive-bound? false))]
       (case operation

--- a/modules/eacl/src/eacl/engine/v8.cljc
+++ b/modules/eacl/src/eacl/engine/v8.cljc
@@ -507,6 +507,7 @@
     :routing-schema-identity nil
     :plan-schema-identity schema-identity
     :request-local? true
+    :parsed-schema (atom nil)
     :permission-roots (atom {})
     :permission-paths (atom {})
     :traversal-permissions (atom {})
@@ -560,25 +561,31 @@
   immutable generation even if a later install evicts it from the registry."
   [registry snapshot]
   (let [schema-generation (schema-version snapshot)
-        key (schema-cache-key snapshot schema-generation)
-        existing (get @registry key)]
-    (if existing
-      existing
-      (let [created
-            (make-schema-cache
-             snapshot
-             schema-generation)
-            selected (volatile! created)]
-        (swap! registry
-               (fn [generations]
-                 (if-let [installed (get generations key)]
-                   (do
-                     (vreset! selected installed)
-                     generations)
-                   (trim-schema-generations
-                    (assoc generations key created)
-                    key))))
-        @selected))))
+        ;; Without a complete ordered-generation proof, cross-snapshot reuse
+        ;; must fail closed. A fresh request-local cache still avoids repeating
+        ;; pure schema derivations within this one immutable selected snapshot.
+        request-local? (nil? schema-generation)]
+    (if request-local?
+      (request-schema-cache snapshot)
+      (let [key (schema-cache-key snapshot schema-generation)
+            existing (get @registry key)]
+        (if existing
+          existing
+          (let [created
+                (make-schema-cache
+                 snapshot
+                 schema-generation)
+                selected (volatile! created)]
+            (swap! registry
+                   (fn [generations]
+                     (if-let [installed (get generations key)]
+                       (do
+                         (vreset! selected installed)
+                         generations)
+                       (trim-schema-generations
+                        (assoc generations key created)
+                        key))))
+            @selected))))))
 
 (defn- permission-paths-cache-key
   [resource-type permission-name]

--- a/modules/eacl/src/eacl/relay.cljc
+++ b/modules/eacl/src/eacl/relay.cljc
@@ -1,6 +1,7 @@
 (ns eacl.relay
   "Portable opaque Relay cursor handling for synchronous v8 adapters."
-  (:require [eacl.backend.v8 :as backend]
+  (:require [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.backend.v8 :as backend]
             [eacl.consistency :as consistency]
             [eacl.core :as eacl :refer [spice-object]]
             [eacl.cursor :as cursor]
@@ -684,10 +685,10 @@
      (continuation-decision opts current envelope nil))
     true))
 
-(defn- select-envelope-adapter
+(defn- select-envelope-context
   [adapter opts envelope]
   (if-not envelope
-    adapter
+    {:adapter adapter}
     (let [current (current-context adapter opts)
           initial
           (continuation-decision opts current envelope nil)]
@@ -699,49 +700,71 @@
             (stale-context!
              "The backend cannot reconstruct the cursor's changed proof."
              :dependency-proof-changed))
-          (let [exact
-                (do
-                  (execution/check!
+          (let [provider (:snapshot-provider opts)
+                revision
+                {:revision
+                 (get-in envelope [:native-revision :revision])
+                 :exact-locator
+                 (get-in envelope [:native-revision :exact-locator])}
+                _ (execution/check!
                    (:execution-contract opts)
                    :cursor-exact-selection)
-                (backend/invoke
-                 adapter
-                 :select-exact
-                 {:revision
-                  (get-in envelope [:native-revision :revision])
-                  :exact-locator
-                  (get-in envelope [:native-revision :exact-locator])}
-                 (:timeout-ms opts)))]
-            (execution/check!
-             (:execution-contract opts)
-             :cursor-exact-selected)
-            (when-not exact
-              (throw
-               (ex-info
-                "The cursor's exact snapshot is no longer retained."
-                {:type :eacl.consistency/snapshot-expired
-                 :eacl/error
-                 :eacl.consistency/snapshot-expired})))
-            (let [exact-context
-                  (request-dependency-context exact opts)
-                  decision
-                  (continuation-decision
-                   opts current envelope exact-context)]
-              (apply-continuation-decision!
-               exact exact-context envelope decision)
-              exact)))
+                selected
+                (when provider
+                  (snapshot-provider/acquire!
+                   provider :exact revision (:timeout-ms opts)))]
+            (try
+              (let [exact
+                    (if selected
+                      (snapshot-provider/adapter selected)
+                      (backend/invoke
+                       adapter :select-exact revision (:timeout-ms opts)))
+                    _
+                    (execution/check!
+                     (:execution-contract opts)
+                     :cursor-exact-selected)
+                    _
+                    (when-not exact
+                      (throw
+                       (ex-info
+                        "The cursor's exact snapshot is no longer retained."
+                        {:type :eacl.consistency/snapshot-expired
+                         :eacl/error
+                         :eacl.consistency/snapshot-expired})))
+                    exact-context
+                    (request-dependency-context exact opts)
+                    decision
+                    (continuation-decision
+                     opts current envelope exact-context)]
+                (apply-continuation-decision!
+                 exact exact-context envelope decision)
+                {:adapter exact
+                 :selected-snapshot selected})
+              (catch #?(:clj Throwable :cljs :default) error
+                (when selected
+                  (snapshot-provider/release! selected))
+                (throw error)))))
 
         (do
           (apply-continuation-decision!
            adapter current envelope initial)
-          adapter)))))
+          {:adapter adapter})))))
 
 (defn select-continuation-adapter
   "Uses an equal current proof or a verified exact historical fallback."
   [adapter opts operation query]
   (let [token (or (:after query) (:before query))
-        envelope (decode-envelope adapter opts operation query token)]
-    (select-envelope-adapter adapter opts envelope)))
+        envelope (decode-envelope adapter opts operation query token)
+        context (select-envelope-context adapter opts envelope)]
+    (if-let [selected (:selected-snapshot context)]
+      (do
+        (snapshot-provider/release! selected)
+        (throw
+         (ex-info
+          "Provider-owned cursor recovery requires a resource-scoped page request."
+          {:type :eacl/snapshot-scope-required
+           :eacl/error :eacl/snapshot-scope-required})))
+      (:adapter context))))
 
 (defn- internalize-tracked-edge
   [adapter edge]
@@ -789,23 +812,31 @@
                     adapter opts operation query (get query field))])))
              vec)
         primary-envelope (some second envelopes)
-        page-adapter
-        (select-envelope-adapter adapter opts primary-envelope)
-        prepared-query
-        (reduce
-         (fn [query [field envelope]]
-           (if-not envelope
-             (assoc query field nil)
-             (do
-               (when-not (identical? envelope primary-envelope)
-                 (validate-context! page-adapter opts envelope))
-               (assoc query field
-                      (internalize-continued-edge
-                       page-adapter (:edge envelope))))))
-         query
-         envelopes)]
-    {:adapter page-adapter
-     :query prepared-query}))
+        page-context
+        (select-envelope-context adapter opts primary-envelope)
+        page-adapter (:adapter page-context)
+        selected (:selected-snapshot page-context)]
+    (try
+      (let [prepared-query
+            (reduce
+             (fn [query [field envelope]]
+               (if-not envelope
+                 (assoc query field nil)
+                 (do
+                   (when-not (identical? envelope primary-envelope)
+                     (validate-context! page-adapter opts envelope))
+                   (assoc query field
+                          (internalize-continued-edge
+                           page-adapter (:edge envelope))))))
+             query
+             envelopes)]
+        {:adapter page-adapter
+         :selected-snapshot selected
+         :query prepared-query})
+      (catch #?(:clj Throwable :cljs :default) error
+        (when selected
+          (snapshot-provider/release! selected))
+        (throw error)))))
 
 (defn- decode-page-edge
   [adapter opts operation query token]

--- a/modules/eacl/test/eacl/backend/snapshot_provider_test.cljc
+++ b/modules/eacl/test/eacl/backend/snapshot_provider_test.cljc
@@ -1,0 +1,355 @@
+(ns eacl.backend.snapshot-provider-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [eacl.backend.snapshot-provider :as provider]
+            [eacl.backend.v8 :as backend]))
+
+(defn- adapter
+  ([] (adapter :test backend/strict-sequential-traversal-execution))
+  ([backend-id traversal-execution]
+   (adapter backend-id traversal-execution {}))
+  ([backend-id traversal-execution
+    {:keys [source-id branch lifecycle revision exact-locator
+            schema-identity snapshot-database-id]
+     :or {source-id ::source
+          branch nil
+          lifecycle ::lifecycle
+          revision 1
+          exact-locator 1}}]
+   (backend/make-adapter
+    {:id backend-id
+     :capabilities backend/empty-capabilities
+     :traversal-execution traversal-execution
+     :operations
+     (merge
+      (into {}
+            (map (fn [operation-key]
+                   [operation-key (fn [& _] nil)]))
+            backend/required-snapshot-operations)
+      {:snapshot-id
+       (constantly
+        (cond-> {:database-id (or snapshot-database-id backend-id)
+                 :basis-t revision}
+          schema-identity (assoc :schema-identity schema-identity)))
+       :source-scope
+       (constantly {:source-id source-id :branch branch})
+       :source-lifecycle (constantly lifecycle)
+       :native-revision
+       (constantly {:revision revision :exact-locator exact-locator})
+       :order-hint (constantly revision)
+       :exact-locator (constantly exact-locator)})})))
+
+(defn- snapshot-provider
+  [{:keys [candidate ownership-policy release-calls
+           traversal-execution backend-id execution-constraints
+           acquire-calls]
+    :or {candidate (adapter)
+         ownership-policy :owned
+         release-calls (atom [])
+         traversal-execution backend/strict-sequential-traversal-execution
+         backend-id :test}}]
+  (let [acquire
+        (fn [& _]
+          (when acquire-calls
+            (swap! acquire-calls inc))
+          {:adapter candidate
+           :ownership (if (= :borrowed ownership-policy)
+                        :borrowed
+                        :owned)
+           :release-token ::reader})]
+    (provider/make-provider
+     {:id backend-id
+      :capabilities backend/empty-capabilities
+      :traversal-execution traversal-execution
+      :topology {:deployment :embedded}
+      :execution-constraints
+      (or execution-constraints provider/default-execution-constraints)
+      :snapshot-ownership ownership-policy
+      :operations
+      {:source-scope
+       (constantly {:source-id ::source :branch nil})
+       :source-lifecycle (constantly ::lifecycle)
+       :acquire-current! acquire
+       :acquire-authoritative! acquire
+       :acquire-at-least! acquire
+       :acquire-exact! acquire
+       :release! #(swap! release-calls conj %)}})))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) error
+      (ex-data error))))
+
+(deftest provider-contract-is-closed-test
+  (testing "unknown provider fields fail validation"
+    (is (= [:surprise]
+           (:unknown-keys
+            (error-data
+             #(provider/make-provider
+               {:id :test
+                :capabilities backend/empty-capabilities
+                :traversal-execution
+                backend/strict-sequential-traversal-execution
+                :topology {}
+                :execution-constraints
+                provider/default-execution-constraints
+                :snapshot-ownership :borrowed
+                :operations {}
+                :surprise true}))))))
+  (testing "every lifecycle operation is mandatory"
+    (is (= provider/required-provider-operations
+           (set
+            (:missing-operations
+             (error-data
+              #(provider/make-provider
+                {:id :test
+                 :capabilities backend/empty-capabilities
+                 :traversal-execution
+                 backend/strict-sequential-traversal-execution
+                 :topology {}
+                 :execution-constraints
+                 provider/default-execution-constraints
+                 :snapshot-ownership :borrowed
+                 :operations {}})))))))
+  (testing "execution constraints are closed enums"
+    (is (= :eacl/invalid-snapshot-provider
+           (:type
+            (error-data
+             #(provider/make-provider
+               {:id :test
+                :capabilities backend/empty-capabilities
+                :traversal-execution
+                backend/strict-sequential-traversal-execution
+                :topology {}
+                :execution-constraints
+                {:virtual-threads :sometimes
+                 :snapshot-thread :any
+                 :release-thread :any}
+                :snapshot-ownership :borrowed
+                :operations
+                (zipmap provider/required-provider-operations
+                        (repeat (fn [& _] nil)))})))))))
+
+(deftest provider-static-profile-does-not-acquire-test
+  (let [calls (atom {})
+        source (snapshot-provider {})]
+    (binding [provider/*provider-op-stats* calls]
+      (is (= :test (:backend-id (provider/static-profile source))))
+      (is (= {:source-id ::source :branch nil}
+             (provider/source-scope source)))
+      (is (= ::lifecycle (provider/source-lifecycle source))))
+    (is (= {:source-scope 1 :source-lifecycle 1} @calls))
+    (is (not-any? #(contains? @calls %)
+                  (vals provider/acquisition-operations)))))
+
+(deftest selected-snapshot-owns-one-idempotent-release-test
+  (let [release-calls (atom [])
+        source (snapshot-provider {:release-calls release-calls})
+        selected (provider/acquire! source :current)]
+    (is (provider/provider? source))
+    (is (provider/selected-snapshot? selected))
+    (is (= :owned (provider/ownership selected)))
+    (is (= :test (backend/backend-id (provider/adapter selected))))
+    (is (= {:backend :test
+            :source-id ::source
+            :branch nil
+            :source-lifecycle ::lifecycle
+            :revision 1
+            :exact-locator 1
+            :schema-identity nil
+            :backend-snapshot-id {:database-id :test :basis-t 1}}
+           (provider/semantic-identity selected)))
+    (is (false? (provider/released? selected)))
+    (is (true? (provider/release! selected)))
+    (is (true? (provider/released? selected)))
+    (is (false? (provider/release! selected)))
+    (is (= [::reader] @release-calls))
+    (is (= :eacl/snapshot-released
+           (:type (error-data #(provider/adapter selected)))))))
+
+(deftest failed-release-is-classified-and-remains-retryable-test
+  (let [attempts (atom 0)
+        source (snapshot-provider {})
+        retryable
+        (assoc-in
+         source
+         [::provider/operations :release!]
+         (fn [_]
+           (when (= 1 (swap! attempts inc))
+             (throw (ex-info "injected release failure"
+                             {:type :injected/release})))))
+        selected (provider/acquire! retryable :current)]
+    (is (= :eacl/snapshot-release-failed
+           (:type (error-data #(provider/release! selected)))))
+    (is (false? (provider/released? selected)))
+    (is (= :test (backend/backend-id (provider/adapter selected))))
+    (is (true? (provider/release! selected)))
+    (is (true? (provider/released? selected)))
+    (is (= 2 @attempts))
+    (is (false? (provider/release! selected)))))
+
+(deftest semantic-identity-covers-every-independent-state-dimension-test
+  (let [identity
+        (fn [overrides]
+          (let [source
+                (snapshot-provider
+                 {:candidate
+                  (adapter
+                   :test backend/strict-sequential-traversal-execution
+                   overrides)})
+                selected (provider/acquire! source :current)]
+            (try
+              (provider/semantic-identity selected)
+              (finally
+                (provider/release! selected)))))
+        baseline (identity {})]
+    (testing "separately acquired readers of the same semantic state compare equal"
+      (is (= baseline (identity {}))))
+    (doseq [[field overrides]
+            [[:backend {:snapshot-database-id :other-database}]
+             [:source {:source-id ::other-source}]
+             [:branch {:branch "other-branch"}]
+             [:lifecycle {:lifecycle ::other-lifecycle}]
+             [:revision {:revision 2 :exact-locator 2}]
+             [:exact-locator {:exact-locator :other-locator}]
+             [:schema {:schema-identity "other-schema"}]]]
+      (testing (name field)
+        (is (not= baseline (identity overrides)))))))
+
+(deftest acquisition-validates-provider-boundaries-test
+  (testing "backend identity cannot change during acquisition"
+    (let [release-calls (atom [])
+          source
+          (snapshot-provider
+           {:candidate (adapter :other
+                                backend/strict-sequential-traversal-execution)
+            :release-calls release-calls})]
+      (is (= :eacl/invalid-selected-snapshot
+             (:type (error-data #(provider/acquire! source :current)))))
+      (is (= [::reader] @release-calls))))
+  (testing "the adapter must retain the provider-static traversal profile"
+    (let [source
+          (snapshot-provider
+           {:candidate (adapter :test backend/default-traversal-execution)})]
+      (is (= :eacl/invalid-selected-snapshot
+             (:type (error-data #(provider/acquire! source :current)))))))
+  (testing "ownership cannot contradict the static policy"
+    (let [source
+          (snapshot-provider
+           {:candidate (adapter)
+            :ownership-policy :owned})
+          broken
+          (assoc-in
+           source
+           [::provider/operations :acquire-current!]
+           (fn []
+             {:adapter (adapter)
+              :ownership :borrowed
+              :release-token nil}))]
+      (is (= :eacl/invalid-selected-snapshot
+             (:type (error-data #(provider/acquire! broken :current)))))))
+  (testing "acquisition result shape is closed"
+    (let [release-calls (atom [])
+          source (snapshot-provider {:release-calls release-calls})
+          broken
+          (assoc-in
+           source
+           [::provider/operations :acquire-current!]
+           (fn []
+             {:adapter (adapter)
+              :ownership :owned
+              :release-token ::reader
+              :native-handle :escaped}))]
+      (is (= #{:adapter :ownership :release-token :native-handle}
+             (:actual-keys
+              (error-data #(provider/acquire! broken :current)))))
+      (is (= [::reader] @release-calls))))
+  (testing "a malformed acquisition missing its token still gets one cleanup attempt"
+    (let [release-calls (atom [])
+          source (snapshot-provider {:release-calls release-calls})
+          broken
+          (assoc-in
+           source
+           [::provider/operations :acquire-current!]
+           (fn []
+             {:adapter (adapter)
+              :ownership :owned}))]
+      (is (= :eacl/invalid-selected-snapshot
+             (:type (error-data #(provider/acquire! broken :current)))))
+      (is (= [nil] @release-calls)))))
+
+#?(:clj
+   (deftest acquiring-thread-constraints-fail-before-access-or-release-test
+     (let [release-calls (atom [])
+           source
+           (snapshot-provider
+            {:release-calls release-calls
+             :execution-constraints
+             {:virtual-threads :supported
+              :snapshot-thread :acquiring-thread
+              :release-thread :acquiring-thread}})
+           selected (provider/acquire! source :current)
+           access-error @(future (error-data #(provider/adapter selected)))
+           release-error @(future (error-data #(provider/release! selected)))]
+       (is (= :eacl/snapshot-thread-violation (:type access-error)))
+       (is (= :snapshot-access (:phase access-error)))
+       (is (= :eacl/snapshot-thread-violation (:type release-error)))
+       (is (= :snapshot-release (:phase release-error)))
+       (is (false? (provider/released? selected)))
+       (is (empty? @release-calls))
+       (is (true? (provider/release! selected)))
+       (is (= [::reader] @release-calls)))))
+
+#?(:clj
+   (deftest access-is-rejected-while-release-is-in-progress-test
+     (let [release-started (promise)
+           finish-release (promise)
+           source
+           (assoc-in
+            (snapshot-provider {})
+            [::provider/operations :release!]
+            (fn [_]
+              (deliver release-started true)
+              @finish-release))
+           selected (provider/acquire! source :current)
+           release-result (future (provider/release! selected))]
+       @release-started
+       (is (= :eacl/snapshot-release-in-progress
+              (:type (error-data #(provider/adapter selected)))))
+       (deliver finish-release true)
+       (is (true? @release-result))
+       (is (true? (provider/released? selected))))))
+
+#?(:clj
+   (deftest rejected-virtual-thread-fails-before-native-acquisition-test
+     (let [virtual-builder
+           (try
+             (clojure.lang.Reflector/invokeStaticMethod
+              "java.lang.Thread" "ofVirtual" (object-array 0))
+             (catch Throwable _ nil))]
+       (when virtual-builder
+         (let [acquire-calls (atom 0)
+               result (promise)
+               source
+               (snapshot-provider
+                {:acquire-calls acquire-calls
+                 :execution-constraints
+                 {:virtual-threads :rejected
+                  :snapshot-thread :acquiring-thread
+                  :release-thread :acquiring-thread}})
+               runnable
+               (reify Runnable
+                 (run [_]
+                   (deliver
+                    result
+                    (error-data #(provider/acquire! source :current)))))
+               thread
+               (clojure.lang.Reflector/invokeInstanceMethod
+                virtual-builder "start" (object-array [runnable]))]
+           (.join ^Thread thread)
+           (is (= :eacl/unsupported-runtime (:type @result)))
+           (is (= :snapshot-acquisition (:phase @result)))
+           (is (zero? @acquire-calls)))))))

--- a/modules/eacl/test/eacl/backend/v8_test.cljc
+++ b/modules/eacl/test/eacl/backend/v8_test.cljc
@@ -156,6 +156,27 @@
     (is (every? #(= :one (get-in % [3 :source-id]))
                 (keys @registry)))))
 
+(deftest unavailable-proof-uses-a-fresh-request-local-schema-cache-test
+  (let [registry (atom {})
+        adapter
+        (backend/make-adapter
+         {:id :test
+          :capabilities
+          {:consistency #{:fully-consistent}
+           :snapshots #{:current}
+           :cursor #{:forward :reverse}
+           :transactions #{}
+           :cache-proofs #{:snapshot-bound}
+           :runtime #{#?(:clj :clj :cljs :cljs)}}
+          :operations (operation-map)})
+        first-cache (engine/schema-cache-for! registry adapter)
+        second-cache (engine/schema-cache-for! registry adapter)]
+    (is (true? (:request-local? first-cache)))
+    (is (nil? (:schema-version first-cache)))
+    (is (some? (:parsed-schema first-cache)))
+    (is (not (identical? first-cache second-cache)))
+    (is (empty? @registry))))
+
 (deftest invalid-v8-adapter-test
   (is (= :eacl/invalid-backend-adapter
          (:type

--- a/modules/eacl/test/eacl/consistency_provider_test.cljc
+++ b/modules/eacl/test/eacl/consistency_provider_test.cljc
@@ -1,0 +1,311 @@
+(ns eacl.consistency-provider-test
+  (:require [#?(:clj clojure.test :cljs cljs.test)
+             :refer [deftest is testing]]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
+            [eacl.backend.v8 :as backend]
+            [eacl.causal-token :as causal-token]
+            [eacl.consistency :as consistency]
+            [eacl.spicedb.consistency :as public-consistency]))
+
+(def format-options
+  {:current-kid :test
+   :keyring {:test (vec (range 32))}
+   :token-ttl-seconds 60})
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+           error
+      (ex-data error))))
+
+(defn- adapter
+  [{:keys [backend-id source-id lifecycle branch revision schema-identity]
+    :or {backend-id :test
+         source-id "source"
+         lifecycle "life"
+         branch nil
+         revision 1}}]
+  (backend/make-adapter
+   {:id backend-id
+    :capabilities
+    {:consistency backend/known-consistency-modes
+     :snapshots #{:current :authoritative :causal :exact}
+     :source #{:stable-scope :source-lifecycle :native-revision}
+     :cursor #{}
+     :transactions #{}
+     :cache-proofs #{}
+     :runtime #{#?(:clj :clj :cljs :cljs)}}
+    :traversal-execution backend/strict-sequential-traversal-execution
+    :operations
+    (merge
+     (into {}
+           (map (fn [operation-key]
+                  [operation-key (fn [& _] nil)]))
+           backend/required-snapshot-operations)
+     {:snapshot-id
+      (constantly
+       (cond-> {:database-id source-id :basis-t revision}
+         schema-identity (assoc :schema-identity schema-identity)))
+      :source-scope
+      (constantly {:source-id source-id :branch branch})
+      :source-lifecycle (constantly lifecycle)
+      :native-revision
+      (constantly {:revision revision :exact-locator revision})
+      :order-hint (constantly revision)
+      :exact-locator (constantly revision)})}))
+
+(defn- next-candidate!
+  [!candidates]
+  (let [candidate (first @!candidates)]
+    (swap! !candidates #(vec (rest %)))
+    candidate))
+
+(defn- provider
+  [{:keys [candidates release-calls acquire-calls modes source-id lifecycle]
+    :or {release-calls (atom [])
+         acquire-calls (atom [])
+         modes backend/known-consistency-modes
+         source-id "source"
+         lifecycle "life"}}]
+  (let [acquire
+        (fn [operation-key & args]
+          (swap! acquire-calls conj [operation-key args])
+          (let [candidate (next-candidate! candidates)
+                revision
+                (when candidate
+                  (:revision
+                   (backend/invoke candidate :native-revision)))]
+            {:adapter candidate
+             :ownership :owned
+             :release-token revision}))]
+    (snapshot-provider/make-provider
+     {:id :test
+      :capabilities
+      {:consistency modes
+       :snapshots #{:current :authoritative :causal :exact}
+       :source #{:stable-scope :source-lifecycle :native-revision}
+       :cursor #{}
+       :transactions #{}
+       :cache-proofs #{}
+       :runtime #{#?(:clj :clj :cljs :cljs)}}
+      :traversal-execution backend/strict-sequential-traversal-execution
+      :topology {:deployment :embedded :writer :sole}
+      :execution-constraints snapshot-provider/default-execution-constraints
+      :snapshot-ownership :owned
+      :operations
+      {:source-scope
+       (constantly {:source-id source-id :branch nil})
+       :source-lifecycle (constantly lifecycle)
+       :acquire-current!
+       #(acquire :acquire-current!)
+       :acquire-authoritative!
+       #(acquire :acquire-authoritative! %)
+       :acquire-at-least!
+       #(acquire :acquire-at-least! %1 %2)
+       :acquire-exact!
+       #(acquire :acquire-exact! %1 %2)
+       :release! #(swap! release-calls conj %)}})))
+
+(defn- token
+  [revision]
+  (causal-token/issue
+   format-options
+   {:backend :test
+    :source-id "source"
+    :source-lifecycle "life"
+    :branch nil
+    :revision revision
+    :exact-locator revision}))
+
+(deftest provider-current-and-authoritative-selection-transfer-ownership-test
+  (doseq [[consistency-value expected-operation]
+          [[public-consistency/minimize-latency :acquire-current!]
+           [public-consistency/fully-consistent :acquire-authoritative!]]]
+    (let [release-calls (atom [])
+          acquire-calls (atom [])
+          selected-adapter (adapter {:revision 11})
+          source
+          (provider {:candidates (atom [selected-adapter])
+                     :release-calls release-calls
+                     :acquire-calls acquire-calls})
+          selection
+          (consistency/select
+           source
+           consistency-value
+           {:format-options format-options
+            :timeout-ms 1000})
+          selected (:selected-snapshot selection)]
+      (is (identical? selected-adapter (:adapter selection)))
+      (is (snapshot-provider/selected-snapshot? selected))
+      (is (= expected-operation (ffirst @acquire-calls)))
+      (is (empty? @release-calls))
+      (is (true? (snapshot-provider/release! selected)))
+      (is (= [11] @release-calls)))))
+
+(deftest provider-at-least-closes-insufficient-candidates-test
+  (let [release-calls (atom [])
+        acquire-calls (atom [])
+        source
+        (provider
+         {:candidates
+          (atom [(adapter {:revision 5})
+                 (adapter {:revision 7})
+                 (adapter {:revision 10})])
+          :release-calls release-calls
+          :acquire-calls acquire-calls})
+        selection
+        (consistency/select
+         source
+         (public-consistency/at-least-as-fresh (token 10))
+         {:format-options format-options
+          :timeout-ms 1000})
+        selected (:selected-snapshot selection)
+        remaining-values
+        (mapv (comp second second) @acquire-calls)]
+    (is (= 10 (get-in selection [:native-revision :revision])))
+    (is (= [5 7] @release-calls))
+    (is (= 3 (count @acquire-calls)))
+    (is (every? pos? remaining-values))
+    (is (apply >= remaining-values))
+    (is (true? (snapshot-provider/release! selected)))
+    (is (= [5 7 10] @release-calls))))
+
+(deftest provider-at-least-uses-captured-revision-without-a-late-observation-test
+  (let [native-revision-calls (atom 0)
+        release-calls (atom [])
+        candidate
+        (assoc-in
+         (adapter {:revision 10})
+         [::backend/operations :native-revision]
+         (fn []
+           (let [call (swap! native-revision-calls inc)]
+             (if (= 1 call)
+               {:revision 10 :exact-locator 10}
+               (throw (ex-info "late native observation"
+                               {:type :test/late-observation}))))))
+        source (provider {:candidates (atom [])
+                          :release-calls release-calls})
+        source
+        (assoc-in
+         source
+         [::snapshot-provider/operations :acquire-at-least!]
+         (fn [_payload _remaining-ms]
+           {:adapter candidate
+            :ownership :owned
+            :release-token 10}))
+        selection
+        (consistency/select
+         source
+         (public-consistency/at-least-as-fresh (token 10))
+         {:format-options format-options :timeout-ms 1000})
+        selected (:selected-snapshot selection)]
+    (is (= 10 (get-in selection [:native-revision :revision])))
+    (is (= 1 @native-revision-calls))
+    (is (empty? @release-calls))
+    (is (true? (snapshot-provider/release! selected)))
+    (is (= [10] @release-calls))))
+
+#?(:clj
+   (deftest provider-at-least-rejects-candidate-returned-after-deadline-test
+     (let [release-calls (atom [])
+           candidate (adapter {:revision 10})
+           source (provider {:candidates (atom [])
+                             :release-calls release-calls})
+           slow-source
+           (assoc-in
+            source
+            [::snapshot-provider/operations :acquire-at-least!]
+            (fn [_payload _remaining-ms]
+              (Thread/sleep 15)
+              {:adapter candidate
+               :ownership :owned
+               :release-token 10}))]
+       (is (= :eacl.consistency/freshness-timeout
+              (:type
+               (error-data
+                #(consistency/select
+                  slow-source
+                  (public-consistency/at-least-as-fresh (token 10))
+                  {:format-options format-options :timeout-ms 1})))))
+       (is (= [10] @release-calls)))))
+
+(deftest provider-selection-releases-before-propagating-failure-test
+  (testing "scope mismatch closes the acquired candidate"
+    (let [release-calls (atom [])
+          source
+          (provider
+           {:candidates (atom [(adapter {:source-id "other" :revision 2})])
+            :release-calls release-calls})]
+      (is (= :eacl.consistency/incomparable-scope
+             (:type
+              (error-data
+               #(consistency/select
+                 source
+                 public-consistency/minimize-latency
+                 {:format-options format-options :timeout-ms 1000})))))
+      (is (= [2] @release-calls))))
+  (testing "cancellation after acquisition closes the candidate"
+    (let [release-calls (atom [])
+          source
+          (provider
+           {:candidates (atom [(adapter {:revision 3})])
+            :release-calls release-calls})]
+      (is (= :test/cancelled
+             (:type
+              (error-data
+               #(consistency/select
+                 source
+                 public-consistency/minimize-latency
+                 {:format-options format-options
+                  :timeout-ms 1000
+                  :selection-check!
+                  (fn [phase]
+                    (when (= :after-snapshot-acquisition phase)
+                      (throw (ex-info "cancelled" {:type :test/cancelled}))))})))))
+      (is (= [3] @release-calls)))))
+
+(deftest token-selection-fails-closed-across-a-concurrent-lifecycle-rotation-test
+  (let [lifecycle (atom "life")
+        release-calls (atom [])
+        source (provider {:candidates (atom [])
+                          :release-calls release-calls})
+        source
+        (-> source
+            (assoc-in
+             [::snapshot-provider/operations :source-lifecycle]
+             #(deref lifecycle))
+            (assoc-in
+             [::snapshot-provider/operations :acquire-at-least!]
+             (fn [_payload _remaining-ms]
+               (reset! lifecycle "rotated-life")
+               {:adapter (adapter {:revision 10
+                                   :lifecycle "rotated-life"})
+                :ownership :owned
+                :release-token 10})))]
+    (is (= :eacl.consistency/incomparable-scope
+           (:type
+            (error-data
+             #(consistency/select
+               source
+               (public-consistency/at-least-as-fresh (token 10))
+               {:format-options format-options :timeout-ms 1000})))))
+    (is (= [10] @release-calls))))
+
+(deftest unsupported-provider-mode-does-not-acquire-test
+  (let [acquire-calls (atom [])
+        source
+        (provider
+         {:candidates (atom [])
+          :acquire-calls acquire-calls
+          :modes #{:minimize-latency}})]
+    (is (= :eacl.consistency/exact-snapshot-unavailable
+           (:type
+            (error-data
+             #(consistency/select
+               source
+               (public-consistency/at-exact-snapshot (token 1))
+               {:format-options format-options :timeout-ms 1000})))))
+    (is (empty? @acquire-calls))))

--- a/modules/eacl/test/eacl/contract_support.cljc
+++ b/modules/eacl/test/eacl/contract_support.cljc
@@ -2,6 +2,7 @@
   (:require [#?(:clj clojure.test :cljs cljs.test) :refer [is testing]]
             [clojure.string :as str]
             [eacl.authorization-oracle :as oracle]
+            [eacl.backend.snapshot-provider :as snapshot-provider]
             [eacl.cache :as cache]
             [eacl.core :as eacl]
             [eacl.spicedb.consistency :as consistency]))
@@ -928,9 +929,17 @@
         (eacl/create-relationship!
          client denied :auditor (folder 0))
         (let [after-unrelated-write
-              (eacl/lookup-resources client all-query)]
-          (is (true? (:cached? after-unrelated-write))
-              "an unrelated stamped write preserves the dependency frontier")
+              (eacl/lookup-resources client all-query)
+              ordered-proofs?
+              (contains?
+               (:cache-proofs
+                (snapshot-provider/capabilities
+                 (get-in client [:opts :snapshot-provider])))
+               :ordered-generations)]
+          (is (= ordered-proofs? (:cached? after-unrelated-write))
+              (if ordered-proofs?
+                "an unrelated stamped write preserves the dependency frontier"
+                "a backend without ordered proofs recomputes after any revision"))
           (is (= (mapv folder (range recursive-connected-folder-count))
                  (:data after-unrelated-write))))
 

--- a/modules/eacl/test/eacl/engine/relationships_test.cljc
+++ b/modules/eacl/test/eacl/engine/relationships_test.cljc
@@ -113,6 +113,17 @@
     (is (= 3 @realized))
     (is (true? (get-in page [:page-info :has-next-page?])))))
 
+(deftest keyset-page-propagates-the-remaining-physical-budget-test
+  (let [budgets (atom [])
+        scan-fn
+        (fn [{:keys [idx physical-limit]} _edge _direction]
+          (swap! budgets conj [idx physical-limit])
+          (take physical-limit (get rows-by-spec idx)))
+        page (relationships/execute-page scan-specs {:first 2} scan-fn)]
+    (is (= [:r-0-0 :r-0-1] (:data page)))
+    (is (= [[0 3]] @budgets))
+    (is (true? (get-in page [:page-info :has-next-page?])))))
+
 (deftest keyset-cursor-is-a-direction-neutral-exclusive-position-test
   (let [scan-fn (scanner (atom 0))
         forward-page

--- a/src-build/eacl/build/config.clj
+++ b/src-build/eacl/build/config.clj
@@ -60,12 +60,25 @@
     :directory "modules/eacl-datalevin"
     :description "Datalevin adapter for the EACL authorization engine"
     :required-entry "eacl/datalevin/core.cljc"
+    ;; Keep workspace identity/build metadata complete without admitting an
+    ;; artifact whose pinned runtime dependency is not public yet.
+    :release-ready? false
+    :release-blocker :datalevin-fork-artifact-unpublished
     :dependencies
     {'org.clojure/clojure {:mvn/version "1.12.4"}
      'dev.eacl/eacl ::eacl-version
      'com.rpl/specter {:mvn/version "1.1.4"}
      'dev.eacl/datalevin-embedded-eacl
      {:mvn/version datalevin-fork-version}}}})
+
+(def release-module-order
+  "Modules eligible for the coordinated Maven release pipeline. A workspace
+  module joins only after all of its declared Maven dependencies resolve from
+  the clean public repositories used by release consumers."
+  (into
+   []
+   (filter #(not= false (:release-ready? (get modules %))))
+   module-order))
 
 (def scm
   {:connection "scm:git:https://github.com/theronic/eacl.git"

--- a/src-build/eacl/build/config.clj
+++ b/src-build/eacl/build/config.clj
@@ -7,7 +7,9 @@
 (def minimum-java-release 8)
 
 (def module-order
-  [:eacl :eacl-datomic :eacl-datahike :eacl-datascript])
+  [:eacl :eacl-datomic :eacl-datahike :eacl-datascript :eacl-datalevin])
+
+(def datalevin-fork-version "1.0.2-eacl.1")
 
 (def modules
   {:eacl
@@ -51,7 +53,19 @@
     {'org.clojure/clojure {:mvn/version "1.11.4"}
      'dev.eacl/eacl ::eacl-version
      'com.rpl/specter {:mvn/version "1.1.4"}
-     'datascript/datascript {:mvn/version "1.7.8"}}}})
+     'datascript/datascript {:mvn/version "1.7.8"}}}
+
+   :eacl-datalevin
+   {:lib 'dev.eacl/eacl-datalevin
+    :directory "modules/eacl-datalevin"
+    :description "Datalevin adapter for the EACL authorization engine"
+    :required-entry "eacl/datalevin/core.cljc"
+    :dependencies
+    {'org.clojure/clojure {:mvn/version "1.12.4"}
+     'dev.eacl/eacl ::eacl-version
+     'com.rpl/specter {:mvn/version "1.1.4"}
+     'dev.eacl/datalevin-embedded-eacl
+     {:mvn/version datalevin-fork-version}}}})
 
 (def scm
   {:connection "scm:git:https://github.com/theronic/eacl.git"
@@ -155,7 +169,8 @@
         '#{dev.eacl/eacl
            dev.eacl/eacl-datomic
            dev.eacl/eacl-datahike
-           dev.eacl/eacl-datascript}]
+           dev.eacl/eacl-datascript
+           dev.eacl/eacl-datalevin}]
     (when-not (= expected (set libs))
       (throw
        (ex-info

--- a/src-build/eacl/build/config_test.clj
+++ b/src-build/eacl/build/config_test.clj
@@ -4,7 +4,7 @@
             [eacl.build.module :as module]))
 
 (deftest coordinated-module-identities-and-versions
-  (testing "the release set has exactly the requested dependency order"
+  (testing "the workspace has exactly the requested dependency order"
     (is (= [:eacl :eacl-datomic :eacl-datahike :eacl-datascript
             :eacl-datalevin]
            config/module-order))
@@ -15,6 +15,11 @@
              dev.eacl/eacl-datalevin]
            (mapv (comp :lib config/module) config/module-order)))
     (is (true? (config/assert-coordinate-set!))))
+  (testing "the release set excludes modules with unpublished dependencies"
+    (is (= [:eacl :eacl-datomic :eacl-datahike :eacl-datascript]
+           config/release-module-order))
+    (is (= :datalevin-fork-artifact-unpublished
+           (:release-blocker (config/module :eacl-datalevin)))))
   (testing "one version is applied to every transitive core edge"
     (doseq [module-id (rest config/module-order)]
       (is (= {:mvn/version "8.3.1"}
@@ -25,6 +30,7 @@
           dependencies
           (config/dependencies :eacl-datalevin "8.3.1")]
       (is (= "eacl/datalevin/core.cljc" (:required-entry module)))
+      (is (false? (:release-ready? module)))
       (is (= #{'org.clojure/clojure
                'dev.eacl/eacl
                'com.rpl/specter

--- a/src-build/eacl/build/config_test.clj
+++ b/src-build/eacl/build/config_test.clj
@@ -5,12 +5,14 @@
 
 (deftest coordinated-module-identities-and-versions
   (testing "the release set has exactly the requested dependency order"
-    (is (= [:eacl :eacl-datomic :eacl-datahike :eacl-datascript]
+    (is (= [:eacl :eacl-datomic :eacl-datahike :eacl-datascript
+            :eacl-datalevin]
            config/module-order))
     (is (= '[dev.eacl/eacl
              dev.eacl/eacl-datomic
              dev.eacl/eacl-datahike
-             dev.eacl/eacl-datascript]
+             dev.eacl/eacl-datascript
+             dev.eacl/eacl-datalevin]
            (mapv (comp :lib config/module) config/module-order)))
     (is (true? (config/assert-coordinate-set!))))
   (testing "one version is applied to every transitive core edge"
@@ -18,6 +20,25 @@
       (is (= {:mvn/version "8.3.1"}
              (get (config/dependencies module-id "8.3.1")
                   'dev.eacl/eacl)))))
+  (testing "the Datalevin module pins the maintained fork exactly"
+    (let [module (config/module :eacl-datalevin)
+          dependencies
+          (config/dependencies :eacl-datalevin "8.3.1")]
+      (is (= "eacl/datalevin/core.cljc" (:required-entry module)))
+      (is (= #{'org.clojure/clojure
+               'dev.eacl/eacl
+               'com.rpl/specter
+               'dev.eacl/datalevin-embedded-eacl}
+             (set (keys dependencies))))
+      (is (= {:mvn/version "1.0.2-eacl.1"}
+             (get dependencies
+                  'dev.eacl/datalevin-embedded-eacl)))
+      (is (not-any?
+           #(contains? dependencies %)
+           '[com.datomic/peer
+             org.replikativ/datahike
+             datascript/datascript
+             org.datalevin/datalevin-embedded]))))
   (testing "local and explicit versions are validated"
     (is (= config/default-version (config/version {})))
     (is (= "8.1.0" (config/version {:version "8.1.0"})))

--- a/src-build/eacl/build/module.clj
+++ b/src-build/eacl/build/module.clj
@@ -238,10 +238,18 @@
       (some #(string/ends-with? entry-name %)
             [".clj" ".cljc" ".cljs" ".edn" ".xml"])))
 
+(def ^:private credential-patterns
+  [#"-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----"
+   #"AKIA[0-9A-Z]{16}"
+   #"gh[pousr]_[A-Za-z0-9_]{20,}"])
+
+(declare jar-entries)
+
 (defn- assert-no-workspace-content!
   [{:keys [root jar-file pom-file]}]
   (let [root-path (.getCanonicalPath ^java.io.File root)
-        forbidden [root-path "target/formal" "cloudafrica/"]
+        forbidden [root-path "target/formal" "cloudafrica/"
+                   "/Users/" "/home/" "C:\\Users\\"]
         pom (slurp pom-file)]
     (doseq [fragment forbidden]
       (when (string/includes? pom fragment)
@@ -267,8 +275,49 @@
                   {:type :eacl.build/workspace-content
                    :path jar-file
                    :entry entry-name
-                   :fragment fragment}))))))))
+                   :fragment fragment}))))
+            (doseq [pattern credential-patterns]
+              (when (re-find pattern content)
+                (throw
+                 (ex-info
+                  "Generated JAR contains credential-shaped material."
+                  {:type :eacl.build/credential-content
+                   :path jar-file
+                   :entry entry-name
+                   :pattern (str pattern)}))))))))
     true))
+
+(defn assert-adapter-jar-isolation!
+  "Rejects backend implementation or native payloads outside the selected
+  adapter's source namespace. Datalevin's native runtime belongs exclusively
+  to its pinned dependency artifact, never to the EACL adapter JAR."
+  [module-id jar-file]
+  (when (= :eacl-datalevin module-id)
+    (let [entries (jar-entries jar-file)
+          forbidden-prefixes
+          ["eacl/datomic/"
+           "eacl/datahike/"
+           "eacl/datascript/"
+           "datalevin/"
+           "org/bytedeco/"
+           "META-INF/native-image/"]
+          forbidden
+          (into
+           []
+           (filter
+            (fn [entry]
+              (and (not (string/ends-with? entry "/"))
+                   (some #(string/starts-with? entry %)
+                         forbidden-prefixes))))
+           entries)]
+      (when (seq forbidden)
+        (throw
+         (ex-info
+          "The Datalevin EACL adapter JAR contains another backend or native runtime payload."
+          {:type :eacl.build/backend-isolation-failed
+           :module module-id
+           :entries (vec (sort forbidden))})))))
+  true)
 
 (defn assert-generated-bytecode!
   ([class-root]
@@ -415,6 +464,7 @@
         missing (vec (sort (remove entries required)))]
     (assert-pom! module-id artifact)
     (assert-no-workspace-content! artifact)
+    (assert-adapter-jar-isolation! module-id jar-file)
     (when (seq missing)
       (throw
        (ex-info

--- a/src-build/eacl/build/module_test.clj
+++ b/src-build/eacl/build/module_test.clj
@@ -22,6 +22,21 @@
     (.writeShort output 0)
     (.writeShort output major)))
 
+(defn- write-entry!
+  [root entry]
+  (let [file (io/file root entry)]
+    (.mkdirs (.getParentFile file))
+    (spit file "fixture")
+    file))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
 (deftest generated-bytecode-target-defaults-to-java-26-and-allows-older-java
   (let [directory (temporary-directory)
         class-file (io/file directory "Generated.class")]
@@ -49,5 +64,36 @@
         (is (true? (module/assert-generated-bytecode!
                     (.getPath directory)
                     {:java-release 8}))))
+      (finally
+        (b/delete {:path (.getPath directory)})))))
+
+(deftest datalevin-adapter-jar-cannot-bundle-backends-or-native-runtime
+  (let [directory (temporary-directory)
+        classes (io/file directory "classes")
+        jar-file (io/file directory "adapter.jar")]
+    (try
+      (write-entry! classes "eacl/datalevin/core.cljc")
+      (b/jar {:class-dir (.getPath classes)
+              :jar-file (.getPath jar-file)})
+      (is (true?
+           (module/assert-adapter-jar-isolation!
+            :eacl-datalevin (.getPath jar-file))))
+      (doseq [forbidden-entry
+              ["eacl/datomic/core.clj"
+               "eacl/datahike/core.clj"
+               "eacl/datascript/core.cljc"
+               "datalevin/dtlvnative/linux-arm64/libdtlv.so"
+               "org/bytedeco/javacpp.class"]]
+        (b/delete {:path (.getPath classes)})
+        (write-entry! classes "eacl/datalevin/core.cljc")
+        (write-entry! classes forbidden-entry)
+        (b/jar {:class-dir (.getPath classes)
+                :jar-file (.getPath jar-file)})
+        (let [failure
+              (error-data
+               #(module/assert-adapter-jar-isolation!
+                 :eacl-datalevin (.getPath jar-file)))]
+          (is (= :eacl.build/backend-isolation-failed (:type failure)))
+          (is (= [forbidden-entry] (:entries failure)))))
       (finally
         (b/delete {:path (.getPath directory)})))))

--- a/src-build/eacl/build/release.clj
+++ b/src-build/eacl/build/release.clj
@@ -15,7 +15,8 @@
   {:eacl 'eacl.core
    :eacl-datomic 'eacl.datomic.core
    :eacl-datahike 'eacl.datahike.core
-   :eacl-datascript 'eacl.datascript.core})
+   :eacl-datascript 'eacl.datascript.core
+   :eacl-datalevin 'eacl.datalevin.core})
 
 (defn- temporary-directory
   [prefix]
@@ -48,7 +49,7 @@
     (when-not (= expected actual)
       (throw
        (ex-info
-        "The release set must contain all four modules in dependency order."
+        "The release set must contain every coordinated module in dependency order."
         {:type :eacl.release/invalid-artifact-set
          :expected expected
          :actual actual})))
@@ -84,12 +85,58 @@
          :output output})))
     output))
 
+(def ^:private datalevin-jvm-options
+  ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+   "--add-opens=java.base/java.nio=ALL-UNNAMED"
+   "--add-opens=java.base/java.util=ALL-UNNAMED"
+   "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+   "--enable-native-access=ALL-UNNAMED"])
+
+(defn- datalevin-smoke-source
+  []
+  (str
+   "  (let [dir (u/tmp-dir (str \"eacl-packaged-datalevin-\" (random-uuid)))\n"
+   "        conn (datalevin/create-conn dir)\n"
+   "        watermark (atom 0)]\n"
+   "    (try\n"
+   "      (let [client\n"
+   "            (datalevin/make-client\n"
+   "             conn\n"
+   "             {:security-key \"01234567890123456789012345678901\"\n"
+   "              :source-lifecycle \"packaged-smoke\"\n"
+   "              :revision-watermark watermark\n"
+   "              :advance-revision-watermark! #(swap! watermark max %)\n"
+   "              :datalevin-topology\n"
+   "              backend/certified-topology-declaration})\n"
+   "            alice (eacl/spice-object :user \"alice\")\n"
+   "            document (eacl/spice-object :document \"document-1\")]\n"
+   "        (eacl/write-schema!\n"
+   "         client\n"
+   "         \"definition user {}\\ndefinition document {\\n  relation viewer: user\\n  permission view = viewer\\n}\")\n"
+   "        (d/transact! conn [{:eacl/id \"alice\"}\n"
+   "                           {:eacl/id \"document-1\"}])\n"
+   "        (eacl/create-relationship! client alice :viewer document)\n"
+   "        (assert (true? (eacl/can? client alice :view document)))\n"
+   "        (assert (= {:active 0 :oldest-age-ms nil}\n"
+   "                   (d/active-read-snapshot-info))))\n"
+   "      (finally\n"
+   "        (d/close conn)\n"
+   "        (u/delete-files dir))))\n"))
+
 (defn- smoke-source
-  [entry-point expected-major]
+  [module-id entry-point expected-major]
   (str
    "(ns smoke\n"
    "  (:require [clojure.java.io :as io]\n"
-   "            [" entry-point "]\n"
+   (when-not (= :eacl-datalevin module-id)
+     (str "            [" entry-point "]\n"))
+   (when (= :eacl-datalevin module-id)
+     (str
+      "            [datalevin.core :as d]\n"
+      "            [datalevin.util :as u]\n"
+      "            [eacl.core :as eacl]\n"
+      "            [eacl.datalevin.backend :as backend]\n"
+      "            [eacl.datalevin.core :as datalevin]\n"))
    "            [eacl.formal.production-kernel])\n"
    "  (:import (java.io DataInputStream)\n"
    "           (dafny DafnySequence TypeDescriptor)\n"
@@ -112,23 +159,39 @@
    "         (biginteger 1))]\n"
    "    (assert (instance? WireResult_Accepted result))\n"
    "    (assert (= [7N] (mapv bigint (.dtor_items result)))))\n"
+   (when (= :eacl-datalevin module-id)
+     (datalevin-smoke-source))
    "  (println \"EACL Maven smoke passed\"))\n"))
 
 (defn- write-consumer!
   [consumer-root local-repo version module-id expected-major]
   (let [project (io/file consumer-root (name module-id))
         source-directory (io/file project "src")
-        {:keys [lib]} (config/module module-id)]
+        {:keys [lib]} (config/module module-id)
+        clojure-coordinate
+        (get (config/dependencies module-id version)
+             'org.clojure/clojure)]
     (.mkdirs source-directory)
     (spit
      (io/file project "deps.edn")
      (pr-str
       {:paths ["src"]
        :mvn/local-repo (.getCanonicalPath (io/file local-repo))
-       :deps {lib {:mvn/version version}}}))
+       ;; The installation-level Clojure CLI basis may carry a newer Clojure
+       ;; version. Pin the module's declared runtime so the smoke process
+       ;; exercises the packaged graph instead of silently selecting that
+       ;; installation default.
+       :deps {lib {:mvn/version version}
+              'org.clojure/clojure clojure-coordinate}
+       :aliases
+       {:smoke
+        (cond-> {}
+          (= :eacl-datalevin module-id)
+          (assoc :jvm-opts datalevin-jvm-options))}}))
     (spit
      (io/file source-directory "smoke.clj")
-     (smoke-source (consumer-entry-points module-id) expected-major))
+     (smoke-source
+      module-id (consumer-entry-points module-id) expected-major))
     project))
 
 (defn- assert-isolated-classpath!
@@ -166,7 +229,8 @@
                     (run-command!
                      project ["clojure" "-Srepro" "-Spath"])]]
         (assert-isolated-classpath! repository-root classpath)
-        (run-command! project ["clojure" "-Srepro" "-M" "-m" "smoke"]))
+        (run-command!
+         project ["clojure" "-Srepro" "-M:smoke" "-m" "smoke"]))
       true
       (finally
         (b/delete {:path (.getPath consumer-root)})

--- a/src-build/eacl/build/release.clj
+++ b/src-build/eacl/build/release.clj
@@ -33,7 +33,7 @@
     (module/assert-module-coordinates!)
     (mapv #(module/jar! % {:version version
                            :java-release java-release})
-          config/module-order)))
+          config/release-module-order)))
 
 (defn assert-release-set!
   [artifacts expected-version]
@@ -41,7 +41,7 @@
         (mapv
          (fn [module-id]
            [module-id (:lib (config/module module-id)) expected-version])
-         config/module-order)
+         config/release-module-order)
         actual
         (mapv (juxt :module-id :lib :version) artifacts)
         java-targets
@@ -221,7 +221,7 @@
     (try
       (doseq [artifact artifacts]
         (module/install-built! artifact local-repo))
-      (doseq [module-id config/module-order
+      (doseq [module-id config/release-module-order
               :let [project
                     (write-consumer!
                      consumer-root local-repo version module-id expected-major)

--- a/src-build/eacl/build/release_test.clj
+++ b/src-build/eacl/build/release_test.clj
@@ -26,7 +26,7 @@
                      :java-class-major-version
                      (config/java-class-major-version options)})]
       (release/build-set! {:version "8.1.0" :java-release 17})
-      (is (= config/module-order (mapv first @builds)))
+      (is (= config/release-module-order (mapv first @builds)))
       (is (every? #(= {:version "8.1.0" :java-release 17} (second %))
                   @builds)))))
 
@@ -54,7 +54,7 @@
             :version "8.1.0"
             :java-release 26
             :java-class-major-version 70})
-         config/module-order)]
+         config/release-module-order)]
     (testing "a local audit failure occurs before the first deploy call"
       (with-redefs [module/audit-built!
                     (fn [module-id _]
@@ -80,7 +80,7 @@
       :version "8.1.0"
       :java-release 26
       :java-class-major-version 70})
-   config/module-order))
+   config/release-module-order))
 
 (deftest every-local-release-failure-precedes-all-uploads
   (let [credentials {:username "theronic" :token "not-a-real-token"}]

--- a/src-build/eacl/release_guard.clj
+++ b/src-build/eacl/release_guard.clj
@@ -9,6 +9,7 @@
     "isolated-modules (eacl-datomic)"
     "isolated-modules (eacl-datahike)"
     "isolated-modules (eacl-datascript)"
+    "isolated-modules (eacl-datalevin)"
     "dafny-and-generated-boundaries"
     "temporal-models"
     "parity-corpus-and-mutations"})

--- a/src-build/eacl/release_guard.clj
+++ b/src-build/eacl/release_guard.clj
@@ -9,7 +9,6 @@
     "isolated-modules (eacl-datomic)"
     "isolated-modules (eacl-datahike)"
     "isolated-modules (eacl-datascript)"
-    "isolated-modules (eacl-datalevin)"
     "dafny-and-generated-boundaries"
     "temporal-models"
     "parity-corpus-and-mutations"})


### PR DESCRIPTION
## Summary

This PR adds the CLJ-only `dev.eacl/eacl-datalevin` backend and the shared snapshot-provider machinery it requires.

- Add schema, relationship, mutation, safe-retraction, consistency, cursor, and lifecycle support for Datalevin.
- Evaluate each authorization request against one explicitly acquired Datalevin read snapshot and release that snapshot exactly once.
- Restrict the supported Datalevin deployment topology to one embedded database, one JVM/connection, and a synchronous sole writer.
- Reuse the snapshot-provider boundary in the Datomic, Datahike, and DataScript adapters.
- Reduce read-path work by avoiding repeated connection reads, avoiding duplicate schema derivation, and passing remaining page demand into native relationship scans.
- Add module/build metadata, documentation, release guards, adapter certification tests, differential tests, mutation-race tests, and local benchmarks.

## Datalevin consistency contract

The adapter advertises only guarantees supported by the qualified embedded topology:

- `minimize-latency` and `fully-consistent` acquire a fresh read snapshot at the local sole-writer head.
- `at-least-as-fresh` retries fresh snapshots until the authenticated revision floor is visible or the request deadline/cancellation ends the attempt.
- `at-exact-snapshot` fails closed because this adapter cannot reconstruct arbitrary historical snapshots.
- Cache and cursor reuse is limited to the identical selected revision.
- No ordered-generation proof, cross-revision cache lifting, remote/server topology, HA topology, replica topology, or multiple-writer topology is claimed.
- Source lifecycle and committed-revision watermark state must be supplied and durably maintained by the deployment.

## Correctness and performance

- Datalevin read handles are owned by the acquiring platform thread; use-after-release and cross-thread use fail before backend work.
- Snapshot acquisition, semantic identity, request ownership, release, and cursor recovery are handled explicitly.
- Schema derivation remains request-local where no ordered proof exists.
- Physical relationship scans are bounded by the remaining logical page demand instead of realizing an unnecessarily large tail.
- The retained local benchmark records sub-millisecond p50s for the module's warmed permission, lookup, count, scan, and snapshot operations. The end-to-end HTTP demo remains slower because it includes transport, serialization, orchestration, and permission-filtered point checks.

## Validation

- Datalevin module suite: 205 tests, 5,103 assertions, zero failures/errors.
- Build and release tests: 13 tests, 108 assertions, zero failures/errors.
- Datalevin module JAR build and isolation audit: passed.
- Clean Maven build/install/consumer smoke for the publishable release set: passed.
- Required GitHub checks on this PR are passing.
- The public-source closure artifact was regenerated with 70 roots and 1,587 reachable internal definitions. It is deliberately classified as `closure-enumerated-verification-incomplete`; it is not a formal source-refinement or runtime-correctness proof.

## Release prerequisite

`eacl-datalevin` is intentionally excluded from coordinated Maven publication until `dev.eacl/datalevin-embedded-eacl:1.0.2-eacl.1` is published from the maintained immutable Datalevin fork and passes the clean remote-consumer gate. Local development currently resolves the sibling `../datalevin` checkout. Release tooling fails closed while that prerequisite is unmet.
