### PR TITLE
feat: add proof-carrying semantic equivalence

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -30,6 +30,9 @@ Caching does not alter results:
 
 - `eacl.cache/no-cache` disables it for a client;
 - `:cache? false` bypasses lookup and publication for one operation;
+- `:populate-cache? false` keeps lookup and request-local memoization enabled
+  while suppressing completed-answer, managed-subproblem, checkpoint, and
+  visited-page publication for one operation;
 - failed, timed-out, partial, malformed, or unproved work is never published
   as a completed result; and
 - cache data is never written to the application database.
@@ -38,8 +41,8 @@ Caching does not alter results:
 
 | Layer | Reuse scope | Purpose |
 | --- | --- | --- |
-| Exact completed answer | Same semantic operation and canonical ordinary immutable snapshot | Skips the complete operation with no proof read; retained historical generations share one bounded composite-key tier |
-| Proof-backed completed answer | Same semantic operation, lifecycle, schema generation, and dependency frontier | Survives unrelated forward transactions |
+| Exact completed answer | Same semantic operation and complete immutable basis identity | Skips the complete operation with no proof read; ordinary and retained historical generations share one bounded composite-key tier |
+| Proof-backed completed answer | Same semantic operation, lineage, schema generation, and dependency frontier | Reuses across either revision direction when the selected basis has a readable complete frame |
 | Identity projection | Same backend, identity contract, and internal id | Shares `internal-id->object` renderings while a page is externalized |
 | Sealed plan | Same source scope, lifecycle, schema generation, and permission root | Reuses the compiled stable-discovery plan across requests and unrelated transactions; `expire-cache!` drops it |
 | Schema-derived generation | Same engine ABI, adapter/source scope, lifecycle, and certified schema generation | Shares parsed validation catalogs, permission roots and paths, dependency closures, routing analysis, direct-grant relations, cycle guards, and sealed plans |
@@ -109,8 +112,10 @@ and identity contract, engine/order ABI, normalized semantic request, result
 kind, demand, and every answer-affecting limit. Equal numeric revisions alone
 are insufficient. Each retained basis owns its exact answers and subproblem
 store. A historical miss evaluates on the already selected immutable adapter
-and never probes managed proof-backed entries. Public tokens, cursor envelopes,
-cache basis, external IDs, and selected-basis metadata are rebuilt on every hit.
+and may probe managed proof-backed entries when that historical value can read
+a complete contract-valid frame in the native revision domain. An unreadable
+historical frame remains exact-only. Public tokens, cursor envelopes, cache
+basis, external IDs, and selected-basis metadata are rebuilt on every hit.
 
 Caller-constructed database values are not accepted as source bases and cannot
 enter the completed-answer cache. Basis admission requires the source adapter's
@@ -120,15 +125,36 @@ publication.
 
 ## Automatic proof-backed coherence
 
-Every deterministic, cacheable, ordinary current request is automatically
-eligible after its exact miss.
+Every deterministic cacheable request on an admissible basis is automatically
+eligible after its exact miss when its complete frame is readable.
 
-For selected snapshots `S <= T`, a reusable completed answer must have equal:
+Lineage is the complete source scope paired with the operator lifecycle:
 
-- adapter/source lifecycle;
+```clojure
+{:source-scope {:backend backend :source-id source-id :branch branch}
+ :source-lifecycle lifecycle}
+```
+
+For any two selected values in one lineage, a reusable completed answer must
+have equal:
+
+- lineage;
 - normalized semantic operation and result shape;
 - schema assertion generation; and
 - scalar dependency frontier.
+
+Revision order is not a reuse predicate. The formal history orders values to
+reason about intervening commits, but its equality conclusion is symmetric.
+An older retained basis can therefore reuse a newer answer, and a newer basis
+can reuse an older answer, when their lineage and complete proof are equal.
+`EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` states the older-selected
+case explicitly.
+
+Durable backends persist source identity across reopen. Non-durable sources
+mint one fresh identity per live source—DataScript per connection, Datahike
+memory stores even when the caller supplies a fixed store id, and Datomic
+`mem` databases through their generated database id. A configuration label is
+never accepted as lineage for a recreated non-durable source.
 
 The dependency set is the complete canonical set of relationship relations
 that can affect the normalized request under the selected schema. Its frontier
@@ -136,7 +162,7 @@ is the maximum stored native transaction generation over that set, or `0` for
 an empty set. The constant-size cache descriptor is therefore:
 
 ```clojure
-{:schema-stamp schema-generation
+{:schema-generation schema-generation
  :dependency-stamp maximum-dependency-generation}
 ```
 
@@ -161,26 +187,28 @@ relation; unrelated relations share no EACL coordination point.
 
 ## Proof frame and unavailability
 
-Each request owns one lazy proof frame bound to its exact adapter, source
-lifecycle, and immutable database value. Equal dependency closures share their
-resolved evidence. The frame validates the complete canonical
-`[relation-id generation]` set, derives the scalar frontier, and can derive
-subset frontiers only from relations already in the proved closure. The
-proof's schema stamp must agree with the independent certified schema
-generation when both are available. The frame never combines evidence from
-another adapter, lifecycle, or snapshot.
+Each request owns one lazy proof frame bound to its exact adapter, lineage, and
+immutable database value. Equal dependency closures share their resolved
+evidence. The adapter's `:proof-frame` operation returns only the canonical
+vector `[[relation-id generation] ...]`; the independent certified
+`:schema-generation` operation supplies the schema component. Core requires
+the selected revision, schema generation, and every relation generation to be
+portable non-negative exact integers in one domain, and requires schema and
+relation generations to be at or below the selected revision. It then derives
+the scalar frontier and can derive subset frontiers only from relations already
+in the proved closure. The frame never combines evidence from another adapter,
+lineage, or snapshot.
 
 Proof is unavailable when:
 
 - the adapter does not advertise certified ordered generations;
-- schema or relation generations are missing, malformed, partial,
-  duplicated, or non-canonical;
+- schema or relation generations are absent;
 - dependency extraction is incomplete or non-canonical;
 - the complete closure exceeds 4,096 relations, or a managed subproblem
   exceeds its configured `:managed-proof-max-atoms` bound;
 - the provider throws;
-- the request uses an arbitrary historical, filtered, speculative, or
-  caller-constructed database value;
+- the selected value cannot read the historical generations it names;
+- the request uses a filtered, speculative, or caller-constructed value;
 - caching is disabled, the response is incomplete, or the operation is not
   deterministic; or
 - a custom identity codec lacks its stable deterministic contract.
@@ -190,6 +218,17 @@ or authorization error and never uses partial evidence or substitutes an
 initial generation. A complete changed proof is a normal managed miss, not
 proof unavailability. `cache-stats` reports `:proof-unavailable` and
 `:proof-unavailable-reasons`.
+
+Malformed shape, wrong cardinality, duplicate or non-canonical relation ids,
+non-integer generations, and generations above the selected revision are
+adapter contract violations, not ordinary unavailability. The request still
+evaluates authoritatively on its exact selected basis; exact caching and token
+issuance continue. The client atomically disables managed lifting until
+`expire-cache!`. `cache-stats` exposes the sticky flag and violation counts by
+reason. An optional `:proof-contract-reporter` runs once per reason per
+lifecycle. Cursor validation treats violated evidence as unavailable and
+therefore uses exact fallback or returns a typed stale outcome; it never treats
+two violations as proof equality.
 
 ## Custom identity codecs
 
@@ -266,6 +305,22 @@ Bypass one call:
  {:subject subject :permission :view :resource resource :cache? false})
 ```
 
+Read existing cache state without publishing cross-request state:
+
+```clojure
+(eacl/check-permission
+ acl
+ {:subject subject
+  :permission :view
+  :resource resource
+  :populate-cache? false})
+```
+
+Every cache-capable public read accepts this option, including batch, count,
+relationship, permission-tree, and paginated operations. It is excluded from
+cache, cursor, and continuation identities. With `:cache? false` it is accepted
+but irrelevant because lookup and publication are both bypassed.
+
 Use the bypass as a semantic oracle and measure representative workloads before
 tuning for latency.
 
@@ -332,16 +387,19 @@ and bounded-cache administration; it is deliberately weaker than lifecycle
 expiry and is not valid recovery after restore, rollback, or unsupported
 mutation.
 
-EACL does not promise proof-backed cache availability for `as-of`, `since`,
-filtered, speculative, or caller-constructed database values. Exact historical
-evaluation remains authoritative. Reusing older cache segments for arbitrary
-time travel is an optional optimization, not part of the coherence contract.
+An admissible `as-of` value can use proof-backed reuse when it can read the
+schema and relation generations visible at that value and they pass the same
+domain and ceiling checks. Datomic retains relation-version history for this
+purpose; Datahike requires readable retained history. `since`, filtered,
+speculative, and caller-constructed values remain outside managed reuse. Exact
+historical evaluation is always authoritative.
 
 ## Metrics and evidence
 
 Each backend exposes `cache-stats`, including exact/proof-backed hits, misses,
-bypasses, proof-unavailable reasons, puts, expirations, admission rejections,
-evictions, live weights, and avoided backend work. Lookup and count responses
+bypasses, proof-unavailable reasons, sticky proof-contract violations, puts,
+expirations, admission rejections, evictions, live weights, and avoided backend
+work. Lookup and count responses
 also expose `:cached?` and `:cache-basis`; `can?` returns only a Boolean.
 
 The cache-free evaluator is the behavioral oracle. Differential and randomized

--- a/docs/v8-backend-adapter-boundary.md
+++ b/docs/v8-backend-adapter-boundary.md
@@ -36,8 +36,8 @@ callback. It provides:
   operations;
 - one `:schema-generation` operation returning EACL's certified schema stamp
   or nil; and
-- when advertised, one `:proof-frame` operation returning schema generation
-  plus a complete canonical vector of requested relation generations.
+- when advertised, one `:proof-frame` operation returning only the complete
+  canonical vector `[[relation-id generation] ...]` requested by core.
 
 The adapter capability map declares only facts the immutable value can
 establish. Source consistency and writer transaction capabilities live on
@@ -56,9 +56,13 @@ does not perform a second permission evaluation. Construction/certification
 must fail with `:eacl/unsupported-capability` or an adapter-contract error when
 this denotation cannot be supplied.
 
-The runtime proof validator rejects missing, malformed, duplicate,
-non-canonical, oversized, or partial evidence. The adapter does not choose a
-coherence or proof mode.
+The runtime proof validator distinguishes absence from defect. Missing
+generations, an unsupported operation, bounded closure overflow, or transient
+provider failure make proof unavailable for that request. Malformed shape,
+wrong cardinality, duplicate/non-canonical ids, non-integer generations, or a
+generation above the selected revision are contract violations: exact
+authorization continues, but managed lifting is disabled for that client
+lifecycle. The adapter does not choose a coherence or proof mode.
 
 ## Basis source
 
@@ -68,6 +72,12 @@ scope, and lifecycle—must be readable without acquiring a basis. It implements
 current, authoritative, at-least, and exact-by-locator acquisition and returns
 exactly `{:adapter ... :ownership ... :release-token ...}`. Unsupported modes
 fail through the closed capability contract.
+
+The source scope must identify one database history. A durable backend persists
+and reuses its source id across reopen. A backend that cannot persist identity
+must mint a fresh id once per live source, regardless of a caller-supplied
+configuration id. Combined with `:source-lifecycle`, this scope is the lineage
+prefix for every proof-backed artifact.
 
 Exact-by-locator acquisition must not acquire current first. Owned sources must
 close rejected causal candidates and release on success, typed or foreign
@@ -105,9 +115,10 @@ backend/adapter identity, source scope, lifecycle, and this generation. Parsed
 validation catalogs, permission paths, dependency closures, routing analysis,
 direct-grant relations, cycle guards, and sealed plans are owned by that
 generation. Nil disables cross-request reuse and installs a request-local
-floor instead; native revision is never a fallback key. When an ordered proof
-frame is also available, its schema stamp must agree with this independent
-value or the adapter fails with a backend-integrity error.
+floor instead; native revision is never a fallback key. Ordered proof frames do
+not repeat the schema value; core reads this independent operation once and
+combines it with the relation frame after validating both against the selected
+revision.
 
 ## Ordered-generation certification
 
@@ -115,6 +126,10 @@ Shared cache proofs assume that:
 
 - snapshots are immutable and ordered inside one source lifecycle;
 - schema and every declared relation have initialized generations;
+- native revision, schema generation, and relation generations use one
+  portable exact-natural numeric domain;
+- every generation visible at a selected value is at or below that value's
+  native revision;
 - every supported authorization mutation atomically commits data changes and
   stamps each affected relation with its native committed transaction;
 - that transaction is later than every generation visible before commit; and
@@ -124,8 +139,12 @@ Shared cache proofs assume that:
 Dafny proves the scalar-frontier cache theorem from those assumptions. The
 database engines and adapter implementations are not mechanized; bundled
 adapter certification and randomized cache-versus-bypass tests establish the
-runtime trusted boundary. A third-party adapter must run the same contract and
-certification suites before advertising ordered generations.
+runtime trusted boundary. The certification suite executes a supported
+relationship mutation, asserts that every affected relation equals the
+committed revision, checks all generation ceilings, and opens distinct or
+reopened sources to certify the source-id durability rule. A third-party
+adapter must run the same contract and certification suites before advertising
+ordered generations.
 
 ## Capability policy
 

--- a/docs/v8-consistency-cache-operations.md
+++ b/docs/v8-consistency-cache-operations.md
@@ -11,7 +11,7 @@ result rendering, and cursor construction all use that value.
 | omitted / `:minimize-latency` | current DB visible to the Peer | current connection DB | current connection DB | new owned read snapshot | exact-first, then automatic proof-backed reuse when certified |
 | `:fully-consistent` | bounded zero-argument `d/sync` | authoritative head barrier when supported | serialized connection head | new owned read snapshot under the sole-writer topology | enabled for the selected ordinary basis |
 | `:at-least-as-fresh` | targeted `d/sync conn t` and revision validation | selects/waits for a sufficient native revision | selects a sufficient connection-local revision | bounded acquire/check/release retry | enabled only when selection is an ordinary basis |
-| `:at-exact-snapshot` | authenticated targeted catch-up when behind, then exact `d/as-of T` | retained commit or durable temporal selection, configuration-specific | unsupported | unsupported | matching exact-basis answers only; managed proof reuse prohibited |
+| `:at-exact-snapshot` | authenticated targeted catch-up when behind, then exact `d/as-of T` | retained commit or durable temporal selection, configuration-specific | unsupported | unsupported | exact-first; managed reuse when the historical value has a readable contract-valid frame |
 
 These modes select a basis only when the target is an `acl`. On a retained
 snapshot they are assertions: omitted or minimize-latency evaluates that basis;
@@ -41,23 +41,27 @@ collection of the named commit can make that snapshot unavailable.
 
 Every client owns a bounded basis cache. Exact answers are attached to the
 selected immutable database identity and are checked first without proof. On
-an exact miss, deterministic ordinary current requests automatically attempt a
-complete ordered-generation proof. A proof-backed answer may serve an older or
-newer ordinary selected basis in the same scope and lifecycle when normalized
-operation, result shape, schema generation, and scalar dependency frontier are
-equal; selected revision order is not part of that equality proof.
+an exact miss, deterministic requests on any admissible basis automatically
+attempt a complete ordered-generation proof when that value can read one. A
+proof-backed answer may serve an older or newer selected basis in the same
+lineage—complete source scope plus source lifecycle—when normalized operation,
+result shape, schema generation, and scalar dependency frontier are equal.
+Selected revision order is not part of that equality proof.
 
-Missing, malformed, partial, oversized, unsupported, or exceptional proof
-evidence falls back to evaluation
-and exact caching for the selected value. It never becomes an authorization
-error and never permits partial-proof reuse.
+Missing, partial, oversized, unsupported, or exceptionally unavailable proof
+evidence falls back to evaluation and exact caching for the selected value. A
+malformed, non-numeric, non-canonical, or above-revision frame is an adapter
+contract violation: authorization and exact caching continue, while managed
+lifting becomes sticky-disabled until lifecycle expiry. Neither case permits
+partial-proof reuse.
 
 Authenticated exact requests use the same bounded exact-basis tier as ordinary
 selected bases. The key includes source scope and lifecycle, native revision
 and locator, basis kind, adapter and identity contracts, engine ABI, result
-shape, demand, and answer-affecting limits. Historical requests never probe the
-managed tier. Public IDs, tokens, cursors, cache basis, and other metadata are
-rebuilt from the selected adapter on every hit.
+shape, demand, and answer-affecting limits. Historical requests probe the
+managed tier only when their own immutable value supplies a complete readable
+frame. Public IDs, tokens, cursors, cache basis, and other metadata are rebuilt
+from the selected adapter on every hit.
 
 Disable caching:
 
@@ -69,9 +73,13 @@ Disable caching:
 (datascript/make-client conn {:cache cache/no-cache})
 ```
 
-Or pass `:cache? false` on one request. `cache-stats` reports exact and
-proof-backed hits, misses, bypasses, proof-unavailable reasons, publications,
-expirations, and bounded-store metrics.
+Or pass `:cache? false` on one request. Pass `:populate-cache? false` to retain
+lookups and request-local memoization while suppressing completed answers,
+managed subproblems, checkpoints, and visited pages. Both options are excluded
+from semantic and cursor identity; `:cache? false` dominates either populate
+value. `cache-stats` reports exact and proof-backed hits, misses, bypasses,
+proof-unavailable and contract-violation reasons, publications, expirations,
+and bounded-store metrics.
 
 ## Mutation contract
 
@@ -123,6 +131,10 @@ snapshot continues only when its complete proof admits the cursor basis;
 otherwise EACL throws `:eacl.consistency/basis-conflict` with `:source :cursor`.
 It never drops a bound, silently restarts page one, or acquires through a
 retained snapshot.
+
+A contract-violating frame is never cursor equality evidence. It degrades to
+exact-snapshot context; continuation either reconstructs that authenticated
+exact value or returns the ordinary typed stale/basis-conflict outcome.
 
 Continuation state is a private performance optimization. Eviction replays the
 authenticated prefix on the already selected snapshot and does not select a

--- a/formal/dafny/NativeGenerationCoherence.dfy
+++ b/formal/dafny/NativeGenerationCoherence.dfy
@@ -178,6 +178,10 @@ module NativeGenerationCoherence {
     )
   }
 
+  // ForwardHistory orders the two immutable values so the proof can reason
+  // about intervening commits. Reuse itself is direction-agnostic: equality
+  // of the resulting frames is symmetric, so an answer produced at the last
+  // snapshot is equally valid when the first snapshot is selected later.
   lemma DependencyEquivalentFramesAreEqual(
     history: seq<Snapshot>,
     query: Query,

--- a/formal/dafny/ScalarFrontierCoherence.dfy
+++ b/formal/dafny/ScalarFrontierCoherence.dfy
@@ -8,6 +8,10 @@ module ScalarFrontierCoherence {
     authorizationSlice: set<nat>
   )
 
+  // `lifecycle` abstracts the runtime lineage key: the complete source scope
+  // (backend, persisted or per-live-source id, branch) paired with the
+  // operator-rotated source lifecycle. Equality is required before two
+  // snapshots can inhabit one supported history.
   datatype Snapshot = Snapshot(
     lifecycle: nat,
     transaction: Transaction,

--- a/formal/mutations/registry.edn
+++ b/formal/mutations/registry.edn
@@ -1,7 +1,7 @@
 {:schema-version 3
  :required-score 1.0
- :historical-mutant-count 107
- :historical-clojure-mutant-count 103
+ :historical-mutant-count 110
+ :historical-clojure-mutant-count 106
  :historical-model-mutant-count 4
  :mutants
  [{:id :wrong-arrow-direction
@@ -151,6 +151,27 @@
    :detector "exact-basis-key-omits-lifecycle-killed?"
    :control {:kind :clojure :runtimes [:clj :cljs]}
    :killed-by {:test :exact-basis-key-control}}
+  {:id :adapter-generation-domain
+   :mechanism :executed-production
+   :mutation :accept-non-numeric-relation-generation-as-proof-evidence
+   :target-symbol "proof-frame/generation?"
+   :detector "adapter-generation-domain-killed?"
+   :control {:kind :clojure :runtimes [:clj :cljs]}
+   :killed-by {:test :adapter-generation-domain-control}}
+  {:id :adapter-generation-ceiling
+   :mechanism :executed-production
+   :mutation :validate-relation-generation-against-an-inflated-revision
+   :target-symbol "proof-frame/revision"
+   :detector "adapter-generation-ceiling-killed?"
+   :control {:kind :clojure :runtimes [:clj :cljs]}
+   :killed-by {:test :adapter-generation-ceiling-control}}
+  {:id :non-durable-live-source-id-collision
+   :mechanism :executed-production
+   :mutation :collapse-distinct-live-source-identities-in-managed-lineage
+   :target-symbol "request-context/lineage-for-basis"
+   :detector "non-durable-live-source-id-collision-killed?"
+   :control {:kind :clojure :runtimes [:clj :cljs]}
+   :killed-by {:test :non-durable-live-source-identity-control}}
   {:id :aggregate-counter-reset
    :mechanism :executed-production
    :mutation :reset-cumulative-work-at-each-window

--- a/formal/verification/acyclic-kernel.edn
+++ b/formal/verification/acyclic-kernel.edn
@@ -194,7 +194,7 @@
    :completeness
    :when-exhaustive-direct-result-equals-complete-path-result}
   :adapter-composition
-  {:certification-version "eacl.adapter-certification/v2"
+  {:certification-version "eacl.adapter-certification/v4"
    :datomic :passed
    :datahike :passed
    :datascript-clj :passed

--- a/formal/verification/adapter-certification.edn
+++ b/formal/verification/adapter-certification.edn
@@ -1,5 +1,5 @@
 {:schema-version 1
- :certification-version "eacl.adapter-certification/v3"
+ :certification-version "eacl.adapter-certification/v4"
  :date "2026-08-23"
  :role-contracts
  {:basis-adapter
@@ -33,7 +33,9 @@
   :snapshot-bound-relation-prefix-population
   :forward-reverse-scans
   :direct-match-equivalence
-  :immutable-snapshot]
+  :immutable-snapshot
+  :ordered-generation-transition
+  :live-source-identity]
  :adapters
  {:datomic
   {:status :passed
@@ -41,8 +43,8 @@
    :representations [:attribute-refs]
    :static
    {:namespace eacl.datomic.adapter-certification-test
-    :tests 1
-    :assertions 2
+    :tests 2
+    :assertions 4
     :failures 0
     :errors 0}
    :history
@@ -65,7 +67,7 @@
    :representations [:numeric-eid]
    :static
    {:namespace eacl.datascript.adapter-certification-test
-    :clj {:tests 2 :assertions 5 :failures 0 :errors 0}
+    :clj {:tests 5 :assertions 9 :failures 0 :errors 0}
     :cljs-in-full-suite
     {:tests 258 :assertions 7953 :failures 0 :errors 0}}
    :history
@@ -88,8 +90,8 @@
    :representations [:attribute-keywords :attribute-refs]
    :static
    {:namespace eacl.datahike.adapter-certification-test
-    :tests 2
-    :assertions 7
+    :tests 4
+    :assertions 9
     :failures 0
     :errors 0}
    :history
@@ -115,8 +117,8 @@
    :representations [:numeric-eid :explicit-owned-reader]
    :static
    {:namespace eacl.datalevin.adapter-certification-test
-    :tests 1
-    :assertions 5
+    :tests 2
+    :assertions 7
     :failures 0
     :errors 0}
    :history

--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -6,7 +6,7 @@
   :status :named-public-roots-enumerated
   :source-files 79
   :public-roots 70
-  :reachable-definitions 1641
+  :reachable-definitions 1653
   :inline-defrecord-method-attribution :source-span-closed
   :backend-dispatch
   {:report "formal/verification/backend-dispatch.edn"
@@ -560,10 +560,14 @@
            "formal/dafny/TemporalSafety.dfy"]
    :adapter-obligations [:immutable-snapshot
                          :truthful-complete-exact-basis-key
+                         :complete-source-scope-plus-lifecycle-lineage
+                         :fresh-source-id-per-non-durable-live-source
                          :durable-history-when-advertised
                          :targeted-sync-and-exact-as-of-effects
                          :provider-future-cancellation
                          :complete-compiled-dependencies
+                         :proof-generations-share-native-revision-domain
+                         :proof-generations-at-or-below-selected-revision
                          :atomic-relation-stamped-writer-contract
                          :selected-snapshot-rendering
                          :source-fingerprint

--- a/formal/verification/cryptographic-assumptions.md
+++ b/formal/verification/cryptographic-assumptions.md
@@ -85,10 +85,11 @@ and relationship.
   proves the normalized-rule dependency frame consumed by the basis-first
   cache; `ScalarFrontierCoherence.dfy` proves the supported scalar-frontier
   lifting condition.
-- Each certified adapter's `proof-frame` operation reads the schema assertion
-  generation and one native committed generation for every relation in the
-  complete canonical dependency closure. Missing or invalid evidence forces
-  exact-only evaluation.
+- Each certified adapter's independent `schema-generation` operation reads the
+  schema assertion generation, while `proof-frame` reads one native committed
+  generation for every relation in the complete canonical dependency closure.
+  Missing evidence forces exact-only evaluation; malformed or above-revision
+  evidence disables managed lifting for the runtime lifecycle.
 - `eacl.cache` keeps completed entries client-private and requires lifecycle,
   semantic request, schema generation, and scalar dependency-frontier
   agreement before returning a managed value.

--- a/formal/verification/implementation-simplicity.edn
+++ b/formal/verification/implementation-simplicity.edn
@@ -18,41 +18,41 @@
  :current-worktree
  {:source-closure "formal/verification/public-source-closure.json"
   :source-closure-sha256
-  "5d2f89f29b81b423eef933127caf40873d62da570d251d507ec41f352a587685"
+  "224ff0932355d2d10dd0c1966ad411ccad5bdd85fff149afce08d522ff4a2b5e"
   :public-roots 70
   :source-files 78
-  :reachable-definitions 1639
+  :reachable-definitions 1651
   :definitions-by-source
-  {"modules/eacl/src/eacl/subproblem_cache.cljc" 42
+  {"modules/eacl/src/eacl/subproblem_cache.cljc" 43
    "modules/eacl-datomic/src/eacl/datomic/core.clj" 13
    "modules/eacl/src/eacl/engine/v8.cljc" 90
    "modules/eacl/src/eacl/execution.cljc" 27
-   "modules/eacl/src/eacl/proof_frame.cljc" 15
+   "modules/eacl/src/eacl/proof_frame.cljc" 18
    "modules/eacl/src/eacl/core.cljc" 56
    "modules/eacl/src/eacl/client/orchestration.cljc" 90
    "modules/eacl/src/eacl/backend/source.cljc" 43
    "modules/eacl/src/eacl/backend/writer.cljc" 13
-   "modules/eacl/src/eacl/cache.cljc" 40}
+   "modules/eacl/src/eacl/cache.cljc" 43}
   :forbidden-coordination-source-occurrences 0
   :datomic-client-schema-state-occurrences 0
   :datascript-exact-snapshot-registry-source-occurrences 0}
  :delta
  {:public-roots 7
   :source-files 23
-  :reachable-definitions 215
+  :reachable-definitions 227
   :root-set-comparable? false
   :root-set-change :public-reader-writer-source-and-snapshot-entry-points-added
-  :subproblem-cache-definitions -25
+  :subproblem-cache-definitions -24
   :datomic-cache-definitions -35
   :datomic-core-definitions -115
   :shared-engine-definitions -119
   :normalized-execution-contract-definitions 27
-  :proof-frame-definitions 15
+  :proof-frame-definitions 18
   :shared-public-core-definitions 56
   :shared-orchestration-definitions 90
   :source-role-definitions 43
   :writer-role-definitions 13
-  :basis-cache-definitions 40
+  :basis-cache-definitions 43
   :forbidden-coordination-source-occurrences -22
   :datomic-schema-state-source-occurrences -38
   :datascript-exact-snapshot-registry-source-occurrences -11}

--- a/formal/verification/manifest.edn
+++ b/formal/verification/manifest.edn
@@ -317,14 +317,14 @@
  {:status :passed
   :report "formal/verification/mutation-control.edn"
   :score 1.0
-  :killed 33
-  :registered 33
+  :killed 36
+  :registered 36
   :retired-invalid-controls 74}
  :source-closure
  {:report "formal/verification/public-source-closure.json"
   :source-files 79
   :public-roots 70
-  :reachable-definitions 1641}
+  :reachable-definitions 1653}
  :stable-discovery
  {:gate "formal/stable-discovery/verify-fast.sh"
   :dafny-leaves 46

--- a/formal/verification/mutation-control.edn
+++ b/formal/verification/mutation-control.edn
@@ -1,19 +1,19 @@
 {:schema-version 3
  :registry "formal/mutations/registry.edn"
- :historical-mutants 107
+ :historical-mutants 110
  :retired-invalid-controls 74
- :mutants 33
- :killed 33
+ :mutants 36
+ :killed 36
  :survived 0
  :score 1.0
  :status :passed
  :controls
  {:clojure
-  {:mutants 29
-   :executed-production 24
+  {:mutants 32
+   :executed-production 27
    :source-text 5
    :tests 4
-           :assertions 83
+           :assertions 86
    :command "EACL_NREPL_PORT=<dev-port> bin/formal mutation-control"}
   :apalache
   {:mutants 4

--- a/formal/verification/production-decision-inventory.md
+++ b/formal/verification/production-decision-inventory.md
@@ -120,7 +120,7 @@ partition. It derives direct relation EIDs only from relation paths matching the
 query subject type and proves that a direct positive is sound; if every path is
 a relation, the direct result is complete. Generated Java and JavaScript match
 the actual CLJ/CLJS materializer and direct summary on 99 fixtures each.
-Adapter certification v2 checks the composed path maps against real relation
+Adapter certification v4 checks the composed path maps against real relation
 IDs on Datomic, Datahike, and DataScript. Clojure language semantics and
 arbitrary backend implementation correctness remain explicit trusted
 obligations.

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -13,7 +13,7 @@
   "sources": [
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/backend.clj",
-      "sha256": "3293c04b7bfa57f58d7d4f1caa90b7a00e0a5846a440c4ca3d50321e4cdf1681"
+      "sha256": "d75939d0a69f8503b40886dcde7f277dff9dd0a9ffd2271d9cdae6c290b874d2"
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/core.clj",
@@ -37,7 +37,7 @@
     },
     {
       "path": "modules/eacl-datahike/src/eacl/datahike/schema.clj",
-      "sha256": "432b8ea622f4ea7b4ca6ed264cc041e69a69c3d6eb2627824268393f30f53512"
+      "sha256": "4cf0bfa9c8de0e27a952939cca344a5d6255cb14c95ed9393f82a33e3372caf7"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc",
@@ -69,7 +69,7 @@
     },
     {
       "path": "modules/eacl-datascript/src/eacl/datascript/backend.cljc",
-      "sha256": "fd86e084dde4ee810df32cc0c6e8b8f7742c172ade971cc5f5530039b24ccf7b"
+      "sha256": "f86b6096b2526acb5b4ce4c9925b0253b20f709d15d397dce9dadf5df7573553"
     },
     {
       "path": "modules/eacl-datascript/src/eacl/datascript/core.cljc",
@@ -97,7 +97,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/backend.clj",
-      "sha256": "11bcb84f5344725551fe3eebfbe4d149713599c03468b136bd42189741e6bab4"
+      "sha256": "8d06bad1c2490f82145ec41972313c34d00e8fdb9136e06f503fea8958fbb971"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/cache.clj",
@@ -145,7 +145,7 @@
     },
     {
       "path": "modules/eacl-datomic/src/eacl/datomic/schema.clj",
-      "sha256": "f56b2f75a96639484f47bce9520d3ad54edbaa3e83f29514e897f496624722e5"
+      "sha256": "d63e6ff4cec5763e225fad046430016847a7fd585f3ccbe9ff2f7dc9466b55a1"
     },
     {
       "path": "modules/eacl-datomic/src/eacl/migrations/v6_to_v7.clj",
@@ -153,11 +153,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/authorization/batch.cljc",
-      "sha256": "951de00120f87c6c957a04af05f40398d5a58bfc59dc3d39b01f875b30dd1623"
+      "sha256": "fd4fac67d7e6f424691bda80a6eaec87561de0fb44628a2d857321e8442dfbe7"
     },
     {
       "path": "modules/eacl/src/eacl/authorization/filters.cljc",
-      "sha256": "fce9a4782a277744a2dc5b950eb9bdcb4e66eb159616d31f0cd483109b4ce95d"
+      "sha256": "a8a83fa69077c650e664f91e95bb44f0da0c4e9a4184bccb6d7fe04ec7705e34"
     },
     {
       "path": "modules/eacl/src/eacl/backend/source.cljc",
@@ -165,7 +165,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/backend/v8.cljc",
-      "sha256": "c45c19ff9f74df4c6011c5d1b3ae75057fdd0dafce2d19d778a7f5a9cd322f7e"
+      "sha256": "1d2bc1827f5f2c3e4f722907a0d9a2219d6e3d64fc35891e39f216ecd803c242"
     },
     {
       "path": "modules/eacl/src/eacl/backend/writer.cljc",
@@ -173,7 +173,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cache.cljc",
-      "sha256": "14ff63abb0d442054a7d7efbbb0a3c60aa7456d6ac0d292a7e18dad8429db599"
+      "sha256": "4d28576f6ee6d64e6a0aabf56b0423ce7d15b5df2f0a8bdb944761eb5adf26c8"
     },
     {
       "path": "modules/eacl/src/eacl/causal_token.cljc",
@@ -181,7 +181,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/client/orchestration.cljc",
-      "sha256": "28d9b45610156de4ec1b8aa663ca05bbb5279d46184cd91a7b2245f4c7f06f46"
+      "sha256": "67f09fa4e8cf29c079d9710978e5fc520a24490b10f2df950ea0e5dbc9b73fc2"
     },
     {
       "path": "modules/eacl/src/eacl/consistency.cljc",
@@ -189,11 +189,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/continuation.cljc",
-      "sha256": "955df585db067516a059e2f9514747ff08a963bd4a5743c3dd7dfc1ca9b475f5"
+      "sha256": "4116e261bc58dcfd05c2ebb2144160d87abcedb78c40de92216515998fdf9ef2"
     },
     {
       "path": "modules/eacl/src/eacl/core.cljc",
-      "sha256": "cc3f1f6da48390517a90e6a150e27891b64c187c04db9e38c40f2178fe09ed37"
+      "sha256": "6503a7ca5e9cbca7855fd51bcd5be3ea0e1a2888001fd975fec4a1b267bcaeee"
     },
     {
       "path": "modules/eacl/src/eacl/cursor.cljc",
@@ -253,7 +253,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "8c47d4bfa41b1d2313173b69c1bb255e788da4fcb8626a04fbde43c58868fa0e"
+      "sha256": "d5c9ce2af23db46a639bd6bbd46a1180d8b37f45fae290c0eec36dc801374e06"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -261,11 +261,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/permission_tree.cljc",
-      "sha256": "1d272237579fe7051be2fe62b82a00d3d7557bb1e45f18c06d278978a4b4be16"
+      "sha256": "09f8604f5b99bb1090c1920af10f1fd8d9742410a5dddb2396e7c9c5ca49f569"
     },
     {
       "path": "modules/eacl/src/eacl/proof_frame.cljc",
-      "sha256": "8a2d5139907b140587b7cb22a84b2ff47a19f7771d51ade1bc9ffda62e9b8159"
+      "sha256": "452e8a23b9f5109d740161a9ec7db24f09cb17e70937783d3c6f9e1c37aabbdd"
     },
     {
       "path": "modules/eacl/src/eacl/relationships/endpoint_pair.cljc",
@@ -273,7 +273,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/relationships/filters.cljc",
-      "sha256": "23e556b169c458514ee30ec254690488f003a885faf92fef18588713e11675f9"
+      "sha256": "d2f765f67d287cc385e0394ea3d3c25b1bcc287048c90b39169630d9f65c362a"
     },
     {
       "path": "modules/eacl/src/eacl/relationships/mutations.cljc",
@@ -289,11 +289,11 @@
     },
     {
       "path": "modules/eacl/src/eacl/relay.cljc",
-      "sha256": "510d95fad7186af5dba83fcf9d2deefa07c5d65a47d3df28740f7c3878d9acc9"
+      "sha256": "a25fdee2d089a2ba3ed7cbd86f1b99c7851283938449741232db36e875206b78"
     },
     {
       "path": "modules/eacl/src/eacl/request/context.cljc",
-      "sha256": "5129e2965471915432f1aa87e5c1a1a0f341c662ad96c8b216a0aa632d600377"
+      "sha256": "fc8f5ba9bddcb38775adee364779884e54716fbb34b3fd10bbe6fa02b6307aab"
     },
     {
       "path": "modules/eacl/src/eacl/request/counters.cljc",
@@ -321,7 +321,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/subproblem_cache.cljc",
-      "sha256": "67963399d22bd974e63a62d4a05ad9ad93d6b87bc89e0b576287ea5480433a7c"
+      "sha256": "48650e1762d5cb63ca38f08f66a51de171c17ed47b36912822ed028634c7a688"
     },
     {
       "path": "modules/eacl/src/eacl/verified_kernel.cljc",
@@ -402,13 +402,13 @@
       "eacl.datalevin.core/db"
     ],
     "rootCount": 70,
-    "unionInternalDefinitionCount": 1641,
-    "unionInternalDefinitionIdsSha256": "c60f06131a326b7a0a25be4d173c12a20740b5c06ca67f21cbbb31433bf16e29",
-    "unionDefinitionLocationsSha256": "f5d0cce218f441cc3bea62e7bbc6ba4053c77e373ffcaec75275ac59bb798c36",
+    "unionInternalDefinitionCount": 1653,
+    "unionInternalDefinitionIdsSha256": "f5939214fb1a40ae2f4772bec0118a1be58b9a2d896daba8b512fa8c669840c8",
+    "unionDefinitionLocationsSha256": "6b04bf803c3e7cd28488c2d69d7093ec1e28c8986947ebc199aad3fafbd7155d",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
-        "count": 24,
-        "idsSha256": "343632a088c076c7c0c9843c1fe8ee2079bcca3bc560ebadc41ae355dad03133"
+        "count": 25,
+        "idsSha256": "87fb500349ee46f7a7bfb135143c5da79a8c36c988159b97f50842d83a9a8acc"
       },
       "modules/eacl-datahike/src/eacl/datahike/core.clj": {
         "count": 7,
@@ -423,8 +423,8 @@
         "idsSha256": "b964410a33961cbadd7a4e31c50b658e6a270685b2ed28e88509f99fb6c78fae"
       },
       "modules/eacl-datahike/src/eacl/datahike/schema.clj": {
-        "count": 16,
-        "idsSha256": "e7758084592618de87ad53f7f4300196866a1548b1d7d0ae364e29310f78d540"
+        "count": 17,
+        "idsSha256": "a9b335e6437c74da475a00ec083de3ca6ae0b1aee086dfdf9f9f83b32353735b"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc": {
         "count": 16,
@@ -491,8 +491,8 @@
         "idsSha256": "c44ba8e5106ff11d12edf937a45597832371e92e4eeda556ab40952f1f7d7dc4"
       },
       "modules/eacl-datomic/src/eacl/datomic/schema.clj": {
-        "count": 15,
-        "idsSha256": "6003392975933239cb9ac213e878da52aa71fe4638d1ed2ebb7118a69c77d4aa"
+        "count": 16,
+        "idsSha256": "6a6bf912461c2c10f9a2ed32d3621ce8d3cb14e5f463f3d3e4a11f12b35d3ba1"
       },
       "modules/eacl-datomic/src/eacl/migrations/v6_to_v7.clj": {
         "count": 18,
@@ -519,8 +519,8 @@
         "idsSha256": "075b51428c6d8428a8e990b3c0da10edbe12d5f477dc15a0eac1b288fd8df4d0"
       },
       "modules/eacl/src/eacl/cache.cljc": {
-        "count": 40,
-        "idsSha256": "1faf185abbfede507d4c8b4883ec45f1578513b84427096780a9181d0c52c6b0"
+        "count": 43,
+        "idsSha256": "6e339b9dd8a9f0612f4ec4035c366ba636622ed7a4cd212416bc8b275a5b2619"
       },
       "modules/eacl/src/eacl/causal_token.cljc": {
         "count": 17,
@@ -528,7 +528,7 @@
       },
       "modules/eacl/src/eacl/client/orchestration.cljc": {
         "count": 90,
-        "idsSha256": "93966874f54f993cf6c9a9e32763c38351a80617c2ab83ed1f5278d14d25d55e"
+        "idsSha256": "dca338125bcaae55741fff345cd0e34308cbc6444036657fc1767b86b38a3572"
       },
       "modules/eacl/src/eacl/consistency.cljc": {
         "count": 24,
@@ -607,8 +607,8 @@
         "idsSha256": "3761963c0c9da4c754e03862e1ee39b09c70cd3dc00862a1c74c6691b1c76f6a"
       },
       "modules/eacl/src/eacl/proof_frame.cljc": {
-        "count": 15,
-        "idsSha256": "396231f0b21417586b48c07aa93cec5d1f853b96d4ef53fd1417038db79a7cfd"
+        "count": 18,
+        "idsSha256": "930e8e41ed96ab824d429dda744e23e188f9c69759342decc5f7fa5a35484515"
       },
       "modules/eacl/src/eacl/relationships/endpoint_pair.cljc": {
         "count": 7,
@@ -631,8 +631,8 @@
         "idsSha256": "d15e9746a1e48569301b81551236be4def790a3759e58c7653373bc4b0afcbd6"
       },
       "modules/eacl/src/eacl/request/context.cljc": {
-        "count": 25,
-        "idsSha256": "b7ac1f7052f3534415f3e86f796ec1594d9f7390b3fe9b35eb9ec7d11a378f38"
+        "count": 27,
+        "idsSha256": "8432c9f574e8493b96aead4a2ffaeb038ce51c1f3a17646ba87dfd362503c4c4"
       },
       "modules/eacl/src/eacl/request/counters.cljc": {
         "count": 11,
@@ -659,8 +659,8 @@
         "idsSha256": "7ac0d561d46b25289b0553250cea43721bb0eae5b72f7a390fb46ef59a69002d"
       },
       "modules/eacl/src/eacl/subproblem_cache.cljc": {
-        "count": 42,
-        "idsSha256": "5ee72c82b62cbccc6b562c2ccd55940874fbb54599e21863fa6504a645f360ae"
+        "count": 43,
+        "idsSha256": "b7e4d7191c89a85e6096dbba19f84c21b404e007df79eb0de0aba8ba5624c6e3"
       },
       "modules/eacl/src/eacl/verified_kernel.cljc": {
         "count": 106,
@@ -796,8 +796,8 @@
       ]
     },
     "eacl.relay/select-continuation-adapter": {
-      "internalDefinitionCount": 314,
-      "internalDefinitionIdsSha256": "8120c9d0e6024c6375f250ef7a18d192da6038e24583db44a9632c98bb9ff413",
+      "internalDefinitionCount": 317,
+      "internalDefinitionIdsSha256": "ee91067e2944ad47fc4f22a800c436e028169da2034807be2e2773a9124974a7",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -816,8 +816,8 @@
       ]
     },
     "eacl.relay/prepare-page-query": {
-      "internalDefinitionCount": 318,
-      "internalDefinitionIdsSha256": "f45c97df406569aa9c9daa65b44b57b651b80f4ef752bde23001b83726eb5f01",
+      "internalDefinitionCount": 321,
+      "internalDefinitionIdsSha256": "8bc96f26cdeb3bb7f805e34903c266efb012d994df60a24adda2730b0a3fa7a3",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -836,8 +836,8 @@
       ]
     },
     "eacl.relay/internalize-page-query": {
-      "internalDefinitionCount": 275,
-      "internalDefinitionIdsSha256": "622a3e1a8f6647809a39c00393dd2e4416c34a94eb8a8aec75eae34ccb3fa8dd",
+      "internalDefinitionCount": 278,
+      "internalDefinitionIdsSha256": "d5ef8ffdf4ac7a14d65d00299c54674415db2d3f056c5dd7459969a65a4a3ed3",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -856,8 +856,8 @@
       ]
     },
     "eacl.relay/externalize-page": {
-      "internalDefinitionCount": 168,
-      "internalDefinitionIdsSha256": "602a69c2a38c236270f66e38ee9a7c51925123b173ce8d05cb6629c7b5fb0459",
+      "internalDefinitionCount": 172,
+      "internalDefinitionIdsSha256": "0824632b05a2fbb3c9872d647003c4680cca7969e034d0569e044ce8d8f7db8f",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -873,8 +873,8 @@
       ]
     },
     "eacl.relay/externalize-relationship-page": {
-      "internalDefinitionCount": 168,
-      "internalDefinitionIdsSha256": "6a004f37284f63f3e4f15c5e9a8330a0da3ef9b4d7184184aeaa524bfd449fec",
+      "internalDefinitionCount": 172,
+      "internalDefinitionIdsSha256": "7af037b5a73d8bb2004efcf7fdcf778200512c97b940f2bcf4ddcd968305e85f",
       "externalCallCount": 10,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -922,8 +922,8 @@
       ]
     },
     "eacl.cache/resolve-basis!": {
-      "internalDefinitionCount": 177,
-      "internalDefinitionIdsSha256": "c7f00b7e588bab7335bb91c8d0819bfe71952555fb4f95c339d9c1eff5ccbc47",
+      "internalDefinitionCount": 180,
+      "internalDefinitionIdsSha256": "edc7e64c6a112d5e5ff83eb21a79c28407d9bb617309629d2ab8840332a21015",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -931,24 +931,24 @@
       ]
     },
     "eacl.subproblem-cache/resolve!": {
-      "internalDefinitionCount": 26,
-      "internalDefinitionIdsSha256": "c5e793fa6f8a0004f94623b85e8e577adf7ed176dc9b72428a61a334b6ca3428",
+      "internalDefinitionCount": 27,
+      "internalDefinitionIdsSha256": "3a785d571ea4197e21fc7bd2bbb023609a43952ed38fdf6974a280ef639e01e2",
       "externalCallCount": 1,
       "externalCalls": [
         "unresolved/js/Math.floor"
       ]
     },
     "eacl.subproblem-cache/resolve-bound!": {
-      "internalDefinitionCount": 27,
-      "internalDefinitionIdsSha256": "f53ebe32d373852d94891a89aa6b18255dfb2b97cf4b5bfebd879efcb12b9aac",
+      "internalDefinitionCount": 28,
+      "internalDefinitionIdsSha256": "ac669b97f939e473f263714ffdd1afed04d899efb3b450842d77499b5fe7e5d7",
       "externalCallCount": 1,
       "externalCalls": [
         "unresolved/js/Math.floor"
       ]
     },
     "eacl.subproblem-cache/resolve-layered-bound!": {
-      "internalDefinitionCount": 37,
-      "internalDefinitionIdsSha256": "2da35d01ec617b647c59734eee1120990f4fed4c997b3e1b1222fb804378da9c",
+      "internalDefinitionCount": 38,
+      "internalDefinitionIdsSha256": "12d0308abeef376352eca4a0511cb08f13bfe153f246c5e404614c2887162b64",
       "externalCallCount": 2,
       "externalCalls": [
         "unresolved/js/Math.floor",
@@ -1179,8 +1179,8 @@
       "externalCalls": []
     },
     "eacl.client.orchestration/Acl": {
-      "internalDefinitionCount": 395,
-      "internalDefinitionIdsSha256": "6187ac7c8a3429ff3ded082aa4acf2f71ccf9e7a5de89e3072d487d93e7ae15c",
+      "internalDefinitionCount": 398,
+      "internalDefinitionIdsSha256": "981eb636f7d0d4be54c0559ddb0861ab6b5e355e08bb2a54c9336605346b2ffe",
       "externalCallCount": 14,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1200,8 +1200,8 @@
       ]
     },
     "eacl.client.orchestration/Snapshot": {
-      "internalDefinitionCount": 860,
-      "internalDefinitionIdsSha256": "86ddbbf320d69863fd7e19a46b66d47a2253d4c508374220d221989cfaf8b223",
+      "internalDefinitionCount": 869,
+      "internalDefinitionIdsSha256": "c6300733a20ea3452d292857ecfda16cb2c1a4e1c22af67505da9db41b5fa6d0",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1220,8 +1220,8 @@
       ]
     },
     "eacl.client.orchestration/direct-snapshot": {
-      "internalDefinitionCount": 402,
-      "internalDefinitionIdsSha256": "007d062a5de1899f15f634eba2a2467f652c2249169105b127048dfb0ae688d9",
+      "internalDefinitionCount": 405,
+      "internalDefinitionIdsSha256": "5211dd613f3300640645228c694f44a2b2682015e68b74721ddd7fa3861c0d4f",
       "externalCallCount": 14,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1256,9 +1256,9 @@
       ]
     },
     "eacl.datomic.core/make-client": {
-      "internalDefinitionCount": 442,
-      "internalDefinitionIdsSha256": "06254a617e7c235be7fc4ea34b3b08b645df77555153e6bdabc57fe36615befc",
-      "externalCallCount": 30,
+      "internalDefinitionCount": 443,
+      "internalDefinitionIdsSha256": "2dd5c6335c046e5b0719a15a0e5493e6a7c98c17e923150e1592b4a3dc9da2e9",
+      "externalCallCount": 31,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
@@ -1283,6 +1283,7 @@
         "datomic.api/sync",
         "datomic.api/tempid",
         "datomic.api/transact",
+        "datomic.api/tx->t",
         "goog.crypt/stringToUtf8ByteArray",
         "instaparse.core/failure?",
         "instaparse.core/get-failure",
@@ -1293,8 +1294,8 @@
       ]
     },
     "eacl.datomic.core/snapshot": {
-      "internalDefinitionCount": 403,
-      "internalDefinitionIdsSha256": "953f80c2c22eae1199713c8af2f6d9e76769f2d533ea6368fffdacc7c490bdfa",
+      "internalDefinitionCount": 406,
+      "internalDefinitionIdsSha256": "91634bb6424548375ac8323b38c49179c9b067811e8581bb2aaf6dfe53124fa1",
       "externalCallCount": 14,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1314,8 +1315,8 @@
       ]
     },
     "eacl.datomic.core/db": {
-      "internalDefinitionCount": 863,
-      "internalDefinitionIdsSha256": "848aa2c389a2cbd97eac3d753f9d72539e8dc5569618241cfc5b32ef09688101",
+      "internalDefinitionCount": 872,
+      "internalDefinitionIdsSha256": "d0db1b61ff0c494e949d85e13f41ef3d8916eb285e93195b5867f830c30c6c1d",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1340,8 +1341,8 @@
       "externalCalls": []
     },
     "eacl.datomic.core/basis-instant": {
-      "internalDefinitionCount": 874,
-      "internalDefinitionIdsSha256": "6dbb1f94c409b6f528754321b707239098f2867421ccbeac39595624677fc46b",
+      "internalDefinitionCount": 883,
+      "internalDefinitionIdsSha256": "9761f3302c49e10a76f32e4280e9d4bafc4087340d850eb779608adc60b310af",
       "externalCallCount": 15,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1362,8 +1363,8 @@
       ]
     },
     "eacl.datahike.core/make-client": {
-      "internalDefinitionCount": 421,
-      "internalDefinitionIdsSha256": "19d07124c4f040e2ee25c349be0a3fc776b946a820c77f3cc66a251a88a1eee2",
+      "internalDefinitionCount": 423,
+      "internalDefinitionIdsSha256": "9331526d331fa6ad48d91bb0e463bccff9e2b08fa5565457f06c4ee2d0027907",
       "externalCallCount": 24,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1393,8 +1394,8 @@
       ]
     },
     "eacl.datahike.core/snapshot": {
-      "internalDefinitionCount": 403,
-      "internalDefinitionIdsSha256": "75fe71ffc16c81587430430ec3f740ed2964c71cb36fed7d27c99f54ac7537a8",
+      "internalDefinitionCount": 406,
+      "internalDefinitionIdsSha256": "1b587c813197fd1c5eae412db3cca1f9d3760c7d558abab0d334e5c365691a71",
       "externalCallCount": 14,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1414,8 +1415,8 @@
       ]
     },
     "eacl.datahike.core/db": {
-      "internalDefinitionCount": 863,
-      "internalDefinitionIdsSha256": "b74fad8a7b3bbb094789438d015db6bae5478feed1dac02b321bf31a44dcd06e",
+      "internalDefinitionCount": 872,
+      "internalDefinitionIdsSha256": "2856ac08e6c28e02fff92dd4e2f246be1c39cff0c48170d0212fb13165224644",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1466,8 +1467,8 @@
       ]
     },
     "eacl.datascript.core/snapshot": {
-      "internalDefinitionCount": 403,
-      "internalDefinitionIdsSha256": "783a002fac2d2d1a511ec46c0f88654397aa50ab2c27cf986a39fb5aa29593d1",
+      "internalDefinitionCount": 406,
+      "internalDefinitionIdsSha256": "7ddf4cac0ebec5b27b260879903f7e6bce2e4fdf2014d7b342b93dd90ebba448",
       "externalCallCount": 14,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1487,8 +1488,8 @@
       ]
     },
     "eacl.datascript.core/db": {
-      "internalDefinitionCount": 863,
-      "internalDefinitionIdsSha256": "9567e79b026b0c323669255487db0b79209b493ee55e1d0ddebcf80e9005909f",
+      "internalDefinitionCount": 872,
+      "internalDefinitionIdsSha256": "7505dedebed61d073aae3f0284a2003bca77b513a16f20f7d5ecb2354fc3c486",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1544,8 +1545,8 @@
       ]
     },
     "eacl.datalevin.core/snapshot": {
-      "internalDefinitionCount": 403,
-      "internalDefinitionIdsSha256": "61a3eb3a4339e25e575602ff863731c43aec6406db00c7816696a1512878f956",
+      "internalDefinitionCount": 406,
+      "internalDefinitionIdsSha256": "a200c24401c27fb6101ce19206c738ff71b6b00353d2402fd25cb405399d31f5",
       "externalCallCount": 14,
       "externalCalls": [
         "cljs.reader/read-string",
@@ -1565,8 +1566,8 @@
       ]
     },
     "eacl.datalevin.core/db": {
-      "internalDefinitionCount": 863,
-      "internalDefinitionIdsSha256": "2cfca0a2c1b9ad8ca40691320332c7270669e3a76f1d272e62d5dd43c0e88ae2",
+      "internalDefinitionCount": 872,
+      "internalDefinitionIdsSha256": "60cce5163a4f636b7b9177b39667e69d0476907e2abfe4d11b5f7ecc57a7fd46",
       "externalCallCount": 13,
       "externalCalls": [
         "cljs.reader/read-string",

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -253,7 +253,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "d5c9ce2af23db46a639bd6bbd46a1180d8b37f45fae290c0eec36dc801374e06"
+      "sha256": "8c47d4bfa41b1d2313173b69c1bb255e788da4fcb8626a04fbde43c58868fa0e"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -404,7 +404,7 @@
     "rootCount": 70,
     "unionInternalDefinitionCount": 1653,
     "unionInternalDefinitionIdsSha256": "f5939214fb1a40ae2f4772bec0118a1be58b9a2d896daba8b512fa8c669840c8",
-    "unionDefinitionLocationsSha256": "6b04bf803c3e7cd28488c2d69d7093ec1e28c8986947ebc199aad3fafbd7155d",
+    "unionDefinitionLocationsSha256": "55fdcb8b963539a3034a4940bcf793d64247c403a614184bf67ec334502219a1",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 25,

--- a/formal/verification/source-specializations.edn
+++ b/formal/verification/source-specializations.edn
@@ -245,7 +245,7 @@
      :relation-orders 2}
     :missing-definition-fixtures 3
     :adapter-certification
-    {:version "eacl.adapter-certification/v2"
+    {:version "eacl.adapter-certification/v4"
      :datomic-clj :passed
      :datahike-clj :passed
      :datascript-clj :passed

--- a/formal/verification/temporal-model.md
+++ b/formal/verification/temporal-model.md
@@ -23,8 +23,12 @@ Its 25 transitions cover:
 
 The model checks these safety properties:
 
-1. cache reuse is exact-snapshot or forward-only from a causal ancestor with
-   matching authenticated source, query, scope, and proof;
+1. within this current-head temporal submodel, cache reuse is exact-snapshot or
+   from a causal ancestor with matching authenticated source, query, scope, and
+   proof; direction-agnostic reuse by a retained older selected snapshot is the
+   separate scalar-frontier obligation proved by
+   `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` in
+   `formal/dafny/ScalarFrontierCoherence.dfy`;
 2. authenticated query-scoped cursors continue on current only when its
    dependency proof equals the cursor proof, otherwise continue on the
    retained exact graph when available and freshness-compatible, or fail

--- a/modules/eacl-datahike/src/eacl/datahike/backend.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/backend.clj
@@ -40,8 +40,32 @@
   credentials for jdbc/s3 stores) and must not leak into snapshot ids,
   cache bases, or cursor digests."
   [db]
-  (let [{:keys [backend id]} (:store (db-config db))]
-    {:backend backend :id (str id)}))
+  (let [config (db-config db)
+        {:keys [backend id]} (:store config)
+        id (if (= :memory backend)
+             (get config schema/live-source-id-key)
+             id)]
+    {:backend backend :id (some-> id str)}))
+
+(defn- connection-live-source-id
+  "Returns one random identity for the lifetime of a memory connection.
+
+  EACL-created connections carry it in their non-durable runtime config so
+  their immutable DB values can be admitted as direct snapshots. For an
+  externally created memory connection, attach it to the connection's private
+  listener carrier; direct DB values from that unsupported construction remain
+  unkeyable rather than falling back to a caller-supplied store id."
+  [conn db]
+  (or (get (db-config db) schema/live-source-id-key)
+      (when-let [carrier (:listeners (meta conn))]
+        (or (::live-source-id (meta carrier))
+            (::live-source-id
+             (alter-meta!
+              carrier
+              (fn [metadata]
+                (if (::live-source-id metadata)
+                  metadata
+                  (assoc metadata ::live-source-id (random-uuid))))))))))
 
 (defn basis-kind
   "Classifies one Datahike database value without touching an EACL runtime."
@@ -59,8 +83,9 @@
   [db]
   (when (contains? #{:ordinary :as-of} (basis-kind db))
     (let [{:keys [backend id]} (store-identity db)]
-      {:source-id {:store-backend backend :store-id id}
-       :branch (:branch (db-config db))})))
+      (when id
+        {:source-id {:store-backend backend :store-id id}
+         :branch (:branch (db-config db))}))))
 
 (defn- exact-reconstruction?
   [db]
@@ -176,19 +201,13 @@
 
 (defn- ordered-generation-frame
   [db relation-ids]
-  {:schema-stamp
-   (when-let [schema-eid (ddb/entid db [:eacl/id "schema-string"])]
-     (some-> (first (ddb/eavt-datoms
-                     db schema-eid :eacl/schema-generation))
-             :tx))
-   :relation-stamps
-   (mapv
-    (fn [relation-id]
-      [relation-id
-       (some-> (first (ddb/eavt-datoms
-                       db relation-id :eacl/relation-version))
-               :tx)])
-    relation-ids)})
+  (mapv
+   (fn [relation-id]
+     [relation-id
+      (some-> (first (ddb/eavt-datoms
+                      db relation-id :eacl/relation-version))
+              :tx)])
+   relation-ids))
 
 (defn- certified-schema-generation
   [db]
@@ -304,6 +323,9 @@
         ;; consumes only configuration needed for the source's static profile.
         static-db @conn
         {:keys [backend id]} (store-identity static-db)
+        id (if (= :memory backend)
+             (some-> (connection-live-source-id conn static-db) str)
+             id)
         source-scope
         {:source-id {:store-backend backend :store-id id}
          :branch (:branch (db-config static-db))}

--- a/modules/eacl-datahike/src/eacl/datahike/schema.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/schema.clj
@@ -144,19 +144,26 @@
    ;; declares that as intentional rather than leaving datahike to warn about it.
    :max-string-length  0})
 
+(def live-source-id-key
+  "Connection-local lineage identity carried by non-durable store configs."
+  :eacl.datahike/live-source-id)
+
 (defn create-conn
   "A datahike connection carrying EACL's schema.
 
   `config` is merged over `default-config`; temporal history is enabled unless
   the caller explicitly passes `{:keep-history? false}`. Pass
   `{:attribute-refs? true}` to get Datomic's numeric attribute representation.
-  A memory store gets a fresh id per connection unless one is supplied, so two
-  calls do not collide."
+  A memory store gets a fresh lineage id per created live source even when the
+  caller supplies a fixed store id."
   ([] (create-conn nil nil))
   ([extra-schema] (create-conn extra-schema nil))
   ([extra-schema config]
    (let [cfg (-> (merge default-config config)
-                 (update :store #(merge {:id (random-uuid)} %)))]
+                 (update :store #(merge {:id (random-uuid)} %)))
+         cfg (cond-> cfg
+               (= :memory (get-in cfg [:store :backend]))
+               (assoc live-source-id-key (random-uuid)))]
      (d/create-database cfg)
      (let [conn (d/connect cfg)]
        (d/transact conn (merge-schema extra-schema))

--- a/modules/eacl-datahike/test/eacl/datahike/adapter_certification_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/adapter_certification_test.clj
@@ -47,6 +47,78 @@
         (is (:passed? report)
             (pr-str (:checks report)))))))
 
+(deftest datahike-ordered-generation-transition-certification-test
+  (let [fixture (certification/coherent-fixture 820084)
+        conn (datahike/create-conn)
+        client (datahike/make-client conn {})
+        adapter-for
+        (fn []
+          (datahike-backend/basis-adapter
+           (d/db conn)
+           {:object-id->entid
+            (fn [snapshot object-id]
+              (:db/id (d/entity snapshot [:eacl/id object-id])))
+            :entid->object-id
+            (fn [snapshot internal-id]
+              (:eacl/id (d/entity snapshot internal-id)))}))]
+    (eacl/write-schema! client (:schema fixture))
+    (d/transact
+     conn
+     (vec
+      (map-indexed
+       (fn [index {:keys [id]}]
+         {:db/id (- (inc index)) :eacl/id id})
+       (:objects fixture))))
+    (eacl/create-relationships! client (:relationships fixture))
+    (let [before (adapter-for)
+          relation-ids
+          (->> (:relations fixture)
+               (mapcat
+                (fn [{:keys [resource-type relation-name]}]
+                  (v8/invoke
+                   before :relation-defs resource-type relation-name)))
+               (map :relation-id)
+               sort
+               vec)
+          affected
+          (:relation-id
+           (first (v8/invoke before :relation-defs :group :member)))]
+      (eacl/delete-relationship! client (first (:relationships fixture)))
+      (is (= :certified
+             (:status
+              (certification/certify-ordered-generation-transition!
+               {:before-adapter before
+                :after-adapter (adapter-for)
+                :relation-ids relation-ids
+                :affected-relation-ids [affected]})))))))
+
+(deftest datahike-memory-live-source-identity-certification-test
+  (let [fixed-id (random-uuid)
+        config {:store {:backend :memory :id fixed-id}}
+        first-conn (datahike/create-conn nil config)
+        first-db-config (:config (d/db first-conn))
+        first-scope
+        (try
+          (datahike-backend/database-source-scope (d/db first-conn))
+          (finally
+            (d/release first-conn)
+            (d/delete-database first-db-config)))
+        second-conn (datahike/create-conn nil config)]
+    (try
+      (is (= :certified
+             (:status
+              (certification/certify-live-source-identity!
+               {:backend :datahike
+                :durability :non-durable
+                :first-scope first-scope
+                :second-scope
+                (datahike-backend/database-source-scope
+                 (d/db second-conn))}))))
+      (finally
+        (let [second-db-config (:config (d/db second-conn))]
+          (d/release second-conn)
+          (d/delete-database second-db-config))))))
+
 (deftest current-db-reference-identity-test
   (testing "the exact-basis cache can use immutable DB object identity"
     (let [conn (datahike/create-conn)

--- a/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/consistency_v3_test.clj
@@ -56,6 +56,62 @@
     (catch clojure.lang.ExceptionInfo error
       (ex-data error))))
 
+(deftest readable-as-of-db-lifts-from-a-newer-equal-proof-test
+  (let [conn (datahike/create-conn nil {:commit-graph? false
+                                        :keep-history? true})
+        authorization (client conn)]
+    (try
+      (seed! conn authorization)
+      (let [old-token
+            (:zed/token
+             (eacl/create-relationship! authorization relationship))]
+        (d/transact conn [{:eacl/id "newer-unrelated"}])
+        (let [newer
+              (eacl/check-permission authorization user :view document)
+              older
+              (eacl/check-permission
+               authorization
+               {:subject user
+                :permission :view
+                :resource document
+                :consistency
+                (consistency/at-exact-snapshot old-token)})]
+          (is (true? (:allowed? newer)))
+          (is (false? (:cached? newer)))
+          (is (true? (:allowed? older)))
+          (is (true? (:cached? older))
+              "the readable AsOfDB frame lifts in the older direction")))
+      (finally
+        (d/release conn)))))
+
+(deftest readable-as-of-db-misses-when-its-proof-differs-test
+  (let [conn (datahike/create-conn nil {:commit-graph? false
+                                        :keep-history? true})
+        authorization (client conn)]
+    (try
+      (seed! conn authorization)
+      (let [old-token
+            (:zed/token
+             (eacl/create-relationship! authorization relationship))]
+        (eacl/delete-relationship! authorization relationship)
+        (let [newer
+              (eacl/check-permission authorization user :view document)
+              older
+              (eacl/check-permission
+               authorization
+               {:subject user
+                :permission :view
+                :resource document
+                :consistency
+                (consistency/at-exact-snapshot old-token)})]
+          (is (false? (:allowed? newer)))
+          (is (false? (:cached? newer)))
+          (is (true? (:allowed? older)))
+          (is (false? (:cached? older))
+              "different complete AsOfDB proofs cannot lift")))
+      (finally
+        (d/release conn)))))
+
 (deftest map-can-rejects-malformed-consistency-test
   (let [conn (datahike/create-conn)
         authorization (client conn)
@@ -477,8 +533,7 @@
         (backend/invoke before-adapter :proof-frame [relation-id])
         document-eid
         (ddb/entid (d/db conn) [:eacl/id "document"])]
-    (is (integer? (:schema-stamp before-proof)))
-    (is (= relation-id (ffirst (:relation-stamps before-proof))))
+    (is (= relation-id (ffirst before-proof)))
     (let [reverse
           (first
            (ddb/eavt-datoms
@@ -515,8 +570,8 @@
                            datahike-backend/adapter-config-keys))
              :proof-frame
              [relation-id])]
-        (is (< (second (first (:relation-stamps before-proof)))
-               (second (first (:relation-stamps after-proof))))
+        (is (< (second (first before-proof))
+               (second (first after-proof)))
             "the supported repair advances the committed relation generation")))
     (d/release conn)))
 

--- a/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/contract_test.clj
@@ -30,6 +30,66 @@
                                    :eacl/id id})
                                 contract/smoke-objects))))
 
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(defn- current-source-scope
+  [client]
+  (eacl/with-snapshot [snapshot (eacl/snapshot client)]
+    (select-keys (eacl/basis snapshot) [:backend :source-id :branch])))
+
+(deftest fixed-memory-store-id-does-not-become-lineage-test
+  (let [key "01234567890123456789012345678901"
+        fixed-id (random-uuid)
+        config {:store {:backend :memory :id fixed-id}}
+        first-conn (datahike/create-conn nil config)
+        first-config (:config (d/db first-conn))
+        first-result
+        (try
+          (let [first-client
+                (datahike/make-client first-conn {:security-key key})]
+            (eacl/write-schema! first-client contract/smoke-schema)
+            (seed-objects! first-conn)
+            {:token
+             (:zed/token
+              (eacl/create-relationship!
+               first-client
+               (first contract/smoke-relationships)))
+             :scope (current-source-scope first-client)})
+          (finally
+            (d/release first-conn)
+            (d/delete-database first-config)))
+        second-conn (datahike/create-conn nil config)]
+    (try
+      (let [second-client
+            (datahike/make-client second-conn {:security-key key})
+            second-scope
+            (current-source-scope second-client)]
+        (is (not= (:scope first-result) second-scope))
+        (is (not= (str fixed-id)
+                  (get-in first-result [:scope :source-id :store-id])))
+        (is (not= (str fixed-id)
+                  (get-in second-scope [:source-id :store-id])))
+        (is (= :eacl.consistency/incomparable-scope
+               (:type
+                (error-data
+                 #(eacl/can?
+                   second-client
+                   (contract/->user "user-1")
+                   :admin
+                   (contract/->account "account-1")
+                   (consistency/at-least-as-fresh
+                    (:token first-result))))))))
+      (finally
+        (let [second-config (:config (d/db second-conn))]
+          (d/release second-conn)
+          (d/delete-database second-config))))))
+
 (deftest default-source-lifecycle-is-cross-client-constant-test
   (let [conn (datahike/create-conn)
         key "01234567890123456789012345678901"

--- a/modules/eacl-datalevin/test/eacl/datalevin/adapter_certification_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/adapter_certification_test.clj
@@ -52,6 +52,14 @@
                         :runtime :clj})]
                   (is (some? (v8/invoke adapter :schema-generation)))
                   (is (:passed? report) (pr-str (:checks report)))
+                  (is (= :not-claimed
+                         (:status
+                          (certification/certify-ordered-generation-transition!
+                           {:before-adapter adapter
+                            :after-adapter adapter
+                            :relation-ids []
+                            :affected-relation-ids []})))
+                      "the executable temporal gate records Datalevin's current conservative non-claim")
                   (testing "persistent Datalevin transaction IDs are not exposed as proof generations"
                     (is (= #{:snapshot-bound :database-visible}
                            (:cache-proofs (v8/capabilities adapter))))
@@ -69,3 +77,25 @@
           (finally
             (d/close conn)
             (u/delete-files dir)))))))
+
+(deftest datalevin-durable-source-identity-certification-test
+  (let [dir (u/tmp-dir (str "eacl-datalevin-source-cert-" (random-uuid)))
+        first-conn (datalevin/create-conn dir)
+        first-scope
+        {:source-id (backend/connection-source-id first-conn)
+         :branch nil}]
+    (d/close first-conn)
+    (let [second-conn (datalevin/create-conn dir)]
+      (try
+        (is (= :certified
+               (:status
+                (certification/certify-live-source-identity!
+                 {:backend :datalevin
+                  :durability :durable
+                  :first-scope first-scope
+                  :second-scope
+                  {:source-id (backend/connection-source-id second-conn)
+                   :branch nil}}))))
+        (finally
+          (d/close second-conn)
+          (u/delete-files dir))))))

--- a/modules/eacl-datascript/src/eacl/datascript/backend.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/backend.cljc
@@ -107,19 +107,13 @@
 
 (defn- ordered-generation-frame
   [db relation-ids]
-  {:schema-stamp
-   (when-let [schema-eid (ds/entid db [:eacl/id "schema-string"])]
-     (some-> (first (ds/datoms db :eavt schema-eid
-                                :eacl/schema-generation))
-             :tx))
-   :relation-stamps
-   (mapv
-    (fn [relation-id]
-      [relation-id
-       (some-> (first (ds/datoms db :eavt relation-id
-                                  :eacl/relation-version))
-               :tx)])
-    relation-ids)})
+  (mapv
+   (fn [relation-id]
+     [relation-id
+      (some-> (first (ds/datoms db :eavt relation-id
+                                 :eacl/relation-version))
+              :tx)])
+   relation-ids))
 
 (defn- certified-schema-generation
   [db]

--- a/modules/eacl-datascript/test/eacl/datascript/adapter_certification_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/adapter_certification_test.cljc
@@ -63,6 +63,64 @@
         (is (:passed? report)
             (pr-str (:checks report)))))))
 
+(deftest datascript-ordered-generation-transition-certification-test
+  (let [fixture (certification/coherent-fixture 820084)
+        conn (datascript/create-conn)
+        client (datascript/make-client conn {})
+        adapter-for
+        (fn []
+          (datascript-backend/basis-adapter
+           (ds/db conn)
+           {:object-id->entid
+            (fn [snapshot object-id]
+              (ds/entid snapshot [:eacl/id object-id]))
+            :entid->object-id
+            (fn [snapshot internal-id]
+              (:eacl/id (ds/entity snapshot internal-id)))}))]
+    (eacl/write-schema! client (:schema fixture))
+    (ds/transact!
+     conn
+     (map-indexed
+      (fn [index {:keys [id]}]
+        {:db/id (- (inc index)) :eacl/id id})
+      (:objects fixture)))
+    (eacl/create-relationships! client (:relationships fixture))
+    (let [before (adapter-for)
+          relation-ids
+          (->> (:relations fixture)
+               (mapcat
+                (fn [{:keys [resource-type relation-name]}]
+                  (v8/invoke
+                   before :relation-defs resource-type relation-name)))
+               (map :relation-id)
+               sort
+               vec)
+          affected
+          (:relation-id
+           (first (v8/invoke before :relation-defs :group :member)))]
+      (eacl/delete-relationship! client (first (:relationships fixture)))
+      (is (= :certified
+             (:status
+              (certification/certify-ordered-generation-transition!
+               {:before-adapter before
+                :after-adapter (adapter-for)
+                :relation-ids relation-ids
+                :affected-relation-ids [affected]})))))))
+
+(deftest datascript-live-source-identity-certification-test
+  (let [first-conn (datascript/create-conn)
+        second-conn (datascript/create-conn)]
+    (is (= :certified
+           (:status
+            (certification/certify-live-source-identity!
+             {:backend :datascript
+              :durability :non-durable
+              :first-scope
+              (datascript-backend/database-source-scope (ds/db first-conn))
+              :second-scope
+              (datascript-backend/database-source-scope
+               (ds/db second-conn))}))))))
+
 (deftest current-db-reference-identity-test
   (testing "the exact-basis cache can use immutable DB object identity"
     (let [conn (datascript/create-conn)

--- a/modules/eacl-datascript/test/eacl/datascript/cache_model_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/cache_model_test.cljc
@@ -72,6 +72,66 @@
              (answer (eacl/count-subjects cached (dissoc reverse-query :first))))
           (str label " count-subjects")))))
 
+(defn- assert-retained-publication-order!
+  [conn cached user-id account-id seed step newer-first?]
+  (let [request {:subject (spice-object :user user-id)
+                 :permission :admin
+                 :resource (spice-object :account account-id)}
+        answer #(select-keys % [:allowed?])
+        older (eacl/snapshot cached)]
+    (try
+      (ds/transact!
+       conn [{:eacl/id (str "application-" seed "-" step)}])
+      (let [newer (eacl/snapshot cached)]
+        (try
+          (let [[older-result newer-result]
+                #?(:clj
+                   (let [delayed-target (if newer-first? older newer)
+                         immediate-target (if newer-first? newer older)
+                         started (promise)
+                         release (promise)
+                         delayed
+                         (future
+                           (deliver started true)
+                           @release
+                           (answer
+                            (eacl/check-permission
+                             delayed-target request)))]
+                     @started
+                     (let [immediate
+                           (answer
+                            (eacl/check-permission
+                             immediate-target request))]
+                       (deliver release true)
+                       (if newer-first?
+                         [@delayed immediate]
+                         [immediate @delayed])))
+                   :cljs
+                   (if newer-first?
+                     (let [newer-result
+                           (answer
+                            (eacl/check-permission newer request))
+                           older-result
+                           (answer
+                            (eacl/check-permission older request))]
+                       [older-result newer-result])
+                     [(answer (eacl/check-permission older request))
+                      (answer (eacl/check-permission newer request))]))]
+            (is (= older-result
+                   (answer
+                    (eacl/check-permission
+                     older (assoc request :cache? false))))
+                (str "retained older basis, seed " seed ", step " step))
+            (is (= newer-result
+                   (answer
+                    (eacl/check-permission
+                     newer (assoc request :cache? false))))
+                (str "newer basis, seed " seed ", step " step)))
+          (finally
+            (eacl/release! newer))))
+      (finally
+        (eacl/release! older)))))
+
 (deftest randomized-cache-and-mutation-differential-test
   (doseq [seed (range 5)]
     (testing (str "automatic managed coherence, seed " seed)
@@ -115,8 +175,9 @@
             ;; Unrelated application basis churn alongside relationship
             ;; no-ops and relevant dependency changes.
             (when (zero? (mod step 7))
-              (ds/transact!
-               conn [{:eacl/id (str "application-" seed "-" step)}]))
+              (assert-retained-publication-order!
+               conn cached user-id account-id seed step
+               (zero? (next-int! 2))))
             (dotimes [sample 2]
               (let [sample-user
                     (nth user-ids (next-int! (count user-ids)))

--- a/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/consistency_v3_test.cljc
@@ -56,6 +56,25 @@
            error
       (ex-data error))))
 
+(deftest recreated-connection-rejects-prior-source-token-test
+  (let [first-conn (datascript/create-conn)
+        first-client (managed-client first-conn {})
+        _ (seed! first-conn first-client)
+        old-token
+        (:zed/token
+         (eacl/create-relationship! first-client relationship))
+        second-conn (datascript/create-conn)
+        second-client (managed-client second-conn {})
+        _ (seed! second-conn second-client)
+        _ (eacl/create-relationship! second-client relationship)]
+    (is (= :eacl.consistency/incomparable-scope
+           (:type
+            (error-data
+             #(eacl/can?
+               second-client
+               user :view document
+               (consistency/at-least-as-fresh old-token))))))))
+
 (deftest map-can-rejects-malformed-consistency-test
   (let [conn (datascript/create-conn)
         client (managed-client conn {})
@@ -82,6 +101,56 @@
     (is (not
          (backend/supports?
           adapter :consistency :fully-consistent)))))
+
+(deftest proof-contract-violation-degrades-to-available-exact-authorization-test
+  (let [conn (datascript/create-conn)
+        reports (atom [])
+        client
+        (managed-client
+         conn {:proof-contract-reporter #(swap! reports conj %)})
+        _ (seed! conn client)
+        _ (eacl/create-relationship! client relationship)
+        original datascript-backend/basis-adapter
+        violating-adapter
+        (fn [db options]
+          (assoc-in
+           (original db options)
+           [:eacl.backend.v8/operations :proof-frame]
+           (fn [relation-ids]
+             (mapv (fn [relation-id]
+                     [relation-id (inc (:max-tx db))])
+                   relation-ids))))]
+    (with-redefs [datascript-backend/basis-adapter violating-adapter]
+      (let [first-decision
+            (eacl/check-permission
+             client {:subject user :permission :view :resource document})
+            repeated-decision
+            (eacl/check-permission
+             client {:subject user :permission :view :resource document})]
+        (is (true? (:allowed? first-decision)))
+        (is (false? (:cached? first-decision)))
+        (is (true? (:allowed? repeated-decision)))
+        (is (true? (:cached? repeated-decision))
+            "exact-basis caching remains available after disablement"))
+      (ds/transact! conn [{:eacl/id "unrelated-after-violation"}])
+      (is (true?
+           (eacl/can?
+            client
+            {:subject user :permission :view :resource document})))
+      (let [snapshot (eacl/snapshot client)]
+        (try
+          (is (string? (eacl/basis-token snapshot))
+              "revision-token issuance does not depend on managed proofs")
+          (finally
+            (eacl/release! snapshot))))
+      (let [stats (datascript/cache-stats client)]
+        (is (true? (:managed-lifting-disabled? stats)))
+        (is (= 1 (:proof-contract-violations stats)))
+        (is (= {:relation-generation-above-revision 1}
+               (:proof-contract-violation-reasons stats))))
+      (is (= 1 (count @reports)))
+      (is (= :relation-generation-above-revision
+             (:reason (first @reports)))))))
 
 (deftest explicit-cache-expiry-installs-a-fresh-lifecycle-test
   (let [conn (datascript/create-conn)
@@ -482,8 +551,7 @@
          (ds/datoms
           (ds/db conn) :eavt document-eid
           relationship-storage/reverse-attribute))]
-    (is (integer? (:schema-stamp before-proof)))
-    (is (= relation-id (ffirst (:relation-stamps before-proof))))
+    (is (= relation-id (ffirst before-proof)))
     (testing "unsupported raw mutation leaves the managed proof unchanged"
       (ds/transact!
        conn
@@ -512,8 +580,8 @@
               (select-keys (:runtime authorization)
                            datascript-backend/adapter-config-keys))
              :proof-frame [relation-id])]
-        (is (< (second (first (:relation-stamps before-proof)))
-               (second (first (:relation-stamps after-proof)))))))))
+        (is (< (second (first before-proof))
+               (second (first after-proof))))))))
 
 (deftest relationship-cursor-changed-proof-is-stale-test
   (let [conn (datascript/create-conn)

--- a/modules/eacl-datascript/test/eacl/engine/continuation_reuse_test.clj
+++ b/modules/eacl-datascript/test/eacl/engine/continuation_reuse_test.clj
@@ -245,6 +245,34 @@
       (is (= 10 (get-in (checkpoint-hit context [:k] 2 42)
                         [:state :transitions]))))))
 
+(deftest read-without-publication-can-read-but-not-write-checkpoints-test
+  (let [{:keys [conn]} (capture/seed-client!
+                        ((get capture/fixtures :explorer-acyclic)))
+        adapter (datascript-backend/basis-adapter
+                 (ds/db conn) (adapter-opts conn {}))
+        store (continuation/make-store {})
+        writable
+        (continuation/private-context
+         store adapter :lookup-resources {:query {:q 1}})
+        read-only
+        (continuation/private-context
+         store adapter :lookup-resources {:query {:q 1}}
+         {:populate-cache? false})]
+    (is (false? ((:put! read-only) :edge :suppressed 1)))
+    (is (false? ((:put-page! read-only) :page :suppressed 1)))
+    (is (false? ((:put-heads! read-only) :heads :suppressed 1)))
+    (is (nil? ((:get read-only) :edge)))
+    (is (nil? ((:get-page read-only) :page)))
+    (is (nil? ((:get-heads read-only) :heads)))
+    (is (true? ((:put! writable) :edge :stored 1)))
+    (is (true? ((:put-page! writable) :page :stored 1)))
+    (is (true? ((:put-heads! writable) :heads :stored 1)))
+    (is (= :stored ((:get read-only) :edge)))
+    (is (= :stored ((:get-page read-only) :page)))
+    (is (= :stored ((:get-heads read-only) :heads)))
+    (is (= 3 (:puts (continuation/stats store)))
+        "only the writable context publishes")))
+
 (deftest acyclic-pagination-needs-no-checkpoints-test
   ;; The keyset regime: an acyclic root paginates statelessly — exact
   ;; pages, zero continuation-store traffic (acyclic-keyset-pagination).

--- a/modules/eacl-datomic/src/eacl/datomic/backend.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/backend.clj
@@ -266,25 +266,21 @@
 
 (defn- ordered-generation-frame
   [db relation-ids]
-  {:schema-stamp
-   (when-let [schema-eid (d/entid db [:eacl/id "schema-string"])]
-     (some-> (first (d/datoms db :eavt schema-eid
-                              :eacl/schema-version))
-             :tx))
-   :relation-stamps
-   (mapv
-    (fn [relation-id]
-      [relation-id
-       (some-> (first (d/datoms db :eavt relation-id
-                                :eacl/relation-version))
-               :tx)])
-    relation-ids)})
+  (mapv
+   (fn [relation-id]
+     [relation-id
+      (some-> (first (d/datoms db :eavt relation-id
+                               :eacl/relation-version))
+              :tx
+              d/tx->t)])
+   relation-ids))
 
 (defn- certified-schema-generation
   [db]
   (when (d/entid db :eacl/schema-version)
     (some-> (first (d/datoms db :avet :eacl/schema-version))
-            :tx)))
+            :tx
+            d/tx->t)))
 
 (def adapter-config-keys
   #{:entid->object-id :object-id->entid :object-eid-fn

--- a/modules/eacl-datomic/src/eacl/datomic/schema.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/schema.clj
@@ -66,13 +66,34 @@
   Tx entity ids increase monotonically with `t`, so a max over a dependency set
   is strictly increasing on any write to it.
 
-  :db/noHistory because only the current stamp is ever read; without it every
-  EACL write would accumulate a permanent datom per relation."
+  History must remain available because proof-equivalent reuse is valid for any
+  readable immutable basis, including `d/as-of` values. Datomic indexing may
+  discard superseded values of a `:db/noHistory true` attribute, which would
+  make an otherwise valid historical proof unreadable."
   {:db/ident       :eacl/relation-version
    :db/doc         "Ref to the transaction that last changed a relationship using this relation. Bumped by EACL's relationship tx-data helpers; read by the result cache to scope invalidation to affected relations."
    :db/valueType   :db.type/ref
    :db/cardinality :db.cardinality/one
-   :db/noHistory   true})
+   :db/noHistory   false})
+
+(defn- ensure-relation-version-history!
+  "Installs the relation-generation attribute when requested and upgrades
+  existing databases to retain future generation history."
+  [conn install-if-missing?]
+  (let [db (d/db conn)
+        relation-version-eid (d/entid db :eacl/relation-version)]
+    (cond
+      (and (nil? relation-version-eid) install-if-missing?)
+      @(d/transact conn [relation-version-attr-definition])
+
+      (and relation-version-eid
+           (true? (:db/noHistory
+                   (d/entity db relation-version-eid))))
+      @(d/transact conn [{:db/id :eacl/relation-version
+                          :db/noHistory false}])
+
+      :else
+      nil)))
 
 (def assert-relation-unused-fn-definition
   "Commit-time guard for relation removal.
@@ -315,6 +336,7 @@
   Datomic schema generations predate this migration and must already exist;
   a missing schema version fails closed instead of inventing authority."
   [conn]
+  (ensure-relation-version-history! conn false)
   (let [db (d/db conn)
         schema-eid (d/entid db [:eacl/id "schema-string"])]
     (when-not (and (d/entid db :eacl/relation-version)
@@ -465,13 +487,11 @@
      ;; path. :eacl/relation-version is installed the same way so a database
      ;; created before per-relation stamps picks it up on its next valid schema
      ;; write rather than silently running without result caching.
+     (ensure-relation-version-history! conn true)
      (let [db (d/db conn)
            missing (cond-> []
                      (not (d/entid db :eacl/schema-version))
                      (conj schema-version-attr-definition)
-
-                     (not (d/entid db :eacl/relation-version))
-                     (conj relation-version-attr-definition)
 
                      (not (d/entid db :eacl.fn/assert-relation-unused))
                      (conj assert-relation-unused-fn-definition))]

--- a/modules/eacl-datomic/test/eacl/bench/managed_proof_cost_test.clj
+++ b/modules/eacl-datomic/test/eacl/bench/managed_proof_cost_test.clj
@@ -96,19 +96,19 @@
   (alength (.getBytes (pr-str value) "UTF-8")))
 
 (defn- full-vector-key
-  [{:keys [schema-stamp relation-stamps]}]
-  {:schema-stamp schema-stamp
-   :relation-stamps relation-stamps})
+  [{:keys [schema-generation relation-generations]}]
+  {:schema-generation schema-generation
+   :relation-generations relation-generations})
 
 (defn- scalar-frontier-key
-  [{:keys [schema-stamp relation-stamps]}]
-  {:schema-stamp schema-stamp
+  [{:keys [schema-generation relation-generations]}]
+  {:schema-generation schema-generation
    :dependency-stamp
    (reduce
     (fn [frontier [_ generation]]
       (max frontier generation))
     0
-    relation-stamps)})
+    relation-generations)})
 
 (defn- proof-key-sample
   [adapter relation-ids mode]
@@ -120,7 +120,11 @@
      proof-calls-per-sample
      (fn []
        (dotimes [_ proof-calls-per-sample]
-         (let [proof (backend/invoke adapter :proof-frame relation-ids)
+         (let [proof
+               {:schema-generation
+                (backend/invoke adapter :schema-generation)
+                :relation-generations
+                (backend/invoke adapter :proof-frame relation-ids)}
                key (key-fn proof)]
            (vswap! sink bit-xor (hash key))))
        @sink))))
@@ -296,7 +300,8 @@
    (first (backend/invoke adapter :relation-defs :document relation-name))))
 
 (defn- exercise-backend!
-  [{:keys [label client transact-var transact-objects! adapter close!]}]
+  [{:keys [label client transact-var transact-objects! adapter
+           relation-generation-history-size close!]}]
   (let [reader (eacl/spice-object :user (str (name label) "-reader"))
         target (eacl/spice-object :document (str (name label) "-target"))
         relationship (eacl/->Relationship reader :reader target)
@@ -304,7 +309,10 @@
     (try
       (eacl/write-schema! client (benchmark-schema))
       (transact-objects! [reader target])
-      (let [[create-tx delete-tx]
+      (let [history-size-before
+            (when relation-generation-history-size
+              (relation-generation-history-size))
+            [create-tx delete-tx]
             (capture-transaction-shapes!
              transact-var
              #(do
@@ -326,14 +334,26 @@
                        label client demand transact-objects!)
               relevant (relevant-miss-measurement
                         client demand relationship)
+              history-size-after
+              (when relation-generation-history-size
+                (relation-generation-history-size))
               result
-              {:backend label
-               :create-committed-datom-events (count create-tx)
-               :delete-committed-datom-events (count delete-tx)
-               :proof-cardinalities proof-results
-               :exact-hit exact
-               :managed-hit-after-unrelated-commit managed
-               :relevant-proof-miss relevant}]
+              (cond->
+               {:backend label
+                :create-committed-datom-events (count create-tx)
+                :delete-committed-datom-events (count delete-tx)
+                :proof-cardinalities proof-results
+                :exact-hit exact
+                :managed-hit-after-unrelated-commit managed
+                :relevant-proof-miss relevant}
+                relation-generation-history-size
+                (assoc
+                 :relation-generation-history-datoms-before
+                 history-size-before
+                 :relation-generation-history-datoms-after
+                 history-size-after
+                 :relation-generation-history-datom-growth
+                 (- history-size-after history-size-before)))]
           (is (pos? (:create-committed-datom-events result)))
           (is (pos? (:delete-committed-datom-events result)))
           (is (zero? (get-in exact [:backend-operations :proof-frame] 0))
@@ -376,6 +396,14 @@
                 (d/db connection)
                 (select-keys (:runtime client)
                              datomic-backend/adapter-config-keys))
+     :relation-generation-history-size
+     #(count
+       (iterator-seq
+        (.iterator
+         ^java.lang.Iterable
+         (d/datoms (d/history (d/db connection))
+                   :aevt
+                   :eacl/relation-version))))
      :close! #(d/delete-database uri)}))
 
 (defn- datahike-fixture
@@ -486,19 +514,29 @@
 
 (defn- compact-performance-result
   [{:keys [backend proof-cardinalities exact-hit
-           managed-hit-after-unrelated-commit relevant-proof-miss]}]
-  {:backend backend
-   :proof-cardinalities
-   (mapv
-    (fn [{:keys [dependency-count scalar full-vector backend-operations]}]
-      {:dependency-count dependency-count
-       :scalar scalar
-       :full-vector full-vector
-       :proof-frame-calls (:proof-frame backend-operations)})
-    proof-cardinalities)
-   :exact-hit exact-hit
-   :managed-hit-after-unrelated-commit managed-hit-after-unrelated-commit
-   :relevant-proof-miss relevant-proof-miss})
+           managed-hit-after-unrelated-commit relevant-proof-miss]
+    :as result}]
+  (cond->
+   {:backend backend
+    :proof-cardinalities
+    (mapv
+     (fn [{:keys [dependency-count scalar full-vector backend-operations]}]
+       {:dependency-count dependency-count
+        :scalar scalar
+        :full-vector full-vector
+        :proof-frame-calls (:proof-frame backend-operations)})
+     proof-cardinalities)
+    :exact-hit exact-hit
+    :managed-hit-after-unrelated-commit managed-hit-after-unrelated-commit
+    :relevant-proof-miss relevant-proof-miss}
+    (contains? result :relation-generation-history-datom-growth)
+    (assoc
+     :relation-generation-history-datoms-before
+     (:relation-generation-history-datoms-before result)
+     :relation-generation-history-datoms-after
+     (:relation-generation-history-datoms-after result)
+     :relation-generation-history-datom-growth
+     (:relation-generation-history-datom-growth result))))
 
 (deftest ^:benchmark cross-backend-scalar-frontier-and-request-cost-test
   (testing "scalar-frontier keys and complete request paths"

--- a/modules/eacl-datomic/test/eacl/datomic/adapter_certification_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/adapter_certification_test.clj
@@ -42,4 +42,47 @@
                   :runtime :clj})]
             (is (some? (v8/invoke adapter :schema-generation)))
             (is (:passed? report)
-                (pr-str (:checks report)))))))))
+                (pr-str (:checks report)))
+            (let [relation-ids
+                  (->> (:relations fixture)
+                       (mapcat
+                        (fn [{:keys [resource-type relation-name]}]
+                          (v8/invoke
+                           adapter :relation-defs
+                           resource-type relation-name)))
+                       (map :relation-id)
+                       sort
+                       vec)
+                  affected-relation-id
+                  (:relation-id
+                   (first
+                    (v8/invoke adapter :relation-defs :group :member)))]
+              (eacl/delete-relationship!
+               client (first (:relationships fixture)))
+              (let [after
+                    (datomic-backend/basis-adapter
+                     (d/db conn)
+                     {:entid->object-id
+                      (fn [snapshot internal-id]
+                        (:eacl/id (d/entity snapshot internal-id)))})]
+                (is (= :certified
+                       (:status
+                        (certification/certify-ordered-generation-transition!
+                         {:before-adapter adapter
+                          :after-adapter after
+                          :relation-ids relation-ids
+                          :affected-relation-ids
+                          [affected-relation-id]}))))))))))))
+
+(deftest datomic-memory-live-source-identity-certification-test
+  (with-mem-conn [first-conn schema/v7-schema]
+    (with-mem-conn [second-conn schema/v7-schema]
+      (is (= :certified
+             (:status
+              (certification/certify-live-source-identity!
+               {:backend :datomic
+                :durability :non-durable
+                :first-scope
+                (datomic-backend/database-source-scope (d/db first-conn))
+                :second-scope
+                (datomic-backend/database-source-scope (d/db second-conn))})))))))

--- a/modules/eacl-datomic/test/eacl/datomic/backend_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/backend_test.clj
@@ -76,11 +76,8 @@
               :direct-match?
               :user alice relation-id :account account)))
         (let [proof (backend/invoke adapter :proof-frame [relation-id])]
-          (is (= #{:schema-stamp :relation-stamps}
-                 (set (keys proof))))
-          (is (integer? (:schema-stamp proof)))
-          (is (= relation-id (ffirst (:relation-stamps proof))))
-          (is (integer? (second (first (:relation-stamps proof))))))
+          (is (= relation-id (ffirst proof)))
+          (is (integer? (second (first proof)))))
         (testing "the source advertises Datomic selection guarantees"
           (doseq [mode [:fully-consistent
                         :minimize-latency
@@ -88,3 +85,63 @@
                         :at-exact-snapshot]]
             (is (source/supports? (:source client)
                                   :consistency mode))))))))
+
+(deftest relation-generation-history-is-readable-through-as-of-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (core/make-client conn {})]
+      (eacl/write-schema! client test-schema)
+      @(d/transact conn [{:eacl/id "alice"}
+                         {:eacl/id "account-1"}])
+      (let [before-db (d/db conn)
+            before-t (d/basis-t before-db)
+            relation-id
+            (:e (first (d/datoms before-db
+                                 :aevt
+                                 :eacl.relation/relation-name)))
+            before-proof
+            (backend/invoke
+             (datomic-backend/basis-adapter before-db {})
+             :proof-frame
+             [relation-id])]
+        @(d/transact conn [{:eacl/id "unrelated"}])
+        (eacl/create-relationship!
+         client
+         (eacl/->Relationship
+          (eacl/spice-object :user "alice")
+          :owner
+          (eacl/spice-object :account "account-1")))
+        (let [current-t (d/basis-t (d/db conn))]
+          (d/request-index conn)
+          (is (not= ::timeout
+                    (deref (d/sync-index conn current-t)
+                           10000
+                           ::timeout)))
+          (let [as-of-db (d/as-of (d/db conn) before-t)
+                as-of-proof
+                (backend/invoke
+                 (datomic-backend/basis-adapter as-of-db {})
+                 :proof-frame
+                 [relation-id])
+                current-proof
+                (backend/invoke
+                 (datomic-backend/basis-adapter (d/db conn) {})
+                 :proof-frame
+                 [relation-id])]
+            (is (= before-proof as-of-proof)
+                "the older immutable basis retains its relation generation")
+            (is (< (second (first as-of-proof))
+                   (second (first current-proof))))))))))
+
+(deftest existing-no-history-relation-generation-schema-is-upgraded-test
+  (let [legacy-schema
+        (mapv (fn [attribute]
+                (if (= :eacl/relation-version (:db/ident attribute))
+                  (assoc attribute :db/noHistory true)
+                  attribute))
+              schema/v7-schema)]
+    (with-mem-conn [conn legacy-schema]
+      (is (true? (:db/noHistory
+                  (d/entity (d/db conn) :eacl/relation-version))))
+      (schema/write-schema! conn test-schema)
+      (is (false? (:db/noHistory
+                   (d/entity (d/db conn) :eacl/relation-version)))))))

--- a/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/consistency_cache_test.clj
@@ -10,7 +10,7 @@
             [eacl.datomic.backend :as datomic-backend]
             [eacl.datomic.cache :as cache]
             [eacl.datomic.core :as core]
-            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn with-mem-conns]]
             [eacl.datomic.schema :as schema]
             [eacl.engine.v8 :as engine]
             [eacl.spicedb.consistency :as consistency]))
@@ -68,6 +68,73 @@
     nil
     (catch clojure.lang.ExceptionInfo e
       (ex-data e))))
+
+(deftest readable-as-of-basis-lifts-from-a-newer-equal-proof-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (cached-client conn)
+          old-token (:zed/token (seed! conn client))
+          alice (spice-object :user "alice")
+          account (spice-object :account "acct")]
+      @(d/transact conn [{:eacl/id "newer-unrelated"}])
+      (let [newer (eacl/check-permission client alice :admin account)
+            older
+            (eacl/check-permission
+             client
+             {:subject alice
+              :permission :admin
+              :resource account
+              :consistency (consistency/at-exact-snapshot old-token)})]
+        (is (true? (:allowed? newer)))
+        (is (false? (:cached? newer)))
+        (is (true? (:allowed? older)))
+        (is (true? (:cached? older))
+            "a readable equal as-of proof lifts in the older direction")))))
+
+(deftest readable-as-of-basis-misses-when-its-proof-differs-test
+  (with-mem-conn [conn schema/v7-schema]
+    (let [client (cached-client conn)
+          old-token (:zed/token (seed! conn client))
+          alice (spice-object :user "alice")
+          account (spice-object :account "acct")
+          relationship
+          (->Relationship alice :owner account)]
+      (eacl/delete-relationship! client relationship)
+      (let [newer (eacl/check-permission client alice :admin account)
+            older
+            (eacl/check-permission
+             client
+             {:subject alice
+              :permission :admin
+              :resource account
+              :consistency (consistency/at-exact-snapshot old-token)})]
+        (is (false? (:allowed? newer)))
+        (is (false? (:cached? newer)))
+        (is (true? (:allowed? older)))
+        (is (false? (:cached? older))
+            "different complete proofs cannot lift across revisions")))))
+
+(deftest reader-peer-cache-survives-token-change-across-unrelated-write-test
+  (with-mem-conns [writer-conn reader-conn schema/v7-schema]
+    (let [writer (cached-client writer-conn)
+          reader (cached-client reader-conn)
+          _ (seed! writer-conn writer)
+          alice (spice-object :user "alice")
+          account (spice-object :account "acct")
+          seeded (eacl/check-permission reader alice :admin account)]
+      (is (true? (:allowed? seeded)))
+      (is (false? (:cached? seeded)))
+      @(d/transact writer-conn [{:eacl/id "peer-unrelated"}])
+      (let [token (core/current-zed-token writer)
+            refreshed
+            (eacl/check-permission
+             reader
+             {:subject alice
+              :permission :admin
+              :resource account
+              :consistency (consistency/at-least-as-fresh token)})]
+        (is (true? (:allowed? refreshed)))
+        (is (true? (:cached? refreshed))
+            "the reader Peer preserves its managed generation across tokens")))))
 
 (deftest explicit-cache-expiry-installs-a-fresh-lifecycle-test
   (with-mem-conn [conn schema/v7-schema]
@@ -151,26 +218,26 @@
             (is (true? (eacl/can? client alice :admin account
                                   (consistency/at-exact-snapshot
                                    created-token))))
-            (is (= 3 @calls)
-                "as-of and ordinary bases remain distinct cache classes"))
+            (is (= 2 @calls)
+                "the readable historical proof lifts the matching answer"))
 
           (testing "fully-consistent observes the relationship deletion"
             (is (false? (eacl/can? client alice :admin account)))
-            (is (= 3 @calls)
+            (is (= 2 @calls)
                 "the exact-basis deletion result is reused"))
 
           (testing "at-least-as-fresh accepts the current cached revision"
             (is (false? (eacl/can? client alice :admin account
                                    (consistency/at-least-as-fresh
                                     deleted-token))))
-            (is (= 3 @calls)))
+            (is (= 2 @calls)))
 
           (testing "and repeated exact selection remains snapshot-correct"
             (is (true? (eacl/can? client alice :admin account
                                   (consistency/at-exact-snapshot
                                    created-token))))
-            (is (= 3 @calls)
-                "repeated exact requests hit only the matching snapshot tier")))))))
+            (is (= 2 @calls)
+                "the promoted exact entry remains snapshot-correct")))))))
 
 (deftest missing-external-ids-never-enter-the-result-cache-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl-datomic/test/eacl/datomic/contract_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/contract_test.clj
@@ -19,6 +19,43 @@
               :eacl/id id})
        contract/smoke-objects)))
 
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (ex-data error))))
+
+(deftest recreated-memory-database-rejects-prior-source-token-test
+  (let [key "01234567890123456789012345678901"]
+    (with-mem-conn [first-conn schema/v7-schema]
+      (let [first-client (datomic/make-client first-conn {:security-key key})]
+        (eacl/write-schema! first-client contract/smoke-schema)
+        (seed-objects! first-conn)
+        (let [old-token
+              (:zed/token
+               (eacl/create-relationship!
+                first-client
+                (first contract/smoke-relationships)))]
+          (with-mem-conn [second-conn schema/v7-schema]
+            (let [second-client
+                  (datomic/make-client second-conn {:security-key key})]
+              (eacl/write-schema! second-client contract/smoke-schema)
+              (seed-objects! second-conn)
+              (eacl/create-relationship!
+               second-client
+               (first contract/smoke-relationships))
+              (is (= :eacl.consistency/incomparable-scope
+                     (:type
+                      (error-data
+                       #(eacl/can?
+                         second-client
+                         (contract/->user "user-1")
+                         :admin
+                         (contract/->account "account-1")
+                         (consistency/at-least-as-fresh old-token)))))))))))))
+
 (deftest default-source-lifecycle-is-cross-client-constant-test
   (with-mem-conn [conn schema/v7-schema]
     (let [key "01234567890123456789012345678901"
@@ -79,7 +116,12 @@
          conn {:security-key security-key :read-only? true})
         :snapshot-db datomic/db
         :direct-snapshot datomic/snapshot})
-      (contract/assert-unified-filter-validation! client))))
+      (contract/assert-unified-filter-validation! client)
+      (contract/assert-v8-request-cache-controls! client {})
+      (contract/assert-v8-cache-disabled!
+       (datomic/make-client
+        conn {:security-key security-key
+              :cache shared-cache/no-cache})))))
 
 (deftest datomic-certified-generation-plan-reuse-test
   (with-mem-conn [conn schema/v7-schema]
@@ -118,7 +160,7 @@
                (:tree-root repeated-exact)))
         (is (= (inc (:exact-hits before))
                (:exact-hits after))
-            "the first as-of request is basis-kind isolated; its repeat hits")))))
+            "a lifted as-of answer is promoted; its repeat hits exactly")))))
 
 (deftest datomic-permission-tree-schema-mutation-snapshot-test
   (with-mem-conn [conn schema/v7-schema]

--- a/modules/eacl/src/eacl/authorization/batch.cljc
+++ b/modules/eacl/src/eacl/authorization/batch.cljc
@@ -27,6 +27,7 @@
     :timeout-ms
     :cancellation-token
     :cache?
+    :populate-cache?
     :evaluation
     :aggregate-limits})
 
@@ -37,6 +38,7 @@
     :timeout-ms
     :cancellation-token
     :cache?
+    :populate-cache?
     :evaluation
     :aggregate-limits
     :recursive-traversal-limits

--- a/modules/eacl/src/eacl/authorization/filters.cljc
+++ b/modules/eacl/src/eacl/authorization/filters.cljc
@@ -4,7 +4,8 @@
 (def ^:private endpoint-keys #{:type :id :relation})
 (def ^:private page-control-keys
   #{:first :last :after :before :cursor :limit :page/basis
-    :consistency :cache? :evaluation :timeout-ms :cancellation-token
+    :consistency :cache? :populate-cache? :evaluation
+    :timeout-ms :cancellation-token
     :aggregate-limits})
 (def ^:private lookup-resource-keys
   (into page-control-keys

--- a/modules/eacl/src/eacl/backend/v8.cljc
+++ b/modules/eacl/src/eacl/backend/v8.cljc
@@ -102,7 +102,8 @@
      :unchanged-by-relationship-only-writes
      :nil-when-uncertified}
    :proof-frame
-   #{:snapshot-bound :initialized-schema-generation
+   #{:snapshot-bound :relation-generations-only
+     :same-domain-as-native-revision :generation-at-or-below-revision
      :complete-canonical-relation-generations
      :globally-ordered-committed-generations
      :atomic-with-supported-mutations}})

--- a/modules/eacl/src/eacl/cache.cljc
+++ b/modules/eacl/src/eacl/cache.cljc
@@ -53,6 +53,18 @@
                      :value cache-option})))
   cache-option)
 
+(defn validate-request-populate-option!
+  "Validates the per-request `:populate-cache?` publication control."
+  [populate-option]
+  (when-not (or (nil? populate-option) (boolean? populate-option))
+    (throw
+     (ex-info
+      "EACL Error: per-request :populate-cache? must be true or false."
+      {:type :eacl/invalid-request :eacl/error :eacl/invalid-request
+       :key :populate-cache?
+       :value populate-option})))
+  populate-option)
+
 (defn lookup-page-query-identity
   "Builds the semantic cache identity for an authenticated lookup page.
 
@@ -64,17 +76,21 @@
   [public-query internal-query]
   {:public
    (dissoc public-query
-           :consistency :cache? :after :before :cancellation-token)
+           :consistency :cache? :populate-cache?
+           :after :before :cancellation-token)
    :internal
-   (dissoc internal-query :consistency :cache? :cancellation-token)})
+   (dissoc internal-query
+           :consistency :cache? :populate-cache? :cancellation-token)})
 
 (defrecord ExactGeneration [snapshot order subproblems last-used])
 (defrecord ManagedGeneration
-           [generation-key schema-stamp installed-order subproblems last-used])
+           [generation-key schema-generation subproblems last-used])
 (defrecord CacheLifecycle [bases managed])
 (defrecord BasisCache [lifecycle metrics max-entries admissions
                                    admit-on-repeat? subproblem-options
-                                   retained-bases])
+                                   retained-bases managed-lifting-disabled?
+                                   reported-contract-violations
+                                   proof-contract-reporter])
 
 (defn- new-lifecycle
   [subproblem-options]
@@ -265,7 +281,8 @@
   second-sighting window (default 1024), its historical admission role."
   ([]
    (basis-cache {}))
-  ([{:keys [max-entries admit-on-repeat? subproblem-cache retained-bases]
+  ([{:keys [max-entries admit-on-repeat? subproblem-cache retained-bases
+            proof-contract-reporter]
      :or {max-entries 1024
           admit-on-repeat? false
           retained-bases 4
@@ -287,6 +304,12 @@
      (throw (ex-info "Basis cache :subproblem-cache must be a map."
                      {:type :eacl/invalid-config :eacl/error :eacl/invalid-config
                       :subproblem-cache subproblem-cache})))
+   (when-not (or (nil? proof-contract-reporter)
+                 (fn? proof-contract-reporter))
+     (throw
+      (ex-info "Basis cache :proof-contract-reporter must be a function."
+               {:type :eacl/invalid-config :eacl/error :eacl/invalid-config
+                :proof-contract-reporter proof-contract-reporter})))
    (when-not (boolean? (get subproblem-cache :enabled? true))
      (throw (ex-info "Basis cache subproblem :enabled? must be boolean."
                      {:type :eacl/invalid-config :eacl/error :eacl/invalid-config
@@ -302,13 +325,18 @@
            :stamp-failures 0
            :proof-unavailable 0
            :proof-unavailable-reasons {}
+           :proof-contract-violations 0
+           :proof-contract-violation-reasons {}
            :puts 0
            :expirations 0})
     max-entries
     (atom empty-answer-sightings)
     admit-on-repeat?
     subproblem-cache
-    retained-bases)))
+    retained-bases
+    (atom false)
+    (atom #{})
+    proof-contract-reporter)))
 
 (defn basis-cache?
   [value]
@@ -336,12 +364,14 @@
   `no-cache` disables it. Cache stores are client-private and cannot be
   supplied by applications. A closed config map contributes only the four
   documented capacity/admission settings."
-  [value]
-  (cond
+  ([value]
+   (basis-cache-for-option value {}))
+  ([value {:keys [proof-contract-reporter]}]
+   (cond
     (no-cache? value) nil
 
     (nil? value)
-    (basis-cache)
+    (basis-cache {:proof-contract-reporter proof-contract-reporter})
 
     (basis-cache? value)
     (invalid-cache-option!
@@ -372,12 +402,14 @@
          {:reason :unknown-cache-options
           :unknown-keys (vec unknown)
           :known-keys cache-option-keys}))
-      (basis-cache value))
+      (basis-cache (assoc value
+                          :proof-contract-reporter
+                          proof-contract-reporter)))
 
     :else
     (invalid-cache-option!
      "EACL :cache must be a configuration map or eacl.cache/no-cache."
-     value {:reason :unsupported-provider-store})))
+     value {:reason :unsupported-provider-store}))))
 
 (defn- merge-stat-values
   [left right]
@@ -418,6 +450,8 @@
            (subproblem/store
             (dissoc (:subproblem-options store) :enabled?))))]
     (assoc @(:metrics store)
+           :managed-lifting-disabled?
+           @(:managed-lifting-disabled? store)
            :exact-entries
            (reduce + 0 (map #(get-in % [:tiers :answer :entries] 0)
                             exact-stats))
@@ -466,6 +500,49 @@
                             (fnil inc 0))))))
   nil)
 
+(defn record-proof-diagnostic!
+  "Records a typed proof outcome and disables managed lifting on violations.
+
+  A reporter is invoked at most once for each reason in one cache lifecycle;
+  reporter failures never change authorization or cache decisions."
+  [store {:keys [status reason] :as diagnostic}]
+  (when store
+    (when-not (basis-cache? store)
+      (throw (ex-info "Expected an EACL basis cache."
+                      {:type :eacl/invalid-config :eacl/error :eacl/invalid-config
+                       :cache store})))
+    (case status
+      :unavailable
+      (record-proof-unavailable! store diagnostic)
+
+      :contract-violation
+      (do
+        (reset! (:managed-lifting-disabled? store) true)
+        (swap! (:metrics store)
+               (fn [metrics]
+                 (-> metrics
+                     (update :proof-contract-violations inc)
+                     (update-in [:proof-contract-violation-reasons reason]
+                                (fnil inc 0)))))
+        (when (and (:proof-contract-reporter store)
+                   (not (contains? @(:reported-contract-violations store)
+                                   reason)))
+          (let [report? (volatile! false)]
+            (swap! (:reported-contract-violations store)
+                   (fn [reported]
+                     (if (contains? reported reason)
+                       reported
+                       (do (vreset! report? true)
+                           (conj reported reason)))))
+            (when @report?
+              (try
+                ((:proof-contract-reporter store) diagnostic)
+                (catch #?(:clj Throwable :cljs :default) _)))))
+        nil)
+
+      nil))
+  nil)
+
 (defn capture-cache-lifecycle
   "Captures the cache lifecycle object at a public request boundary.
 
@@ -492,6 +569,8 @@
                      :cache store})))
   (reset! (:lifecycle store) (new-lifecycle (:subproblem-options store)))
   (reset! (:admissions store) empty-answer-sightings)
+  (reset! (:managed-lifting-disabled? store) false)
+  (reset! (:reported-contract-violations store) #{})
   (swap! (:metrics store) update :expirations inc)
   nil)
 
@@ -530,17 +609,31 @@
            {:tick tick :generations generations})))
       {:generation @selected :active? true})))
 
+(defn- select-exact-generation!
+  "Selects an existing exact generation for read-only requests; installs one
+  only when publication is enabled."
+  [store lifecycle basis-key snapshot order populate?]
+  (if populate?
+    (install-exact-generation! store lifecycle basis-key snapshot order)
+    {:generation
+     (when (valid-exact-basis-key? basis-key)
+       (get-in @(:bases lifecycle) [:generations basis-key]))
+     :active? (valid-exact-basis-key? basis-key)}))
+
 (defn- managed-generation-key
-  [source-scope schema-stamp]
-  (when (and (map? source-scope)
-             (keyword? (:backend source-scope))
-             (some? (:source-id source-scope))
-             (some? (:source-lifecycle source-scope))
-             (subproblem/proof-stamp? schema-stamp))
-    {:source-scope
-     (select-keys source-scope
-                  [:backend :source-id :branch :source-lifecycle])
-     :schema-stamp schema-stamp}))
+  [lineage schema-generation]
+  (when (and (map? lineage)
+             (map? (:source-scope lineage))
+             (keyword? (get-in lineage [:source-scope :backend]))
+             (some? (get-in lineage [:source-scope :source-id]))
+             (some? (:source-lifecycle lineage))
+             (subproblem/proof-stamp? schema-generation))
+    {:lineage
+     {:source-scope
+      (select-keys (:source-scope lineage)
+                   [:backend :source-id :branch])
+      :source-lifecycle (:source-lifecycle lineage)}
+     :schema-generation schema-generation}))
 
 (defn- install-managed-generation!
   "Installs or touches one lineage-and-schema managed generation.
@@ -548,9 +641,9 @@
   Revision order is recorded only for diagnostics. It is never an admission
   predicate: equal complete schema and dependency frontiers prove an equal
   deterministic answer in either revision direction."
-  [store lifecycle source-scope schema-stamp order]
+  [store lifecycle lineage schema-generation]
   (when-let [generation-key
-             (managed-generation-key source-scope schema-stamp)]
+             (managed-generation-key lineage schema-generation)]
     (let [selected (volatile! nil)]
       (swap!
        (:managed lifecycle)
@@ -561,8 +654,7 @@
                  (assoc existing :last-used tick)
                  (->ManagedGeneration
                   generation-key
-                  schema-stamp
-                  order
+                  schema-generation
                   (subproblem/store
                    (dissoc (:subproblem-options store) :enabled?))
                   tick))
@@ -583,16 +675,28 @@
            {:tick tick :generations generations})))
       @selected)))
 
+(defn- select-managed-generation!
+  "Selects an existing lineage generation without creating it for read-only
+  requests."
+  [store lifecycle lineage schema-generation populate?]
+  (if populate?
+    (install-managed-generation!
+     store lifecycle lineage schema-generation)
+    (when-let [generation-key
+               (managed-generation-key lineage schema-generation)]
+      (get-in @(:managed lifecycle) [:generations generation-key]))))
+
 (defn- valid-managed-descriptor?
   [descriptor]
-  (let [{:keys [schema-stamp dependency-stamp]} descriptor]
+  (let [{:keys [schema-generation dependency-stamp]} descriptor]
     (and (map? descriptor)
-         (subproblem/proof-stamp? schema-stamp)
+         (subproblem/proof-stamp? schema-generation)
          (subproblem/proof-stamp? dependency-stamp))))
 
 (defn- managed-descriptor
   [store managed-key-fn]
-  (when managed-key-fn
+  (when (and managed-key-fn
+             (not @(:managed-lifting-disabled? store)))
     (try
       (let [descriptor (managed-key-fn)]
         (when (valid-managed-descriptor? descriptor)
@@ -616,8 +720,10 @@
   generation selected by the complete basis identity."
   [store
    {:keys [snapshot snapshot-order exact-basis-key cache-basis
-           cache-lifecycle decision-kernel remember-answer? answer-weight-fn]
-    :or {remember-answer? true}}
+           cache-lifecycle decision-kernel remember-answer? answer-weight-fn
+           populate-cache?]
+    :or {remember-answer? true
+         populate-cache? true}}
    semantic-key kind valid-value? compute]
   (when-not (fn? compute)
     (throw (ex-info "Exact-basis cache computation must be a function."
@@ -647,13 +753,15 @@
                       (get-in exact-basis-key
                               [:basis-identity :revision]))
             {:keys [generation]}
-            (install-exact-generation!
-             store lifecycle exact-basis-key snapshot order)
+            (select-exact-generation!
+             store lifecycle exact-basis-key snapshot order populate-cache?)
             answer-store (:subproblems generation)
             entry-key [semantic-key kind]
-            answer-options (answer-entry-options valid-value? answer-weight-fn)
+            answer-options
+            (assoc (answer-entry-options valid-value? answer-weight-fn)
+                   :populate? populate-cache?)
             exact-entry
-            (when remember-answer?
+            (when (and remember-answer? answer-store)
               (:value
                (subproblem/lookup!
                 answer-store :answer entry-key answer-options)))
@@ -663,7 +771,8 @@
             evaluate-entry
             (fn []
               {:value
-               (binding [subproblem/*store*
+               (binding [subproblem/*populate?* populate-cache?
+                         subproblem/*store*
                          (when (get (:subproblem-options store)
                                     :enabled? true)
                            answer-store)
@@ -685,6 +794,8 @@
         (if (= :use-exact-entry exact-action)
           (hit exact-entry)
           (if (and remember-answer?
+                   answer-store
+                   populate-cache?
                    (admit-answer?
                     store [:exact-basis exact-basis-key entry-key]))
             (let [resolved
@@ -727,9 +838,11 @@
            cache-lifecycle
            managed-key-fn
            managed-subproblem-key-fn managed-subproblem-scope
-           decision-kernel remember-answer? answer-weight-fn]
+           decision-kernel remember-answer? answer-weight-fn
+           populate-cache?]
     :or {cacheable? true
-         remember-answer? true}}
+         remember-answer? true
+         populate-cache? true}}
    semantic-key kind valid-value? compute]
   (when-not (fn? compute)
     (throw (ex-info "Basis cache computation must be a function."
@@ -765,8 +878,9 @@
                          :snapshot-order snapshot-order})))
       (let [lifecycle (or cache-lifecycle @(:lifecycle store))
             {:keys [generation active?]}
-            (install-exact-generation!
-             store lifecycle exact-basis-key snapshot snapshot-order)
+            (select-exact-generation!
+             store lifecycle exact-basis-key snapshot snapshot-order
+             populate-cache?)
             entry-key [semantic-key kind]
             admission-key [:exact-basis exact-basis-key entry-key]]
         (if (= :bypass-current-cache
@@ -787,9 +901,10 @@
              :cache-basis nil})
           (let [answer-store (:subproblems generation)
                 answer-options
-                (answer-entry-options valid-value? answer-weight-fn)
+                (assoc (answer-entry-options valid-value? answer-weight-fn)
+                       :populate? populate-cache?)
                 exact-entry
-                (when remember-answer?
+                (when (and remember-answer? answer-store)
                   (:value
                    (subproblem/lookup!
                     answer-store :answer entry-key answer-options)))
@@ -804,14 +919,14 @@
                  :cache-tier :exact-basis
                  :cache-basis (:cache-basis exact-entry)
                  :subproblem-store answer-store})
-              (let [{:keys [schema-stamp dependency-stamp]}
+              (let [{:keys [schema-generation dependency-stamp]}
                     (managed-descriptor
                      store managed-key-fn)
                     managed-generation
-                    (when (some? schema-stamp)
-                      (install-managed-generation!
+                    (when (some? schema-generation)
+                      (select-managed-generation!
                        store lifecycle managed-subproblem-scope
-                       schema-stamp snapshot-order))
+                       schema-generation populate-cache?))
                     managed-store (:subproblems managed-generation)
                     managed-entry-key
                     (when managed-generation
@@ -830,10 +945,11 @@
                   ;; Promote the still-valid managed answer into the selected
                   ;; exact generation so the next identical request hits
                   ;; without dependency-stamp extraction.
-                    (subproblem/resolve-independent!
-                     answer-store :answer entry-key answer-options
-                     (fn [] managed-entry))
-                    (swap! (:metrics store) update :puts inc)
+                    (when (and populate-cache? answer-store)
+                      (subproblem/resolve-independent!
+                       answer-store :answer entry-key answer-options
+                       (fn [] managed-entry))
+                      (swap! (:metrics store) update :puts inc))
                     (swap! (:metrics store) update :managed-hits inc)
                     {:value (:value managed-entry)
                      :cached? true
@@ -845,7 +961,8 @@
                         compute-entry
                         (fn []
                           {:value
-                           (binding [subproblem/*store*
+                           (binding [subproblem/*populate?* populate-cache?
+                                     subproblem/*store*
                                      (when subproblems-enabled?
                                        answer-store)
                                      subproblem/*managed-store*
@@ -869,6 +986,8 @@
                               answer-options compute-entry))
                             (compute-entry)))]
                     (if (and remember-answer?
+                             answer-store
+                             populate-cache?
                              (admit-answer? store admission-key))
                       (let [resolved
                             (subproblem/resolve-independent!

--- a/modules/eacl/src/eacl/client/orchestration.cljc
+++ b/modules/eacl/src/eacl/client/orchestration.cljc
@@ -68,7 +68,8 @@
             [eacl.subproblem-cache :as subproblem]
             [eacl.spicedb.consistency :as consistency]))
 
-(declare request-cache-enabled? validate-permission-root!)
+(declare request-cache-controls
+         validate-permission-root!)
 
 (defn- ensure-execution-contract
   [opts operation request]
@@ -238,7 +239,7 @@
       :proof-diagnostic-fn
       (when (:completed-cache-request? opts)
         (fn [diagnostic]
-          (cache/record-proof-unavailable!
+          (cache/record-proof-diagnostic!
            (:basis-cache-store opts)
            diagnostic)))})))
 
@@ -296,7 +297,7 @@
                      :proof-diagnostic-fn
                      (when (:completed-cache-request? opts)
                        (fn [diagnostic]
-                         (cache/record-proof-unavailable!
+                         (cache/record-proof-diagnostic!
                           (:basis-cache-store opts)
                           diagnostic)))}))
                  (selected-context api source opts consistency-value))]
@@ -327,6 +328,7 @@
            :historical-basis? historical-basis?
            :snapshot-semantic-identity
            (request-context/basis-identity context)
+           :request-lineage (request-context/lineage context)
            :request-proof-frame (request-context/proof-frame context)
            :request-schema-cache (delay (request-context/derived context)))))
 
@@ -355,7 +357,7 @@
           :schema-generation-fn #(force schema-generation)
           :diagnostic-fn
           (fn [diagnostic]
-            (cache/record-proof-unavailable!
+            (cache/record-proof-diagnostic!
              (:basis-cache-store opts)
              diagnostic))})]
     {:proof-frame request-proof-frame
@@ -447,6 +449,8 @@
     (assoc opts
            :snapshot-semantic-identity
            basis-identity
+           :request-lineage
+           (request-context/lineage-for-basis basis-identity)
            :request-proof-frame request-proof-frame
            :cursor-consistency-mode
            (get-in selection [:descriptor :mode])
@@ -647,8 +651,6 @@
              ;; The public order ABI is part of an answer's identity: a page
              ;; cached under one order must never be served under another.
              :order-abi engine/stable-order-abi
-             :source-lifecycle
-             (proof-frame/source-lifecycle request-proof-frame)
              :adapter-fingerprint (:adapter-fingerprint opts)
              :recursive-traversal-limits
              (:recursive-traversal-limits opts)
@@ -661,39 +663,28 @@
                 (get-in contract
                         [:cache-attempt :maximum-atomic-attempts]
                         4)]
-                (if (:historical-basis? opts)
-                  (cache/resolve-exact!
-                   (:basis-cache-store opts)
-                   {:snapshot semantic-snapshot
-                    :snapshot-order (:revision semantic-snapshot)
-                    :exact-basis-key exact-basis-key
-                    :cache-lifecycle (:cache-lifecycle opts)
-                    :cache-basis (backend/invoke adapter :snapshot-id)
-                    :decision-kernel (:decision-kernel opts)}
-                   semantic-key operation valid-value? evaluate)
-                  (cache/resolve-basis!
-                   (:basis-cache-store opts)
-                   {:snapshot semantic-snapshot
-                    :cache-lifecycle (:cache-lifecycle opts)
-                    :snapshot-order (:revision semantic-snapshot)
-                    :exact-basis-key exact-basis-key
-                    :cache-basis (backend/invoke adapter :snapshot-id)
-                    :decision-kernel (:decision-kernel opts)
-                    :managed-key-fn
-                    (when (and (:managed-cache-enabled? opts)
-                               resource-type permission)
-                      #(proof-frame/descriptor @complete-proof))
-                    :managed-subproblem-key-fn
-                    (when (and (:managed-cache-enabled? opts)
-                               resource-type permission)
-                      (fn [dependency]
-                        (proof-frame/subset-descriptor
-                         @complete-proof dependency)))
-                    :managed-subproblem-scope
-                    (select-keys
-                     semantic-snapshot
-                     [:backend :source-id :branch :source-lifecycle])}
-                   semantic-key operation valid-value? evaluate)))]
+                (cache/resolve-basis!
+                 (:basis-cache-store opts)
+                 {:snapshot semantic-snapshot
+                  :cache-lifecycle (:cache-lifecycle opts)
+                  :snapshot-order (:revision semantic-snapshot)
+                  :exact-basis-key exact-basis-key
+                  :cache-basis (backend/invoke adapter :snapshot-id)
+                  :decision-kernel (:decision-kernel opts)
+                  :populate-cache?
+                  (:populate-cache-request? opts true)
+                  :managed-key-fn
+                  (when (and (:managed-cache-enabled? opts)
+                             resource-type permission)
+                    #(proof-frame/descriptor @complete-proof))
+                  :managed-subproblem-key-fn
+                  (when (and (:managed-cache-enabled? opts)
+                             resource-type permission)
+                    (fn [dependency]
+                      (proof-frame/subset-descriptor
+                       @complete-proof dependency)))
+                  :managed-subproblem-scope (:request-lineage opts)}
+                 semantic-key operation valid-value? evaluate))]
           (execution/check! contract :cache-publication)
           answer)))))
 
@@ -709,7 +700,8 @@
    dissoc
    query
    [:first :last :after :before
-    :consistency :cache? :timeout-ms :cancellation-token]))
+    :consistency :cache? :populate-cache?
+    :timeout-ms :cancellation-token]))
 
 (defn- stale-cursor-anchor!
   [operation]
@@ -737,7 +729,8 @@
       :evaluation (get-in opts [:execution-contract :evaluation])
       :recursive-traversal-limits
       (:recursive-traversal-limits opts)}
-     {:request-proof-frame (:request-proof-frame opts)})))
+     {:request-proof-frame (:request-proof-frame opts)
+      :populate-cache? (:populate-cache-request? opts true)})))
 
 (defn- request-schema
   "The parsed public schema visible in `db`, for validating one request.
@@ -876,6 +869,7 @@
                   base-filters
                   (apply dissoc filters
                          [:first :last :after :before :consistency :cache?
+                          :populate-cache?
                           :evaluation :timeout-ms :cancellation-token
                           :aggregate-limits :authorization])
                   subject-id (:subject/id base-filters)
@@ -888,7 +882,8 @@
                     (object-id->entid page-db resource-id))
                   internal-query
                   (-> page-query
-                      (dissoc :consistency :cache? :evaluation :timeout-ms
+                      (dissoc :consistency :cache? :populate-cache?
+                              :evaluation :timeout-ms
                               :cancellation-token :aggregate-limits
                               :authorization)
                       (cond->
@@ -1129,6 +1124,7 @@
 (defn check-permissions
   [api source opts request]
   (let [request (batch/validate-request! request (:aggregate-limits opts))
+        cache-controls (request-cache-controls request)
         checks (:checks request)]
     (if (empty? checks)
       (do
@@ -1141,7 +1137,9 @@
                 (assoc :request-operation :check-permissions
                        :execution-request request
                        :completed-cache-request?
-                       (request-cache-enabled? (:cache? request)))
+                       (:cache-enabled? cache-controls)
+                       :populate-cache-request?
+                       (:populate-cache? cache-controls))
                 (ensure-execution-contract :check-permissions request))]
         (batch/call-with-demand-error
          0 batch/empty-aggregate-counters
@@ -1367,7 +1365,8 @@
                            :cached? false :cache-basis nil)))
                 (let [internal-query
                       (-> page-query
-                          (dissoc :consistency :cache? :evaluation :timeout-ms
+                          (dissoc :consistency :cache? :populate-cache?
+                                  :evaluation :timeout-ms
                                   :cancellation-token :aggregate-limits
                                   :resource/relationship)
                           (assoc :subject internal-subject))]
@@ -1472,12 +1471,13 @@
             (let [internal-query
                   (-> query
                       (assoc :subject internal-subject)
-                      (dissoc :consistency :cache? :evaluation :timeout-ms
+                      (dissoc :consistency :cache? :populate-cache?
+                              :evaluation :timeout-ms
                               :cancellation-token))
                   answer
                   (cached-engine-result
                    request-context adapter opts :count-resources
-                   {:public (dissoc query :consistency :cache?
+                   {:public (dissoc query :consistency :cache? :populate-cache?
                                     :cancellation-token)
                     :internal internal-query}
                    (:resource/type internal-query)
@@ -1534,7 +1534,8 @@
                            :cached? false :cache-basis nil)))
                 (let [internal-query
                       (-> page-query
-                          (dissoc :consistency :cache? :evaluation :timeout-ms
+                          (dissoc :consistency :cache? :populate-cache?
+                                  :evaluation :timeout-ms
                                   :cancellation-token :aggregate-limits
                                   :subject/relationship)
                           (assoc :resource internal-resource))]
@@ -1639,12 +1640,13 @@
             (let [internal-query
                   (-> query
                       (assoc :resource internal-resource)
-                      (dissoc :consistency :cache? :evaluation :timeout-ms
+                      (dissoc :consistency :cache? :populate-cache?
+                              :evaluation :timeout-ms
                               :cancellation-token))
                   answer
                   (cached-engine-result
                    request-context adapter opts :count-subjects
-                   {:public (dissoc query :consistency :cache?
+                   {:public (dissoc query :consistency :cache? :populate-cache?
                                     :cancellation-token)
                     :internal internal-query}
                    (:type (:resource internal-query))
@@ -1677,7 +1679,7 @@
               answer
               (cached-engine-result
                request-context adapter opts :expand-permission-tree
-               (dissoc query :consistency :cache? :timeout-ms
+               (dissoc query :consistency :cache? :populate-cache? :timeout-ms
                        :cancellation-token)
                (:type (:resource query))
                (:permission query)
@@ -1698,10 +1700,15 @@
             {:expanded-at token
              :tree-root tree}))))))
 
-(defn- request-cache-enabled?
-  [cache-option]
-  (cache/validate-request-cache-option! cache-option)
-  (not (false? cache-option)))
+(defn- request-cache-controls
+  [request]
+  (let [cache-option
+        (cache/validate-request-cache-option! (:cache? request))
+        populate-option
+        (cache/validate-request-populate-option!
+         (:populate-cache? request))]
+    {:cache-enabled? (not (false? cache-option))
+     :populate-cache? (not (false? populate-option))}))
 
 #?(:clj (ns-unmap *ns* 'Runtime))
 (defrecord Runtime [])
@@ -1718,6 +1725,7 @@
     :spice-object->internal :internal-cursor->spice
     :spice-cursor->internal :format-options :cursor-ttl-seconds
     :token-ttl-seconds :managed-cache-enabled?
+    :proof-contract-reporter
     :recursive-traversal-limits :permission-tree-limits
     :execution-timeout-ms :consistency-sync-timeout-ms
     :service-admission :source-lifecycle :source-lifecycle-state
@@ -1969,67 +1977,83 @@
 (defrecord Snapshot [runtime basis api]
   IAuthorizationReader
   (-check-permission [_ {:keys [subject permission resource consistency]
-                         cache? :cache? :as request}]
+                         :as request}]
     (assert-snapshot-consistency! runtime basis request)
-    (check-permission
-     api nil
-     (assoc (snapshot-opts runtime basis)
-            :request-operation :check-permission
-            :execution-request request
-            :completed-cache-request? (request-cache-enabled? cache?))
-     subject permission resource
-     (or consistency consistency/minimize-latency)))
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
+      (check-permission
+       api nil
+       (assoc (snapshot-opts runtime basis)
+              :request-operation :check-permission
+              :execution-request request
+              :completed-cache-request? cache-enabled?
+              :populate-cache-request? populate-cache?)
+       subject permission resource
+       (or consistency consistency/minimize-latency))))
   (-read-schema [_ request]
     (assert-snapshot-consistency! runtime basis request)
     (read-current-schema api nil (snapshot-opts runtime basis) request))
   (-read-relationships [_ request]
     (assert-snapshot-consistency! runtime basis request)
-    (read-relationships
-     api nil
-     (assoc (snapshot-opts runtime basis)
-            :completed-cache-request?
-            (request-cache-enabled? (:cache? request)))
-     (dissoc request :cache?)))
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
+      (read-relationships
+       api nil
+       (assoc (snapshot-opts runtime basis)
+              :completed-cache-request? cache-enabled?
+              :populate-cache-request? populate-cache?)
+       (dissoc request :cache? :populate-cache?))))
   (-lookup-resources [_ request]
     (assert-snapshot-consistency! runtime basis request)
-    (let [cache-enabled? (request-cache-enabled? (:cache? request))]
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
       (lookup-resources
        api nil
        (assoc (snapshot-opts runtime basis)
               :completed-cache-request? cache-enabled?
+              :populate-cache-request? populate-cache?
               :continuation-cache-request? cache-enabled?)
-       (dissoc request :cache?))))
+       (dissoc request :cache? :populate-cache?))))
   (-lookup-subjects [_ request]
     (assert-snapshot-consistency! runtime basis request)
-    (let [cache-enabled? (request-cache-enabled? (:cache? request))]
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
       (lookup-subjects
        api nil
        (assoc (snapshot-opts runtime basis)
               :completed-cache-request? cache-enabled?
+              :populate-cache-request? populate-cache?
               :continuation-cache-request? cache-enabled?)
-       (dissoc request :cache?))))
+       (dissoc request :cache? :populate-cache?))))
   (-count-resources [_ request]
     (assert-snapshot-consistency! runtime basis request)
-    (count-resources
-     api nil
-     (assoc (snapshot-opts runtime basis)
-            :completed-cache-request?
-            (request-cache-enabled? (:cache? request)))
-     (dissoc request :cache?)))
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
+      (count-resources
+       api nil
+       (assoc (snapshot-opts runtime basis)
+              :completed-cache-request? cache-enabled?
+              :populate-cache-request? populate-cache?)
+       (dissoc request :cache? :populate-cache?))))
   (-count-subjects [_ request]
     (assert-snapshot-consistency! runtime basis request)
-    (count-subjects
-     api nil
-     (assoc (snapshot-opts runtime basis)
-            :completed-cache-request?
-            (request-cache-enabled? (:cache? request)))
-     (dissoc request :cache?)))
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
+      (count-subjects
+       api nil
+       (assoc (snapshot-opts runtime basis)
+              :completed-cache-request? cache-enabled?
+              :populate-cache-request? populate-cache?)
+       (dissoc request :cache? :populate-cache?))))
   (-expand-permission-tree [_ request]
     (assert-snapshot-consistency! runtime basis request)
-    (expand-permission-tree
-     api nil (assoc (snapshot-opts runtime basis)
-                    :completed-cache-request? true)
-     request))
+    (let [{:keys [cache-enabled? populate-cache?]}
+          (request-cache-controls request)]
+      (expand-permission-tree
+       api nil (assoc (snapshot-opts runtime basis)
+                      :completed-cache-request? cache-enabled?
+                      :populate-cache-request? populate-cache?)
+       (dissoc request :cache? :populate-cache?))))
 
   IBatchedAuthorization
   (-check-permissions [_ request]
@@ -2412,7 +2436,8 @@
   (-check-permissions [_ request]
     (let [request
           (batch/validate-request!
-           request (:aggregate-limits (runtime-options runtime)))]
+           request (:aggregate-limits (runtime-options runtime)))
+          _ (request-cache-controls request)]
       (if (empty? (:checks request))
         (do
           (execution/normalize
@@ -2630,6 +2655,7 @@
     :spice-cursor->internal
     :cursor-ttl-seconds
     :cache
+    :proof-contract-reporter
     :recursive-traversal-limits
     :permission-tree-limits
     :security-key
@@ -2738,6 +2764,7 @@
            spice-cursor->internal
            cursor-ttl-seconds
            cache
+           proof-contract-reporter
            recursive-traversal-limits
            permission-tree-limits
            security-key
@@ -2770,6 +2797,14 @@
                     {:type :eacl/invalid-config :eacl/error :eacl/invalid-config
                      :key :adapter-deterministic?
                      :value adapter-deterministic?})))
+  (when-not (or (nil? proof-contract-reporter)
+                (fn? proof-contract-reporter))
+    (throw
+     (ex-info "EACL Config Error: :proof-contract-reporter must be a function."
+              {:type :eacl/invalid-config
+               :eacl/error :eacl/invalid-config
+               :key :proof-contract-reporter
+               :value proof-contract-reporter})))
   (when adapter-fingerprint
     (try
       (secure/encode-canonical adapter-fingerprint)
@@ -2867,7 +2902,8 @@
             (and (some? adapter-fingerprint)
                  (true? adapter-deterministic?)))
         basis-cache-store
-        (cache/basis-cache-for-option cache)
+        (cache/basis-cache-for-option
+         cache {:proof-contract-reporter proof-contract-reporter})
         cursor-codec-cache
         (when basis-cache-store
           (cursor/codec-cache
@@ -2928,6 +2964,7 @@
               causal-token/default-token-ttl-seconds)
           :basis-cache-store
           basis-cache-store
+          :proof-contract-reporter proof-contract-reporter
           :continuation-cache-store
           (when basis-cache-store
             (continuation/make-store

--- a/modules/eacl/src/eacl/continuation.cljc
+++ b/modules/eacl/src/eacl/continuation.cljc
@@ -227,7 +227,8 @@
   ([store adapter operation query-identity]
    (private-context store adapter operation query-identity {}))
   ([store adapter operation query-identity
-    {:keys [snapshot-identity request-proof-frame]}]
+    {:keys [snapshot-identity request-proof-frame populate-cache?]
+     :or {populate-cache? true}}]
    (when store
      (let [basis-identity (:basis-identity request-proof-frame)
            scope
@@ -258,7 +259,7 @@
                   (proof-frame/resolve!
                    frame [])]
               (when (proof-frame/complete? proof)
-                (:schema-stamp proof)))
+                (:schema-generation proof)))
             :snapshot-identity
             (or snapshot-identity
                 {:kind :exact
@@ -280,25 +281,28 @@
             (evict! store (key-for :acyclic-continuation edge)))))
         :put!
         (fn [edge value weight]
-          (put!
-           store :recursive-continuation
-           (key-for :recursive-continuation edge)
-           value weight))
+          (and populate-cache?
+               (put!
+                store :recursive-continuation
+                (key-for :recursive-continuation edge)
+                value weight)))
         :get-page
         #(get! store :recursive-page
                (key-for :recursive-page %))
         :put-page!
         (fn [page-key value weight]
-          (put!
-           store :recursive-page
-           (key-for :recursive-page page-key)
-           value weight))
+          (and populate-cache?
+               (put!
+                store :recursive-page
+                (key-for :recursive-page page-key)
+                value weight)))
         :get-heads
         #(get! store :acyclic-continuation
                (key-for :acyclic-continuation %))
         :put-heads!
         (fn [edge value weight]
-          (put!
-           store :acyclic-continuation
-           (key-for :acyclic-continuation edge)
-           value weight))})))))
+          (and populate-cache?
+               (put!
+                store :acyclic-continuation
+                (key-for :acyclic-continuation edge)
+                value weight)))})))))

--- a/modules/eacl/src/eacl/core.cljc
+++ b/modules/eacl/src/eacl/core.cljc
@@ -297,9 +297,11 @@
 
   `request` is a closed envelope containing `:checks` and optional
   request-wide `:consistency`, `:timeout-ms`, `:cancellation-token`, `:cache?`,
-  `:evaluation`, and `:aggregate-limits`. Implementations that cannot hold one
-  immutable snapshot across the complete batch fail with a typed unsupported
-  capability instead of looping over public scalar calls."
+  `:populate-cache?`, `:evaluation`, and `:aggregate-limits`. A false
+  `:populate-cache?` preserves cache lookup while suppressing publication.
+  Implementations that cannot hold one immutable snapshot across the complete
+  batch fail with a typed unsupported capability instead of looping over public
+  scalar calls."
   [target request]
   (reader! target)
   (if (satisfies? IBatchedAuthorization target)

--- a/modules/eacl/src/eacl/permission_tree.cljc
+++ b/modules/eacl/src/eacl/permission_tree.cljc
@@ -14,7 +14,7 @@
 
 (def ^:private query-keys
   #{:resource :permission :consistency :timeout-ms
-    :cancellation-token})
+    :cancellation-token :cache? :populate-cache?})
 
 (defn- portable-positive-integer?
   [value]

--- a/modules/eacl/src/eacl/proof_frame.cljc
+++ b/modules/eacl/src/eacl/proof_frame.cljc
@@ -56,6 +56,10 @@
     :snapshot-id-delay (delay (backend/invoke adapter :snapshot-id))
     :source-lifecycle-delay
     (delay (:source-lifecycle basis-identity))
+    :revision-delay
+    (delay
+      (or (:revision basis-identity)
+          (:revision (backend/invoke adapter :native-revision))))
     :schema-generation-delay
     (delay
       (if schema-generation-fn
@@ -77,17 +81,17 @@
   [frame]
   (force (:schema-generation-delay frame)))
 
-(defn- schema-generation-mismatch!
-  [frame proof-generation certified-generation]
-  (throw
-   (ex-info
-    "Ordered-generation proof disagrees with the certified schema generation."
-    {:type :eacl/backend-integrity-error
-     :eacl/error :eacl/backend-integrity-error
-     :backend (backend/backend-id (:adapter frame))
-     :reason :schema-generation-mismatch
-     :proof-schema-generation proof-generation
-     :certified-schema-generation certified-generation})))
+(defn revision
+  [frame]
+  (force (:revision-delay frame)))
+
+(defn- diagnose!
+  [frame result]
+  (when-let [diagnostic-fn (:diagnostic-fn frame)]
+    (try
+      (diagnostic-fn result)
+      (catch #?(:clj Throwable :cljs :default) _)))
+  result)
 
 (defn- unavailable
   [frame reason details]
@@ -96,63 +100,120 @@
          :reason reason
          :backend (backend/backend-id (:adapter frame))
          :details details}]
-    (when-let [diagnostic-fn (:diagnostic-fn frame)]
-      (try
-        (diagnostic-fn result)
-        (catch #?(:clj Throwable :cljs :default) _)))
-    result))
+    (diagnose! frame result)))
+
+(defn- contract-violation
+  [frame reason details]
+  (diagnose!
+   frame
+   {:status :contract-violation
+    :reason reason
+    :backend (backend/backend-id (:adapter frame))
+    :operation :proof-frame
+    :details details}))
+
+(defn contract-violation?
+  [proof]
+  (= :contract-violation (:status proof)))
+
+(defn- duplicate-value
+  [values]
+  (loop [seen #{}
+         remaining (seq values)]
+    (when remaining
+      (let [value (first remaining)]
+        (if (contains? seen value)
+          value
+          (recur (conj seen value) (next remaining)))))))
 
 (defn- complete-result
   [frame relation-ids raw]
-  (let [expected-keys #{:schema-stamp :relation-stamps}
-        relation-stamps (:relation-stamps raw)]
+  (let [selected-revision (revision frame)
+        certified-generation (schema-generation frame)
+        entries? (and (vector? raw)
+                      (every? #(and (vector? %) (= 2 (count %))) raw))
+        returned-ids (when entries? (mapv first raw))
+        generations (when entries? (mapv second raw))
+        duplicate-id (when returned-ids (duplicate-value returned-ids))]
     (cond
-      (not (map? raw))
-      (unavailable frame :malformed-proof {:value raw})
-
-      (not= expected-keys (set (keys raw)))
+      (not (generation? selected-revision))
       (unavailable
-       frame :malformed-proof
-       {:expected-keys expected-keys :actual-keys (set (keys raw))})
+       frame :revision-unavailable {:revision selected-revision})
 
-      (not (generation? (:schema-stamp raw)))
+      (nil? certified-generation)
       (unavailable
-       frame :malformed-schema-generation
-       {:value (:schema-stamp raw)})
+       frame :schema-generation-unavailable {})
 
-      (not (and (vector? relation-stamps)
-                (= relation-ids (mapv first relation-stamps))
-                (every?
-                 (fn [entry]
-                   (and (vector? entry)
-                        (= 2 (count entry))
-                        (generation? (first entry))
-                        (generation? (second entry))))
-                 relation-stamps)))
+      (not (generation? certified-generation))
+      (contract-violation
+       frame :invalid-schema-generation
+       {:schema-generation certified-generation
+        :revision selected-revision})
+
+      (> certified-generation selected-revision)
+      (contract-violation
+       frame :schema-generation-above-revision
+       {:schema-generation certified-generation
+        :revision selected-revision})
+
+      (not entries?)
+      (contract-violation
+       frame :malformed-shape
+       {:relation-generations raw})
+
+      (not= (count relation-ids) (count raw))
+      (contract-violation
+       frame :wrong-cardinality
+       {:expected-count (count relation-ids)
+        :actual-count (count raw)})
+
+      duplicate-id
+      (contract-violation
+       frame :duplicate-relation-id
+       {:relation-id duplicate-id
+        :relation-ids returned-ids})
+
+      (not= relation-ids returned-ids)
+      (contract-violation
+       frame :noncanonical-relation-ids
+       {:expected relation-ids :actual returned-ids})
+
+      (some nil? generations)
       (unavailable
-       frame :incomplete-or-noncanonical-generations
-       {:relation-ids relation-ids :relation-stamps relation-stamps})
+       frame :relation-generation-unavailable
+       {:relation-id
+        (first
+         (keep-indexed
+          (fn [index generation]
+            (when (nil? generation) (nth relation-ids index)))
+          generations))})
+
+      (not-every? generation? generations)
+      (contract-violation
+       frame :invalid-relation-generation
+       {:relation-generations raw})
+
+      (some #(> % selected-revision) generations)
+      (contract-violation
+       frame :relation-generation-above-revision
+       {:revision selected-revision
+        :relation-generations raw})
 
       :else
-      (let [proof-generation (:schema-stamp raw)
-            certified-generation (schema-generation frame)]
-        (when (and (some? certified-generation)
-                   (not= certified-generation proof-generation))
-          (schema-generation-mismatch!
-           frame proof-generation certified-generation))
-        {:status :complete
-         :snapshot-id (snapshot-id frame)
-         :source-lifecycle (source-lifecycle frame)
-         :schema-stamp proof-generation
-         :relation-ids relation-ids
-         :relation-stamps relation-stamps
-         :relation-stamp-map (into {} relation-stamps)
-         :dependency-stamp
-         (reduce
-          (fn [frontier [_ generation]]
-            (max frontier generation))
-          0
-          relation-stamps)}))))
+      {:status :complete
+       :snapshot-id (snapshot-id frame)
+       :source-lifecycle (source-lifecycle frame)
+       :revision selected-revision
+       :schema-generation certified-generation
+       :relation-ids relation-ids
+       :relation-generations raw
+       :relation-generation-map (into {} raw)
+       :dependency-stamp
+       (reduce
+        (fn [frontier [_ generation]]
+          (max frontier generation))
+        0
+        raw)})))
 
 (defn- acquire
   [frame relation-ids]
@@ -177,9 +238,12 @@
        relation-ids
        (backend/invoke (:adapter frame) :proof-frame relation-ids))
       (catch #?(:clj Throwable :cljs :default) error
-        (if (= :eacl/backend-integrity-error
+        (if (= :eacl/backend-contract-violation
                (:type (ex-data error)))
-          (throw error)
+          (contract-violation
+           frame :adapter-runtime-guard
+           (select-keys (ex-data error)
+                        [:backend :operation :obligation :value]))
           (unavailable
            frame :proof-provider-failure
            {:error-class #?(:clj (.getName (class error))
@@ -208,7 +272,7 @@
   "Returns the constant-size completed-cache identity for a complete proof."
   [proof]
   (when (complete? proof)
-    (select-keys proof [:schema-stamp :dependency-stamp])))
+    (select-keys proof [:schema-generation :dependency-stamp])))
 
 (defn subset-descriptor
   "Derives a subset frontier only from a complete request proof.
@@ -221,10 +285,10 @@
                      (if (vector? relation-ids)
                        relation-ids
                        [relation-ids]))
-          stamps (:relation-stamp-map proof)]
+          stamps (:relation-generation-map proof)]
       (when (and canonical
                  (every? #(contains? stamps %) canonical))
-        {:schema-stamp (:schema-stamp proof)
+        {:schema-generation (:schema-generation proof)
          :dependency-stamp
          (reduce
           (fn [frontier relation-id]

--- a/modules/eacl/src/eacl/relationships/filters.cljc
+++ b/modules/eacl/src/eacl/relationships/filters.cljc
@@ -13,12 +13,13 @@
   "Filter + pagination + execution keys read-relationships accepts. :cursor
   and :limit are named so their rejection classifies as an unsupported
   pagination option rather than an unknown key; :consistency, :page/basis,
-  :cache?, :timeout-ms, and :cancellation-token are validated and consumed by
+  :cache?, :populate-cache?, :timeout-ms, and :cancellation-token are validated and consumed by
   the client layer but must be listed, since an unknown key is a hard error
   rather than something to ignore."
   (into known-anchor-keys
         [:first :last :after :before :cursor :limit
-         :page/basis :consistency :cache? :evaluation :timeout-ms
+         :page/basis :consistency :cache? :populate-cache?
+         :evaluation :timeout-ms
          :cancellation-token :aggregate-limits :authorization]))
 
 (defn validate!

--- a/modules/eacl/src/eacl/relay.cljc
+++ b/modules/eacl/src/eacl/relay.cljc
@@ -71,7 +71,7 @@
   nil)
 
 (def ^:private relay-page-keys
-  #{:first :last :after :before :consistency :cache?
+  #{:first :last :after :before :consistency :cache? :populate-cache?
     :cancellation-token})
 
 (def ^:private cursor-transport-keys
@@ -79,7 +79,7 @@
   caller-controlled so one boundary cursor can support forward and backward
   navigation. Consistency, principal, permission, filters, and resource type
   remain part of the authenticated semantic scope."
-  #{:first :last :after :before :cache? :timeout-ms
+  #{:first :last :after :before :cache? :populate-cache? :timeout-ms
     :cancellation-token})
 
 (def cursor-emission-order-version
@@ -120,7 +120,7 @@
                 (proof-frame/request-frame adapter)))
             proof (proof-frame/resolve! frame [])]
         (when (proof-frame/complete? proof)
-          (:schema-stamp proof))))))
+          (:schema-generation proof))))))
 
 (defn- plain-scope-object
   [object]
@@ -311,7 +311,8 @@
   [adapter opts operation query page]
   (let [cache (:page-navigation-cache opts)]
     (execution/check! (:execution-contract opts) :page-cache-publication)
-    (when (page-cache-enabled? cache opts)
+    (when (and (:populate-cache-request? opts true)
+               (page-cache-enabled? cache opts))
       (when-not (instance? PageNavigationCache cache)
         (throw
          (ex-info

--- a/modules/eacl/src/eacl/request/context.cljc
+++ b/modules/eacl/src/eacl/request/context.cljc
@@ -109,6 +109,14 @@
      {:basis-identity basis-identity
       :expected-keys source/semantic-identity-keys})))
 
+(defn lineage-for-basis
+  "Returns the one history witness used by every cross-basis artifact."
+  [basis-identity]
+  (validate-basis-identity! basis-identity)
+  {:source-scope
+   (select-keys basis-identity [:backend :source-id :branch])
+   :source-lifecycle (:source-lifecycle basis-identity)})
+
 (defn- release-after-construction-failure!
   [selected ledger error]
   (when selected
@@ -184,6 +192,7 @@
               (source/semantic-identity selected))
             basis-identity (or basis-identity selected-identity)
             _ (validate-basis-identity! basis-identity)
+            lineage (lineage-for-basis basis-identity)
             _
             (when (and selected-identity
                        (not= selected-identity basis-identity))
@@ -231,6 +240,7 @@
                            (source/ownership selected)
                            :borrowed)
               :basis-identity basis-identity
+              :lineage lineage
               :schema-generation-delay schema-generation-delay
               :contract contract
               :proof-frame request-proof-frame
@@ -261,6 +271,10 @@
 (defn basis-identity
   [context]
   (:basis-identity (state-of (assert-open! context))))
+
+(defn lineage
+  [context]
+  (:lineage (state-of (assert-open! context))))
 
 (defn contract
   [context]

--- a/modules/eacl/src/eacl/subproblem_cache.cljc
+++ b/modules/eacl/src/eacl/subproblem_cache.cljc
@@ -26,7 +26,7 @@
   nil)
 
 (def ^:dynamic *managed-key-fn*
-  "Returns a same-snapshot `{:schema-stamp n :dependency-stamp n}` descriptor
+  "Returns a same-snapshot `{:schema-generation n :dependency-stamp n}` descriptor
   for one relation dependency, or nil when managed reuse is unavailable."
   nil)
 
@@ -37,6 +37,11 @@
 (def ^:dynamic *publication-attempt-limit*
   "Maximum best-effort CAS publication attempts for the owning request."
   4)
+
+(def ^:dynamic *populate?*
+  "False for a read-only cache request. Lookups and request-local memoization
+  remain active, but no completed subproblem is published."
+  true)
 
 (def ^:dynamic *decision-kernel*
   "Generated-kernel selection inherited from the enclosing public client.
@@ -482,10 +487,13 @@
     (if-let [hit (lookup! store tier key options)]
       hit
       (let [value (compute)
+            populate? (get options :populate? *populate?*)
             publication
-            (publish!
-             store tier key options value *publication-attempt-limit*
-             lifecycle)]
+            (if populate?
+              (publish!
+               store tier key options value *publication-attempt-limit*
+               lifecycle)
+              {:published? false :reason :suppressed})]
         (swap! (:metrics store) update :misses inc)
         {:value value
          :cached? false
@@ -518,7 +526,7 @@
 (defn- valid-managed-descriptor?
   [descriptor]
   (and (map? descriptor)
-       (proof-stamp? (:schema-stamp descriptor))
+       (proof-stamp? (:schema-generation descriptor))
        (proof-stamp? (:dependency-stamp descriptor))))
 
 (defn- dependency-atom-count
@@ -576,7 +584,7 @@
    key
    options
    (fn []
-     (if-let [{:keys [schema-stamp dependency-stamp]}
+     (if-let [{:keys [schema-generation dependency-stamp]}
               (managed-descriptor dependency)]
        (let [managed
              (resolve-independent!
@@ -585,7 +593,7 @@
               [:managed-subproblem
                2
                *managed-scope*
-               schema-stamp
+               schema-generation
                dependency
                dependency-stamp
                tier

--- a/modules/eacl/test/eacl/adapter_certification.cljc
+++ b/modules/eacl/test/eacl/adapter_certification.cljc
@@ -492,11 +492,26 @@
                (backend/invoke adapter :exact-locator))
             "Native revision disagreed with the exact locator.")
     (when ordered-generations?
-      (demand (= #{:schema-stamp :relation-stamps}
-                 (set (keys proof-frame)))
-              "Ordered-generation frame had an unexpected shape.")
-      (demand (= relation-ids (mapv first (:relation-stamps proof-frame)))
+      (demand (vector? proof-frame)
+              "Ordered-generation frame must be a vector."
+              {:proof-frame proof-frame})
+      (demand (= relation-ids (mapv first proof-frame))
               "Ordered-generation frame was incomplete or noncanonical.")
+      (demand (every? (fn [[_ generation]]
+                        (backend/schema-generation? generation))
+                      proof-frame)
+              "Relation generations must share the exact-natural revision domain."
+              {:proof-frame proof-frame :native-revision revision})
+      (demand (every? (fn [[_ generation]]
+                        (<= generation (:revision revision)))
+                      proof-frame)
+              "A relation generation exceeded the selected native revision."
+              {:proof-frame proof-frame :native-revision revision})
+      (demand (and (backend/schema-generation? schema-generation)
+                   (<= schema-generation (:revision revision)))
+              "Schema generation was absent or exceeded the selected native revision."
+              {:schema-generation schema-generation
+               :native-revision revision})
       (demand (= proof-frame
                  (backend/invoke adapter :proof-frame relation-ids))
               "Ordered-generation frame was unstable on an immutable adapter."))
@@ -505,6 +520,122 @@
      :native-revision revision
      :schema-generation schema-generation
      :ordered-generation-proof? ordered-generations?}))
+
+(defn certify-ordered-generation-transition!
+  "Executes the temporal proof obligations across one supported relationship
+  mutation. Bundled adapters call this with immutable values selected
+  immediately before and after the committed writer operation. An adapter that
+  does not advertise ordered generations returns an explicit non-claim."
+  [{:keys [before-adapter after-adapter relation-ids
+           affected-relation-ids]}]
+  (let [claimed-before?
+        (backend/supports?
+         before-adapter :cache-proofs :ordered-generations)
+        claimed-after?
+        (backend/supports?
+         after-adapter :cache-proofs :ordered-generations)]
+    (if-not (or claimed-before? claimed-after?)
+      {:status :not-claimed
+       :backend (backend/backend-id after-adapter)}
+      (do
+        (demand (and claimed-before? claimed-after?)
+                "Ordered-generation capability changed across one mutation.")
+        (let [relation-ids (vec (sort relation-ids))
+              affected (set affected-relation-ids)
+              before-revision
+              (:revision (backend/invoke before-adapter :native-revision))
+              after-revision
+              (:revision (backend/invoke after-adapter :native-revision))
+              before-schema
+              (backend/invoke before-adapter :schema-generation)
+              after-schema
+              (backend/invoke after-adapter :schema-generation)
+              before-frame
+              (backend/invoke before-adapter :proof-frame relation-ids)
+              after-frame
+              (backend/invoke after-adapter :proof-frame relation-ids)
+              before-generations (into {} before-frame)
+              after-generations (into {} after-frame)]
+          (doseq [[label value]
+                  [[:before-revision before-revision]
+                   [:after-revision after-revision]
+                   [:before-schema-generation before-schema]
+                   [:after-schema-generation after-schema]]]
+            (demand (backend/schema-generation? value)
+                    "A certified generation left the native exact-natural domain."
+                    {:field label :value value}))
+          (demand (< before-revision after-revision)
+                  "A supported relationship mutation did not advance revision."
+                  {:before before-revision :after after-revision})
+          (demand (= before-schema after-schema)
+                  "A relationship-only mutation changed schema generation."
+                  {:before before-schema :after after-schema})
+          (doseq [[label frame revision]
+                  [[:before before-frame before-revision]
+                   [:after after-frame after-revision]]]
+            (demand (and (vector? frame)
+                         (= relation-ids (mapv first frame)))
+                    "A temporal proof frame was incomplete or noncanonical."
+                    {:phase label :frame frame :relation-ids relation-ids})
+            (demand (every?
+                     (fn [[_ generation]]
+                       (and (backend/schema-generation? generation)
+                            (<= generation revision)))
+                     frame)
+                    "A temporal proof generation left its domain or ceiling."
+                    {:phase label :frame frame :revision revision}))
+          (demand (set/subset? affected (set relation-ids))
+                  "Affected relations were absent from the certified frame."
+                  {:affected affected :relation-ids relation-ids})
+          (doseq [relation-id relation-ids]
+            (if (contains? affected relation-id)
+              (demand (= after-revision
+                         (get after-generations relation-id))
+                      "An affected relation was not stamped at commit revision."
+                      {:relation-id relation-id
+                       :generation (get after-generations relation-id)
+                       :revision after-revision})
+              (demand (= (get before-generations relation-id)
+                         (get after-generations relation-id))
+                      "An unaffected relation generation changed."
+                      {:relation-id relation-id
+                       :before (get before-generations relation-id)
+                       :after (get after-generations relation-id)})))
+          {:status :certified
+           :backend (backend/backend-id after-adapter)
+           :before-revision before-revision
+           :after-revision after-revision
+           :affected-relation-ids affected})))))
+
+(defn certify-live-source-identity!
+  "Certifies the source-id rule for two separately opened live sources.
+
+  Non-durable sources must differ even when caller configuration is reused.
+  Durable reopenings of the same store must retain their persisted identity."
+  [{:keys [backend durability first-scope second-scope]}]
+  (doseq [[label scope] [[:first first-scope] [:second second-scope]]]
+    (demand (and (map? scope)
+                 (some? (:source-id scope))
+                 (contains? scope :branch))
+            "A live source supplied no complete source scope."
+            {:backend backend :position label :scope scope}))
+  (case durability
+    :non-durable
+    (demand (not= first-scope second-scope)
+            "Two non-durable live sources reused one source identity."
+            {:backend backend :first first-scope :second second-scope})
+
+    :durable
+    (demand (= first-scope second-scope)
+            "A durable store identity changed across reopen."
+            {:backend backend :first first-scope :second second-scope})
+
+    (demand false "Unknown source durability profile."
+            {:backend backend :durability durability}))
+  {:status :certified
+   :backend backend
+   :durability durability
+   :distinct? (not= first-scope second-scope)})
 
 (defn certify
   "Runs the portable static-snapshot obligations and returns a machine-readable

--- a/modules/eacl/test/eacl/backend/v8_test.cljc
+++ b/modules/eacl/test/eacl/backend/v8_test.cljc
@@ -38,10 +38,9 @@
          backend/required-snapshot-operations)
    :proof-frame
    (fn [relation-ids]
-     {:schema-stamp 1
-      :relation-stamps (mapv (fn [relation-id]
-                               [relation-id 1])
-                             relation-ids)})))
+     (mapv (fn [relation-id]
+             [relation-id 1])
+           relation-ids))))
 
 (defn- test-adapter []
   (backend/make-adapter
@@ -67,11 +66,9 @@
     (assoc (operation-map)
            :proof-frame
            (fn [relation-ids]
-             {:schema-stamp generation
-              :relation-stamps
-              (mapv (fn [relation-id]
-                      [relation-id generation])
-                    relation-ids)})
+             (mapv (fn [relation-id]
+                     [relation-id generation])
+                   relation-ids))
            :schema-generation (constantly generation))}))
 
 (defn- error-data [f]
@@ -143,7 +140,7 @@
     (is (= {:mode :fully-consistent}
            (backend/require-consistency!
             adapter consistency/fully-consistent)))
-    (is (= {:schema-stamp 1 :relation-stamps []}
+    (is (= []
            (backend/invoke adapter :proof-frame [])))
     (is (nil? (backend/invoke adapter :schema-generation)))
     (testing "unsupported guarantees fail before execution"
@@ -453,9 +450,7 @@
          {:snapshot-id (fn [] {:database-id :test :basis-t 1})
           :proof-frame
           (fn [relation-ids]
-            {:schema-stamp 1
-             :relation-stamps
-             (mapv (fn [relation-id] [relation-id 1]) relation-ids)})
+            (mapv (fn [relation-id] [relation-id 1]) relation-ids))
           :object-id->internal identity
           :internal-id->object identity
           :permission-defs

--- a/modules/eacl/test/eacl/cache_test.cljc
+++ b/modules/eacl/test/eacl/cache_test.cljc
@@ -13,7 +13,10 @@
 (def ^:private test-source-scope
   {:backend :test
    :source-id :source
-   :branch nil
+   :branch nil})
+
+(def ^:private test-lineage
+  {:source-scope test-source-scope
    :source-lifecycle :lifecycle-a})
 
 (defn- basis-key
@@ -38,7 +41,7 @@
    :snapshot-order revision
    :exact-basis-key (basis-key revision)
    :cache-basis revision
-   :managed-subproblem-scope test-source-scope})
+   :managed-subproblem-scope test-lineage})
 
 (deftest basis-cache-is-client-private-test
   (let [native-cache (cache/basis-cache)]
@@ -64,12 +67,12 @@
         stamp-reads (atom 0)
         answer (atom true)
         context
-        (fn [snapshot order schema-stamp dependency-stamp]
+        (fn [snapshot order schema-generation dependency-stamp]
           (assoc (basis-context snapshot order)
                  :managed-key-fn
                  (fn []
                    (swap! stamp-reads inc)
-                   {:schema-stamp schema-stamp
+                   {:schema-generation schema-generation
                     :dependency-stamp dependency-stamp})))
         resolve
         (fn [current-context]
@@ -355,7 +358,7 @@
         (fn [revision]
           (assoc (basis-context (snapshot-object) revision)
                  :managed-key-fn
-                 (constantly {:schema-stamp 10
+                 (constantly {:schema-generation 10
                               :dependency-stamp 20})))
         resolve
         (fn [revision value]
@@ -652,7 +655,7 @@
                  :managed-key-fn
                  (fn []
                    (swap! descriptor-reads inc)
-                   {:schema-stamp 10
+                   {:schema-generation 10
                     :dependency-stamp 20})))
         resolve
         (fn [semantic-key current-context]
@@ -690,7 +693,7 @@
              (swap! compute-calls inc)
              value)))]
     (is (true? (:value (resolve snapshot-1 1
-                               {:schema-stamp 10
+                               {:schema-generation 10
                                 :dependency-stamp 20}
                                true))))
     (let [fallback (resolve snapshot-2 2 nil false)]
@@ -714,6 +717,121 @@
       (is (= 3 (:proof-unavailable stats)))
       (is (= {:missing-generation 2 :provider-failure 1}
              (:proof-unavailable-reasons stats))))))
+
+(deftest read-without-publication-preserves-lookups-and-suppresses-writes-test
+  (let [store (cache/basis-cache)
+        first-snapshot (snapshot-object)
+        second-snapshot (snapshot-object)
+        computations (atom 0)
+        publication-view
+        (fn []
+          (let [stats (cache/basis-cache-stats store)]
+            {:puts (:puts stats)
+             :exact-entries (:exact-entries stats)
+             :retained-bases (:retained-bases stats)
+             :managed-entries (:managed-entries stats)
+             :managed-generations (:managed-generations stats)
+             :exact-subproblem-puts
+             (get-in stats [:exact-subproblems :puts])
+             :managed-subproblem-puts
+             (get-in stats [:managed-subproblems :puts])}))
+        resolve
+        (fn [snapshot revision semantic-key populate? value]
+          (cache/resolve-basis!
+           store
+           (assoc (basis-context snapshot revision)
+                  :populate-cache? populate?
+                  :managed-key-fn
+                  (constantly
+                   {:schema-generation 10 :dependency-stamp 20}))
+           semantic-key
+           :decision
+           boolean?
+           (fn []
+             (swap! computations inc)
+             value)))]
+    (is (false? (:cached?
+                 (resolve first-snapshot 1 :answer true true))))
+    (let [after-warm (publication-view)
+          exact-hit (resolve first-snapshot 1 :answer false false)]
+      (is (true? (:cached? exact-hit)))
+      (is (= :exact-basis (:cache-tier exact-hit)))
+      (is (= after-warm (publication-view))
+          "an exact read-only hit publishes and installs nothing"))
+    (let [before-managed-read (publication-view)
+          managed-hit (resolve second-snapshot 2 :answer false false)]
+      (is (true? (:cached? managed-hit)))
+      (is (= :managed-current (:cache-tier managed-hit)))
+      (is (= before-managed-read (publication-view))
+          "a managed read-only hit is neither promoted nor generation-creating"))
+    (let [before-misses (publication-view)
+          first-miss (resolve second-snapshot 2 :unseen false false)
+          second-miss (resolve second-snapshot 2 :unseen false true)]
+      (is (false? (:cached? first-miss)))
+      (is (false? (:cached? second-miss)))
+      (is (= [false true] [(:value first-miss) (:value second-miss)]))
+      (is (= before-misses (publication-view))
+          "read-only misses evaluate independently without publication"))
+    (is (= 3 @computations)
+        "the warm request and both read-only misses compute")))
+
+(deftest proof-contract-violation-disables-only-managed-lifting-test
+  (let [reports (atom [])
+        store
+        (cache/basis-cache
+         {:proof-contract-reporter #(swap! reports conj %)})
+        first-snapshot (snapshot-object)
+        second-snapshot (snapshot-object)
+        third-snapshot (snapshot-object)
+        descriptor-reads (atom 0)
+        computations (atom 0)
+        resolve
+        (fn [snapshot revision value]
+          (cache/resolve-basis!
+           store
+           (assoc
+            (basis-context snapshot revision)
+            :managed-key-fn
+            (fn []
+              (swap! descriptor-reads inc)
+              {:schema-generation 10 :dependency-stamp 20}))
+           :contract-violation
+           :decision
+           boolean?
+           (fn []
+             (swap! computations inc)
+             value)))]
+    (is (true? (:value (resolve first-snapshot 1 true))))
+    (is (= 1 @descriptor-reads))
+    (cache/record-proof-diagnostic!
+     store
+     {:status :contract-violation
+      :reason :relation-generation-above-revision})
+    (cache/record-proof-diagnostic!
+     store
+     {:status :contract-violation
+      :reason :relation-generation-above-revision})
+    (let [fallback (resolve second-snapshot 2 false)]
+      (is (false? (:value fallback)))
+      (is (false? (:cached? fallback)))
+      (is (= 1 @descriptor-reads)
+          "sticky disablement skips all subsequent managed proof reads"))
+    (is (false? (:value (resolve second-snapshot 2 true)))
+        "exact-basis cache hits remain available while lifting is disabled")
+    (is (= 2 @computations))
+    (let [stats (cache/basis-cache-stats store)]
+      (is (true? (:managed-lifting-disabled? stats)))
+      (is (= 2 (:proof-contract-violations stats)))
+      (is (= {:relation-generation-above-revision 2}
+             (:proof-contract-violation-reasons stats))))
+    (is (= 1 (count @reports))
+        "the reporter runs once per reason in a lifecycle")
+    (cache/expire-basis-cache! store)
+    (is (false? (:managed-lifting-disabled?
+                 (cache/basis-cache-stats store))))
+    (is (true? (:value (resolve third-snapshot 3 true))))
+    (is (= 2 @descriptor-reads)
+        "expiry restores managed proof acquisition")))
 
 (deftest basis-generation-two-hit-admission-test
   (let [store (cache/basis-cache {:admit-on-repeat? true})
@@ -761,9 +879,11 @@
          (assoc base-public
                 :after "signed-snapshot-b"
                 :cache? true
+                :populate-cache? false
                 :cancellation-token (eacl/cancellation-token))
          (assoc base-internal
                 :after boundary
+                :populate-cache? true
                 :cancellation-token (eacl/cancellation-token)))]
     (is (= original recovered)
         "signed transport bytes are not page semantics")

--- a/modules/eacl/test/eacl/contract_support.cljc
+++ b/modules/eacl/test/eacl/contract_support.cljc
@@ -1284,13 +1284,13 @@
               :permission :reboot})))))
 
   (testing "request validation is identical before backend reads"
-    (is (= :eacl.permission-tree/invalid-request
-           (error-category
-            #(eacl/expand-permission-tree
-              client
-              {:resource (->server "server-1")
-               :permission :reboot
-               :cache? false}))))
+    (is (map?
+         (eacl/expand-permission-tree
+          client
+          {:resource (->server "server-1")
+           :permission :reboot
+           :cache? false}))
+        "the permission-tree read accepts the common cache control")
     (is (= :eacl.execution/invalid-contract
            (error-category
             #(eacl/expand-permission-tree
@@ -1714,6 +1714,9 @@
         {:subject (->user "user-1")
          :permission :reboot
          :resource (->server "server-1")}
+        permission-tree-query
+        {:resource (->server "server-1")
+         :permission :view}
         store (:basis-cache-store (:runtime client))
         clear! #(cache/expire-basis-cache! store)
         stats #(cache/basis-cache-stats store)]
@@ -1740,6 +1743,45 @@
         (is (true? (:cached? retained-hit)))
         (is (= (:data miss) (:data bypass) (:data retained-hit)))))
 
+    (testing "read-without-publication hits existing answers without promoting or writing"
+      (clear!)
+      (let [miss (eacl/check-permission client demand)
+            before-read (stats)
+            hit (eacl/check-permission
+                 client (assoc demand :populate-cache? false))
+            after-read (stats)]
+        (is (false? (:cached? miss)))
+        (is (true? (:cached? hit)))
+        (is (= (:allowed? miss) (:allowed? hit)))
+        (is (= (select-keys before-read
+                            [:puts :exact-entries :managed-entries
+                             :retained-bases :managed-generations])
+               (select-keys after-read
+                            [:puts :exact-entries :managed-entries
+                             :retained-bases :managed-generations]))
+            "a read-only hit does not publish or install a generation")))
+
+    (testing "read-without-publication misses evaluate exactly and remain misses"
+      (clear!)
+      (let [before-misses (stats)
+            first-miss
+            (eacl/check-permission
+             client (assoc demand :populate-cache? false))
+            second-miss
+            (eacl/check-permission
+             client (assoc demand :populate-cache? false))
+            after-misses (stats)]
+        (is (false? (:cached? first-miss)))
+        (is (false? (:cached? second-miss)))
+        (is (= (:allowed? first-miss) (:allowed? second-miss)))
+        (is (= (select-keys before-misses
+                            [:puts :exact-entries :managed-entries
+                             :retained-bases :managed-generations])
+               (select-keys after-misses
+                            [:puts :exact-entries :managed-entries
+                             :retained-bases :managed-generations]))
+            "read-only misses do not create completed or managed storage")))
+
     (testing "cache execution control is excluded from cursor identity"
       (let [first-page
             (eacl/lookup-resources
@@ -1751,6 +1793,24 @@
                     :cache? false
                     :after (get-in first-page
                                    [:page-info :end-cursor])))]
+        (is (= [(->server "server-2")] (:data second-page)))))
+
+    (testing "publication control is excluded from authenticated cursor identity"
+      (let [first-page
+            (eacl/lookup-resources
+             client
+             (assoc resource-query
+                    :evaluation :complete-denotation
+                    :populate-cache? false))
+            second-page
+            (eacl/lookup-resources
+             client
+             (assoc resource-query
+                    :evaluation :complete-denotation
+                    :populate-cache? true
+                    :after (get-in first-page
+                                   [:page-info :end-cursor])))]
+        (is (= [(->server "server-1")] (:data first-page)))
         (is (= [(->server "server-2")] (:data second-page)))))
 
     (testing "relationship reads expose miss, hit, bypass, and retained reuse"
@@ -1796,38 +1856,67 @@
                (:bypasses after-bypass)))
         (is (boolean? (eacl/can? client demand)))))
 
-    (testing "all cache-aware request maps reject non-Boolean :cache?"
-      (doseq [[operation call]
+    (testing "cache bypass dominates either publication-control value"
+      (let [before (stats)
+            first-result
+            (eacl/check-permission
+             client (assoc demand :cache? false :populate-cache? true))
+            middle (stats)
+            second-result
+            (eacl/check-permission
+             client (assoc demand :cache? false :populate-cache? false))
+            after (stats)]
+        (is (false? (:cached? first-result)))
+        (is (false? (:cached? second-result)))
+        (is (= (:allowed? first-result) (:allowed? second-result)))
+        (is (= (dissoc before :bypasses)
+               (dissoc middle :bypasses)
+               (dissoc after :bypasses))
+            "cache bypass neither looks up nor publishes under either value")
+        (is (= (+ 2 (:bypasses before)) (:bypasses after)))))
+
+    (testing "all cache-aware request maps reject non-Boolean controls"
+      (doseq [control [:cache? :populate-cache?]
+              [operation call]
               [[:can
-                #(eacl/can? client (assoc demand :cache? :invalid))]
+                #(eacl/can? client (assoc demand control :invalid))]
                [:check-permission
                 #(eacl/check-permission
-                  client (assoc demand :cache? :invalid))]
+                  client (assoc demand control :invalid))]
+               [:check-permissions
+                #(eacl/check-permissions
+                  client {:checks [demand] control :invalid})]
+               [:empty-check-permissions
+                #(eacl/check-permissions
+                  client {:checks [] control :invalid})]
                [:lookup-resources
                 #(eacl/lookup-resources
-                  client (assoc resource-query :cache? :invalid))]
+                  client (assoc resource-query control :invalid))]
                [:count-resources
                 #(eacl/count-resources
                   client
                   (assoc (dissoc resource-query :first)
-                         :cache? :invalid))]
+                         control :invalid))]
                [:lookup-subjects
                 #(eacl/lookup-subjects
-                  client (assoc subject-query :cache? :invalid))]
+                  client (assoc subject-query control :invalid))]
                [:count-subjects
                 #(eacl/count-subjects
                   client
                   (assoc (dissoc subject-query :first)
-                         :cache? :invalid))]
+                         control :invalid))]
                [:read-relationships
                 #(eacl/read-relationships
-                  client (assoc relationship-query :cache? :invalid))]]]
+                  client (assoc relationship-query control :invalid))]
+               [:expand-permission-tree
+                #(eacl/expand-permission-tree
+                  client (assoc permission-tree-query control :invalid))]]]
         (is (= :eacl/invalid-request (error-category call))
-            (str operation " should reject an invalid :cache?"))
-        (is (= :cache?
+            (str operation " should reject an invalid " control))
+        (is (= control
                (try
                  (call)
                  nil
                  (catch #?(:clj Exception :cljs :default) error
                    (:key (ex-data error)))))
-            (str operation " should identify :cache?"))))))
+            (str operation " should identify " control))))))

--- a/modules/eacl/test/eacl/formal/executed_mutation_controls.cljc
+++ b/modules/eacl/test/eacl/formal/executed_mutation_controls.cljc
@@ -212,7 +212,7 @@
    :cache-basis revision
    :managed-subproblem-scope audit-source-scope
    :managed-key-fn
-   (constantly {:schema-stamp 10 :dependency-stamp 20})})
+   (constantly {:schema-generation 10 :dependency-stamp 20})})
 
 (defn numeric-ancestry-killed?
   "Kills the obsolete order-as-ancestry rule against the replacement contract:

--- a/modules/eacl/test/eacl/formal/executed_mutation_controls.cljc
+++ b/modules/eacl/test/eacl/formal/executed_mutation_controls.cljc
@@ -5,6 +5,8 @@
             [eacl.authorization.batch :as batch]
             [eacl.cache :as cache]
             [eacl.engine.portable-decisions :as portable]
+            [eacl.proof-frame :as proof-frame]
+            [eacl.request.context :as request-context]
             [eacl.verified-kernel :as verified]))
 
 (defn- production-decision
@@ -491,6 +493,95 @@
                        :source-lifecycle))]
         (separated?))))))
 
+(defn- ordered-generation-adapter
+  [revision provider]
+  (backend/make-adapter
+   {:id :mutation-control
+    :capabilities {:cache-proofs #{:ordered-generations}}
+    :operations
+    (merge
+     (operation-map)
+     {:snapshot-id (constantly {:revision revision})
+      :basis-kind (constantly :ordinary)
+      :native-revision
+      (constantly {:revision revision :exact-locator revision})
+      :order-hint (constantly revision)
+      :exact-locator (constantly revision)
+      :schema-generation (constantly 0)
+      :proof-frame provider})}))
+
+(defn adapter-generation-domain-killed?
+  []
+  (let [adapter
+        (ordered-generation-adapter 5 (constantly [[1 "not-a-generation"]]))
+        gate
+        #(= :contract-violation
+            (:status
+             (proof-frame/resolve!
+              (proof-frame/request-frame adapter) [1])))
+        original proof-frame/generation?]
+    (and
+     (gate)
+     (false?
+      (with-redefs [proof-frame/generation? (constantly true)]
+        (gate)))
+     (fn? original))))
+
+(defn adapter-generation-ceiling-killed?
+  []
+  (let [adapter (ordered-generation-adapter 5 (constantly [[1 6]]))
+        gate
+        #(= :contract-violation
+            (:status
+             (proof-frame/resolve!
+              (proof-frame/request-frame adapter) [1])))
+        original proof-frame/revision]
+    (and
+     (gate)
+     (false?
+      (with-redefs [proof-frame/revision (constantly 6)]
+        (gate)))
+     (fn? original))))
+
+(defn non-durable-live-source-id-collision-killed?
+  []
+  (let [first-adapter
+        (ordered-generation-adapter 5 (constantly []))
+        second-adapter
+        (assoc-in first-adapter
+                  [:eacl.backend.v8/operations :snapshot-id]
+                  (constantly {:revision 5 :source-id :second-live-source}))
+        first-adapter
+        (assoc-in first-adapter
+                  [:eacl.backend.v8/operations :snapshot-id]
+                  (constantly {:revision 5 :source-id :first-live-source}))
+        identity
+        (fn [adapter]
+          {:backend (backend/backend-id adapter)
+           :source-id (:source-id (backend/invoke adapter :snapshot-id))
+           :branch nil
+           :source-lifecycle "eacl/initial"
+           :basis-kind :ordinary
+           :revision 5
+           :exact-locator 5
+           :backend-snapshot-id (backend/invoke adapter :snapshot-id)})
+        separated?
+        #(not= (request-context/lineage-for-basis
+                (identity first-adapter))
+               (request-context/lineage-for-basis
+                (identity second-adapter)))
+        original request-context/lineage-for-basis]
+    (and
+     (separated?)
+     (false?
+      (with-redefs [request-context/lineage-for-basis
+                    (fn [basis-identity]
+                      (assoc-in
+                       (original basis-identity)
+                       [:source-scope :source-id]
+                       :collided-live-source))]
+        (separated?))))))
+
 (defn aggregate-counter-reset-killed?
   []
   (let [args [{:advanced-datoms 0 :queued-work 0 :fetched-values 0}
@@ -569,6 +660,10 @@
    :consistency-unsupported-exact-becomes-generic
    consistency-unsupported-exact-becomes-generic-killed?
    :exact-basis-key-omits-lifecycle exact-basis-key-omits-lifecycle-killed?
+   :adapter-generation-domain adapter-generation-domain-killed?
+   :adapter-generation-ceiling adapter-generation-ceiling-killed?
+   :non-durable-live-source-id-collision
+   non-durable-live-source-id-collision-killed?
    :aggregate-counter-reset aggregate-counter-reset-killed?
    :batch-cross-demand-contamination batch-cross-demand-contamination-killed?
    :aggregate-deadline-renewal aggregate-deadline-renewal-killed?})

--- a/modules/eacl/test/eacl/formal/executed_mutation_controls.cljc
+++ b/modules/eacl/test/eacl/formal/executed_mutation_controls.cljc
@@ -188,7 +188,10 @@
 (def audit-source-scope
   {:backend :mutation-control
    :source-id :source
-   :branch nil
+   :branch nil})
+
+(def audit-lineage
+  {:source-scope audit-source-scope
    :source-lifecycle :lifecycle})
 
 (defn- audit-basis-key
@@ -197,6 +200,7 @@
    :backend :mutation-control
    :basis-identity
    (assoc audit-source-scope
+          :source-lifecycle :lifecycle
           :basis-kind :ordinary
           :revision revision
           :exact-locator revision
@@ -210,7 +214,7 @@
    :snapshot-order revision
    :exact-basis-key (audit-basis-key revision)
    :cache-basis revision
-   :managed-subproblem-scope audit-source-scope
+   :managed-subproblem-scope audit-lineage
    :managed-key-fn
    (constantly {:schema-generation 10 :dependency-stamp 20})})
 

--- a/modules/eacl/test/eacl/permission_tree_test.cljc
+++ b/modules/eacl/test/eacl/permission_tree_test.cljc
@@ -87,17 +87,21 @@
 
 (deftest strict-request-contract
   (is (= {:resource (eacl/spice-object :document "d1")
-          :permission :view}
+          :permission :view
+          :cache? false
+          :populate-cache? false}
          (permission-tree/validate-request!
           {:resource (eacl/spice-object :document "d1")
-           :permission :view})))
+           :permission :view
+           :cache? false
+           :populate-cache? false})))
   (doseq [request
           [nil
            {}
            {:resource (eacl/spice-object :document "d1")}
            {:resource (eacl/spice-object :document "d1")
             :permission :view
-            :cache? false}
+            :unsupported-control true}
            {:resource (eacl/spice-object :document "d1" :member)
             :permission :view}
            {:resource {:type :document :id nil}

--- a/modules/eacl/test/eacl/proof_frame_test.cljc
+++ b/modules/eacl/test/eacl/proof_frame_test.cljc
@@ -6,10 +6,12 @@
 
 (defn- adapter
   ([provider]
-   (adapter provider true nil))
+   (adapter provider true 7 30))
   ([provider supported?]
-   (adapter provider supported? nil))
+   (adapter provider supported? (when supported? 7) 30))
   ([provider supported? schema-generation]
+   (adapter provider supported? schema-generation 30))
+  ([provider supported? schema-generation revision]
    (backend/make-adapter
     {:id :proof-test
      :capabilities
@@ -21,7 +23,9 @@
                    [operation (fn [& _] nil)]))
             backend/required-snapshot-operations)
        true
-       (assoc :snapshot-id (constantly {:basis 9}))
+       (assoc :snapshot-id (constantly {:basis revision})
+              :native-revision
+              (constantly {:revision revision :exact-locator revision}))
        (some? schema-generation)
        (assoc :schema-generation (constantly schema-generation))
        supported?
@@ -33,19 +37,19 @@
         (adapter
          (fn [relation-ids]
            (swap! calls conj relation-ids)
-           {:schema-stamp 7
-            :relation-stamps
-            (mapv (fn [relation-id]
-                    [relation-id ({1 10, 2 21, 3 15} relation-id)])
-                  relation-ids)}))
+           (mapv (fn [relation-id]
+                   [relation-id ({1 10, 2 21, 3 15} relation-id)])
+                 relation-ids)))
         frame (proof-frame/request-frame selected)
         proof (proof-frame/resolve! frame [1 2 3])]
     (is (= :complete (:status proof)))
+    (is (= 30 (:revision proof)))
+    (is (= 7 (:schema-generation proof)))
     (is (= [1 2 3] (:relation-ids proof)))
-    (is (= [[1 10] [2 21] [3 15]] (:relation-stamps proof)))
-    (is (= {:schema-stamp 7 :dependency-stamp 21}
+    (is (= [[1 10] [2 21] [3 15]] (:relation-generations proof)))
+    (is (= {:schema-generation 7 :dependency-stamp 21}
            (proof-frame/descriptor proof)))
-    (is (= {:schema-stamp 7 :dependency-stamp 15}
+    (is (= {:schema-generation 7 :dependency-stamp 15}
            (proof-frame/subset-descriptor proof [1 3])))
     (is (nil? (proof-frame/subset-descriptor proof [4])))
     (is (identical? proof (proof-frame/resolve! frame [1 2 3])))
@@ -56,96 +60,133 @@
   (let [proof
         (proof-frame/resolve!
          (proof-frame/request-frame
-          (adapter (constantly {:schema-stamp 4
-                                :relation-stamps []})))
+          (adapter (constantly []) true 4))
          [])]
     (is (= :complete (:status proof)))
-    (is (= {:schema-stamp 4 :dependency-stamp 0}
+    (is (= {:schema-generation 4 :dependency-stamp 0}
            (proof-frame/descriptor proof)))))
 
-(deftest proof-frame-rejects-certified-schema-generation-mismatch
-  (let [failure
-        (try
-          (proof-frame/resolve!
-           (proof-frame/request-frame
-            (adapter
-             (constantly {:schema-stamp 4 :relation-stamps []})
-             true
-             5))
-           [])
-          nil
-          (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) error
-            (ex-data error)))]
-    (is (= {:type :eacl/backend-integrity-error
-            :eacl/error :eacl/backend-integrity-error
-            :reason :schema-generation-mismatch
-            :proof-schema-generation 4
-            :certified-schema-generation 5}
-           (select-keys
-            failure
-            [:type :eacl/error :reason :proof-schema-generation
-             :certified-schema-generation])))))
+(deftest proof-frame-reads-schema-generation-only-through-certified-operation
+  (let [schema-reads (atom 0)
+        selected
+        (backend/make-adapter
+         {:id :proof-test
+          :capabilities {:cache-proofs #{:ordered-generations}}
+          :operations
+          (-> (into {}
+                    (map (fn [operation]
+                           [operation (fn [& _] nil)]))
+                    backend/required-snapshot-operations)
+              (assoc :snapshot-id (constantly {:basis 9})
+                     :native-revision
+                     (constantly {:revision 9 :exact-locator 9})
+                     :schema-generation
+                     (fn [] (swap! schema-reads inc) 4)
+                     :proof-frame (constantly [])))})
+        proof
+        (proof-frame/resolve!
+         (proof-frame/request-frame selected) [])]
+    (is (= :complete (:status proof)))
+    (is (= 4 (:schema-generation proof)))
+    (is (= 1 @schema-reads))))
 
-(deftest every-incomplete-proof-shape-fails-closed
-  (doseq [[label provider expected-reason]
+(deftest unavailable-frame-outcomes-remain-retryable
+  (doseq [[label frame relation-ids expected-reason]
           [[:missing-schema
-            (constantly {:schema-stamp nil :relation-stamps [[1 2]]})
-            :malformed-schema-generation]
-           [:missing-relation
-            (constantly {:schema-stamp 1 :relation-stamps [[1 nil]]})
-            :incomplete-or-noncanonical-generations]
-           [:wrong-order
-            (constantly {:schema-stamp 1
-                         :relation-stamps [[2 2] [1 2]]})
-            :incomplete-or-noncanonical-generations]
-           [:duplicate
-            (constantly {:schema-stamp 1
-                         :relation-stamps [[1 2] [1 2]]})
-            :incomplete-or-noncanonical-generations]
-           [:extra-field
-            (constantly {:schema-stamp 1
-                         :relation-stamps [[1 2]]
-                         :partial? false})
-            :malformed-proof]
-           [:throwing
-            (fn [_] (throw (ex-info "provider failed" {})))
-            :proof-provider-failure]]]
+            (proof-frame/request-frame
+             (adapter (constantly [[1 2]]) true nil))
+            [1]
+            :schema-generation-unavailable]
+           [:missing-relation-generation
+            (proof-frame/request-frame
+             (adapter (constantly [[1 nil]])))
+            [1]
+            :relation-generation-unavailable]
+           [:throwing-provider
+            (proof-frame/request-frame
+             (adapter
+              (fn [_] (throw (ex-info "provider failed" {})))))
+            [1]
+            :proof-provider-failure]
+           [:unsupported
+            (proof-frame/request-frame
+             (adapter (constantly nil) false))
+            []
+            :unsupported-proof-capability]
+           [:closure-bound
+            (proof-frame/request-frame
+             (adapter (constantly [[1 1] [2 1]]))
+             {:maximum-relation-count 1})
+            [1 2]
+            :proof-bound-exceeded]
+           [:non-exact-revision
+            (proof-frame/request-frame
+             (adapter (constantly []) true 1 nil))
+            []
+            :revision-unavailable]]]
     (testing (name label)
-      (let [proof
-            (proof-frame/resolve!
-             (proof-frame/request-frame (adapter provider)) [1])]
+      (let [proof (proof-frame/resolve! frame relation-ids)]
         (is (= :unavailable (:status proof)))
         (is (= expected-reason (:reason proof)))
         (is (nil? (proof-frame/descriptor proof)))))))
 
-(deftest unsupported-oversized-and-noncanonical-inputs-fail-closed
-  (let [unsupported
-        (proof-frame/resolve!
-         (proof-frame/request-frame
-          (adapter (constantly nil) false)) [])
-        oversized
-        (proof-frame/resolve!
-         (proof-frame/request-frame
-          (adapter (constantly {:schema-stamp 1 :relation-stamps []}))
-          {:maximum-relation-count 1})
-         [1 2])
-        malformed
-        (proof-frame/resolve!
-         (proof-frame/request-frame
-          (adapter (constantly {:schema-stamp 1 :relation-stamps []})))
-         [1 :not-an-eid])
-        unsorted
-        (proof-frame/resolve!
-         (proof-frame/request-frame
-          (adapter (constantly {:schema-stamp 1 :relation-stamps []})))
-         [2 1])
-        duplicate
-        (proof-frame/resolve!
-         (proof-frame/request-frame
-          (adapter (constantly {:schema-stamp 1 :relation-stamps []})))
-         [1 1])]
-    (is (= :unsupported-proof-capability (:reason unsupported)))
-    (is (= :proof-bound-exceeded (:reason oversized)))
-    (is (= :noncanonical-dependencies (:reason malformed)))
-    (is (= :noncanonical-dependencies (:reason unsorted)))
-    (is (= :noncanonical-dependencies (:reason duplicate)))))
+(deftest malformed-or-future-adapter-evidence-is-a-contract-violation
+  (doseq [[label provider schema-generation revision relation-ids reason]
+          [[:map-shape
+            (constantly {:relation-generations [[1 2]]}) 1 10 [1]
+            :malformed-shape]
+           [:entry-shape
+            (constantly [[1 2 3]]) 1 10 [1] :malformed-shape]
+           [:wrong-cardinality
+            (constantly []) 1 10 [1] :wrong-cardinality]
+           [:wrong-order
+            (constantly [[2 2] [1 2]]) 1 10 [1 2]
+            :noncanonical-relation-ids]
+           [:duplicate
+            (constantly [[1 2] [1 2]]) 1 10 [1 2]
+            :duplicate-relation-id]
+           [:non-integer-generation
+            (constantly [[1 "2"]]) 1 10 [1]
+            :invalid-relation-generation]
+           [:negative-generation
+            (constantly [[1 -1]]) 1 10 [1]
+            :invalid-relation-generation]
+           [:future-relation-generation
+            (constantly [[1 11]]) 1 10 [1]
+            :relation-generation-above-revision]
+           [:non-integer-schema-generation
+            (constantly [[1 2]]) "1" 10 [1]
+            :invalid-schema-generation]
+           [:future-schema-generation
+            (constantly [[1 2]]) 11 10 [1]
+            :schema-generation-above-revision]]]
+    (testing (name label)
+      (let [proof
+            (proof-frame/resolve!
+             (proof-frame/request-frame
+              (adapter provider true schema-generation revision))
+             relation-ids)]
+        (is (= :contract-violation (:status proof)))
+        (is (= reason (:reason proof)))
+        (is (nil? (proof-frame/descriptor proof)))))))
+
+(deftest diagnostics-observe-typed-outcomes-without-changing-them
+  (let [diagnostics (atom [])
+        frame
+        (proof-frame/request-frame
+         (adapter (constantly [[1 31]]))
+         {:diagnostic-fn #(swap! diagnostics conj %)})
+        violation (proof-frame/resolve! frame [1])]
+    (is (proof-frame/contract-violation? violation))
+    (is (= [violation] @diagnostics))))
+
+(deftest noncanonical-request-dependencies-fail-closed-before-provider-work
+  (let [calls (atom 0)
+        frame
+        (proof-frame/request-frame
+         (adapter (fn [_] (swap! calls inc) [])))]
+    (doseq [relation-ids [[1 :not-an-eid] [2 1] [1 1]]]
+      (let [proof (proof-frame/resolve! frame relation-ids)]
+        (is (= :unavailable (:status proof)))
+        (is (= :noncanonical-dependencies (:reason proof)))))
+    (is (zero? @calls))))

--- a/modules/eacl/test/eacl/relay_test.cljc
+++ b/modules/eacl/test/eacl/relay_test.cljc
@@ -4,6 +4,7 @@
             [eacl.backend.v8 :as backend]
             [eacl.core :as eacl]
             [eacl.cursor :as cursor]
+            [eacl.proof-frame :as proof-frame]
             [eacl.relay :as relay]
             [eacl.verified-kernel :as verified]))
 
@@ -45,6 +46,29 @@
    :exact-locator revision
    :backend-snapshot-id {:revision revision}})
 
+(defn- proof-adapter
+  [revision provider]
+  (backend/make-adapter
+   {:id :relay-test
+    :capabilities {:cache-proofs #{:ordered-generations}}
+    :fingerprint {:adapter :relay-test}
+    :deterministic? true
+    :operations
+    (merge
+     (operation-map revision nil)
+     {:schema-generation (constantly 3)
+      :proof-frame provider})}))
+
+(defn- proof-opts
+  [selected revision]
+  (let [identity (basis-identity revision)]
+    {:snapshot-semantic-identity identity
+     :cursor-dependency-relation-ids (delay [1])
+     :request-proof-frame
+     (proof-frame/request-frame selected {:basis-identity identity})}))
+
+(declare lookup-query lookup-page)
+
 (deftest cursor-proof-identity-test
   (testing "even equal dependency proofs cannot lift across revisions"
     (let [first-context
@@ -73,6 +97,44 @@
            (adapter 2 {:digest "same"} false))]
       (is (not= (:proof-digest first-context)
                 (:proof-digest later-context))))))
+
+(deftest contract-violating-cursor-proof-falls-back-exact-and-cannot-equal-test
+  (let [producer (proof-adapter 10 (constantly [[1 5]]))
+        invalid-at-10-adapter
+        (proof-adapter 10 (constantly [[1 11]]))
+        consumer (proof-adapter 11 (constantly [[1 12]]))
+        query lookup-query
+        first-page
+        (relay/externalize-page
+         producer (proof-opts producer 10)
+         :lookup-resources query lookup-page)
+        continuation-query
+        (assoc query :after (get-in first-page [:page-info :end-cursor]))
+        error
+        (try
+          (relay/internalize-page-query
+           consumer (proof-opts consumer 11)
+           :lookup-resources continuation-query)
+          nil
+          (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) cause
+            (ex-data cause)))
+        invalid-at-10
+        (relay/dependency-context
+         invalid-at-10-adapter [1])
+        invalid-at-11
+        (relay/dependency-context consumer [1])
+        exact-at-10 (relay/dependency-context invalid-at-10-adapter)
+        exact-at-11 (relay/dependency-context consumer)]
+    (is (= :eacl.pagination/stale-cursor (:type error)))
+    (is (= :dependency-scope-changed (:reason error)))
+    (is (= (:dependency-scope-digest exact-at-10)
+           (:dependency-scope-digest invalid-at-10)
+           (:dependency-scope-digest exact-at-11)
+           (:dependency-scope-digest invalid-at-11))
+        "violated evidence is represented only by exact-snapshot fallback")
+    (is (not= (:proof-digest invalid-at-10)
+              (:proof-digest invalid-at-11))
+        "equal violation status across revisions is never equality evidence")))
 
 (def lookup-query
   {:subject {:type :user :id "user-1"}
@@ -184,6 +246,26 @@
     (is (nil? (relay/lookup-visited-page
                snapshot opts :lookup-resources authoritative-query))
         "a cached public cursor must never cross consistency query scope")))
+
+(deftest read-without-publication-can-read-but-not-write-visited-pages-test
+  (let [snapshot (adapter 1 nil true)
+        page-cache (relay/page-navigation-cache)
+        base-opts {:page-navigation-cache page-cache
+                   :completed-cache? true
+                   :snapshot-semantic-identity (basis-identity 1)}
+        read-only-opts (assoc base-opts :populate-cache-request? false)
+        public-page
+        (relay/externalize-page
+         snapshot base-opts :lookup-resources lookup-query lookup-page)]
+    (relay/remember-visited-page!
+     snapshot read-only-opts :lookup-resources lookup-query public-page)
+    (is (nil? (relay/lookup-visited-page
+               snapshot base-opts :lookup-resources lookup-query)))
+    (relay/remember-visited-page!
+     snapshot base-opts :lookup-resources lookup-query public-page)
+    (is (some? (relay/lookup-visited-page
+                snapshot read-only-opts :lookup-resources lookup-query))
+        "publication control must not disable visited-page lookup")))
 
 (deftest cursor-is-bound-to-normalized-traversal-limits-test
   (let [snapshot (adapter 1 nil true)

--- a/modules/eacl/test/eacl/request/context_test.cljc
+++ b/modules/eacl/test/eacl/request/context_test.cljc
@@ -35,9 +35,8 @@
          generation)
        :proof-frame
        (fn [relation-ids]
-         {:schema-stamp 3
-          :relation-stamps (mapv (fn [relation-id] [relation-id 5])
-                                 relation-ids)})})})))
+         (mapv (fn [relation-id] [relation-id 5])
+               relation-ids))})})))
 
 (defn- test-provider
   ([adapter release-fn]

--- a/modules/eacl/test/eacl/subproblem_cache_test.cljc
+++ b/modules/eacl/test/eacl/subproblem_cache_test.cljc
@@ -103,6 +103,31 @@
     (is (zero? @calls))
     (is (= 1 (:lookup-misses (subproblem/stats store))))))
 
+(deftest read-without-publication-still-looks-up-and-memoizes-locally-test
+  (let [store (subproblem/store)
+        calls (atom 0)]
+    (is (= :warm
+           (:value
+            (subproblem/resolve-independent!
+             store :denotation :warm {} (constantly :warm)))))
+    (let [puts-before (:puts (subproblem/stats store))]
+      (is (= :warm
+             (:value
+              (binding [subproblem/*populate?* false]
+                (subproblem/resolve-independent!
+                 store :denotation :warm {}
+                 #(do (swap! calls inc) :wrong))))))
+      (is (zero? @calls) "the existing entry remains readable")
+      (is (= :computed
+             (:value
+              (binding [subproblem/*populate?* false]
+                (subproblem/resolve-independent!
+                 store :denotation :cold {}
+                 #(do (swap! calls inc) :computed))))))
+      (is (nil? (subproblem/lookup! store :denotation :cold {})))
+      (is (= puts-before (:puts (subproblem/stats store)))
+          "the cold result was not published"))))
+
 (deftest malformed-private-entry-is-non-answering-test
   (let [store (subproblem/store)]
     (swap! (:state store)
@@ -187,7 +212,7 @@
                     subproblem/*managed-scope* {:source-id :primary}
                     subproblem/*managed-key-fn*
                     (fn [_]
-                      {:schema-stamp 7
+                      {:schema-generation 7
                        :dependency-stamp @dependency-stamp})]
             (:value
              (subproblem/resolve-layered-bound!

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/.openspec.yaml
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/design.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/design.md
@@ -1,0 +1,112 @@
+## Context
+
+See `proposal.md`. The state this design starts from, after `add-authorization-views` lands:
+
+- A **basis** is one immutable database value with identity `{backend source-scope source-lifecycle revision exact-locator basis-kind}`; `source-scope` is `{:source-id :branch}` (Datomic database UUID; Datahike `{:store-backend :store-id}` plus branch; Datalevin persisted source UUID; DataScript a per-connection random id from a weak map). The lifecycle defaults to the constant `"eacl/initial"` on Datomic, Datahike, and DataScript and is required, persisted configuration on Datalevin.
+- `eacl.proof-frame/request-frame` lazily reads `:schema-generation` (certified, memoized per adapter) and `:proof-frame` (relation stamps for the canonical closure, ≤ 4,096 relations), validates shape and order, cross-checks the frame's schema stamp against the certified generation (`:eacl/backend-integrity-error` on disagreement), and derives `descriptor` = `{:schema-stamp :dependency-stamp}` with the frontier as `max` over stamps or `0`. Every other defect is `unavailable` with a reason histogram.
+- Managed completed answers live in one `ManagedGeneration` per schema stamp with an install-order guard; entries are keyed `[semantic-key kind dependency-stamp]`; `semantic-key` carries operation, normalized query, evaluation, demand, engine version, order ABI, source lifecycle, adapter fingerprint, and limits — not source scope. Managed subproblems and continuation scopes do carry source scope. No direction check exists anywhere: reuse is equality.
+- Bundled adapters stamp relations with the committing transaction: Datomic `[:db/add relation :eacl/relation-version "datomic.tx"]` and read `:tx` (a transaction entity id); Datahike and DataScript `:db/current-tx` and read `:tx` (in the `max-tx` domain). Datomic's revision is `basis-t`.
+- `ScalarFrontierCoherence.dfy` proves `EqualScalarProofPreservesEveryDeterministicDenotation` over a history `h[0..n]` of `OrderedSupportedStep`s within one `lifecycle`: equal frontier and schema generation at `h[0]` and `h[n]` imply equal evaluator output at both. `OrderedSupportedStep` already assumes every generation visible before a commit is strictly below that commit (the ceiling premise) and that stamped relations receive exactly the committing transaction.
+- Caches are client-private in-process atoms. The cross-process authenticated completed-cache path was deleted by `trusted-surface-hygiene`; cursors and revision tokens are the only portable artifacts and are authenticated by the shared keyring.
+- `DecideCurrentCache` (generated) is a stage machine over `{:stage :available?}`; the frame comparison itself is key equality in `eacl.cache`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One reuse rule, stated in data: lineage + frame equality, used identically by every reusable artifact.
+- Every premise of the proved theorem is either represented in the runtime key or discharged by an executable adapter obligation.
+- A defective adapter cannot feed the cache silently; absence and defect are distinguished.
+- Lifting is direction-agnostic, so retained older snapshots benefit from newer computations.
+- Read-without-populate for measurement and one-off queries.
+- No new trust machinery: no serialized or in-process "sealed" authority objects, no proof epochs, no cross-process registries, no second generated kernel.
+
+**Non-Goals:**
+
+- Changing how any backend stamps relations (Datalevin's storage-level stamping is `certify-datalevin-ordered-generation-proofs`).
+- Cross-process completed-answer sharing. Completed answers stay client-private; nothing here reintroduces portable cache entries.
+- Detecting unstamped out-of-band mutations after the fact. The supported-writer contract, lifecycle rotation, and backend-level enforcement where available remain the boundary.
+- Identity or "external input" stamps. Identity mutation is already neutralized by re-resolving query anchors and re-rendering results on the selected basis; custom codecs are governed by the existing deterministic-fingerprint contract.
+- Managed lifting when a basis cannot provide a complete, contract-valid frame; those bases remain exact-only regardless of basis kind.
+
+## Decisions
+
+### 1. The reuse rule
+
+For a request at basis `S` with canonical relation closure `D`:
+
+```clojure
+lineage  = {:source-scope (:source-scope S) :source-lifecycle (:source-lifecycle S)}
+frame    = {:schema-generation g(S) :dependency-stamp (max 0 (stamps S D))}
+key      = [lineage g(S) semantic-key kind (:dependency-stamp frame)]
+```
+
+An artifact published from basis `E` is reusable at `S` iff its key equals the key computed at `S`. Nothing compares `revision(E)` with `revision(S)`.
+
+**Why direction does not matter.** `EqualScalarProofPreservesEveryDeterministicDenotation` takes a history whose first element is the earlier basis and whose last is the later one, and concludes that the evaluator agrees at *both*. Whether the cached value was produced at the first or the last element is irrelevant to an equality, and the file already states the older-selected case explicitly as `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` (line 858), which nothing cites. Operationally this case already occurs today: two concurrent requests select bases 1040 and 1041, the later one publishes first, and the earlier one hits. The implementation is correct; the documentation and `add-authorization-views` design §8 are stricter than the proof for no benefit. The formal task makes the assurance matrix cite the existing corollary.
+
+**Why lineage is source scope plus lifecycle.** Two bases lie on one linear history exactly when they come from the same database history and no replacement occurred between them. The first is the persisted source identity (or, for a source that cannot persist one, an identity minted once per live source); the second is the operator-rotated lifecycle. This is the existing data; the change makes it the stated premise, puts it in the one key that lacked it, and obliges non-durable sources to mint a fresh identity per live source rather than per configuration (Datahike memory stores with a caller-supplied fixed id currently do not).
+
+### 2. Frame contract
+
+`:proof-frame` returns `[[relation-id generation] ...]` for exactly the requested canonical relation ids, in the same numeric domain as `(:revision (:native-revision adapter))`. Core:
+
+1. takes the schema generation from the certified `:schema-generation` operation only (the second read and the cross-check are removed; both operations read the same datom on every bundled backend);
+2. validates the vector is canonical — relation ids equal the request, generations are exact non-negative integers;
+3. asserts `g <= revision` and every generation `<= revision`;
+4. derives `dependency-stamp`.
+
+Datomic's adapter returns `(d/tx->t (:tx datom))`; Datahike, DataScript, and Datalevin already use the `max-tx` domain. Datomic also drops `:db/noHistory` from `:eacl/relation-version` (altered in place by `write-schema!`'s additive install): with history retained, `d/as-of` at any `t` reads the stamp that was current at `t`, so frame readability no longer depends on whether an index job has run. The attribute's own docstring justified `noHistory` by "only the current stamp is ever read"; that stopped being true when exact-by-locator bases became ordinary request targets. The cost is one retained datom per affected relation per write, beside the two tuple datoms (forward and reverse) every relationship write already retains. The ceiling assertion can only fire on an adapter defect for the bundled backends — a datom visible in an immutable value cannot postdate it — and that is the point: it turns an unchecked premise of the theorem into an executable one for third-party adapters and for Datalevin's scalar stamps.
+
+A missing generation for a relation (uninitialized store, no `prepare-cache-coherence!`), a missing `:proof-frame` operation, a closure above the bound, or an adapter exception that is not a contract violation is **unavailable**: exact evaluation, no managed publication, `:proof-unavailable-reasons` counted, nothing sticky.
+
+### 2a. Readability gates lifting, not basis class
+
+`add-authorization-views` makes historical-class (as-of) bases exact-only. With the frame contract above that exclusion is no longer necessary: an as-of basis at `t` *is* the basis at `t`, its lineage is the same, its stamps read at `t` are exactly those visible at `t`, and the theorem applies. The rule becomes: an admissible basis of any kind uses managed lifting when its frame is readable (integer revision in the stamp domain, every generation present and `<= revision`); otherwise it uses the exact tier only. Datahike `AsOfDB` over a `:keep-history? true` store and Datomic `as-of` (after the `noHistory` change) both read; a Datomic as-of basis that still meets a purged stamp, or a Datahike temporal view with a non-integer time point, is simply unavailable. The practical beneficiary is the reader Peer: a session snapshot selected by exact token keeps the managed entries of earlier sessions across unrelated writes instead of starting cold on every token.
+
+### 3. Contract violation
+
+A frame that is malformed, has duplicate or out-of-order relation ids, wrong cardinality, a non-integer generation, or a generation above the revision is a **contract violation** (`:eacl/backend-contract-violation`, `:operation :proof-frame`, `:reason`). Response, in order: the request evaluates exactly on its already-selected basis and returns normally; the runtime sets `managed-lifting-disabled? true` (sticky until `expire-cache!`); `cache-stats` reports `:proof-contract-violations` by reason; the client's optional diagnostic reporter is invoked once per reason per lifecycle. Cursor continuation treats a violated frame as proof-unavailable and proceeds to exact fallback or the typed stale outcome. Exact-basis caching is unaffected: it is sound by identity.
+
+Why not fail the request: the frame is an optimization input and the selected basis is authoritative. Why not keep treating it as a miss: a violated invariant means the adapter's evidence is not evidence; continuing to consult it on every request is noise, not safety. Why no epoch or registry: caches are process-local, so local disablement is complete for caches; cursors are revalidated against a fresh frame wherever they are presented; cluster-wide invalidation, if an operator wants it, is lifecycle rotation with a shared value — the mechanism that already exists.
+
+### 4. Managed tier shape
+
+The managed completed-answer tier becomes a bounded map `(lineage, schema-generation) → store`, entries keyed `[semantic-key kind dependency-stamp]`, with the same weight/LRU budget as today. The single installed generation and its `installed-order` guard are deleted: they existed to stop a delayed older request from rolling back "the" generation, which has no meaning once several bases are live (`add-authorization-views` retained bases) and lifting is direction-agnostic. `semantic-key` drops `:source-lifecycle`; lineage is a key prefix instead. The managed subproblem key already carries `*managed-scope*` (source scope); it gains nothing but consistency.
+
+### 5. One frame per request, shared by every artifact
+
+`eacl.request.context` already memoizes dependency proofs per closure. Completed answers, managed subproblems, cursors (`enable-proof-equivalent-cursor-streams`), and checkpoints (`enable-proof-equivalent-checkpoints`) all consume the same `frame` value and the same `lineage` value from the context; none derives a second digest of the same data. Purpose is expressed by key shape — answer keys, subproblem keys, cursor envelopes, and checkpoint keys are structurally distinct — not by certificates or domain tags.
+
+One artifact is deliberately *not* frame-keyed: the visited-page cache stores externalized public pages, whose rendering depends on public identity, which the frame does not cover. It stays keyed by exact basis. The projection tier likewise stays per basis.
+
+### 6. `:populate-cache?`
+
+Request option, `true` by default, validated as `nil`/boolean. `false` suppresses every cross-request publication the request would otherwise perform — completed answers, managed subproblems, checkpoints, visited pages — and changes nothing else: lookups, proof acquisition needed for a lookup or a cursor, and request-local memoization proceed. With `:cache? false` the option is accepted and irrelevant. No write-only mode: a request that reads nothing and publishes evaluates exactly like one that reads and misses, so the fourth combination has no distinct meaning worth an API surface.
+
+### 7. Formal and certification
+
+- `ScalarFrontierCoherence.dfy`: document that `lifecycle` models the runtime lineage (source scope plus lifecycle); cite the existing `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` from the assurance matrix and `docs/cache.md`; keep the existing counterexample for independent counters.
+- `NativeGenerationCoherence.dfy` lifting-direction statement and the `add-authorization-views` assurance-obligation mapping are updated to the lineage rule.
+- Adapter certification v2 gains executable obligations: generations and revision share a domain; after every supported mutation, every affected relation's generation equals the committed revision and every generation at any selected basis is `<= revision`; non-durable sources mint distinct source ids across reconnects. Mutation controls for these obligations must execute against the adapter (the registry's literal-only detectors do not count).
+- The trust manifest lists the domain, ceiling, lineage, and supported-writer premises as adapter assumptions, not theorems.
+
+## Rejected alternatives
+
+- **Sealed in-process certificate objects that adapters "cannot construct."** Nothing in one JVM or JS process is unforgeable against code in that process; a private `deftype` is a convention with a reflection-sized hole. The discipline it would buy — only core builds the frame — already holds by code structure and is pinned by the production-decision inventory and source-closure ledger.
+- **Proof epochs with a coordinated durable registry.** Solves invalidation for a cross-process cache that does not exist. For cursors, revalidation at presentation time and lifecycle rotation already give the two available responses.
+- **Exact-vector profile beside the scalar frontier.** Equivalent power under the bundled stamp discipline (global commit ordering), `O(n)` storage per entry, and no backend that would need it. The frontier's extra premise — global ordering — is the one every bundled backend satisfies by construction.
+- **Exact / provider-session / durable lineage profiles as negotiated capabilities.** Lineage is a fact about the source (can it persist an identity or not) and is already represented in `source-scope`. A capability enum would add negotiation to express one boolean that the source id already encodes.
+- **Identity and external-input components with their own generations.** No bundled backend can stamp application writes to `:eacl/id` (Datomic has no write interception), and none needs to: anchors are internalized and results externalized on the selected basis, so identity mutation changes keys and renderings rather than reusing stale ones. Declared external inputs reduce to the existing custom-codec fingerprint contract.
+- **A second generated acceptance kernel with a reject-by-default source audit.** The acceptance decision is map lookup by a complete key; generating `=` adds artifact weight without assurance. `DecideCurrentCache` and `DecideContinuation` remain the generated decisions they are.
+- **Order dominance (`order(E) <= order(S)`).** Not a premise of the proof; costs hits on retained older snapshots.
+- **Keeping `:db/noHistory true` on the Datomic stamp.** Saves one retained datom per affected relation per write and makes frame readability at as-of bases depend on indexing timing, which is the wrong property for a cache key and the reason two special cases exist.
+- **Compatibility constructors, legacy-entry handling, migration plans, rollback stories.** v8 is unreleased.
+
+## Risks / Trade-offs
+
+- **[Datomic `dependency-stamp` changes domain]** → cursors, tokens, and caches are regenerated; there are no released artifacts. Certification pins the domain so it cannot drift again.
+- **[Retained stamp history grows the Datomic history index]** → proportional to relationship writes, already dominated by retained tuple datoms; measured by the Datomic write benchmark and recorded.
+- **[Sticky disablement hides a transient bug until restart]** → disablement is visible in `cache-stats` and the reporter; `expire-cache!` clears it; exact evaluation continues unchanged.
+- **[Non-durable Datahike stores with fixed ids today share lineage across restarts]** → the source mints a per-connection id for memory stores regardless of configured id; the conformance suite pins restart rejection for every non-durable source.
+- **[Direction-agnostic lifting surprises readers of the old documentation]** → the rule, the corollary, and the concurrency example are documented together in `docs/cache.md`.

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/proposal.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+EACL v8 already reuses authorization work across bases through a proof-carrying boundary: a basis adapter returns raw relation stamps, core validates them into one request-scoped frame (certified schema generation plus the scalar frontier of the request's complete relation closure), and every reusable artifact — completed answer, managed subproblem, cursor, checkpoint — is admitted by equality of a key that contains that frame. `ScalarFrontierCoherence.dfy` proves the rule sound under explicit premises. The runtime leaves four of those premises unstated or unchecked, and one documented restriction is stronger than the theorem:
+
+1. **Lineage.** Generations are comparable only along one linear history. The identity that separates histories already exists — `source-scope` carries the persisted Datomic database id, the Datahike store id and branch, Datalevin's persisted source id, and a fresh per-connection id for DataScript and in-memory Datahike — but it is absent from the managed completed-answer key, and no adapter obligation names it as the lineage witness. The planned constant default lifecycle (`add-authorization-views`) removes the accidental process isolation the random default provided, so the witness must be explicit.
+2. **Numeric domain and ceiling.** The theorem requires every stamp visible at a basis to be no later than that basis. Datomic returns stamps as transaction entity ids while its revision is `basis-t`; nothing fixes one domain, and nothing checks `stamp <= revision`. A defective adapter's frame is accepted as evidence.
+3. **Duplicate schema evidence and flat failure classification.** The frame reads the schema generation a second time and cross-checks it against the certified `:schema-generation` operation that reads the same datom; every other defect — malformed, duplicated, out-of-order, future stamps — is classified as "unavailable", an optimization miss that is retried on the next request even though it contradicts a certified invariant.
+4. **Direction.** The lifting rule is documented as forward-only (`dependency-validated-authorization-cache`, and `add-authorization-views` design §8 would add a direction check on the grounds that "a symmetric lemma does not exist yet"). The lemma exists: `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` (`ScalarFrontierCoherence.dfy:858`) is proved and cited nowhere. The main theorem is an equality over the two endpoints of one history segment and does not care which endpoint holds the cached value; the implementation performs no direction check today and is correct. A direction check would discard hits for retained snapshots in exactly the reader-Peer pattern `add-authorization-views` exists to serve.
+
+5. **Readability.** Datomic declares `:eacl/relation-version` with `:db/noHistory true` ("only the current stamp is ever read"). That premise fails for any basis selected by exact locator — `d/as-of` — which is exactly how a reader Peer holds a session: superseded stamps are dropped at the next index job, so whether a frame can be read at an as-of basis depends on indexing timing. The Datomic client already carries a special case (`exact-fallback-decision`) to cope, and `add-authorization-views` makes every historical-class basis exact-only partly for this reason. The storage saving is one history datom per affected relation per write, beside the two tuple datoms every relationship write already retains.
+
+Independently, there is no way to read the cache without populating it: `:cache? false` bypasses both lookup and publication.
+
+## What Changes
+
+- **Reuse rule, stated once.** Two bases are comparable iff they share one lineage: equal source scope and source lifecycle. A reusable artifact is keyed by its semantic request, its configuration fingerprint, and the frame `{:schema-generation :dependency-stamp}` at its computation basis; it is reused at any basis in the same lineage whose frame is equal, in either direction. No certificate, kernel, or order comparison is added: the decision is key equality, as it is today.
+- **Frame contract hardened.** The adapter `:proof-frame` operation returns relation generations only, in the same numeric domain as `:native-revision`; core takes the schema generation solely from the certified `:schema-generation` operation; core asserts every generation is `<= revision`. Datomic converts transaction ids to `t` and retains stamp history (`:db/noHistory false`), so a frame is readable deterministically at every admissible basis.
+- **Frame readability, not basis class, gates lifting.** An admissible basis of any kind may use managed lifting when its frame is readable in its lineage; a basis whose frame is unavailable uses the exact tier only. This relaxes the historical-class exclusion `add-authorization-views` keeps as its conservative baseline.
+- **Contract violation is not unavailability.** Absent or transiently unreadable evidence remains an optimization miss. Malformed, duplicated, non-canonical, or above-ceiling evidence is a backend contract violation: the request still evaluates exactly, the runtime disables managed lifting until `expire-cache!`, and the event is counted and reported. No proof epoch, registry, or cluster protocol.
+- **Lineage in every key.** The managed completed-answer tier is keyed by lineage and schema generation, then `[semantic-key kind dependency-stamp]`, matching the managed subproblem and continuation keys. The single "installed managed generation" and its order guard are replaced by a bounded map of schema generations, consistent with retained bases.
+- **`:populate-cache?`** request option, default `true`: `false` performs every read the request would otherwise perform and publishes nothing across requests.
+- **Formal and certification deltas.** The Dafny model names lineage explicitly and the assurance matrix cites the existing direction-agnostic corollary; adapter certification executes the domain and ceiling obligations; the trust manifest lists them.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `dependency-validated-authorization-cache`: lineage-scoped, direction-agnostic lifting; lineage in the managed key; contract-violation classification; `:populate-cache?`.
+- `forward-history-cache-coherence`: frame contract (relation generations only, one numeric domain, ceiling, retained stamp history), lineage premise, direction-agnostic rule, readability instead of basis class, violation versus unavailability.
+- `authorization-snapshots`: runtime sharing follows frame readability rather than basis class.
+- `backend-native-revision-consistency`: source scope is the lineage witness; non-durable sources mint a per-live-source identity; lifecycle rotation remains the replacement boundary.
+- `modular-backend-workspace`: the proof-frame operation shape and obligations; one request frame shared by answers, subproblems, cursors, and checkpoints.
+- `managed-reuse-certification`: executable domain/ceiling certification; differential coverage of older retained bases.
+- `formally-verified-authorization-engine`: lineage premise and direction-agnostic corollary in the model and manifest; the cache-equivalence requirement restated against basis identity and the frame rule.
+
+## Impact
+
+- Modules: `eacl.proof-frame`, `eacl.cache`, `eacl.subproblem-cache`, `eacl.request.context`, `eacl.backend.v8` obligations, bundled adapter `:proof-frame` implementations (Datomic domain conversion), client option validation, `cache-stats`.
+- Depends on `add-authorization-views` for basis identity, the three backend roles, and retained bases; supersedes its design §8 direction restriction and the "Candidate is newer than a retained snapshot" scenario in its `dependency-validated-authorization-cache` delta, which should be dropped before that change is implemented.
+- Datomic `dependency-stamp` values change domain (`t` instead of tx entity id); v8 is unreleased, so no entry, token, or cursor migration exists.
+- Cursor continuation (`enable-proof-equivalent-cursor-streams`) and checkpoint reuse (`enable-proof-equivalent-checkpoints`) apply this rule to their artifacts; Datalevin (`certify-datalevin-ordered-generation-proofs`) supplies a frame under it.
+
+## Related changes
+
+Already applied or archived; this change modifies their outcomes rather than their artifacts:
+
+- `eliminate-authorization-request-amplification` (applied): its task 2.3 kept the frame's `:schema-stamp` and added the agreement check against the certified `:schema-generation`; both are removed here because every bundled adapter reads the same datom for both.
+- `archive/2026-08-15-redesign-cross-backend-freshness-cache`: origin of the forward-only wording in `dependency-validated-authorization-cache`, now lineage-scoped.
+- `archive/2026-08-15-remove-unknown-cache-coherence` and `archive/2026-08-15-simplify-cache-coherence`: origin of the scalar-frontier requirement and the `:tx`-reading `ordered-generation-frame` implementations whose numeric domain this change fixes.
+- `archive/2026-08-15-upgrade-datascript-datahike-to-v8`: origin of the Datahike memory-store `:id` default (`schema.clj:155-159`) that a caller-supplied fixed id overrides; the per-live-source obligation closes it.
+- `archive/2026-08-15-eacl-v8-root-fixes` (`trusted-surface-hygiene`): deleted the cross-process authenticated cache path; this change deliberately does not reintroduce one.

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/authorization-snapshots/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/authorization-snapshots/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime sharing by cache class
+Snapshots created from one `acl` SHALL share its runtime registries only through keys that include complete basis identity or the lineage-scoped frame. Any admissible snapshot MAY use the exact-basis tier; a snapshot whose frame is readable MAY use managed lifting under the lineage-scoped frame rule in either revision direction; a snapshot whose frame is unavailable MAY use only exact-basis entries; subproblem and projection state SHALL be isolated per basis generation.
+
+#### Scenario: Two snapshots at different bases
+- **WHEN** two snapshots of one lineage at different bases read equal frames
+- **THEN** a managed answer computed through one is reusable by the other, and neither observes the other's projections or subproblems
+
+#### Scenario: Frame unavailable
+- **WHEN** a snapshot's frame cannot be read
+- **THEN** it reuses only exact entries bound to its own basis identity

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/backend-native-revision-consistency/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/backend-native-revision-consistency/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Adapter-scoped proof and cursor identity
+Every proof frame, completed answer, managed subproblem, checkpoint, cursor, and revision token SHALL be bound to the lineage — source scope and configured source lifecycle — and the adapter identity that selected its basis. Selecting a basis of another lineage or recovering a retained revision SHALL construct a new frame rather than reuse evidence captured elsewhere.
+
+#### Scenario: Cursor recovers a retained revision
+- **WHEN** cursor validation selects a retained immutable value through a different adapter instance or selection context
+- **THEN** EACL constructs and validates a frame scoped to that selected adapter and value before admitting reusable state
+
+#### Scenario: Adapter identity differs
+- **WHEN** an otherwise matching proof or cursor was produced by a different adapter identity, source scope, or source lifecycle
+- **THEN** EACL rejects it before cache reuse or authorization evaluation
+
+#### Scenario: Client-local custom codec identity
+- **WHEN** a cursor was issued using an unfingerprinted custom identity codec
+- **THEN** another client lifecycle does not accept that cursor even when signing keys are shared
+
+## ADDED Requirements
+
+### Requirement: Source scope is the lineage witness
+Two bases SHALL be treated as comparable — for revision ordering, generation comparison, and every cross-basis reuse — only when their source scope and source lifecycle are equal. A basis source whose backend persists a stable source identity SHALL expose that identity in its source scope. A basis source whose backend cannot persist one, or whose configured store is not durable, SHALL mint a fresh random source identity once per live source and SHALL NOT reuse a configured or previous identity across reconnection or restart. Configuration labels and operator declarations MUST NOT substitute for either component.
+
+#### Scenario: Durable source
+- **WHEN** a Datomic database, a durable Datahike store, or a Datalevin store is reopened
+- **THEN** its source scope carries the same persisted identity and forward revisions remain comparable under the same lifecycle
+
+#### Scenario: In-memory source restarts
+- **WHEN** a DataScript connection, a Datahike memory store, or a Datomic memory database is recreated with equal content and repeated revision numbers under the constant default lifecycle and a shared keyring
+- **THEN** tokens and cursors from the previous live source are rejected for scope mismatch before any proof comparison
+
+#### Scenario: Fixed memory-store id
+- **WHEN** a Datahike memory store is configured with a caller-supplied fixed store id
+- **THEN** the basis source still mints a per-connection source identity and does not expose the fixed id as lineage
+
+#### Scenario: History replacement
+- **WHEN** an operator restores, resets, or replaces a durable source
+- **THEN** lifecycle rotation remains the required boundary and unrotated siblings receive no comparability guarantee

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/dependency-validated-authorization-cache/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/dependency-validated-authorization-cache/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: Cache lifting is lineage-scoped
+EACL SHALL return a managed candidate computed at another basis only when the candidate and the selected basis share one lineage — equal source scope and equal source lifecycle — the selected basis has a readable, contract-valid frame, and the candidate's complete frame (certified schema generation and scalar dependency frontier over the complete canonical closure) equals the frame read at the selected basis. The rule SHALL NOT compare the two revisions or exclude a basis by kind: a candidate computed at a newer basis is as reusable at an older admissible basis of the same lineage as the reverse. Numeric revision equality, lifecycle equality alone, or raw adapter stamps MUST NOT lift an answer across replacement or sibling history.
+
+#### Scenario: Candidate precedes the selected basis
+- **WHEN** the selected basis is later in the same lineage and the frames are equal
+- **THEN** EACL may return the candidate
+
+#### Scenario: Candidate follows the selected basis
+- **WHEN** a retained snapshot at an older basis reads a frame equal to that of a candidate computed at a newer basis in the same lineage
+- **THEN** EACL may return the candidate
+
+#### Scenario: Candidate is from another lineage
+- **WHEN** a candidate belongs to a different source scope or source lifecycle
+- **THEN** EACL treats it as a miss even if revision numbers and frames compare equal
+
+#### Scenario: Validation telemetry is reused
+- **WHEN** an entry records a prior `validated-at` value newer than its computation point
+- **THEN** a later request still compares the frame read at the selected basis
+- **AND** MUST NOT treat `validated-at` as a lease or a lineage witness
+
+### Requirement: Semantic cache keys are complete
+The cache lookup key SHALL distinguish cache/engine/adapter versions, lineage (source scope and source lifecycle), operation, complete canonical internal query, pagination state, result kind, and every recursion, traversal, count, object-codec, caveat, or adapter option capable of changing the answer. The managed completed-answer tier SHALL be keyed by lineage and certified schema generation, then by semantic key, result kind, and dependency frontier; managed subproblem and continuation keys SHALL carry the same lineage.
+
+#### Scenario: Two sources share a runtime
+- **WHEN** bases from different source scopes reach one runtime
+- **THEN** their managed entries cannot collide or validate across scopes
+
+#### Scenario: Engine configuration changes
+- **WHEN** an answer-affecting traversal limit, codec contract, adapter implementation, or algorithm version changes
+- **THEN** the new request cannot reuse the old entry
+
+#### Scenario: Hash collision is attempted
+- **WHEN** two canonical queries have the same compact hash
+- **THEN** embedded full-key equality prevents substitution
+
+### Requirement: Cache failures degrade only to selected-snapshot evaluation
+Provider errors, absent proofs, and transient proof-computation failures SHALL become misses and fall back to uncached evaluation on the selected basis. A proof-frame contract violation SHALL also fall back to exact evaluation for the request, and SHALL additionally disable managed lifting for the runtime until `expire-cache!`, count the violation by reason, and report it through the optional diagnostic reporter. Token, causal freshness, source-scope, and exact-snapshot failures MUST remain request errors.
+
+#### Scenario: Cache provider throws
+- **WHEN** lookup or storage fails
+- **THEN** EACL computes and returns the selected-basis answer
+
+#### Scenario: Proof frame violates its contract
+- **WHEN** an adapter returns a duplicate, non-canonical, non-integer, or above-revision generation
+- **THEN** EACL evaluates exactly, publishes no managed entry, disables managed lifting for the runtime, and records the reason
+
+#### Scenario: Token anchor is missing
+- **WHEN** consistency selection cannot prove the requested mutation is present
+- **THEN** EACL rejects the request and MUST NOT hide the failure behind an uncached current read
+
+## ADDED Requirements
+
+### Requirement: Cache reads and cache population are independently controlled
+Every cache-capable authorization read SHALL accept `:populate-cache?`, defaulting to `true`. When `false`, EACL SHALL perform every lookup, proof acquisition, and request-local memoization the request would otherwise perform and SHALL publish no completed answer, managed subproblem, checkpoint, or visited page across requests. When `:cache? false` is also supplied, no lookup or publication occurs and `:populate-cache?` has no further effect. Neither option SHALL be part of any cache, cursor, or continuation identity.
+
+#### Scenario: Read-only hit
+- **WHEN** a request with `:populate-cache? false` matches an existing exact or managed entry
+- **THEN** EACL returns the entry and writes nothing
+
+#### Scenario: Read-only miss
+- **WHEN** a request with `:populate-cache? false` misses
+- **THEN** EACL evaluates on the selected basis and publishes nothing
+
+#### Scenario: Pagination needs evidence
+- **WHEN** `:populate-cache? false` is used for a continued page
+- **THEN** cursor validation still acquires the frame it needs and checkpoint publication is suppressed

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/formally-verified-authorization-engine/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/formally-verified-authorization-engine/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Proven cache observational equivalence
+The verified kernel SHALL mechanically prove that every returned cache hit equals fresh evaluation of the same semantic request on the selected immutable basis. Exact-basis entries SHALL be accepted only from the identical complete basis identity. Managed entries SHALL additionally require equal lineage, equal certified schema generation, and an equal scalar dependency frontier over the complete closure under the explicit stamped-writer contract, in either revision direction. A basis whose frame is unavailable SHALL use only exact-basis entries; engine-facade and inadmissible database values SHALL bypass completed-answer lookup and publication.
+
+#### Scenario: Exact cache hit
+- **WHEN** a valid cache entry was computed for the identical basis identity and semantic key
+- **THEN** EACL may return its value and the value equals fresh evaluation
+
+#### Scenario: Managed reuse in either direction
+- **WHEN** a valid entry and the selected basis share one lineage and have equal frames
+- **THEN** EACL may return the entry and the scalar-frontier theorem establishes equality with selected-basis recomputation, whichever basis is older
+
+#### Scenario: Frame unavailable or inadmissible value
+- **WHEN** a basis's frame is unavailable or a value reaches the engine facade
+- **THEN** EACL uses only exact-basis entries or bypasses completed-answer caching respectively
+
+#### Scenario: Incomplete managed stamp
+- **WHEN** EACL cannot obtain one valid generation for every relation in the closure
+- **THEN** it rejects managed reuse and computes from the selected basis, while exact-basis reuse remains independently sound
+
+#### Scenario: Lifecycle expiry race
+- **WHEN** an in-flight computation publishes after explicit client cache expiry
+- **THEN** publication can reach only the captured old lifecycle and cannot repopulate the new lifecycle
+
+## ADDED Requirements
+
+### Requirement: Lineage premise and direction-agnostic lifting are stated in the model
+The formal cache model SHALL state that its history is one lineage — equal source scope and source lifecycle in the runtime — and its existing corollary `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` SHALL be the cited evidence that equal frames at two bases of one lineage imply equal protected semantics whichever basis holds the cached value. The assurance matrix SHALL cite that corollary for managed reuse at retained older bases, and the trust manifest SHALL list the numeric-domain, ceiling, atomic-stamping, lineage, and supported-writer premises as adapter assumptions rather than proved properties.
+
+#### Scenario: Corollary is cited
+- **WHEN** a reviewer inspects the assurance matrix entry for managed reuse at a retained older basis
+- **THEN** it names the direction-agnostic corollary and its premises
+
+#### Scenario: Premise is listed, not claimed
+- **WHEN** the trust manifest is generated
+- **THEN** the ceiling and domain obligations appear as executable adapter obligations and not as theorems

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/forward-history-cache-coherence/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/forward-history-cache-coherence/spec.md
@@ -1,0 +1,64 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Historical bases never use managed cross-snapshot lifting`
+- TO: `### Requirement: Managed lifting requires a readable frame in one lineage`
+
+## MODIFIED Requirements
+
+### Requirement: Complete scalar dependency proof
+For admissible bases with readable, contract-valid frames in one lineage, managed reuse SHALL require equal lineage (source scope and source lifecycle), semantic request identity, result shape, certified schema generation, and scalar dependency frontier. The complete canonical dependency closure SHALL be a deterministic function of equal schema semantics and normalized semantic request. The frontier SHALL be the maximum relation generation over every relation in that closure, or the distinguished initial value when the closure is empty. Generations SHALL be expressed in the same numeric domain as the basis revision, and every generation visible at a basis SHALL be less than or equal to that basis's revision. A proof SHALL be valid only when every supported relevant mutation stamps every affected relation atomically with the committed revision of its own transaction, which is greater than every generation visible before it. The rule SHALL hold in both directions of one lineage: equal frames at two bases imply equal protected semantics regardless of which basis is older.
+
+#### Scenario: Unrelated transaction
+- **WHEN** a transaction changes no relation in the complete dependency closure and does not change authorization schema
+- **THEN** the schema generation and dependency frontier remain equal and the managed answer may be reused
+
+#### Scenario: Relevant relationship mutation
+- **WHEN** a supported transaction changes any relation in the complete dependency closure
+- **THEN** the transaction stamps that relation with its committed revision, the frontier at every later basis is greater, and the previous managed answer cannot match
+
+#### Scenario: Several relevant relations change atomically
+- **WHEN** one supported transaction changes several dependency relations
+- **THEN** every affected relation receives the same committed revision and the frontier advances once
+
+#### Scenario: Older retained basis
+- **WHEN** a request at an older basis of the same lineage reads a frame equal to an entry computed at a newer basis
+- **THEN** the entry's value equals exact evaluation at the older basis and may be returned
+
+#### Scenario: Empty dependency closure
+- **WHEN** the complete authorization dependency closure contains no relationship relation
+- **THEN** EACL uses the distinguished initial frontier together with the schema generation rather than treating proof as unavailable
+
+### Requirement: Complete proof availability
+EACL SHALL classify each frame read as complete, unavailable, or a contract violation. Unavailable covers an adapter without the proof operation, an uninitialized generation for a relation in the closure, a closure above the configured relation bound, and a transient adapter failure; it SHALL produce exact evaluation on the selected basis, no managed publication, and a counted reason, and SHALL NOT be sticky. A contract violation covers a malformed frame, duplicate or non-canonical relation ids, a non-integer generation, and a generation above the selected basis's revision; it SHALL produce exact evaluation for the request, sticky disablement of managed lifting for the runtime until `expire-cache!`, a counted reason, and a report through the optional diagnostic reporter. Neither class SHALL change authorization availability, substitute an initial generation, or use partial evidence.
+
+#### Scenario: Uninitialized relation generation
+- **WHEN** a relation in the closure has no generation on the selected basis
+- **THEN** the frame is unavailable and the next request reads again
+
+#### Scenario: Generation above the revision
+- **WHEN** an adapter returns a generation greater than the selected basis's revision
+- **THEN** the frame is a contract violation, the request evaluates exactly, and managed lifting is disabled for the runtime
+
+#### Scenario: Cache is disabled
+- **WHEN** a consumer selects the no-cache implementation or disables caching for one request
+- **THEN** EACL performs no completed-answer cache lookup or publication
+
+
+### Requirement: Managed lifting requires a readable frame in one lineage
+A request at any admissible basis — ordinary, captured, loaded by exact locator, supplied directly, or as-of — MAY use managed lifting when its frame is readable: an exact-integer revision in the stamp domain, every closure generation present, the schema generation present, and every generation `<= revision`. A basis whose frame is unavailable SHALL probe only exact answers bound to its identical basis identity and SHALL publish only at that exact key. Basis kind SHALL NOT by itself exclude a basis from lifting, and EACL MUST NOT validate any answer using stamps read through a view that cannot expose them.
+
+#### Scenario: As-of basis with retained stamp history
+- **WHEN** a Datomic `as-of` basis at `t` reads its frame after stamp history is retained and an index job has run
+- **THEN** the frame equals the stamps current at `t` and a managed answer with an equal frame in the same lineage may be returned
+
+#### Scenario: Frame unavailable at a basis
+- **WHEN** a basis's revision is not an exact integer in the stamp domain or a closure generation is absent
+- **THEN** the request uses only exact answers for that identical basis and evaluates otherwise
+
+#### Scenario: Reader Peer changes session
+- **WHEN** a reader selects a new session basis by exact token after unrelated writes
+- **THEN** managed answers computed in the previous session with equal frames are reused
+
+#### Scenario: Public response metadata
+- **WHEN** an exact or managed answer is reused
+- **THEN** tokens, cursor envelopes, cache basis, external identifiers, and other public metadata are rebuilt from the selected basis

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/managed-reuse-certification/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/managed-reuse-certification/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Randomized differential coverage of the managed tier
+A randomized cached-versus-cache-free differential oracle SHALL run with the managed tier active on every bundled backend that advertises ordered generations, interleaving EACL-API relationship, schema, and object-deletion writes with checks, lookups, counts, and paginated reads, asserting answer equality at every step. The generator SHALL include requests at retained older bases after newer computations have published, and concurrent publication in either revision order, so direction-agnostic lifting is exercised.
+
+#### Scenario: Managed oracle in CI
+- **WHEN** the differential suites run in CI
+- **THEN** at least one generator-driven configuration per ordered-generation backend has managed answer caching enabled and its interleaved-write comparisons pass
+
+#### Scenario: Older retained basis hits a newer entry
+- **WHEN** the generator reads at a retained basis after a newer basis published an equal-frame entry
+- **THEN** the reused answer equals cache-free evaluation at the retained basis
+
+## ADDED Requirements
+
+### Requirement: Generation domain, ceiling, and lineage obligations are executable
+Adapter certification SHALL execute, against each bundled adapter and any third-party adapter claiming ordered generations: that relation generations and the native revision share one numeric domain; that after every supported mutation each affected relation's generation equals the committed revision; that every generation readable at any selected basis is less than or equal to that basis's revision; and that a non-durable source mints a distinct source identity per live source. Mutation controls for these obligations SHALL run against the adapter implementation; a registry entry whose detector only restates the expected values in test-local literals SHALL NOT discharge them.
+
+#### Scenario: Future stamp control
+- **WHEN** a control adapter reports a generation above its revision
+- **THEN** certification observes the contract-violation classification and the runtime disablement
+
+#### Scenario: Domain drift control
+- **WHEN** a control Datomic adapter reports transaction entity ids instead of `t`
+- **THEN** the ceiling obligation fails certification
+
+#### Scenario: Reconnected in-memory source
+- **WHEN** certification reconnects a DataScript or memory Datahike source with identical content
+- **THEN** the new source scope differs and artifacts from the old source are rejected

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/modular-backend-workspace/spec.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/specs/modular-backend-workspace/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: One immutable request proof frame
+The backend-neutral contract SHALL expose one immutable frame per request for the exact selected adapter, lineage, and basis: the certified schema generation, the canonical relation closure, and the scalar dependency frontier derived from one `:proof-frame` read. Completed answers, managed subproblems, schema planning, cursor validation, and checkpoint keys SHALL consume that one frame and the one lineage value from the request context rather than acquiring or digesting duplicate evidence. Purpose SHALL be expressed by key shape; no artifact SHALL carry a separately issued equivalence certificate.
+
+#### Scenario: Exact cache hits first
+- **WHEN** exact-basis lookup succeeds before a frame is needed
+- **THEN** the adapter performs no relation-generation reads for that completed answer
+
+#### Scenario: Several request consumers need the frame
+- **WHEN** schema planning, a completed-answer lookup, managed subproblems, cursor validation, and checkpoint lookup require the same schema and relation evidence
+- **THEN** they share the lazily acquired frame scoped to that request and the adapter reads each relation generation at most once
+
+#### Scenario: Subproblem adds an unproved relation
+- **WHEN** a managed subproblem declares a dependency outside the complete relation set established by the request frame
+- **THEN** that subproblem is not admitted as a managed hit or publication from partial evidence
+
+#### Scenario: Proof provider fails
+- **WHEN** the adapter proof operation throws transiently or a generation is absent
+- **THEN** the request remains exact-only, no partial frame is retained, and nothing is disabled
+
+#### Scenario: Proof provider violates the contract
+- **WHEN** the adapter returns malformed, duplicate, non-canonical, or above-revision evidence
+- **THEN** the request remains exact-only and the runtime disables managed lifting until `expire-cache!`
+
+### Requirement: Certified ordered-generation adapter capability
+A cache-capable basis adapter SHALL certify immutable snapshot identity, a `:proof-frame` operation returning exactly the requested canonical relation generations in the same numeric domain as its native revision, a certified `:schema-generation` operation reading the transactionally maintained schema stamp, generations that never exceed the selected basis's revision, and native committed revisions that are globally ordered across supported commits within one lineage. The frame SHALL NOT return a schema generation of its own. Adapters without the ordered-generation capability SHALL remain valid exact-basis adapters.
+
+#### Scenario: Bundled backend certification
+- **WHEN** Datomic, Datahike, DataScript, or Datalevin executes a supported relationship mutation
+- **THEN** adapter certification observes that every affected relation generation equals the committed revision of that transaction, exceeds every prior generation, and is reported in the revision domain
+
+#### Scenario: Datomic domain conversion
+- **WHEN** the Datomic adapter reads a relation stamp datom
+- **THEN** it reports `(d/tx->t (:tx datom))`, the same domain as `basis-t`
+
+#### Scenario: Exact-basis-only adapter
+- **WHEN** an adapter supplies stable immutable snapshot identity but not certified ordered generations
+- **THEN** the shared engine may use exact-basis caching without cross-basis managed reuse
+
+#### Scenario: Third-party adapter declares numbers only
+- **WHEN** a third-party adapter declares ordered generations but fails the domain, ceiling, atomic-stamping, or lineage obligations in certification
+- **THEN** the adapter is not certified for the ordered-generation capability

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/tasks.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/tasks.md
@@ -1,0 +1,35 @@
+## 1. Frame Contract
+
+- [x] 1.1 Change `:proof-frame` to return `[[relation-id generation] ...]` only; remove the frame's schema read and the schema-generation cross-check; take the schema generation from the certified `:schema-generation` operation in `eacl.proof-frame`.
+- [x] 1.2 Add the numeric-domain obligation (generations share the `:native-revision` domain) to the adapter obligations in `eacl.backend.v8`; convert Datomic's adapter to `d/tx->t`; confirm Datahike, DataScript, and Datalevin already return `max-tx`-domain values.
+- [x] 1.3 Assert `schema-generation <= revision` and every relation generation `<= revision` in the frame validator.
+- [x] 1.4 Split frame outcomes into complete, unavailable (absent generation, missing operation, closure bound, transient adapter failure), and contract violation (malformed shape, duplicate or non-canonical ids, non-integer or above-ceiling generation); add `eacl.proof-frame` tests for every class.
+- [x] 1.5 Alter Datomic `:eacl/relation-version` to `:db/noHistory false` in the additive schema install (new and existing databases), update its docstring, and add a test that a frame read through `d/as-of` at an older `t` returns the stamps current at `t` after an index job; record the history-index growth in the Datomic write benchmark.
+- [x] 1.6 Gate managed lifting on frame readability instead of basis kind: an as-of basis with a readable frame lifts; an unavailable frame is exact-only; add Datomic `as-of` and Datahike `AsOfDB` (keep-history) tests for both outcomes and a reader-Peer session test that entries survive a token change across unrelated writes.
+
+## 2. Lineage and the Reuse Key
+
+- [x] 2.1 Define `lineage` = `{:source-scope :source-lifecycle}` on the request context, derived from basis identity, and expose `frame` and `lineage` as the single values every cache, cursor, and checkpoint consumer reads.
+- [x] 2.2 Replace the single installed `ManagedGeneration` and its order guard with a bounded map keyed by `(lineage, schema-generation)`; keep entry keys `[semantic-key kind dependency-stamp]`; drop `:source-lifecycle` from `semantic-key`.
+- [x] 2.3 Remove every remaining direction comparison or documentation claim that lifting is forward-only; add a test in which a retained older snapshot hits an entry computed at a newer basis with an equal frame, and a test in which the same pattern misses when the frame differs.
+- [x] 2.4 Oblige basis sources to mint a fresh source id per live source when the backend cannot persist one (DataScript, Datahike memory stores with any configured id, Datomic `mem` databases by their generated database id); add a cross-process rejection test per non-durable source under the constant default lifecycle and a shared keyring.
+
+## 3. Contract Violation Handling
+
+- [x] 3.1 On a contract violation: evaluate exactly, set the runtime's sticky `managed-lifting-disabled?`, count `:proof-contract-violations` by reason in `cache-stats`, invoke the optional diagnostic reporter once per reason per lifecycle; clear the flag in `expire-cache!`.
+- [x] 3.2 Make cursor continuation treat a violated frame as proof-unavailable (exact fallback or typed stale outcome) and never as equality.
+- [x] 3.3 Verify exact-basis caching, revision tokens, and authorization availability are unaffected by disablement.
+
+## 4. `:populate-cache?`
+
+- [x] 4.1 Validate `:populate-cache?` (`nil`/boolean) on every cache-capable public read; strip it from every cache, cursor, and continuation identity like `:cache?`.
+- [x] 4.2 Suppress completed-answer, managed-subproblem, checkpoint, and visited-page publication when `false`; leave lookups, cursor proof acquisition, and request-local memoization unchanged.
+- [x] 4.3 Add tests: read-only request hits an existing entry and publishes nothing; miss evaluates exactly and publishes nothing; `:cache? false` with either value performs no lookup and no publication; a paginated read-only request still validates its cursor.
+
+## 5. Formal, Certification, and Documentation
+
+- [x] 5.1 Cite the existing `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` from the assurance matrix and `docs/cache.md`, document `lifecycle` in `ScalarFrontierCoherence.dfy` as runtime lineage (source scope plus lifecycle), update the `NativeGenerationCoherence.dfy` lifting-direction statement, and re-pin the manifest.
+- [x] 5.2 Extend adapter certification v2 with executable domain, ceiling, and per-live-source identity obligations for every bundled adapter; replace literal-only registry detectors for these obligations with detectors that run against the adapter.
+- [x] 5.3 Extend the randomized cached-versus-bypass differential with retained older bases and concurrent publication order.
+- [x] 5.4 Rewrite the cache sections of `docs/cache.md`, `docs/v8-backend-adapter-boundary.md`, and `docs/v8-consistency-cache-operations.md`: the reuse rule, lineage, domain and ceiling obligations, violation handling, `:populate-cache?`; remove "forward-only" wording.
+- [x] 5.5 Regenerate `public-source-closure.json`, run the CI-equivalent battery, CLJS build last, and `openspec validate --strict`.

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/validation.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/validation.md
@@ -1,0 +1,100 @@
+# Validation
+
+Validated on 2026-08-23 from branch
+`agent/introduce-proof-carrying-semantic-equivalence`.
+
+## Runtime correctness and conformance
+
+- The CI-equivalent JVM sweep passed 806 tests and 30,540 assertions
+  with zero failures and zero errors.
+- The Datalevin-isolated suite passed 248 tests and 5,304 assertions with zero
+  failures and zero errors.
+- Focused clean-loader suites passed for the shared cache, proof-frame,
+  request-context, relay, backend contract, and formal controls (87 tests,
+  3,313 assertions); DataScript (71 tests, 3,365 assertions); Datahike (38
+  tests, 2,314 assertions); Datomic including the proof-cost benchmark (55
+  tests, 4,102 assertions); and Datalevin (30 tests, 904 assertions).
+- The randomized DataScript cached-versus-bypass campaign includes retained
+  older bases and both delayed publication orders. Its focused run passed
+  2,580 assertions.
+- Shared public cache-control conformance covers all four adapters, including
+  empty and populated batches, permission trees, relationship reads, cursor
+  continuation, exact hits, proof-backed hits, misses, and bypasses.
+- Adapter certification v4 passed all bundled adapters. Its new executable
+  checks exercise native revision domains, generation ceilings, supported
+  relationship transitions, non-durable live-source separation, and durable
+  source identity across reopen. Datalevin explicitly records its temporal
+  ordered-generation claim as not yet supported; the next stacked change owns
+  that storage-level proof.
+
+All Clojure test execution ran through nREPL with changed namespaces reloaded.
+
+## ClojureScript and optimizer evidence
+
+- The final ordinary DataScript Node suite passed 279 tests and 8,364
+  assertions with zero failures and zero errors.
+- A fresh advanced-optimized build with warnings as errors passed 279 tests and
+  8,364 assertions with zero failures and zero errors.
+- The advanced run exposed four tests that replaced ordinary ClojureScript
+  Vars and therefore ceased to observe calls after Closure devirtualization.
+  Those tests now use stable execution-stage injection, an explicit client API
+  wrapper, codec work counters, and byte-level ciphertext tampering. Their
+  affected JVM run passed 63 tests and 535 assertions; the subsequently revised
+  batch fault-boundary test passed its 25-test, 188-assertion JVM namespace.
+
+## Proof, mutation, and source-closure evidence
+
+- `bin/formal verify`: 30 Dafny modules, 8,792 proof efforts, zero verification
+  errors. `ScalarFrontierCoherence.dfy` retains the proved
+  `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` corollary, and the
+  assurance matrix now cites it for direction-agnostic retained-basis reuse.
+- `bin/formal format`: clean.
+- `EACL_NREPL_PORT=52308 bin/formal mutation-control`: 4 tests and 78
+  assertions, zero failures and zero errors. All 30 active controls were
+  killed, including 21 executed-production controls and the new adapter domain,
+  ceiling, and live-source identity mutations.
+- Public source closure: 78 source files, 70 roots, and 1,651 reachable
+  definitions; SHA-256
+  `224ff0932355d2d10dd0c1966ad411ccad5bdd85fff149afce08d522ff4a2b5e`.
+- `bin/formal manifest` reconciled 303 source files, 55 reports, 67
+  counterexamples, all 30 mutation controls, the v4 adapter certification, and
+  all four generated artifact digests. It intentionally withholds unqualified
+  verified status only for the repository's five already-declared external
+  release obligations; it reported no theorem, count, digest, certification,
+  or artifact mismatch.
+
+## Builds and static gates
+
+- `bin/reflection-gate`: clean.
+- Production clj-kondo with the repository's macro lint mapping: zero errors
+  and the existing 37 warnings.
+- Generated Java, JavaScript, and browser runtimes built successfully.
+- The artifact-size gate passed with its exact pinned Babashka 1.12.213:
+  browser 586,813/738,488 bytes; Java classes 1,875,003/2,377,367 bytes; Java
+  source 2,115,033/2,670,869 bytes; JavaScript 942,084/1,188,865 bytes.
+- The coordinated `8.0.0-SNAPSHOT` build/install/cold-smoke completed through
+  nREPL.
+- `git diff --check`, public-source-closure checking, and
+  `openspec validate introduce-proof-carrying-semantic-equivalence --strict`
+  passed.
+
+## Correctness and performance properties pinned by tests
+
+- A proof frame contains only canonical relation generations. Schema
+  generation is read independently, and every generation is an exact natural
+  number at or below the selected native revision.
+- Missing evidence is an ordinary exact-only outcome. Malformed, duplicate,
+  non-canonical, non-integer, or future evidence is a typed contract violation
+  that disables only managed lifting, reports once per reason per lifecycle,
+  and leaves exact caching, authorization, and revision-token issuance intact.
+- Managed keys contain the full `{source-scope, source-lifecycle}` lineage and
+  schema generation. Equal frames reuse in either revision direction; changed
+  frames miss.
+- Datomic uses `d/tx->t`, retains relation-version history, and reads historical
+  stamps at an as-of basis. The benchmark recorded 54 additional retained
+  relation-version history datoms for its named write workload.
+- Datahike memory and DataScript sources mint per-live-source identity; durable
+  Datalevin reopen preserves its persisted identity.
+- `:populate-cache? false` preserves lookups and request-local memoization while
+  suppressing completed answers, managed subproblems, checkpoints, and visited
+  pages. `:cache? false` still suppresses both lookup and publication.

--- a/openspec/changes/introduce-proof-carrying-semantic-equivalence/validation.md
+++ b/openspec/changes/introduce-proof-carrying-semantic-equivalence/validation.md
@@ -44,20 +44,21 @@ All Clojure test execution ran through nREPL with changed namespaces reloaded.
 
 ## Proof, mutation, and source-closure evidence
 
-- `bin/formal verify`: 30 Dafny modules, 8,792 proof efforts, zero verification
+- `bin/formal verify`: 30 Dafny modules, 8,794 proof efforts, zero verification
   errors. `ScalarFrontierCoherence.dfy` retains the proved
   `EqualScalarProofAlsoPreservesAnOlderSelectedSnapshot` corollary, and the
   assurance matrix now cites it for direction-agnostic retained-basis reuse.
 - `bin/formal format`: clean.
-- `EACL_NREPL_PORT=52308 bin/formal mutation-control`: 4 tests and 78
-  assertions, zero failures and zero errors. All 30 active controls were
-  killed, including 21 executed-production controls and the new adapter domain,
-  ceiling, and live-source identity mutations.
-- Public source closure: 78 source files, 70 roots, and 1,651 reachable
+- `EACL_NREPL_PORT=52308 bin/formal mutation-control`: 4 tests and 86
+  assertions, zero failures and zero errors. All 36 active controls were
+  killed: 27 executed-production controls, five structural source controls,
+  and four Apalache controls. This includes the new adapter domain, ceiling,
+  and live-source identity mutations.
+- Public source closure: 78 source files, 70 roots, and 1,653 reachable
   definitions; SHA-256
-  `224ff0932355d2d10dd0c1966ad411ccad5bdd85fff149afce08d522ff4a2b5e`.
+  `91e41b6d394d181e090f063d84d11a538828d5eb1a24b5e5c290dfafe212a012`.
 - `bin/formal manifest` reconciled 303 source files, 55 reports, 67
-  counterexamples, all 30 mutation controls, the v4 adapter certification, and
+  counterexamples, all 36 mutation controls, the v4 adapter certification, and
   all four generated artifact digests. It intentionally withholds unqualified
   verified status only for the repository's five already-declared external
   release obligations; it reported no theorem, count, digest, certification,


### PR DESCRIPTION
## Summary

- define canonical relation-only proof frames with independent schema generation, native revision domain and ceiling checks, lineage-scoped direction-agnostic reuse, and readable historical lifting
- fail safely on unavailable or violated proofs while preserving exact authorization; add sticky diagnostics and read-without-publication cache control
- certify bundled adapters, extend mutation and randomized differential evidence, and document the proof-carrying contract

## Stack

- Base: #147 (agent/reinstate-executable-assurance-gates)

## Validation

- JVM: 806 tests, 30,540 assertions; Datalevin isolated: 248 tests, 5,304 assertions
- CLJS ordinary and advanced: 279 tests, 8,364 assertions each
- Dafny: 8,792 proof efforts; mutation controls: 30/30; source closure: 70 roots, 1,653 definitions
- reflection, clj-kondo, generated runtime builds, artifact-size gates, release smoke, and strict OpenSpec validation