### PR TITLE
feat: certify Datalevin ordered generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Yes.
 | [Datomic Pro](https://www.datomic.com/)             | [eacl-datomic](https://clojars.org/dev.eacl/eacl-datomic)       | DynamoDB (recommended), Cassandra or SQL                                 |
 | [Datahike](https://datahike.io/)                    | [eacl-datahike](https://clojars.org/dev.eacl/eacl-datahike)     | DynamoDB, S3 (cheaper, but slower), LMDB, SQL, Redis, GCS or IndexedDB.  |
 | [DataScript](https://github.com/tonsky/datascript/) | [eacl-datascript](https://clojars.org/dev.eacl/eacl-datascript) | In-memory, but can persist to disk or add a SQL adapter. No time-travel. |
-| [Datalevin](https://datalevin.org/)                 | [`eacl-datalevin`](modules/eacl-datalevin) — implemented, publication pending | Embedded LMDB; certified sole-writer topology only.                       |
+| [Datalevin](https://datalevin.org/)                 | [`eacl-datalevin`](modules/eacl-datalevin) — implemented, publication pending | Embedded LMDB; storage-enforced write policy and ordered generations.      |
 
 
 S3-backed Datahike is attractive for infrequently-accessed apps, because you can trade latency for reduced storage cost, and it supports [serverless](https://github.com/replikativ/datahike-serverless) to reduce running Peer / Transactor costs.
 
-*Note:* DataScript and Datalevin have no `at-exact-snapshot` semantics. Datahike requires a retained commit graph or temporal history to support exact snapshots. Datalevin additionally omits ordered-generation cache proofs, so completed answers only reuse at the identical selected revision; its certified schema generation still reuses schema-derived plans across relationship-only revisions.
+*Note:* DataScript and Datalevin have no `at-exact-snapshot` semantics. Datahike requires a retained commit graph or temporal history to support exact snapshots. Datalevin uses scalar ordered-generation proofs from the maintained fork, so completed answers may reuse across unrelated forward revisions without historical selection.
 
 ## Overview of EACL
 
@@ -515,7 +515,7 @@ But you will probably forget one day, so there are helpers to fined & clean up g
 - `:eacl.relation/relation-name`
 - `:eacl.relation/subject-type`
 - `:eacl.relation/resource-type+relation-name+subject-type`
-- `:eacl/relation-version` tracks cache coherence – it gets bumped on relevant Relationship writes that affect this Relation to prevent stale cache answers.
+- `:eacl/relation-version` tracks cache coherence in Datomic, Datahike, and DataScript. Datalevin uses the scalar `:eacl.datalevin/relation-generation`; each is advanced by relevant Relationship writes.
 
 ### Permissions
 
@@ -538,7 +538,7 @@ But you will probably forget one day, so there are helpers to fined & clean up g
 - `:eacl/id` uniquely identifies Relations & Permissions. It's a string to match SpiceDB IDs, but you can also use it for external ID. Like in SpiceDB, Some IDs are reserved by EACL internals (todo: document EACL ID prefixes).
 - `:eacl/schema-string` stores a valid schema string was written via `eacl/write-schema!`.
 - `:eacl/schema-version` track the schema revision in Datomic Pro.
-- `:eacl/schema-generation` and `:eacl/schema-write-fence` track schema writes in Datahike, DataScript, and Datalevin.
+- `:eacl/schema-generation` and `:eacl/schema-write-fence` track schema writes in Datahike and DataScript. Datalevin uses scalar `:eacl.datalevin/schema-generation` and `:eacl.datalevin/schema-write-fence` values in its native `max-tx` domain.
 - `:eacl/storage-version` identifies Datomic's current Relationship storage model, e.g. version 7 (current).
 - `:eacl.fn/assert-relation-unused` is a Transactor function in Datomic that guards removing Relations with active Relationships (to avoids orphaned Relationships).
 
@@ -643,7 +643,7 @@ Java 26; source builds may target Java 8 through Java 26, subject to their
 backend and application dependencies. See [formal/README.md](formal/README.md)
 for tool versions and the full verification commands.
 
-For module selection, current capability differences, cache mutation rules, and recursive controls, see the [backend guide](docs/v8-backend-modules-and-upgrade.md). Datalevin setup, mandatory topology/lifecycle/watermark inputs, and publication status are documented in the [`eacl-datalevin` module README](modules/eacl-datalevin/README.md). Backend authors should also read the [adapter boundary](docs/v8-backend-adapter-boundary.md) and [basis-source migration guide](docs/v8-snapshot-provider-migration.md).
+For module selection, current capability differences, cache mutation rules, and recursive controls, see the [backend guide](docs/v8-backend-modules-and-upgrade.md). Datalevin setup, mandatory lifecycle/watermark inputs, write-policy boundary, and publication status are documented in the [`eacl-datalevin` module README](modules/eacl-datalevin/README.md). Backend authors should also read the [adapter boundary](docs/v8-backend-adapter-boundary.md) and [basis-source migration guide](docs/v8-snapshot-provider-migration.md).
 
 ### Schema & Relationships
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -26,6 +26,18 @@ transaction data or directly changing authorization schema, relationship
 tuples, permissioned identity, or entity liveness is unsupported and can leave
 a managed entry stale.
 
+The maintained Datalevin fork makes this mutation contract executable for its
+datom transaction and administrative APIs. A persisted store policy guards and
+freezes every physical EACL attribute except application identity, verifies
+schema and relation stamps after transaction-function and `retractEntity`
+expansion, materializes each stamp from the committing `max-tx`, and requires a
+per-open token held by the EACL writer. Consequently an unadmitted protected
+write, including direct retraction of an entity that owns relationship tuples,
+aborts instead of silently invalidating proof. Use `delete-object!` or
+`eacl.datalevin.safe-retraction/transact-retract-entity!` for those deletions.
+Raw KV writes, direct file modification, and opening the directory with an
+upstream artifact that lacks the policy remain outside the trusted boundary.
+
 Caching does not alter results:
 
 - `eacl.cache/no-cache` disables it for a client;
@@ -61,9 +73,9 @@ relationship clauses, page direction/demand, candidate window, and selected
 snapshot. Proof-backed aggregate reuse additionally binds every direct
 relationship dependency used by the filter. A request-local repeated decision
 may remove work inside one aggregate but is not reported as a durable
-`:cached? true` result. Datalevin can hit an aggregate page only at the
-identical selected revision because it deliberately omits ordered-generation
-proofs; its certified schema generation still reuses validation and plans.
+`:cached? true` result. Datalevin applies the same exact-first, proof-backed
+aggregate rules as the other ordered-generation adapters: an unrelated commit
+may reuse a complete aggregate page, while a changed dependency frame misses.
 
 ## Certified schema generation
 
@@ -71,8 +83,8 @@ Every bundled adapter implements the independent `:schema-generation`
 operation. It reads EACL's transactionally maintained schema stamp with at
 most one index probe, and the selected adapter memoizes that result. A managed
 schema write advances the stamp; a relationship-only or unrelated write does
-not. This operation is available on Datalevin even though Datalevin does not
-advertise ordered relationship-generation proofs.
+not. Datalevin reads this scalar stamp and each requested scalar relation stamp
+from the same owned immutable reader used by the authorization request.
 
 A certified stamp selects one bounded, client-owned derived generation. Its
 key contains the engine ABI, backend and adapter identity, source scope,

--- a/docs/release-notes-v8.0.md
+++ b/docs/release-notes-v8.0.md
@@ -138,9 +138,10 @@ schemas, relationships, caches, and tokens require no rewrite.
   no EACL time-travel registry.
 - Datalevin supports minimize-latency, fully-consistent local head, and
   at-least-as-fresh revision-floor selection through fresh explicit readers.
-  It rejects exact selection. Its initial adapter advertises no ordered
-  generations and no proof frame, so it never lifts a cached answer across a
-  different revision.
+  It rejects exact historical selection. The maintained fork enforces scalar
+  commit-generation stamping, and the adapter advertises ordered generations,
+  so an exact miss may lift a completed answer across revisions when the
+  complete dependency frame is unchanged.
 - Low-level operations accepting an arbitrary `db`, including caller-created
   `d/as-of`, `d/with`, prospective, or filtered views, bypass completed-answer
   caching.
@@ -242,17 +243,19 @@ projections) under one relation-stamp framing:
   frontier; an unrelated write leaves it unchanged.
 - Missing/malformed stamps disable managed reuse rather than becoming a
   reusable zero value.
-- All proof-capable backends read the current physical `:eacl/relation-version` assertion;
-  a missing assertion is a fail-closed miss and has no fallback.
+- Datomic, Datahike, and DataScript read the current physical
+  `:eacl/relation-version`; Datalevin reads
+  `:eacl.datalevin/relation-generation`. A missing assertion is a fail-closed
+  miss and has no fallback.
 - Custom object-ID codecs remain exact-basis-only unless they supply the
   additional deterministic dependency contract.
 - Randomized cached-versus-cache-free differential oracles run with the
-  managed tier active on the three ordered-proof backends, interleaving EACL-API writes
+  managed tier active on all four ordered-proof backends, interleaving EACL-API writes
   with checks, lookups, and counts.
-- Datalevin maintains relation versions for mutation fencing and a future
-  proof-capable design, but does not expose those values through a proof frame:
-  persistent datom transaction identity is not certified as an ordered
-  generation.
+- Datalevin stores scalar relation generations because persistent datom
+  transaction identity is not available in EACL proof order. Its maintained
+  fork materializes and enforces those values from the committing `max-tx`,
+  and the adapter exposes them through a snapshot-bound proof frame.
 
 ### Cache operations
 

--- a/docs/v8-backend-adapter-boundary.md
+++ b/docs/v8-backend-adapter-boundary.md
@@ -162,18 +162,19 @@ backend/source/lifecycle scope; exact selection additionally establishes the
 exact locator. Source replacement requires lifecycle rotation before cached or
 token-bearing traffic resumes.
 
-Datalevin demonstrates the conservative capability policy: its persistent
-datoms do not expose the original transaction in a form certified for EACL's
-proof order. The adapter therefore omits `:ordered-generations` and the
-`:proof-frame` operation. It may reuse completed answers only for the same
-complete basis identity and never interprets a datom `:tx` as a
-relation generation. Independently, its one-probe `:schema-generation`
-operation lets schema-derived plans survive relationship-only revisions. Its
-owned-snapshot acquisition reads only the maintained fork's revision bounds;
-it does not enumerate or fingerprint physical schema. Each reader is owned by
-the acquiring platform thread, cannot escape or cross threads, and is closed
-exactly once after the complete response (including cursor/cache publication)
-or after any failure. Datalevin makes no ordered-generation claim.
+Datalevin demonstrates why a capability claim must be backed by executable
+storage invariants. Persistent Datalevin datoms do not expose their original
+transaction in EACL's proof order, so the adapter never interprets datom `:tx`.
+Instead, the maintained fork materializes scalar generation values from the
+committing `max-tx`, enforces complete schema/relation stamping after transaction
+expansion, and rejects discontinuous or unadmitted protected writes. The
+adapter advertises `:ordered-generations`; its `:proof-frame` performs one exact
+EAV probe per requested relation and its independent `:schema-generation`
+operation performs one probe. Owned-snapshot acquisition reads only the fork's
+revision bounds; it does not enumerate or fingerprint physical schema. Each
+reader is owned by the acquiring platform thread, cannot escape or cross
+threads, and is closed exactly once after the complete response (including
+cursor/cache publication) or after any failure.
 
 ## Assurance ownership
 

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -12,7 +12,7 @@ depend on one adapter module; backend authors depend on core.
 | `eacl-datomic` | Clojure/JVM | current Peer DB, explicit sync barrier, causal floor, targeted catch-up plus exact `d/as-of T` | certified generation reuse | authenticated; proof-equivalent current continuation or full-history exact reconstruction |
 | `eacl-datahike` | Clojure/JVM | current connection DB; durable temporal history when enabled, otherwise conditional retained-commit selection | certified generation reuse | authenticated; proof-equivalent current continuation or configuration-honest exact reconstruction |
 | `eacl-datascript` | Clojure and ClojureScript | current connection DB; no arbitrary exact selection | certified generation reuse | authenticated proof-equivalent current continuation |
-| `eacl-datalevin` | Clojure/JVM | fresh owned native read snapshot at the local embedded head; causal-floor polling; no historical exact selection | certified generation reuse | authenticated revision-bound continuation; no ordered-proof lifting |
+| `eacl-datalevin` | Clojure/JVM | fresh owned native read snapshot at the local embedded head; causal-floor polling; no historical exact selection | certified ordered-generation reuse | authenticated proof-equivalent current continuation |
 | `eacl` | Clojure and ClojureScript | supplied by an adapter | shared generation registry and request-local fallback | shared protocol, engine, proof, and cache implementation |
 
 Capabilities are configuration-specific and are validated before
@@ -32,7 +32,7 @@ public SCM revisions.
 | Datomic Pro | current Peer value | bounded `d/sync` then current | targeted catch-up | `d/as-of T` | yes | yes |
 | Datahike | current connection value | qualified writer head | revision/commit catch-up | durable with temporal history; otherwise retained-commit conditional | yes | yes |
 | DataScript | serialized current value | serialized current head | waits for connection revision | unsupported | yes | yes, in the in-process mutation topology |
-| Datalevin | fresh explicit native reader | same local sole-writer head guarantee | retries fresh readers to the authenticated revision floor | unsupported | yes, one snapshot-bound index probe | no; completed answers use exact selected-revision reuse only |
+| Datalevin | fresh explicit native reader | qualified local embedded head | retries fresh readers to the authenticated revision floor | unsupported | yes, one snapshot-bound index probe | yes; storage-enforced scalar commit generations |
 
 ## Aggregate capability matrix
 
@@ -53,11 +53,13 @@ candidate; it does not re-evaluate the permission. Every bundled adapter also
 implements the independent one-probe `:schema-generation` operation. This is a
 separate obligation from ordered-generation proof support.
 
-Datalevin's fully-consistent mode is not a replica barrier. The certified
-topology has one embedded connection and one direct synchronous writer, so a
-fresh read transaction is already the authoritative local head. Remote,
-replica, HA, WAL, multi-connection, multi-writer, and virtual-thread profiles
-are rejected during construction.
+Datalevin's fully-consistent mode is not a replica barrier. A fresh explicit
+reader on the qualified local embedded environment is the local-head
+linearization point. Remote, HA, WAL, virtual-thread, and unsafe LMDB profiles
+are rejected during construction. Multiple connection atoms in one process
+share the store and LMDB serializes commits. A writer from another process is
+detected by persisted `max-tx` continuity; the stale connection aborts and is
+write-unusable until reopened.
 
 All public list operations use Relay controls: `:first`/`:after` or
 `:last`/`:before`. Counts use optional `:count-limit`. `delete-object!` is
@@ -77,7 +79,7 @@ disabled:
 (datomic/make-client conn {:cache cache/no-cache})
 (datalevin/make-client conn {:cache cache/no-cache
                              ;; plus mandatory lifecycle, watermark,
-                             ;; signing, and topology options
+                             ;; and signing options
                              })
 ```
 
@@ -85,8 +87,9 @@ Every bundled adapter also certifies EACL's schema generation independently
 of ordered relationship-generation proofs. The selected adapter memoizes the
 one-probe read. A bounded generation registry reuses validation catalogs,
 permission paths, dependency closures, routing analysis, direct-grant
-relations, and sealed plans across relationship-only revisions. This applies
-to Datalevin even though its completed answers cannot lift across revisions.
+relations, and sealed plans across relationship-only revisions. Datalevin also
+lifts completed answers and managed subproblems when its complete scalar proof
+frame remains equal across revisions.
 An uncertified third-party adapter receives the same reuse within one request
 only; native revision is not used as a derived-state fallback.
 
@@ -107,11 +110,15 @@ hit.
 
 All authorization-relevant schema, relationship, identity/liveness, repair,
 and safe-deletion mutations must use EACL APIs or documented EACL transaction
-data/functions transacted intact. Unsupported raw mutation can leave stale
-proof-backed state. Recovery requires quiescing affected traffic, repairing
-data, expiring or recreating every affected client in every process, and then
-resuming. `prepare-cache-coherence!`, an identical `write-schema!`, and cache
-rotation are not data repair.
+data/functions transacted intact. Datalevin additionally enforces this at its
+datom transaction and administrative boundaries: unadmitted protected writes,
+missing or stale stamps, and frozen-schema mutation abort atomically. Direct KV
+writes, file modification, or opening the database with an upstream artifact
+remain outside that boundary and can leave stale proof-backed state. Recovery
+requires quiescing affected traffic, repairing data, expiring or recreating
+every affected client in every process, and then resuming.
+`prepare-cache-coherence!`, an identical `write-schema!`, and cache rotation
+are not data repair.
 
 The exact lifecycle functions are:
 
@@ -170,7 +177,7 @@ peer-only ghost; a missing lookup ref cannot recover the former eid.
 | DataScript direct in-process form | `eacl.datascript.safe-retraction/prepare!` |
 | Datahike function-safe named topology | `eacl.datahike.safe-retraction/install!` |
 | Datahike direct in-process topology | `eacl.datahike.safe-retraction/prepare!` |
-| Datalevin qualified embedded topology | `eacl.datalevin.safe-retraction/prepare!` |
+| Datalevin qualified embedded profile | call `eacl.datalevin.safe-retraction/prepare!`, then submit through `eacl.datalevin.safe-retraction/transact-retract-entity!` |
 | Function-unsafe remote topology | use `delete-object!`, then native entity deletion |
 
 Do not combine relationship additions involving a target with safe retraction

--- a/formal/verification/adapter-certification.edn
+++ b/formal/verification/adapter-certification.edn
@@ -1,5 +1,5 @@
 {:schema-version 1
- :certification-version "eacl.adapter-certification/v4"
+ :certification-version "eacl.adapter-certification/v5"
  :date "2026-08-23"
  :role-contracts
  {:basis-adapter
@@ -123,17 +123,73 @@
     :errors 0}
    :history
    {:namespace eacl.datalevin.contract-test
-    :tests 24
-    :assertions 1134
+    :tests 29
+    :assertions 922
     :failures 0
     :errors 0
     :coverage
     [:explicit-reader-lifecycle
      :owner-thread
      :identical-basis-cache
-     :no-ordered-generation-claim
+     :durable-source-lifecycle
+     :watermark-regression
+     :fork-capability-admission
+     :unsafe-environment-rejection
+     :persisted-policy-drift
+     :direct-snapshot-private-context
      :direct-match-equivalence
-     :aggregate-scan-and-enumerate]}}}
+     :aggregate-scan-and-enumerate]}
+   :ordered-generations
+   {:suites
+    [{:namespace eacl.datalevin.ordered-generation-test
+      :tests 3 :assertions 20 :failures 0 :errors 0}
+     {:namespace eacl.datalevin.mutation-race-test
+      :tests 5 :assertions 67 :failures 0 :errors 0}
+     {:namespace eacl.datalevin.safe-retraction-test
+      :tests 2 :assertions 14 :failures 0 :errors 0}
+     {:namespace eacl.datalevin.differential-test
+      :tests 1 :assertions 3276 :failures 0 :errors 0}]
+    :coverage
+    [:exact-hit-zero-frame-probes
+     :schema-generation-one-exact-eav-probe
+     :unrelated-commit-managed-lift
+     :relevant-commit-invalidation
+     :missing-generation-unavailable
+     :above-ceiling-contract-violation
+     :provider-restart-token-and-cursor
+     :provider-restart-managed-lift
+     :same-process-distinct-connection-recovery
+     :atomic-create-delete-touch
+     :object-delete-relation-stamping
+     :schema-and-relation-removal-races
+     :safe-retraction-stamping
+     :randomized-cache-bypass-equivalence]}
+   :maintained-fork
+   {:repository "theronic/datalevin"
+    :commit "a7e29c25"
+    :pull-request 2
+    :base-pull-request 1
+    :tests 74
+    :assertions 398
+    :failures 0
+    :errors 0
+    :coverage
+    [:commit-generation-materialization
+     :max-eid-nonallocation
+     :post-expansion-policy-enforcement
+     :exact-stamp-selectors
+     :all-public-transaction-entry-points
+     :frozen-schema-and-admin-paths
+     :per-open-token-rotation
+     :policy-replacement-admission
+     :cross-process-max-tx-continuity
+     :write-unusable-after-continuity-failure
+     :shared-store-commit-state-adoption
+     :explicit-snapshot-regression]}
+   :performance
+   {:status :passed
+    :report
+    "formal/verification/datalevin-ordered-generation-benchmark.edn"}}}
  :runtime-guards
  {:status :passed
   :namespace eacl.backend.v8-test
@@ -151,4 +207,4 @@
   :establishes
   "Executable evidence for the named adapter obligations, including exact resolved/ranked permission paths, on the seeded and adversarial cases."
   :does-not-establish
-  "A proof of Datomic, DataScript, Datahike, Clojure, ClojureScript, storage engines, or arbitrary backend states."}}
+  "A proof of Datomic, DataScript, Datahike, Datalevin, Clojure, ClojureScript, storage engines, raw KV writes, direct file mutation, upstream artifacts, or arbitrary backend states."}}

--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -4,9 +4,9 @@
  :source-closure
  {:report "formal/verification/public-source-closure.json"
   :status :named-public-roots-enumerated
-  :source-files 79
+  :source-files 80
   :public-roots 70
-  :reachable-definitions 1653
+  :reachable-definitions 1673
   :inline-defrecord-method-attribution :source-span-closed
   :backend-dispatch
   {:report "formal/verification/backend-dispatch.edn"

--- a/formal/verification/backend-dispatch.edn
+++ b/formal/verification/backend-dispatch.edn
@@ -53,6 +53,15 @@
  {:every-invoke-operation-is-a-literal-keyword true
   :observed-equals-certified-snapshot-operations true
   :make-adapter-requires-callable-operation-implementations true}
+ :adapter-capability-coverage
+ {:datalevin
+  {:advertised-cache-proofs
+   #{:ordered-generations :snapshot-bound :database-visible}
+   :required-dispatch-operations #{:schema-generation :proof-frame}
+   :implementation
+   "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc"
+   :certification
+   "formal/verification/adapter-certification.edn"}}
  :remaining
  [:backend-operation-semantics-remain-basis-adapter-obligations
   :storage-engine-and-host-runtime-remain-trusted]}

--- a/formal/verification/datalevin-ordered-generation-benchmark.edn
+++ b/formal/verification/datalevin-ordered-generation-benchmark.edn
@@ -1,0 +1,54 @@
+{:format-version 1
+ :benchmark :datalevin-ordered-generation
+ :captured-at "2026-08-23"
+ :environment
+ {:architecture "aarch64"
+  :os "Mac OS X"
+  :java-version "26.0.2"
+  :datalevin-version "1.0.2"
+  :runtime :clj}
+ :maximum-closure-size 4096
+ :regression-budgets-ms
+ {:frame-zero-p95 2.0
+  :frame-typical-p95 5.0
+  :frame-maximum-p95 100.0
+  :exact-hit-p95 5.0
+  :managed-hit-p95 10.0
+  :write-commit-p50 20.0
+  :write-commit-p95 100.0}
+ :frame
+ {:zero
+  {:samples 100
+   :p50-ms 0.000375
+   :p95-ms 0.002708
+   :maximum-ms 0.005792}
+  :typical
+  {:relation-count 8
+   :samples 100
+   :p50-ms 0.014
+   :p95-ms 0.016875
+   :maximum-ms 0.017708}
+  :maximum
+  {:relation-count 4096
+   :samples 12
+   :p50-ms 8.691916
+   :p95-ms 11.568875
+   :maximum-ms 11.568875}}
+ :requests
+ {:exact-hit
+  {:samples 300
+   :p50-ms 0.15175
+   :p95-ms 0.482708
+   :maximum-ms 2.773167}
+  :managed-hit
+  {:samples 100
+   :p50-ms 0.380458
+   :p95-ms 0.850792
+   :maximum-ms 1.322875}}
+ :writes
+ {:policy-active
+  {:samples 100
+   :p50-ms 4.719
+   :p95-ms 5.633083
+   :maximum-ms 6.360417}}
+ :passed? true}

--- a/formal/verification/manifest.edn
+++ b/formal/verification/manifest.edn
@@ -160,7 +160,7 @@
  :datomic :certification-suite-passed
   :datascript :certification-suite-passed
   :datahike :certification-suite-passed
-  :datalevin :certification-suite-passed}
+  :datalevin :ordered-generation-certification-suite-passed}
  :runtime-targets
  {:clj-java
   {:boundary-smoke :passed
@@ -293,6 +293,10 @@
    :explorer-v8-release-report
    "formal/verification/explorer-v8-release.edn"
    :basis-first-cache-heavy-suite :passed
+   :datalevin-ordered-generations
+   {:status :passed
+    :report
+    "formal/verification/datalevin-ordered-generation-benchmark.edn"}
    :generated-authority-heavy-suite :passed
    :shared-subgraph-zero-final-hit :passed
    :completed-answer-hot-nonregression :passed
@@ -322,9 +326,9 @@
   :retired-invalid-controls 74}
  :source-closure
  {:report "formal/verification/public-source-closure.json"
-  :source-files 79
+  :source-files 80
   :public-roots 70
-  :reachable-definitions 1653}
+  :reachable-definitions 1673}
  :stable-discovery
  {:gate "formal/stable-discovery/verify-fast.sh"
   :dafny-leaves 46

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -41,19 +41,23 @@
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc",
-      "sha256": "b1e6c6b6249584dc3daf8523ad5adb5f4b1c96885bb1c62bd26d1c00f3764399"
+      "sha256": "5374c6824d1b15c5f8d6b5aaf00e5b5c5c8749a130c7f7b91496a26c47eed5bf"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/core.cljc",
-      "sha256": "bc81343f021a9b5254e6ddc12c07b34de8764c10400ae07e4c80899855f8766d"
+      "sha256": "758b293399122e583ee52a25f56c3bd2ef46048b2241ca18e4d3f67ec0f094fd"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/db.cljc",
       "sha256": "e07f81c20833871e160cda1a704fa381af5b1f809a156d922d9eb2ed61c13261"
     },
     {
+      "path": "modules/eacl-datalevin/src/eacl/datalevin/fork.cljc",
+      "sha256": "e37704b7244fb5afe265b56e9734306d113f2711655cc9d52eb18a1d3755ad4c"
+    },
+    {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/impl.cljc",
-      "sha256": "7e437e2ce867135dad9949a1cca1491a9e65e34ea359c03530d6861c958ec286"
+      "sha256": "4fa31ec17905a39b7a03e15f7afced6e0d993e170a642c499fe5c9ee150dc5d6"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/integrity.cljc",
@@ -61,11 +65,11 @@
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/safe_retraction.cljc",
-      "sha256": "4796ed3530633eda84d2425e31ddd49a36b9b6c296fbae193a0cffbc7d37e460"
+      "sha256": "857d24bc940722d2121d253868c101a21f991d61b277f335377ae78080f28339"
     },
     {
       "path": "modules/eacl-datalevin/src/eacl/datalevin/schema.cljc",
-      "sha256": "3557672d19df899c3e65c19ce997ca967b9f0d364c9cf7ee7310029c9e7dddf3"
+      "sha256": "9fe6844767756360537cd7162426c23d6d447bfcb74a8e2c027d859560087e23"
     },
     {
       "path": "modules/eacl-datascript/src/eacl/datascript/backend.cljc",
@@ -253,7 +257,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "8c47d4bfa41b1d2313173b69c1bb255e788da4fcb8626a04fbde43c58868fa0e"
+      "sha256": "d5c9ce2af23db46a639bd6bbd46a1180d8b37f45fae290c0eec36dc801374e06"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -402,9 +406,9 @@
       "eacl.datalevin.core/db"
     ],
     "rootCount": 70,
-    "unionInternalDefinitionCount": 1653,
-    "unionInternalDefinitionIdsSha256": "f5939214fb1a40ae2f4772bec0118a1be58b9a2d896daba8b512fa8c669840c8",
-    "unionDefinitionLocationsSha256": "55fdcb8b963539a3034a4940bcf793d64247c403a614184bf67ec334502219a1",
+    "unionInternalDefinitionCount": 1673,
+    "unionInternalDefinitionIdsSha256": "8663cf72e8d8091edc54c3efc816d1aae18844ea1f976474e27e0f1c1f44aa8d",
+    "unionDefinitionLocationsSha256": "f6b129cb227cbaa11367daa10b2f5ccf21ec9676915b80122a829f7d0eb5eed9",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 25,
@@ -427,24 +431,28 @@
         "idsSha256": "a9b335e6437c74da475a00ec083de3ca6ae0b1aee086dfdf9f9f83b32353735b"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/backend.cljc": {
-        "count": 16,
-        "idsSha256": "8e83d7d8565c01076d4a5508e20acbbe8bfe7936b5d530a345203536ba53959a"
+        "count": 20,
+        "idsSha256": "eb3064c7d77adc0b5b8330190d39917cc2dadceacb93d8bf56e2d9fe16b5d1d0"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/core.cljc": {
-        "count": 17,
-        "idsSha256": "000bc11cd0342364a91051f93153ba8e35173fd854404c74386d147b2865021a"
+        "count": 21,
+        "idsSha256": "b657864c7da54d483816220d8b0e25087b688841bc5ed3077463ac9308f7ddd8"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/db.cljc": {
         "count": 13,
         "idsSha256": "43b2ee91d514f424f3e0907b8f132507c34db59d4420937f56bdee2426aa9ba2"
+      },
+      "modules/eacl-datalevin/src/eacl/datalevin/fork.cljc": {
+        "count": 6,
+        "idsSha256": "3ddf545e206b28b0586d94906379c8bd76f9f487b45fca2f095837d2f406818d"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/impl.cljc": {
         "count": 39,
         "idsSha256": "ee9f35fd65d61c0798a33bcecd921a67c8933717aa581cc7c7d989d86ea757ed"
       },
       "modules/eacl-datalevin/src/eacl/datalevin/schema.cljc": {
-        "count": 19,
-        "idsSha256": "5d470063af9c1b929c4462cd664b616c7ce2f742f3a434e68784f5b164ad2ff0"
+        "count": 25,
+        "idsSha256": "640ed69987f19e03a50d63488156daef3cb53f74447b781d92bdee4a8bfdd593"
       },
       "modules/eacl-datascript/src/eacl/datascript/backend.cljc": {
         "count": 13,
@@ -1508,15 +1516,16 @@
       ]
     },
     "eacl.datalevin.core/make-client": {
-      "internalDefinitionCount": 437,
-      "internalDefinitionIdsSha256": "42e7394767f25d7f24bc76c99d65b07cc04dfd2415f0e5f986db2e9de26574c1",
-      "externalCallCount": 30,
+      "internalDefinitionCount": 457,
+      "internalDefinitionIdsSha256": "edce67f3927b1238acb2969976a9af49d405e7a5530510f1945f5779ddb6fd60",
+      "externalCallCount": 31,
       "externalCalls": [
         "cljs.reader/read-string",
         "clojure.edn/read-string",
         "clojure.set/difference",
         "clojure.set/intersection",
         "clojure.string/join",
+        "clojure.string/starts-with?",
         "clojure.walk/postwalk",
         "com.rpl.specter/transform",
         "datalevin.core/close-read-snapshot!",

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -257,7 +257,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "d5c9ce2af23db46a639bd6bbd46a1180d8b37f45fae290c0eec36dc801374e06"
+      "sha256": "8c47d4bfa41b1d2313173b69c1bb255e788da4fcb8626a04fbde43c58868fa0e"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -408,7 +408,7 @@
     "rootCount": 70,
     "unionInternalDefinitionCount": 1673,
     "unionInternalDefinitionIdsSha256": "8663cf72e8d8091edc54c3efc816d1aae18844ea1f976474e27e0f1c1f44aa8d",
-    "unionDefinitionLocationsSha256": "f6b129cb227cbaa11367daa10b2f5ccf21ec9676915b80122a829f7d0eb5eed9",
+    "unionDefinitionLocationsSha256": "86a56bab53655a0769b359ada8847e2ea01d1ff944821aabe88ddbd2d7185dc6",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 25,

--- a/modules/eacl-datalevin/PORTING.md
+++ b/modules/eacl-datalevin/PORTING.md
@@ -6,32 +6,44 @@ enters the shared snapshot-provider lifecycle, owns one public explicit
 Datalevin reader, eagerly externalizes its result, and releases the reader on
 the acquiring platform thread.
 
-The certified declaration is
-`eacl.datalevin.backend/certified-topology-declaration`. Client construction
-requires that exact map and independently checks the native connection profile.
-The module rejects remote stores, WAL, HA, unsafe LMDB durability flags,
-multiple connections or writers, external writer ownership, virtual request
-threads, mutable physical schema, and any undeclared topology variation.
+There is no topology declaration. Client construction checks executable fork
+capabilities and the native connection profile. The module rejects remote
+stores, WAL, HA, and LMDB `:nolock`, `:nosync`, `:nometasync`, `:mapasync`, and
+`:writemap`. Multiple local connection atoms are serialized by the shared
+Store and stale preparations are boundedly replanned. A second writer process
+is detected by persisted `max-tx` continuity and poisons writes until reopen.
 
 Supported consistency modes are minimize latency, fully consistent, and at
 least as fresh. On the sole-writer local topology, a fresh explicit snapshot is
 the local head linearization point. At-least retries fresh candidates until the
 authenticated revision floor is reached, the original request deadline
 expires, or cancellation is observed. Exact historical selection is rejected;
-the module advertises no exact, historical, durable-history, or ordered
-generation capability.
+the module advertises no exact or historical capability. It does advertise
+ordered generations over scalar commit-generation longs.
 
-Physical EACL schema and a random source UUID are installed before readiness.
+Physical EACL schema, a random source UUID, a schema singleton, native scalar
+generations, and a persisted write policy are installed before readiness.
 Every existing physical attribute is compared after Datalevin tuple-type
 inference; missing, renamed, retyped, recardinalized, reindexed, or wrong-arity
-attributes fail startup. Physical schema is frozen after bootstrap. Logical
-SpiceDB schema changes remain ordinary fenced EACL transactions.
+attributes fail startup. Physical EACL schema is frozen after bootstrap.
+Logical SpiceDB schema changes remain fenced, token-admitted EACL transactions.
 
 Relationship writes maintain forward and reverse tuple halves atomically and
-stamp relation versions with `:db/current-tx`. Create conflicts are rechecked
+stamp `:eacl.datalevin/relation-generation` with scalar `:db/current-tx`.
+Schema writes similarly stamp `:eacl.datalevin/schema-generation` and the
+write fence. The fork materializes those values without entity allocation and
+requires equality with committed `max-tx`. Create conflicts are rechecked
 inside the serialized writer. Schema and relationship mutations cross-check
 write fences. Object cleanup rescans inside a Datalevin transaction function,
 so an intervening relationship commit cannot escape a later-linearized delete.
+
+The persisted policy guards every EACL storage attribute except `:eacl/id`,
+requires exact relation/schema stamps after transaction-function and
+`retractEntity` expansion, and protects schema/admin mutation paths. Direct
+retraction of a permissioned object is rejected with guidance to
+`delete-object!`. Safe component retraction must be submitted through
+`eacl.datalevin.safe-retraction/transact-retract-entity!` so it carries the
+admission token and advances the external watermark.
 
 All revisions, entity IDs, relation/permission IDs, cursor bounds, and returned
 scan IDs are restricted to the portable exact-integer domain
@@ -44,9 +56,19 @@ constraints statically, and provide a complete semantic identity containing
 backend, source UUID, lifecycle, revision, exact locator (nil here), and the
 physical-schema fingerprint.
 
+An ordered-generation adapter returns relation-only frames in canonical id
+order, one EAV probe per relation, eagerly realized within the owned reader.
+Missing generations are proof-unavailable. Non-integers, negative values, or
+values above the selected `max-tx` are contract violations that sticky-disable
+managed lifting for that client.
+
 Signing material, source lifecycle, and the monotonic revision watermark are
 external durability inputs. The module rejects the shared default signing key,
 nil/implicit lifecycle generation, and process-local `expire-cache!` rotation.
 Restore tooling must durably rotate lifecycle and establish its new watermark
 before recreating the client; old tokens then fail source-lifecycle
 authentication.
+
+Every Datalog writer must use the maintained fork. Raw KV mutation of the
+datom/meta DBIs, direct file edits, and upstream Datalevin binaries bypass the
+policy and are outside the certified boundary.

--- a/modules/eacl-datalevin/README.md
+++ b/modules/eacl-datalevin/README.md
@@ -1,17 +1,19 @@
 # EACL Datalevin
 
 `dev.eacl/eacl-datalevin` is the CLJ-only EACL v8 adapter for a qualified
-embedded Datalevin database. The initial contract is deliberately narrow:
+embedded Datalevin database. The certified contract is deliberately narrow:
 
-- one local embedded database, JVM, connection, and synchronous writer;
+- one local embedded database and JVM, with storage-serialized local
+  connections and synchronous EACL writers;
 - platform-thread request execution with acquiring-thread snapshot ownership;
 - fresh explicit snapshots for minimize-latency, fully-consistent, and
   at-least-as-fresh reads;
 - no exact historical snapshot selection, remote/server, HA, replica,
   multiple-writer, or WAL qualification;
-- physical schema frozen after bootstrap; and
-- revision-bound completed-answer and cursor reuse with no ordered-generation
-  proofs, plus certified-generation reuse of schema-derived plans.
+- physical EACL schema frozen after bootstrap;
+- a persisted storage write policy enforced after transaction expansion; and
+- scalar ordered-generation frames for exact and dependency-equivalent answer
+  reuse, plus certified-generation reuse of schema-derived plans.
 
 Every transient request snapshot owns a public Datalevin read handle and closes
 it after the complete EACL response is realized. A retained snapshot remains
@@ -20,7 +22,7 @@ its EACL lifetime and fail closed on the next access. The module never treats
 Datalevin's ordinary live DB handle as an immutable snapshot.
 
 Development uses the sibling maintained-fork checkout containing the public
-read-snapshot API. Publication is blocked until that fork is released as the
+read-snapshot and write-policy APIs. Publication is blocked until that fork is released as the
 explicit `dev.eacl/datalevin-embedded-eacl` coordinate and its packaged native
 runtime passes certification.
 
@@ -34,17 +36,16 @@ For a source checkout with the expected sibling layout, use:
 
 The reserved release coordinate is
 `dev.eacl/eacl-datalevin:8.0.0-SNAPSHOT`, depending on
-`dev.eacl/datalevin-embedded-eacl:1.0.2-eacl.1`. Neither is a usable published
+`dev.eacl/datalevin-embedded-eacl:1.0.2-eacl.2`. Neither is a usable published
 dependency until the release and clean remote-consumer gates pass.
 
-Construction requires an exact topology declaration plus externally retained
-lifecycle, signing material, and revision state. Omitting a signing key/keyring
+Construction requires externally retained lifecycle, signing material, and
+revision state. Omitting a signing key/keyring
 or supplying a nil lifecycle fails construction; the shared development key is
 never used by this module:
 
 ```clojure
-(require '[eacl.datalevin.backend :as datalevin-backend]
-         '[eacl.datalevin.core :as datalevin])
+(require '[eacl.datalevin.core :as datalevin])
 
 (def conn (datalevin/create-conn "/var/lib/my-app/eacl"))
 (def watermark (atom (load-watermark-from-durable-storage)))
@@ -59,28 +60,52 @@ never used by this module:
     (fn [revision]
       (persist-watermark-durably! revision)
       (swap! watermark max revision))
-    :maximum-snapshot-retention-ms 30000
-    :datalevin-topology
-    datalevin-backend/certified-topology-declaration}))
+    :maximum-snapshot-retention-ms 30000}))
 ```
+
+`:datalevin-topology` was removed. Advisory declarations cannot establish
+writer exclusivity. Construction instead checks executable fork capabilities,
+the actual embedded environment, WAL/HA state, and LMDB flags. `:nolock`,
+`:nosync`, `:nometasync`, `:mapasync`, and `:writemap` are rejected.
 
 `minimize-latency` and `fully-consistent` each acquire a fresh explicit reader
 at the qualified local sole-writer head. `at-least-as-fresh` retries fresh
 readers until the authenticated revision floor is visible or the original
 deadline/cancellation terminates the request. `at-exact-snapshot` always
-throws `:eacl.consistency/exact-snapshot-unavailable`. The module never
-advertises ordered generations and never supplies a `:proof-frame`, so
-completed answers cannot lift across revisions. Its independent, memoized
-`:schema-generation` probe still lets validation catalogs, dependency
-closures, routing analysis, and sealed plans survive relationship-only
-revisions. Snapshot acquisition reads only revision bounds from the maintained
-fork; it does not read full metadata or fingerprint physical schema.
+throws `:eacl.consistency/exact-snapshot-unavailable`. The module advertises
+certified ordered generations. `:schema-generation` and each requested
+relation generation are scalar `:db.type/long` values equal to the `max-tx` of
+the commit that changed them. The adapter reads one exact EAV probe per
+requested relation from the owned snapshot. Equal lineage and frame permit
+completed answers and managed subproblems to lift across unrelated revisions;
+a relevant relation or schema change misses. Exact hits acquire no frame.
+Snapshot acquisition reads only revision bounds from the maintained fork; it
+does not read full metadata or fingerprint physical schema.
 
 The shared aggregate routes use the same owned reader for their complete
 batch or candidate window. Datalevin's certified `:direct-match?` operation is
 reused by the enumerate route as exactly one snapshot-bound relationship probe
 per candidate. The adapter has no backend-private aggregate loop, makes no
-ordered-generation claim, and never moves an owned reader to another thread.
+backend-private proof rule, and never moves an owned reader to another thread.
+
+At bootstrap the module installs one normalized persisted write policy. Every
+physical `eacl`/`eacl.*` attribute except `:eacl/id` is guarded and frozen; the
+three Datalevin generation attributes are commit-generation longs. The fork
+checks the fully expanded datom set before commit, so direct
+`:db/retractEntity` cannot hide relationship-tuple retractions. Protected
+writes without the module-held per-open token, missing stamps, stale stamps,
+or frozen-schema changes abort atomically. Use EACL relationship operations,
+`eacl/delete-object!`, or
+`eacl.datalevin.safe-retraction/transact-retract-entity!`; do not submit the
+returned safe-retraction transaction data directly when it touches protected
+attributes.
+
+Each commit reads persisted `max-tx` after obtaining LMDB's writer lock. A
+foreign process that advanced the store causes
+`:datalevin/max-tx-continuity-violation` and makes the environment unusable for
+writes until reopen. Distinct local connections are supported: a stale
+prepared generation is refreshed and boundedly replanned. Multi-process
+writers remain unsupported and are detected, not coordinated.
 
 The advance callback is synchronous and release-critical: EACL does not
 acknowledge a bootstrap or authorization commit until the callback returns and
@@ -104,4 +129,6 @@ lifecycle. It is not a recovery operation and must not be used after restore,
 rollback, or an unsupported authorization mutation.
 
 See [PORTING.md](PORTING.md) for the adapter boundary and unsupported
-configurations.
+configurations. The trusted boundary requires this maintained fork for every
+Datalog writer. Raw KV writes to Datalevin's datom/meta DBIs, direct file
+mutation, or opening the directory with upstream Datalevin are outside it.

--- a/modules/eacl-datalevin/src/eacl/datalevin/backend.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/backend.cljc
@@ -5,13 +5,12 @@
             [eacl.backend.source :as source]
             [eacl.backend.v8 :as backend]
             [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.fork :as fork]
             [eacl.datalevin.impl :as impl]))
 
 (def adapter-capabilities
   {:cursor #{:forward :reverse :opaque :authenticated :encrypted}
-   ;; Datalevin persistent datoms do not expose their original transaction.
-   ;; No ordered-generation proof is claimed by the initial adapter.
-   :cache-proofs #{:snapshot-bound :database-visible}
+   :cache-proofs #{:ordered-generations :snapshot-bound :database-visible}
    :runtime #{:clj}})
 
 (def source-capabilities
@@ -27,20 +26,48 @@
    :snapshot-thread :acquiring-thread
    :release-thread :acquiring-thread})
 
-(def certified-topology-declaration
-  {:deployment :embedded
-   :jvms 1
-   :connections 1
-   :writers 1
-   :writer-ownership :application-exclusive
-   :commit-mode :direct-synchronous
-   :physical-schema :frozen
-   :request-threads :platform
-   :wal false})
-
 (def topology
-  (assoc certified-topology-declaration
-         :snapshot-values :owned-explicit))
+  {:deployment :embedded
+   :snapshot-values :owned-explicit
+   :writer-safety :storage-enforced})
+
+(def prepared-schema-eid-key
+  "Module-internal adapter option containing the frozen schema singleton eid."
+  ::prepared-schema-eid)
+
+(def required-write-policy-capabilities
+  {:version 1
+   :commit-generation-materialization true
+   :max-tx-continuity true
+   :post-expansion-enforcement true
+   :persisted-policy true
+   :per-open-admission-token true
+   :shared-store-stale-generation-recovery true})
+
+(defn validate-fork-capabilities!
+  "Requires executable fork support before module bootstrap may write."
+  [_conn]
+  (let [actual (fork/write-policy-capabilities)
+        missing-or-wrong
+        (into {}
+              (keep (fn [[capability required-value]]
+                      (when-not (= required-value (get actual capability))
+                        [capability
+                         {:required required-value
+                          :actual (get actual capability)}])))
+              required-write-policy-capabilities)]
+    (when (seq missing-or-wrong)
+      (throw
+       (ex-info
+        "The Datalevin artifact lacks required ordered-generation enforcement."
+        {:type :eacl/unsupported-capability
+         :eacl/error :eacl/unsupported-capability
+         :backend :datalevin
+         :capability :ordered-generations
+         :required required-write-policy-capabilities
+         :actual actual
+         :missing-or-wrong missing-or-wrong})))
+    actual))
 
 (defn exact-natural!
   [field value]
@@ -86,6 +113,22 @@
    :target-type (:eacl.permission/target-type permission)
    :target-name (:eacl.permission/target-name permission)})
 
+(defn- scalar-generation
+  [db entity-id attribute]
+  (some-> (first (d/datoms db :eav entity-id attribute)) :v))
+
+(defn- ordered-generation-frame
+  [snapshot relation-ids]
+  (ddb/with-db
+   snapshot
+   (fn [db]
+     (mapv
+      (fn [relation-id]
+        [relation-id
+         (scalar-generation
+          db relation-id :eacl.datalevin/relation-generation)])
+      relation-ids))))
+
 (defn- snapshot-revision-info
   [snapshot]
   (when-not (d/read-snapshot? snapshot)
@@ -102,7 +145,8 @@
 
 (def adapter-config-keys
   #{:object-id->entid :entid->object-id
-    :adapter-fingerprint :adapter-deterministic? :identity-contract})
+    :adapter-fingerprint :adapter-deterministic? :identity-contract
+    prepared-schema-eid-key})
 
 (defn basis-adapter
   "Creates an immutable v8 adapter around one open Datalevin read snapshot.
@@ -111,7 +155,10 @@
   [snapshot {:keys [object-id->entid entid->object-id] :as opts}]
   (backend/validate-adapter-config! :datalevin adapter-config-keys opts)
   (let [info (snapshot-revision-info snapshot)
-        revision (:max-tx info)]
+        revision (:max-tx info)
+        schema-eid
+        (exact-natural! :schema-entity-id
+                        (get opts prepared-schema-eid-key))]
     (backend/make-adapter
      {:id :datalevin
       :traversal-execution backend/strict-sequential-traversal-execution
@@ -139,10 +186,9 @@
        :schema-generation
        (fn []
          (ddb/with-db
-           snapshot
-           #(some-> (first (ddb/avet-datoms
-                            % :eacl/schema-generation))
-                    :v)))
+          snapshot
+          #(scalar-generation
+            % schema-eid :eacl.datalevin/schema-generation)))
 
        :exact-locator (constantly nil)
 
@@ -229,7 +275,11 @@
        (fn []
          (ddb/with-db
            snapshot
-           impl/all-permission-nodes))}})))
+           impl/all-permission-nodes))
+
+       :proof-frame
+       (fn [relation-ids]
+         (ordered-generation-frame snapshot relation-ids))}})))
 
 (defn connection-source-id
   "Reads the bounded source UUID installed in Datalevin module metadata.
@@ -260,9 +310,9 @@
         (throw error)))))
 
 (defn validate-topology!
-  "Rejects any connection/runtime/declaration outside the certified embedded
+  "Rejects any connection/runtime state outside the certified embedded
   Datalevin profile before module bootstrap is allowed to mutate the store."
-  [conn opts]
+  [conn _opts]
   (let [snapshot-capabilities (d/read-snapshot-capabilities conn)
         _
         (when-not (:supported? snapshot-capabilities)
@@ -273,17 +323,6 @@
              :eacl/error :eacl/unsupported-topology
              :backend :datalevin
              :reason (:reason snapshot-capabilities)})))
-        declared-topology (:datalevin-topology opts)
-        _
-        (when-not (= certified-topology-declaration declared-topology)
-          (throw
-           (ex-info
-            "Datalevin requires the exact certified sole-writer topology declaration."
-            {:type :eacl/unsupported-topology
-             :eacl/error :eacl/unsupported-topology
-             :backend :datalevin
-             :expected certified-topology-declaration
-             :actual declared-topology})))
         _
         (when (or (:wal? snapshot-capabilities)
                   (some? (:ha-mode snapshot-capabilities)))
@@ -296,7 +335,7 @@
              :wal? (:wal? snapshot-capabilities)
              :ha-mode (:ha-mode snapshot-capabilities)})))
         unsafe-flags
-        (set/intersection #{:nosync :nometasync :mapasync :writemap}
+        (set/intersection #{:nolock :nosync :nometasync :mapasync :writemap}
                           (:env-flags snapshot-capabilities))
         _
         (when (seq unsafe-flags)

--- a/modules/eacl-datalevin/src/eacl/datalevin/core.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/core.cljc
@@ -10,6 +10,7 @@
             [eacl.cursor :as cursor]
             [eacl.datalevin.backend :as datalevin-backend]
             [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.fork :as fork]
             [eacl.datalevin.impl :as impl]
             [eacl.datalevin.schema :as schema]
             [eacl.relationships.storage :as relationship-storage]))
@@ -22,6 +23,13 @@
 
 (def ^:private prepared-native-source-id-key
   ::prepared-native-source-id)
+
+(def ^:private extra-client-opt-keys
+  #{:revision-watermark
+    :advance-revision-watermark!
+    :maximum-snapshot-retention-ms
+    prepared-native-source-id-key
+    datalevin-backend/prepared-schema-eid-key})
 
 (defn- relationship-retraction-count
   [_db tx-data]
@@ -42,20 +50,54 @@
           (recur #?(:clj (.getCause ^Throwable cause)
                     :cljs (ex-cause cause))))))))
 
+(defn- datalevin-failure-data
+  [throwable failure-type]
+  (loop [cause throwable]
+    (when cause
+      (let [data (ex-data cause)]
+        (if (= failure-type (:type data))
+          data
+          (recur #?(:clj (.getCause ^Throwable cause)
+                    :cljs (ex-cause cause))))))))
+
+(defn- stale-connection-contention?
+  [throwable]
+  (= :eacl.datalevin/stale-connection-generation
+     (:type (ex-data throwable))))
+
 (defn- transact-native!
-  [conn {:keys [tx-data]}]
+  [write-token conn {:keys [tx-data]}]
   (try
-    (ds/transact! conn (vec tx-data))
+    (ds/transact!
+     conn (vec tx-data)
+     {:datalevin/write-token write-token})
     (catch #?(:clj Throwable :cljs :default) throwable
-      (if-let [cause-data (cas-failure-data throwable)]
-        (throw
-         (ex-info
-          "A Datalevin relationship mutation lost a commit-time fence."
-          {:type :eacl/relationship-concurrent-write
-           :eacl/error :eacl/relationship-concurrent-write
-           :backend :datalevin
-           :datalevin-error cause-data}
-          throwable))
+      (cond
+        (cas-failure-data throwable)
+        (let [cause-data (cas-failure-data throwable)]
+          (throw
+           (ex-info
+            "A Datalevin relationship mutation lost a commit-time fence."
+            {:type :eacl/relationship-concurrent-write
+             :eacl/error :eacl/relationship-concurrent-write
+             :backend :datalevin
+             :datalevin-error cause-data}
+            throwable)))
+
+        (datalevin-failure-data throwable :datalevin/stale-generation)
+        (let [cause-data
+              (datalevin-failure-data throwable :datalevin/stale-generation)]
+          (fork/refresh-connection! conn)
+          (throw
+           (ex-info
+            "A shared Datalevin connection prepared from a stale generation."
+            {:type :eacl.datalevin/stale-connection-generation
+             :eacl/error :eacl.datalevin/stale-connection-generation
+             :backend :datalevin
+             :datalevin-error cause-data}
+            throwable)))
+
+        :else
         (throw throwable)))))
 
 (defn- derefable?
@@ -126,8 +168,10 @@
     snapshot-or-db
     #(impl/read-relationships % query kernel window-options))))
 
-(def ^:private api
+(def ^:private base-api
   {:backend-id :datalevin
+   :writer-max-attempts 8
+   :writer-contention? stale-connection-contention?
    :db ds/db
    :entid snapshot-entid
    :default-entid->object-id snapshot-object-id
@@ -145,13 +189,14 @@
    :native-source-id datalevin-backend/connection-source-id
    :prepared-native-source-id-key prepared-native-source-id-key
    :relationship-retraction-count relationship-retraction-count
-   :transact! transact-native!
+   ;; The per-open admission token is closed over by `api-for-write-token`.
+   :transact! nil
    ;; Vars, not values: late binding keeps instrumentation (with-redefs in
    ;; the impl suites) and REPL redefinition visible through the shared
    ;; orchestration.
    :schema {:read-schema #'schema/read-schema
             :generation snapshot-schema-generation
-            :write-schema! #'schema/write-schema!}
+            :write-schema! nil}
    :impl {:validate-relationship-operation!
           #'impl/validate-relationship-operation!
           :relationship-relation-id snapshot-relationship-relation-id
@@ -160,11 +205,31 @@
           :affected-relation-ids #'impl/affected-relation-ids
           :read-relationships snapshot-read-relationships}
    :extra-client-opt-keys
-   #{:datalevin-topology
-     :revision-watermark
-     :advance-revision-watermark!
-     :maximum-snapshot-retention-ms
-     prepared-native-source-id-key}})
+   extra-client-opt-keys})
+
+(defn- api-for-client-context
+  [write-token schema-eid]
+  (-> base-api
+      (assoc
+       ;; Direct public snapshots are constructed from the client's API after
+       ;; shared orchestration has reduced runtime options to backend-neutral
+       ;; state. Close the bootstrap-resolved singleton eid over the adapter
+       ;; constructor so that this path keeps the same one-probe generation
+       ;; lookup as provider-owned snapshots without accepting caller input.
+       :basis-adapter
+       (fn [snapshot opts]
+         (datalevin-backend/basis-adapter
+          snapshot
+          (assoc opts
+                 datalevin-backend/prepared-schema-eid-key schema-eid)))
+       :transact!
+       (fn [conn native-tx]
+         (transact-native! write-token conn native-tx)))
+      (assoc-in
+       [:schema :write-schema!]
+       (fn [conn schema-string options expected-generation]
+         (schema/write-schema!
+          conn schema-string options expected-generation write-token)))))
 
 (defn- require-datalevin-client!
   [client fn-name]
@@ -230,10 +295,11 @@
   - :object-id->lookup-ref (fn [external-id] lookup-ref). Default: [:eacl/id id].
   - :cache - omitted creates a bounded client-private basis
     cache; eacl.cache/no-cache disables it; a config map bounds it.
-    Completed answers reuse only at the identical complete basis identity;
-    this adapter makes no ordered-generation proof claim. Certified schema
-    generation still reuses derived plans across relationship-only writes. Authorization
-    mutations must use EACL APIs or intact EACL-produced transaction data.
+    Exact lookup precedes proof-backed reuse. The adapter supplies certified
+    ordered schema/relation generations, so completed answers and managed
+    subproblems may lift across commits that leave their complete dependency
+    frame unchanged. Authorization mutations must use EACL APIs or intact
+    EACL-produced transaction data.
   - :cursor-ttl-seconds - optional cursor token expiry; default nil (tokens never expire).
   - :maximum-snapshot-retention-ms - optional positive upper bound for an
     EACL snapshot wrapper. Once exceeded, the next access releases an owned
@@ -243,6 +309,17 @@
   Datalevin is current-basis-only across requests. It does not retain old DB
   values and rejects :at-exact-snapshot before cache access."
   [conn config-opts]
+  (let [known-keys
+        (into orchestration/base-client-opt-keys extra-client-opt-keys)]
+    (when-let [unknown-keys
+               (seq (remove known-keys (keys config-opts)))]
+      (throw
+       (ex-info
+        "EACL Config Error: unknown Datalevin make-client option."
+        {:type :eacl/invalid-config
+         :eacl/error :eacl/invalid-config
+         :unknown-keys (vec unknown-keys)
+         :known-keys known-keys}))))
   (when (contains? config-opts prepared-native-source-id-key)
     (throw
      (ex-info
@@ -250,6 +327,13 @@
       {:type :eacl/invalid-config
        :eacl/error :eacl/invalid-config
        :key prepared-native-source-id-key})))
+  (when (contains? config-opts datalevin-backend/prepared-schema-eid-key)
+    (throw
+     (ex-info
+      "Datalevin prepared schema identity is module-internal."
+      {:type :eacl/invalid-config
+       :eacl/error :eacl/invalid-config
+       :key datalevin-backend/prepared-schema-eid-key})))
   (when-not (contains? config-opts :source-lifecycle)
     (throw
      (ex-info
@@ -323,6 +407,7 @@
          :eacl/error :eacl/invalid-config
          :key :revision-watermark
          :value watermark})))
+    (datalevin-backend/validate-fork-capabilities! conn)
     (datalevin-backend/validate-topology! conn config-opts)
     (let [revision (:max-tx (ds/db conn))]
       (when (< revision watermark)
@@ -333,7 +418,18 @@
            :eacl/error :eacl.datalevin/revision-regression
            :revision revision
            :revision-watermark watermark})))))
-  (let [source-id (schema/ensure-physical-schema! conn)
+  (let [{:keys [source-id schema-eid write-token]}
+        (schema/ensure-physical-schema! conn)
+        validated-source-id (datalevin-backend/connection-source-id conn)
+        _ (when-not (= (str source-id) validated-source-id)
+            (throw
+             (ex-info
+              "Datalevin bootstrap and persisted source identities disagree."
+              {:type :eacl/invalid-source-identity
+               :eacl/error :eacl/invalid-source-identity
+               :backend :datalevin
+               :bootstrap-source-id source-id
+               :persisted-source-id validated-source-id})))
         native-revision
         {:revision (datalevin-backend/exact-natural!
                     :startup-revision (:max-tx (ds/db conn)))
@@ -342,8 +438,11 @@
     ;; covers every bootstrap transaction visible at this lifecycle.
     (advance-revision-watermark! native-revision config-opts)
     (orchestration/make-client
-     api conn (assoc config-opts prepared-native-source-id-key
-                     (str source-id)))))
+     (api-for-client-context write-token schema-eid)
+     conn
+     (assoc config-opts
+            prepared-native-source-id-key validated-source-id
+            datalevin-backend/prepared-schema-eid-key schema-eid))))
 
 (defn snapshot
   "Constructs a borrowed public snapshot over an open Datalevin read snapshot."

--- a/modules/eacl-datalevin/src/eacl/datalevin/fork.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/fork.cljc
@@ -1,0 +1,43 @@
+(ns eacl.datalevin.fork
+  "Late-bound access to ordered-generation APIs in the maintained fork.
+
+  Late binding lets an older explicit-snapshot fork load far enough for
+  make-client to report a typed capability error instead of failing namespace
+  compilation with a missing Var."
+  (:require [datalevin.core]))
+
+(defn- api-var
+  [symbol]
+  #?(:clj (ns-resolve 'datalevin.core symbol)
+     :cljs nil))
+
+(defn write-policy-capabilities
+  []
+  (when-let [operation (api-var 'write-policy-capabilities)]
+    (operation)))
+
+(defn- required-operation
+  [symbol]
+  (or (api-var symbol)
+      (throw
+       (ex-info
+        "The Datalevin artifact lacks required write-policy support."
+        {:type :eacl/unsupported-capability
+         :eacl/error :eacl/unsupported-capability
+         :backend :datalevin
+         :capability :ordered-generations
+         :missing-operation symbol}))))
+
+(defn write-policy
+  [conn]
+  ((required-operation 'write-policy) conn))
+
+(defn install-write-policy!
+  ([conn policy]
+   ((required-operation 'install-write-policy!) conn policy))
+  ([conn policy tx-meta]
+   ((required-operation 'install-write-policy!) conn policy tx-meta)))
+
+(defn refresh-connection!
+  [conn]
+  ((required-operation 'refresh-connection!) conn))

--- a/modules/eacl-datalevin/src/eacl/datalevin/impl.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/impl.cljc
@@ -241,7 +241,7 @@
 
 (defn tx-relation-version-stamp
   [relation-id]
-  [:db/add relation-id :eacl/relation-version :db/current-tx])
+  [:db/add relation-id :eacl.datalevin/relation-generation :db/current-tx])
 
 (defn- guard-schema-write-fence
   "Fences client-planned relationship data against concurrent schema writes.
@@ -256,7 +256,7 @@
           write-fence
           (when schema-eid
             (some-> (ds/datoms db :eav schema-eid
-                               :eacl/schema-write-fence)
+                               :eacl.datalevin/schema-write-fence)
                     first
                     :v))]
       (when-not write-fence
@@ -266,7 +266,7 @@
           {:type :eacl.cache/generation-unprepared :eacl/error :eacl.cache/generation-unprepared
            :backend :datalevin})))
       (into
-       [[:db.fn/cas schema-eid :eacl/schema-write-fence
+       [[:db.fn/cas schema-eid :eacl.datalevin/schema-write-fence
          write-fence write-fence]]
        tx-data))
     []))
@@ -703,7 +703,7 @@
                       (keep (fn [op]
                               (when (and (vector? op)
                                          (= :db/add (first op))
-                                         (= :eacl/relation-version
+                                         (= :eacl.datalevin/relation-generation
                                             (nth op 2 nil)))
                                 (nth op 1))))
                       ops)]

--- a/modules/eacl-datalevin/src/eacl/datalevin/safe_retraction.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/safe_retraction.cljc
@@ -3,9 +3,11 @@
   retraction. Datalevin cannot persist arbitrary Clojure function values, so
   this adapter deliberately supports only direct `:db.fn/call` invocation."
   (:require [datalevin.core :as ds]
+            [eacl.backend.writer :as backend-writer]
             [eacl.datalevin.db :as ddb]
             [eacl.relationships.safe-retraction :as safe]
-            [eacl.relationships.storage :as storage]))
+            [eacl.relationships.storage :as storage]
+            [eacl.request.counters :as request-counters]))
 
 (def support
   (safe/support-descriptor
@@ -67,6 +69,15 @@
             :local-half-count 0}))))
     (relation-triples db))))
 
+(defn- relation-generation-stamps
+  [relation-ids]
+  (mapv
+   (fn [relation-id]
+     [:db/add relation-id
+      :eacl.datalevin/relation-generation
+      :db/current-tx])
+   (distinct relation-ids)))
+
 (defn retract-entity-function
   "Datalevin target-only transaction function implementation."
   [db target]
@@ -122,7 +133,7 @@
           (into []
                 (concat
                  (:peer-retractions plan)
-                 (safe/relation-stamps (:relation-ids plan))
+                 (relation-generation-stamps (:relation-ids plan))
                  (when live?
                    [[:db.fn/retractEntity target-eid]]))))))))
 
@@ -160,3 +171,43 @@
   Call `prepare!` once for a new connection before submitting this data."
   [target]
   (retract-entity-tx-data target))
+
+(defn transact-retract-entity!
+  "Submits safe retraction through a Datalevin EACL writer.
+
+  The writer supplies the per-open admission token and synchronously advances
+  the external revision watermark after commit. Raw submission is valid only
+  when expansion touches no protected EACL attribute."
+  [client target]
+  (let [writer (:writer client)]
+    (when-not (and (backend-writer/writer? writer)
+                   (= :datalevin (backend-writer/backend-id writer)))
+      (throw
+       (ex-info
+        "Safe Datalevin retraction requires a writable Datalevin EACL client."
+        {:type :eacl/invalid-client
+         :eacl/error :eacl/invalid-client
+         :backend :datalevin})))
+    (let [{:keys [conn options api]} (backend-writer/state writer)
+          report
+          (loop [attempt 1]
+            (let [outcome
+                  (try
+                    {:value
+                     (backend-writer/invoke
+                      writer :transact! conn
+                      {:tx-data (retract-entity-tx-data target)})}
+                    (catch #?(:clj Throwable :cljs :default) error
+                      {:error error}))]
+              (if-let [error (:error outcome)]
+                (if (and (< attempt 8)
+                         (= :eacl.datalevin/stale-connection-generation
+                            (:type (ex-data error))))
+                  (recur (inc attempt))
+                  (throw error))
+                (:value outcome))))
+          native-revision
+          ((:db-native-revision api) (:db-after report))]
+      (request-counters/add! :writer-submissions)
+      ((:after-commit! api) native-revision options)
+      report)))

--- a/modules/eacl-datalevin/src/eacl/datalevin/schema.cljc
+++ b/modules/eacl-datalevin/src/eacl/datalevin/schema.cljc
@@ -1,6 +1,8 @@
 (ns eacl.datalevin.schema
-  (:require [datalevin.core :as ds]
+  (:require [clojure.string :as str]
+            [datalevin.core :as ds]
             [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.fork :as fork]
             [eacl.relationships.storage :as relationship-storage]
             [eacl.schema.model :as model]
             [eacl.spicedb.parser :as parser]))
@@ -9,9 +11,9 @@
   {:eacl/id {:db/valueType :db.type/string
              :db/unique :db.unique/identity}
    :eacl/schema-string {:db/valueType :db.type/string}
-   :eacl/schema-generation {:db/valueType :db.type/ref}
-   :eacl/schema-write-fence {:db/valueType :db.type/ref}
-   :eacl/relation-version {:db/valueType :db.type/ref}
+   :eacl.datalevin/schema-generation {:db/valueType :db.type/long}
+   :eacl.datalevin/schema-write-fence {:db/valueType :db.type/long}
+   :eacl.datalevin/relation-generation {:db/valueType :db.type/long}
    :eacl.datalevin/source-id {:db/valueType :db.type/uuid
                               :db/unique :db.unique/identity}
    :eacl.relation/resource-type {:db/valueType :db.type/keyword
@@ -69,19 +71,96 @@
   ([extra-schema]
    (merge datalevin-schema extra-schema)))
 
+(declare prepare-cache-coherence!)
+
+(defn- eacl-storage-attribute?
+  [attribute]
+  (let [attribute-namespace (some-> attribute namespace)]
+    (and (keyword? attribute)
+         (or (= "eacl" attribute-namespace)
+             (some-> attribute-namespace (str/starts-with? "eacl.")))
+         (not= :eacl/id attribute))))
+
+(defn- definition-attribute?
+  [attribute]
+  (or (= :eacl/schema-string attribute)
+      (contains? #{"eacl.relation" "eacl.permission"}
+                 (namespace attribute))))
+
+(defn- expected-write-policy
+  [conn]
+  (let [db (ds/db conn)
+        schema-eid (ds/entid db [:eacl/id "schema-string"])]
+    (when-not schema-eid
+      (throw
+       (ex-info
+        "Datalevin write-policy installation requires the schema singleton."
+        {:type :eacl.cache/generation-unprepared
+         :eacl/error :eacl.cache/generation-unprepared
+         :backend :datalevin
+         :missing :schema-singleton})))
+    (let [guarded (into #{} (filter eacl-storage-attribute?)
+                        (keys (ds/schema conn)))
+          definition-attributes (filter definition-attribute? guarded)]
+      {:guarded-attributes guarded
+       :frozen-attributes guarded
+       :commit-generation-attributes
+       #{:eacl.datalevin/schema-generation
+         :eacl.datalevin/schema-write-fence
+         :eacl.datalevin/relation-generation}
+       :stamp-rules
+       (into
+        [{:when-attribute relationship-storage/forward-attribute
+          :stamp-attribute :eacl.datalevin/relation-generation
+          :stamp-entity [:tuple-position 1]}
+         {:when-attribute relationship-storage/reverse-attribute
+          :stamp-attribute :eacl.datalevin/relation-generation
+          :stamp-entity [:tuple-position 1]}]
+        (map
+         (fn [attribute]
+           {:when-attribute attribute
+            :stamp-attribute :eacl.datalevin/schema-generation
+            :stamp-entity [:constant schema-eid]}))
+        definition-attributes)
+       :guarded-write-hint
+       "Protected EACL data requires the admitted writer; use delete-object! for permissioned-object relationship cleanup."})))
+
+(defn- generation-gaps
+  [db]
+  (let [schema-eid (ds/entid db [:eacl/id "schema-string"])
+        relations
+        (into [] (map :e)
+              (ddb/avet-datoms
+               db :eacl.relation/resource-type+relation-name+subject-type))]
+    (cond-> []
+      (nil? schema-eid)
+      (conj :schema-singleton)
+
+      (and schema-eid
+           (empty? (ds/datoms db :eav schema-eid
+                              :eacl.datalevin/schema-generation)))
+      (conj :eacl.datalevin/schema-generation)
+
+      (and schema-eid
+           (empty? (ds/datoms db :eav schema-eid
+                              :eacl.datalevin/schema-write-fence)))
+      (conj :eacl.datalevin/schema-write-fence)
+
+      true
+      (into
+       (for [relation-eid relations
+             :when (empty? (ds/datoms db :eav relation-eid
+                                      :eacl.datalevin/relation-generation))]
+         relation-eid)))))
+
 (defn create-conn
   ([] (create-conn nil nil nil))
   ([dir] (create-conn dir nil nil))
   ([dir extra-schema] (create-conn dir extra-schema nil))
   ([dir extra-schema store-options]
-   (let [conn (ds/get-conn dir (merge-schema extra-schema) store-options)]
-     (when-not
-      (ds/entid (ds/db conn) [:eacl/id "datalevin-metadata"])
-       (ds/transact!
-        conn
-        [{:eacl/id "datalevin-metadata"
-          :eacl.datalevin/source-id (random-uuid)}]))
-     conn)))
+   ;; Qualification and bootstrap belong to make-client. Merely opening a
+   ;; connection must not submit an unadmitted protected transaction.
+   (ds/get-conn dir (merge-schema extra-schema) store-options)))
 
 (def ^:private physical-schema-keys
   #{:db/valueType :db/cardinality :db/unique :db/index
@@ -100,9 +179,10 @@
 
 (defn ensure-physical-schema!
   "Installs missing EACL attributes on a quiesced embedded connection and
-  rejects any incompatible definition. Returns the persisted source UUID."
+  rejects any incompatible definition. Installs the storage write policy and
+  returns the persisted source UUID plus the per-open writer token."
   [conn]
-  (let [db (ds/db conn)
+  (let [existing-policy (fork/write-policy conn)
         actual (ds/schema conn)
         drift
         (into {}
@@ -131,23 +211,68 @@
     (let [db (ds/db conn)
           metadata (ds/entity db [:eacl/id "datalevin-metadata"])
           existing (:eacl.datalevin/source-id metadata)]
-      (cond
-        (uuid? existing) existing
-        (some? existing)
+      (when (and existing-policy (not (uuid? existing)))
         (throw
          (ex-info
-          "Datalevin source identity is not a UUID."
+          "A protected Datalevin store has no valid persisted source identity."
           {:type :eacl/invalid-source-identity
            :eacl/error :eacl/invalid-source-identity
            :backend :datalevin
-           :value existing}))
-        :else
-        (let [source-id (random-uuid)]
-          (ds/transact!
-           conn
-           [{:eacl/id "datalevin-metadata"
-             :eacl.datalevin/source-id source-id}])
-          source-id)))))
+           :value existing})))
+      (let [source-id
+            (cond
+              (uuid? existing) existing
+
+              (some? existing)
+              (throw
+               (ex-info
+                "Datalevin source identity is not a UUID."
+                {:type :eacl/invalid-source-identity
+                 :eacl/error :eacl/invalid-source-identity
+                 :backend :datalevin
+                 :value existing}))
+
+              :else
+              (let [source-id (random-uuid)]
+                (ds/transact!
+                 conn
+                 [{:eacl/id "datalevin-metadata"
+                   :eacl.datalevin/source-id source-id}])
+                source-id))]
+        ;; The constant schema stamp selector needs a durable eid, but the
+        ;; generation values themselves cannot use :db/current-tx until the
+        ;; policy declares them as commit-generation attributes.
+        (when-not existing-policy
+          (when-not (ds/entid (ds/db conn) [:eacl/id "schema-string"])
+            (ds/transact! conn [{:eacl/id "schema-string"}])))
+        (let [policy-result
+              (try
+                (fork/install-write-policy! conn (expected-write-policy conn))
+                (catch #?(:clj Throwable :cljs :default) error
+                  (throw
+                   (ex-info
+                    "Datalevin's persisted EACL write policy does not match the module contract."
+                    {:type :eacl.datalevin/write-policy-drift
+                     :eacl/error :eacl.datalevin/write-policy-drift
+                     :backend :datalevin}
+                    error))))
+              _ (when-not existing-policy
+                  (prepare-cache-coherence!
+                   conn (:write-token policy-result)))
+              gaps (generation-gaps (ds/db conn))]
+          (when (seq gaps)
+            (throw
+             (ex-info
+              "A protected Datalevin store has incomplete generation evidence."
+              {:type :eacl.cache/generation-unprepared
+               :eacl/error :eacl.cache/generation-unprepared
+               :backend :datalevin
+               :missing gaps})))
+          {:source-id source-id
+           :schema-eid (ds/entid (ds/db conn) [:eacl/id "schema-string"])
+           :write-token (:write-token policy-result)
+           :write-policy (:policy policy-result)
+           :fork-capabilities (:capabilities policy-result)})))))
 
 (def relation-pull
   [:eacl/id :eacl.relation/subject-type
@@ -191,12 +316,14 @@
 (defn prepare-cache-coherence!
   "Initializes missing physical schema/relation generations and the schema
   write fence additively."
-  [conn]
+  ([conn]
+   (prepare-cache-coherence! conn nil))
+  ([conn write-token]
   (let [db (ds/db conn)
         physical-schema (ds/schema conn)
-        _ (when-not (and (contains? physical-schema :eacl/schema-generation)
-                         (contains? physical-schema :eacl/schema-write-fence)
-                         (contains? physical-schema :eacl/relation-version))
+        _ (when-not (and (contains? physical-schema :eacl.datalevin/schema-generation)
+                         (contains? physical-schema :eacl.datalevin/schema-write-fence)
+                         (contains? physical-schema :eacl.datalevin/relation-generation))
             (throw
              (ex-info
               "Datalevin connection schema lacks native EACL generation attributes."
@@ -209,41 +336,53 @@
               (ddb/avet-datoms
                db :eacl.relation/resource-type+relation-name+subject-type))
         missing-schema?
-        (and schema-eid
-             (empty? (ds/datoms db :eav schema-eid
-                                :eacl/schema-generation)))
+        (or (nil? schema-eid)
+            (empty? (ds/datoms db :eav schema-eid
+                               :eacl.datalevin/schema-generation)))
         missing-schema-fence?
-        (and schema-eid
-             (empty? (ds/datoms db :eav schema-eid
-                                :eacl/schema-write-fence)))
+        (or (nil? schema-eid)
+            (empty? (ds/datoms db :eav schema-eid
+                               :eacl.datalevin/schema-write-fence)))
         missing-relations
         (filterv #(empty? (ds/datoms db :eav %
-                                    :eacl/relation-version))
+                                    :eacl.datalevin/relation-generation))
                  relation-eids)
         tx-data
-        (into (cond-> []
-                missing-schema?
-                (conj [:db/add schema-eid
-                       :eacl/schema-generation :db/current-tx])
+        (into (if (nil? schema-eid)
+                [(cond-> {:eacl/id "schema-string"}
+                   missing-schema?
+                   (assoc :eacl.datalevin/schema-generation :db/current-tx)
 
-                missing-schema-fence?
-                (conj [:db/add schema-eid
-                       :eacl/schema-write-fence :db/current-tx]))
-              (map #(vector :db/add % :eacl/relation-version :db/current-tx))
+                   missing-schema-fence?
+                   (assoc :eacl.datalevin/schema-write-fence :db/current-tx))]
+                (cond-> []
+                  missing-schema?
+                  (conj [:db/add schema-eid
+                         :eacl.datalevin/schema-generation :db/current-tx])
+
+                  missing-schema-fence?
+                  (conj [:db/add schema-eid
+                         :eacl.datalevin/schema-write-fence :db/current-tx])))
+              (map #(vector :db/add % :eacl.datalevin/relation-generation :db/current-tx))
               missing-relations)
-        report (when (seq tx-data) (ds/transact! conn tx-data))
+        report
+        (when (seq tx-data)
+          (ds/transact!
+           conn tx-data
+           (when write-token {:datalevin/write-token write-token})))
         db-after (if report (:db-after report) db)
+        schema-eid-after (ds/entid db-after [:eacl/id "schema-string"])
         schema-missing-after?
-        (and schema-eid
-             (empty? (ds/datoms db-after :eav schema-eid
-                                :eacl/schema-generation)))
+        (or (nil? schema-eid-after)
+            (empty? (ds/datoms db-after :eav schema-eid-after
+                               :eacl.datalevin/schema-generation)))
         schema-fence-missing-after?
-        (and schema-eid
-             (empty? (ds/datoms db-after :eav schema-eid
-                                :eacl/schema-write-fence)))
+        (or (nil? schema-eid-after)
+            (empty? (ds/datoms db-after :eav schema-eid-after
+                               :eacl.datalevin/schema-write-fence)))
         relation-missing-after
         (filterv #(empty? (ds/datoms db-after :eav %
-                                    :eacl/relation-version))
+                                    :eacl.datalevin/relation-generation))
                  relation-eids)]
     {:prepared? true
      :changed? (boolean report)
@@ -252,9 +391,9 @@
      :relation-generations-initialized (count missing-relations)
      :missing-after
      (cond-> relation-missing-after
-       schema-missing-after? (conj :eacl/schema-generation)
-       schema-fence-missing-after? (conj :eacl/schema-write-fence))
-     :db-after db-after}))
+       schema-missing-after? (conj :eacl.datalevin/schema-generation)
+       schema-fence-missing-after? (conj :eacl.datalevin/schema-write-fence))
+     :db-after db-after})))
 
 (def validate-schema-references model/validate-schema-references)
 (def compare-schema model/compare-schema)
@@ -283,39 +422,40 @@
 (defn current-schema-generation
   [db]
   (when-let [schema-eid (ds/entid db [:eacl/id "schema-string"])]
-    (some-> (ds/datoms db :eav schema-eid :eacl/schema-generation)
+    (some-> (ds/datoms db :eav schema-eid :eacl.datalevin/schema-generation)
             first
             :v)))
 
 (defn- current-schema-write-fence
   [db]
   (when-let [schema-eid (ds/entid db [:eacl/id "schema-string"])]
-    (some-> (ds/datoms db :eav schema-eid :eacl/schema-write-fence)
+    (some-> (ds/datoms db :eav schema-eid :eacl.datalevin/schema-write-fence)
             first
             :v)))
 
 (defn- ensure-schema-coherence!
-  "Bootstraps the schema singleton before its first guarded replacement.
-
-  Datalevin does not allow a tempid or :db/current-tx as a :db.fn/cas value,
-  so the first physical generation and fence must exist before the replacement
-  CAS. The parser, reference checks, and empty-schema guard run first."
+  "Bootstraps an unprotected store, but never repairs missing evidence after
+  write-policy installation. Protected stores fail closed."
   [conn]
   (loop []
     (let [db (ds/db conn)]
       (if (and (current-schema-generation db)
                (current-schema-write-fence db))
         db
-        (do
-          (ds/transact!
-           conn
-           [(cond-> {:eacl/id "schema-string"}
-              (nil? (current-schema-generation db))
-              (assoc :eacl/schema-generation :db/current-tx)
+        (throw
+         (ex-info
+          "Datalevin schema writes require prepared generation evidence."
+          {:type :eacl.cache/generation-unprepared
+           :eacl/error :eacl.cache/generation-unprepared
+           :backend :datalevin
+           :policy-installed? (boolean (fork/write-policy conn))
+           :missing
+           (cond-> []
+             (nil? (current-schema-generation db))
+             (conj :eacl.datalevin/schema-generation)
 
-              (nil? (current-schema-write-fence db))
-              (assoc :eacl/schema-write-fence :db/current-tx))])
-          (recur))))))
+             (nil? (current-schema-write-fence db))
+             (conj :eacl.datalevin/schema-write-fence))}))))))
 
 (defn- cas-failure-data
   [throwable]
@@ -327,22 +467,52 @@
           (recur #?(:clj (.getCause ^Throwable cause)
                     :cljs (ex-cause cause))))))))
 
+(defn- datalevin-failure-data
+  [throwable failure-type]
+  (loop [cause throwable]
+    (when cause
+      (let [data (ex-data cause)]
+        (if (= failure-type (:type data))
+          data
+          (recur #?(:clj (.getCause ^Throwable cause)
+                    :cljs (ex-cause cause))))))))
+
 (defn- transact-schema!
-  [conn tx-data expected-generation]
+  [conn tx-data expected-generation write-token]
   (try
-    (ds/transact! conn tx-data)
+    (ds/transact!
+     conn tx-data
+     (when write-token {:datalevin/write-token write-token}))
     (catch #?(:clj Throwable :cljs :default) throwable
-      (if-let [cause-data (cas-failure-data throwable)]
-        (throw
-         (ex-info
-          "The EACL schema changed concurrently; retry from the new database value."
-          {:type :eacl.schema/concurrent-write
-           :eacl/error :eacl.schema/concurrent-write
-           :expected-generation expected-generation
-           :actual-generation (current-schema-generation (ds/db conn))
-           :backend-error cause-data
-           :datalevin-error cause-data}
-          throwable))
+      (cond
+        (cas-failure-data throwable)
+        (let [cause-data (cas-failure-data throwable)]
+          (throw
+           (ex-info
+            "The EACL schema changed concurrently; retry from the new database value."
+            {:type :eacl.schema/concurrent-write
+             :eacl/error :eacl.schema/concurrent-write
+             :expected-generation expected-generation
+             :actual-generation (current-schema-generation (ds/db conn))
+             :backend-error cause-data
+             :datalevin-error cause-data}
+            throwable)))
+
+        (datalevin-failure-data throwable :datalevin/stale-generation)
+        (let [cause-data
+              (datalevin-failure-data throwable :datalevin/stale-generation)]
+          (fork/refresh-connection! conn)
+          (throw
+           (ex-info
+            "A shared Datalevin connection prepared the schema from a stale generation."
+            {:type :eacl.datalevin/stale-connection-generation
+             :eacl/error :eacl.datalevin/stale-connection-generation
+             :backend :datalevin
+             :expected-generation expected-generation
+             :datalevin-error cause-data}
+            throwable)))
+
+        :else
         (throw throwable)))))
 
 (defn write-schema!
@@ -358,6 +528,13 @@
   ([conn schema-string
     {:keys [allow-empty-schema?]}
     known-schema-generation]
+   (write-schema! conn schema-string
+                  {:allow-empty-schema? allow-empty-schema?}
+                  known-schema-generation nil))
+  ([conn schema-string
+    {:keys [allow-empty-schema?]}
+    known-schema-generation
+    write-token]
    (let [new-schema-map  (parser/->eacl-schema (parser/parse-schema schema-string))
          _               (validate-schema-references new-schema-map)
          initial-db      (ds/db conn)
@@ -396,7 +573,7 @@
                             :relation rel
                             :count cnt})))))
      (let [relation-additions
-           (mapv #(assoc % :eacl/relation-version :db/current-tx)
+           (mapv #(assoc % :eacl.datalevin/relation-generation :db/current-tx)
                  (:additions relations))
            schema-eid (ds/entid db [:eacl/id "schema-string"])
            schema-generation
@@ -411,7 +588,7 @@
                     (ds/entid db [:eacl/id (:eacl/id relation)])
                     relation-generation
                     (some-> (ds/datoms db :eav relation-eid
-                                       :eacl/relation-version)
+                                       :eacl.datalevin/relation-generation)
                             first
                             :v)]
                 (when-not relation-generation
@@ -421,13 +598,13 @@
                     {:type :eacl.cache/generation-unprepared :eacl/error :eacl.cache/generation-unprepared
                      :backend :datalevin
                      :relation-id (:eacl/id relation)})))
-                [:db.fn/cas relation-eid :eacl/relation-version
+                [:db.fn/cas relation-eid :eacl.datalevin/relation-generation
                  relation-generation relation-generation]))
             relation-retractions)
            tx-data
            (vec
             (concat
-             [[:db.fn/cas schema-eid :eacl/schema-write-fence
+             [[:db.fn/cas schema-eid :eacl.datalevin/schema-write-fence
                schema-write-fence schema-write-fence]]
              relation-commit-guards
              relation-additions
@@ -443,9 +620,9 @@
              [{:db/id schema-eid
                :eacl/id "schema-string"
                :eacl/schema-string schema-string}
-              [:db/add schema-eid :eacl/schema-generation
+              [:db/add schema-eid :eacl.datalevin/schema-generation
                :db/current-tx]
-              [:db/add schema-eid :eacl/schema-write-fence
+              [:db/add schema-eid :eacl.datalevin/schema-write-fence
                :db/current-tx]]))
            stored-string
            (some-> (ds/entity db [:eacl/id "schema-string"])
@@ -459,7 +636,7 @@
                       (:retractions permissions)]))
            report
            (if changed?
-             (transact-schema! conn tx-data schema-generation)
+             (transact-schema! conn tx-data schema-generation write-token)
              {:db-before db
               :db-after db
               :tx-data []

--- a/modules/eacl-datalevin/test/eacl/bench/authorization_amplification_test.clj
+++ b/modules/eacl-datalevin/test/eacl/bench/authorization_amplification_test.clj
@@ -331,8 +331,6 @@
      {:source-lifecycle "authorization-amplification-baseline"
       :revision-watermark watermark
       :advance-revision-watermark! #(swap! watermark max %)
-      :datalevin-topology
-      datalevin-backend/certified-topology-declaration
       :security-key test-key})))
 
 (defn- fixture-relationships

--- a/modules/eacl-datalevin/test/eacl/bench/datalevin_ordered_generation_test.clj
+++ b/modules/eacl-datalevin/test/eacl/bench/datalevin_ordered_generation_test.clj
@@ -1,0 +1,183 @@
+(ns eacl.bench.datalevin-ordered-generation-test
+  (:require [clojure.test :refer [deftest is]]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.backend.source :as source]
+            [eacl.backend.v8 :as backend]
+            [eacl.core :as eacl]
+            [eacl.datalevin.core :as datalevin]))
+
+(def ^:private test-key "01234567890123456789012345678901")
+(def ^:private maximum-closure-size 4096)
+
+(def ^:private schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     relation editor: user
+     permission view = viewer
+   }")
+
+(def regression-budgets-ms
+  {:frame-zero-p95 2.0
+   :frame-typical-p95 5.0
+   :frame-maximum-p95 100.0
+   :exact-hit-p95 5.0
+   :managed-hit-p95 10.0
+   :write-commit-p50 20.0
+   :write-commit-p95 100.0})
+
+(defn- percentile
+  [samples fraction]
+  (let [ordered (vec (sort samples))
+        index (min (dec (count ordered))
+                   (long (Math/floor (* fraction (count ordered)))))]
+    (nth ordered index)))
+
+(defn- measure
+  [warmups samples f]
+  (dotimes [_ warmups] (f))
+  (let [values
+        (mapv
+         (fn [_]
+           (let [started (System/nanoTime)]
+             (f)
+             (/ (double (- (System/nanoTime) started)) 1000000.0)))
+         (range samples))]
+    {:samples samples
+     :p50-ms (percentile values 0.50)
+     :p95-ms (percentile values 0.95)
+     :maximum-ms (apply max values)}))
+
+(defn- within-budgets?
+  [report]
+  (every?
+   true?
+   [(<= (get-in report [:frame :zero :p95-ms])
+        (:frame-zero-p95 regression-budgets-ms))
+    (<= (get-in report [:frame :typical :p95-ms])
+        (:frame-typical-p95 regression-budgets-ms))
+    (<= (get-in report [:frame :maximum :p95-ms])
+        (:frame-maximum-p95 regression-budgets-ms))
+    (<= (get-in report [:requests :exact-hit :p95-ms])
+        (:exact-hit-p95 regression-budgets-ms))
+    (<= (get-in report [:requests :managed-hit :p95-ms])
+        (:managed-hit-p95 regression-budgets-ms))
+    (<= (get-in report [:writes :policy-active :p50-ms])
+        (:write-commit-p50 regression-budgets-ms))
+    (<= (get-in report [:writes :policy-active :p95-ms])
+        (:write-commit-p95 regression-budgets-ms))]))
+
+(defn run-benchmark!
+  []
+  (let [dir (u/tmp-dir (str "eacl-datalevin-proof-bench-" (random-uuid)))
+        conn (datalevin/create-conn dir)
+        watermark (atom 0)
+        client
+        (datalevin/make-client
+         conn
+         {:security-key test-key
+          :source-lifecycle "ordered-generation-benchmark"
+          :revision-watermark watermark
+          :advance-revision-watermark! #(swap! watermark max %)})]
+    (try
+      (eacl/write-schema! client schema)
+      (d/transact!
+       conn
+       (mapv (fn [id] {:eacl/id id})
+             ["alice" "bob" "document-1" "document-2"]))
+      (let [policy (d/write-policy conn)
+            token (:write-token (d/install-write-policy! conn policy))
+            synthetic-relation-ids
+            (vec (range 10000 (+ 10000 maximum-closure-size)))]
+        (d/transact!
+         conn
+         (mapv
+          (fn [relation-id]
+            [:db/add relation-id
+             :eacl.datalevin/relation-generation
+             :db/current-tx])
+          synthetic-relation-ids)
+         {:datalevin/write-token token})
+        (let [selection (source/acquire! (:source client) :current)]
+          (try
+            (let [adapter (source/adapter selection)
+                  frame
+                  {:zero
+                   (measure 20 100
+                            #(backend/invoke adapter :proof-frame []))
+                   :typical
+                   (measure 20 100
+                            #(backend/invoke
+                              adapter :proof-frame
+                              (subvec synthetic-relation-ids 0 8)))
+                   :maximum
+                   (measure 2 12
+                            #(backend/invoke
+                              adapter :proof-frame
+                              synthetic-relation-ids))}
+                  alice (eacl/spice-object :user "alice")
+                  bob (eacl/spice-object :user "bob")
+                  document-1 (eacl/spice-object :document "document-1")
+                  document-2 (eacl/spice-object :document "document-2")
+                  viewer (eacl/->Relationship alice :viewer document-1)
+                  editor (eacl/->Relationship bob :editor document-2)
+                  demand {:subject alice
+                          :permission :view
+                          :resource document-1}
+                  _ (eacl/create-relationship! client viewer)
+                  _ (eacl/check-permission client demand)
+                  exact
+                  (measure 50 300
+                           #(eacl/check-permission client demand))
+                  present? (atom false)
+                  write-samples (atom [])
+                  managed-samples
+                  (mapv
+                   (fn [_]
+                     (let [started (System/nanoTime)]
+                       (if (swap! present? not)
+                         (eacl/create-relationship! client editor)
+                         (eacl/delete-relationship! client editor))
+                       (swap! write-samples conj
+                              (/ (double (- (System/nanoTime) started))
+                                 1000000.0)))
+                     (let [started (System/nanoTime)
+                           response (eacl/check-permission client demand)
+                           elapsed (/ (double (- (System/nanoTime) started))
+                                      1000000.0)]
+                       (when-not (:cached? response)
+                         (throw
+                          (ex-info "Expected a managed cache hit."
+                                   {:response response})))
+                       elapsed))
+                   (range 100))
+                  report
+                  {:format-version 1
+                   :benchmark :datalevin-ordered-generation
+                   :maximum-closure-size maximum-closure-size
+                   :regression-budgets-ms regression-budgets-ms
+                   :frame frame
+                   :requests
+                   {:exact-hit exact
+                    :managed-hit
+                    {:samples (count managed-samples)
+                     :p50-ms (percentile managed-samples 0.50)
+                     :p95-ms (percentile managed-samples 0.95)
+                     :maximum-ms (apply max managed-samples)}}
+                   :writes
+                   {:policy-active
+                    {:samples (count @write-samples)
+                     :p50-ms (percentile @write-samples 0.50)
+                     :p95-ms (percentile @write-samples 0.95)
+                     :maximum-ms (apply max @write-samples)}}}]
+              (assoc report :passed? (within-budgets? report)))
+            (finally
+              (source/release! selection)))))
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(deftest ^:benchmark ordered-generation-regression-budget-test
+  (let [report (run-benchmark!)]
+    (is (:passed? report) (pr-str report))))

--- a/modules/eacl-datalevin/test/eacl/bench/datalevin_test.clj
+++ b/modules/eacl-datalevin/test/eacl/bench/datalevin_test.clj
@@ -111,8 +111,6 @@
          {:source-lifecycle "benchmark-lifecycle"
           :revision-watermark watermark
           :advance-revision-watermark! #(swap! watermark max %)
-          :datalevin-topology
-          datalevin-backend/certified-topology-declaration
           :security-key test-key})]
     (try
       (eacl/write-schema! client schema)

--- a/modules/eacl-datalevin/test/eacl/datalevin/adapter_certification_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/adapter_certification_test.clj
@@ -31,7 +31,6 @@
                   :revision-watermark watermark
                   :advance-revision-watermark!
                   #(swap! watermark max %)
-                  :datalevin-topology backend/certified-topology-declaration
                   :security-key "01234567890123456789012345678901"})]
             (eacl/write-schema! client (:schema fixture))
             (d/transact!
@@ -45,33 +44,59 @@
                   selected (source/acquire! provider :current)]
               (try
                 (let [adapter (source/adapter selected)
+                      relation-ids
+                      (->> (:relations fixture)
+                           (mapcat
+                            (fn [{:keys [resource-type relation-name]}]
+                              (v8/invoke adapter :relation-defs
+                                         resource-type relation-name)))
+                           (mapv :relation-id)
+                           sort
+                           vec)
                       report
                       (certification/certify
-                      {:adapter adapter
+                       {:adapter adapter
                         :fixture fixture
                         :runtime :clj})]
                   (is (some? (v8/invoke adapter :schema-generation)))
                   (is (:passed? report) (pr-str (:checks report)))
-                  (is (= :not-claimed
-                         (:status
-                          (certification/certify-ordered-generation-transition!
-                           {:before-adapter adapter
-                            :after-adapter adapter
-                            :relation-ids []
-                            :affected-relation-ids []})))
-                      "the executable temporal gate records Datalevin's current conservative non-claim")
-                  (testing "persistent Datalevin transaction IDs are not exposed as proof generations"
-                    (is (= #{:snapshot-bound :database-visible}
+                  (testing "scalar generations are exposed as an ordered proof frame"
+                    (is (= #{:ordered-generations
+                             :snapshot-bound
+                             :database-visible}
                            (:cache-proofs (v8/capabilities adapter))))
-                    (is (not (v8/supports? adapter
-                                           :cache-proofs
-                                           :ordered-generations)))
-                    (is (= {:type :eacl/unsupported-capability
-                            :capability :operation
-                            :requested :proof-frame}
-                           (select-keys
-                            (error-data #(v8/operation adapter :proof-frame))
-                            [:type :capability :requested])))))
+                    (is (v8/supports? adapter
+                                      :cache-proofs
+                                      :ordered-generations))
+                    (is (= relation-ids
+                           (mapv first
+                                 (v8/invoke adapter :proof-frame
+                                            relation-ids)))))
+                  (let [relationship (first (:relationships fixture))
+                        affected-id
+                        (:relation-id
+                         (first
+                          (v8/invoke
+                           adapter :relation-defs
+                           (get-in relationship [:resource :type])
+                           (:relation relationship))))]
+                    (eacl/write-relationship!
+                     client
+                     {:operation :delete
+                      :subject (:subject relationship)
+                      :relation (:relation relationship)
+                      :resource (:resource relationship)})
+                    (let [after-selected (source/acquire! provider :current)]
+                      (try
+                        (is (= :certified
+                               (:status
+                                (certification/certify-ordered-generation-transition!
+                                 {:before-adapter adapter
+                                  :after-adapter (source/adapter after-selected)
+                                  :relation-ids relation-ids
+                                  :affected-relation-ids [affected-id]}))))
+                        (finally
+                          (source/release! after-selected))))))
                 (finally
                   (source/release! selected)))))
           (finally
@@ -81,12 +106,19 @@
 (deftest datalevin-durable-source-identity-certification-test
   (let [dir (u/tmp-dir (str "eacl-datalevin-source-cert-" (random-uuid)))
         first-conn (datalevin/create-conn dir)
+        watermark (atom 0)
+        opts {:source-lifecycle "durable-source-certification"
+              :revision-watermark watermark
+              :advance-revision-watermark! #(swap! watermark max %)
+              :security-key "01234567890123456789012345678901"}
+        _ (datalevin/make-client first-conn opts)
         first-scope
         {:source-id (backend/connection-source-id first-conn)
          :branch nil}]
     (d/close first-conn)
     (let [second-conn (datalevin/create-conn dir)]
       (try
+        (datalevin/make-client second-conn opts)
         (is (= :certified
                (:status
                 (certification/certify-live-source-identity!

--- a/modules/eacl-datalevin/test/eacl/datalevin/contract_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/contract_test.clj
@@ -12,6 +12,7 @@
             [eacl.datalevin.backend :as datalevin-backend]
             [eacl.datalevin.core :as datalevin]
             [eacl.datalevin.db :as ddb]
+            [eacl.datalevin.fork :as datalevin-fork]
             [eacl.datalevin.schema :as datalevin-schema]
             [eacl.engine.sealed-plan :as sealed-plan]
             [eacl.request.counters :as request-counters]
@@ -69,8 +70,6 @@
              (merge
               watermark-config
               {:source-lifecycle "test-lifecycle"
-               :datalevin-topology
-               datalevin-backend/certified-topology-declaration
                :security-key test-key}))]
         (f {:dir dir
             :conn conn
@@ -158,7 +157,6 @@
         (str
          "(do "
          "(require '[eacl.core :as eacl] "
-         "         '[eacl.datalevin.backend :as backend] "
          "         '[eacl.datalevin.core :as datalevin]) "
          "(let [watermark (atom 0) "
          "      conn (datalevin/create-conn " (pr-str dir) ") "
@@ -170,8 +168,6 @@
          "               (fn [revision] "
          "                 (spit " (pr-str watermark-file) " (str revision)) "
          "                 (swap! watermark max revision)) "
-         "               :datalevin-topology "
-         "               backend/certified-topology-declaration "
          "               :security-key " (pr-str test-key) "})] "
          "  (eacl/write-schema! client " (pr-str schema) ") "
          "  (.halt (Runtime/getRuntime) 23)))")
@@ -201,8 +197,6 @@
    (merge
     (watermark-options)
     {:source-lifecycle "test-lifecycle"
-     :datalevin-topology
-     datalevin-backend/certified-topology-declaration
      :security-key test-key}
     overrides)))
 
@@ -398,35 +392,37 @@
            :mutated? @mutated?
            :observations @observations})))))
 
-(deftest construction-requires-certified-topology-and-monotonic-state-test
+(deftest construction-requires-runtime-safety-and-monotonic-state-test
   (with-connection
     (fn [conn]
       (let [before (d/active-read-snapshot-info)]
-        (testing "every unsupported declared topology fails closed"
-          (doseq [topology
-                  [(assoc datalevin-backend/certified-topology-declaration
-                          :deployment :remote)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :jvms 2)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :connections 2)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :writers 2)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :writer-ownership :external)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :commit-mode :wal)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :physical-schema :mutable)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :request-threads :virtual)
-                   (assoc datalevin-backend/certified-topology-declaration
-                          :wal true)]]
-            (is (= :eacl/unsupported-topology
-                   (:type
-                    (error-data
-                     #(datalevin/make-client
-                       conn (client-config {:datalevin-topology topology}))))))))
+        (testing "the removed advisory topology declaration is rejected"
+          (let [error
+                (error-data
+                 #(datalevin/make-client
+                   conn (client-config {:datalevin-topology {}})))]
+            (is (= :eacl/invalid-config (:type error)))
+            (is (= [:datalevin-topology] (:unknown-keys error)))))
+        (testing "the prepared schema singleton cannot be injected by callers"
+          (let [error
+                (error-data
+                 #(datalevin/make-client
+                   conn
+                   (client-config
+                    {datalevin-backend/prepared-schema-eid-key 1})))]
+            (is (= :eacl/invalid-config (:type error)))
+            (is (= datalevin-backend/prepared-schema-eid-key
+                   (:key error)))))
+        (testing "missing fork enforcement fails before bootstrap mutation"
+          (let [before-revision (:max-tx (d/db conn))
+                error
+                (with-redefs
+                  [datalevin-fork/write-policy-capabilities (constantly nil)]
+                  (error-data
+                   #(datalevin/make-client conn (client-config))))]
+            (is (= :eacl/unsupported-capability (:type error)))
+            (is (= :ordered-generations (:capability error)))
+            (is (= before-revision (:max-tx (d/db conn))))))
         (testing "watermark is mandatory, bounded, exact, and monotonic"
           (is (= :eacl/invalid-config
                  (:type
@@ -514,8 +510,6 @@
                   :ok (swap! watermark max revision)
                   :no-op nil
                   :throw (throw (ex-info "injected" {:mode :throw}))))
-              :datalevin-topology
-              datalevin-backend/certified-topology-declaration
               :security-key test-key})]
         (try
           (reset! mode failure-mode)
@@ -542,8 +536,6 @@
         {:source-lifecycle lifecycle
          :revision-watermark watermark
          :advance-revision-watermark! #(swap! watermark max %)
-         :datalevin-topology
-         datalevin-backend/certified-topology-declaration
          :security-key test-key}
         conn (datalevin/create-conn dir)]
     (try
@@ -626,8 +618,6 @@
                     (fn [revision]
                       (spit watermark-file (str revision))
                       (swap! watermark max revision))
-                    :datalevin-topology
-                    datalevin-backend/certified-topology-declaration
                     :security-key test-key})]
               (is (pos? persisted))
               (is (<= persisted @watermark))
@@ -676,7 +666,8 @@
 (deftest actual-wal-and-unsafe-lmdb-flags-are-rejected-test
   (doseq [[label store-options]
           [[:wal {:wal? true :wal-durability-profile :strict}]
-           [:unsafe-flags {:kv-opts {:flags #{:nosync}}}]]]
+           [:unsafe-flags {:kv-opts {:flags #{:nosync}}}]
+           [:nolock {:kv-opts {:flags #{:nolock}}}]]]
     (testing (name label)
       (let [dir (u/tmp-dir (str "eacl-datalevin-unsafe-" (random-uuid)))
             conn (datalevin/create-conn dir nil store-options)]
@@ -684,8 +675,14 @@
           (let [error (error-data
                        #(datalevin/make-client conn (client-config)))]
             (is (= :eacl/unsupported-topology (:type error)))
-            (when (= label :unsafe-flags)
-              (is (= #{:nosync} (:unsafe-env-flags error)))))
+            (case label
+              :unsafe-flags
+              (is (= #{:nosync} (:unsafe-env-flags error)))
+
+              :nolock
+              (is (= #{:nolock} (:unsafe-env-flags error)))
+
+              nil))
           (finally
             (d/close conn)
             (u/delete-files dir)))))))
@@ -705,13 +702,29 @@
         (d/close conn)
         (u/delete-files dir)))))
 
+(deftest persisted-write-policy-drift-is-rejected-test
+  (with-connection
+    (fn [conn]
+      (datalevin/make-client conn (client-config))
+      (let [policy (d/write-policy conn)
+            token (:write-token (d/install-write-policy! conn policy))]
+        (d/install-write-policy!
+         conn
+         (assoc policy :guarded-write-hint "tampered policy")
+         {:datalevin/write-token token})
+        (is (= :eacl.datalevin/write-policy-drift
+               (:type
+                (error-data
+                 #(datalevin/make-client conn (client-config))))))))))
+
 (deftest exact-integer-domain-is-enforced-at-every-adapter-boundary-test
   (with-connection
     (fn [conn]
       (let [too-large 9007199254740992
             snapshot (d/open-read-snapshot conn)
             info (d/read-snapshot-revision-info snapshot)
-            adapter-opts {}]
+            adapter-opts
+            {datalevin-backend/prepared-schema-eid-key 0}]
         (try
           (doseq [field [:max-tx :max-eid]]
             (is (= :eacl/numeric-domain-error
@@ -1289,8 +1302,6 @@
              (watermark-options)
              {:cache store
               :security-key test-key
-              :datalevin-topology
-              datalevin-backend/certified-topology-declaration
               :source-lifecycle "shared-contract"})
             client
             (datalevin/make-client conn client-options)]
@@ -1320,8 +1331,6 @@
            (watermark-options)
            {:cache cache/no-cache
             :security-key test-key
-            :datalevin-topology
-            datalevin-backend/certified-topology-declaration
             :source-lifecycle "shared-contract"})))
         (is (= {:active 0 :oldest-age-ms nil}
                (d/active-read-snapshot-info)))))))
@@ -1337,8 +1346,6 @@
               (watermark-options)
               {:cache store
                :security-key test-key
-               :datalevin-topology
-               datalevin-backend/certified-topology-declaration
                :source-lifecycle "aggregate-lifecycle"}))
             user-1 (contract/->user "user-1")
             user-2 (contract/->user "user-2")
@@ -1441,13 +1448,15 @@
                      (d/active-read-snapshot-info))
                   (name label)))))
 
-        (testing "cache reuse is identical-basis-only without ordered generations"
+        (testing "source capabilities remain role-pure and relevant writes invalidate"
           (let [capabilities
                 (source/capabilities
                  (:source client))]
             (is (= "aggregate-lifecycle"
                    (source/source-lifecycle
                     (:source client))))
+            ;; Ordered-generation evidence belongs to each selected immutable
+            ;; adapter, not to the source role that performs basis acquisition.
             (is (not (contains? (:cache-proofs capabilities)
                                 :ordered-generations)))
             (doseq [[label invoke]
@@ -1526,8 +1535,6 @@
              (merge
               (watermark-options)
               {:security-key test-key
-               :datalevin-topology
-               datalevin-backend/certified-topology-declaration
                :source-lifecycle "plan-reuse"}))]
         (eacl/write-schema! client contract/smoke-schema)
         (d/transact!
@@ -1550,8 +1557,6 @@
              (merge
               (watermark-options)
               {:security-key test-key
-               :datalevin-topology
-               datalevin-backend/certified-topology-declaration
                :source-lifecycle "one-hundred-checks"}))
             original-seal sealed-plan/seal-plan
             seals (atom 0)]
@@ -1619,8 +1624,6 @@
              (merge
               (watermark-options)
               {:security-key test-key
-               :datalevin-topology
-               datalevin-backend/certified-topology-declaration
                :source-lifecycle "recursive-contract"}))]
         (eacl/write-schema! client contract/recursive-schema)
         (d/transact!

--- a/modules/eacl-datalevin/test/eacl/datalevin/differential_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/differential_test.clj
@@ -65,8 +65,6 @@
         {:source-lifecycle (str "differential-" seed)
          :revision-watermark watermark
          :advance-revision-watermark! #(swap! watermark max %)
-         :datalevin-topology
-         datalevin-backend/certified-topology-declaration
          :security-key key})
        :transact! #(datalevin-native/transact! datalevin-conn %)}
       {:backend :datahike
@@ -182,6 +180,26 @@
       (is (= expected actual)
           (str "seed=" seed " phase=" phase " backend=" backend))))))
 
+(defn- assert-cached-bypass-equal!
+  [seed phase systems users folders permissions]
+  (doseq [{:keys [backend client]} systems
+          permission permissions
+          user users
+          folder folders]
+    (let [request {:subject user
+                   :permission permission
+                   :resource folder}
+          cached (eacl/check-permission client request)
+          bypass (eacl/check-permission
+                  client (assoc request :cache? false))]
+      (is (= (:allowed? bypass) (:allowed? cached))
+          (str "seed=" seed
+               " phase=" phase
+               " backend=" backend
+               " permission=" permission
+               " user=" (:id user)
+               " folder=" (:id folder))))))
+
 (deftest randomized-public-api-differential-test
   (doseq [seed [41 820084 20260822]]
     (testing (str "seed " seed)
@@ -199,6 +217,8 @@
             (eacl/create-relationships! client relationships))
           (assert-equal-observations!
            seed :initial systems users folders)
+          (assert-cached-bypass-equal!
+           seed :initial systems users folders [:view])
 
           (let [deletions (vec (take-nth 3 relationships))
                 touches (vec (take-nth 4 (drop 1 relationships)))]
@@ -208,16 +228,22 @@
                client
                (mapv #(eacl/->RelationshipUpdate :touch %) touches)))
             (assert-equal-observations!
-             seed :mutated systems users folders))
+             seed :mutated systems users folders)
+            (assert-cached-bypass-equal!
+             seed :mutated systems users folders [:view]))
 
           (doseq [{:keys [client]} systems]
             (eacl/write-schema! client schema-with-inspect))
           (assert-equal-observations!
            seed :schema-changed systems users folders [:view :inspect])
+          (assert-cached-bypass-equal!
+           seed :schema-changed systems users folders [:view :inspect])
 
           (doseq [{:keys [client]} systems]
             (eacl/delete-object! client (first folders)))
           (assert-equal-observations!
+           seed :object-deleted systems users folders [:view :inspect])
+          (assert-cached-bypass-equal!
            seed :object-deleted systems users folders [:view :inspect])
           (finally
             (close-systems! fixture)))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/mutation_race_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/mutation_race_test.clj
@@ -5,6 +5,7 @@
             [eacl.core :as eacl]
             [eacl.datalevin.backend :as backend]
             [eacl.datalevin.core :as datalevin]
+            [eacl.datalevin.schema :as physical-schema]
             [eacl.relationships.storage :as storage]
             [eacl.schema.model :as model])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
@@ -53,13 +54,14 @@
          {:source-lifecycle "race-lifecycle"
           :revision-watermark watermark
           :advance-revision-watermark! #(swap! watermark max %)
-          :datalevin-topology backend/certified-topology-declaration
           :security-key test-key})]
     (try
       (eacl/write-schema! client schema)
       (d/transact! conn [{:eacl/id "alice"}
                          {:eacl/id "document-1"}])
       (f {:conn conn
+          :dir dir
+          :watermark watermark
           :client client
           :alice (eacl/spice-object :user "alice")
           :document (eacl/spice-object :document "document-1")})
@@ -102,18 +104,19 @@
 (defn- coherence-state
   [conn]
   (let [db (d/db conn)]
-    {:schema-generation
-     (ref-value db [:eacl/id "schema-string"] :eacl/schema-generation)
+    {:max-tx (:max-tx db)
+     :schema-generation
+     (ref-value db [:eacl/id "schema-string"] :eacl.datalevin/schema-generation)
      :schema-write-fence
-     (ref-value db [:eacl/id "schema-string"] :eacl/schema-write-fence)
+     (ref-value db [:eacl/id "schema-string"] :eacl.datalevin/schema-write-fence)
      :viewer-version
      (ref-value db
                 [:eacl/id (model/->relation-id :document :viewer :user)]
-                :eacl/relation-version)
+                :eacl.datalevin/relation-generation)
      :editor-version
      (ref-value db
                 [:eacl/id (model/->relation-id :document :editor :user)]
-                :eacl/relation-version)}))
+                :eacl.datalevin/relation-generation)}))
 
 (defn- assert-advanced!
   [before after key]
@@ -122,7 +125,9 @@
     (is (integer? before-value) (str key " has a baseline value"))
     (is (integer? after-value) (str key " has a committed value"))
     (when (and (integer? before-value) (integer? after-value))
-      (is (< before-value after-value) (str key " advances")))))
+      (is (< before-value after-value) (str key " advances"))
+      (is (= (:max-tx after) after-value)
+          (str key " equals the committing max-tx")))))
 
 (defn- run-at-same-commit-boundary
   [intercept? left right]
@@ -185,6 +190,34 @@
                  #(eacl/delete-relationship! client rel))]
             (is (= [nil nil] results))
             (assert-paired! conn)))))))
+
+(deftest distinct-connections-to-one-environment-share-policy-serialization-test
+  (with-system
+    (fn [{:keys [conn dir watermark client] :as system}]
+      (let [second-conn (d/create-conn dir physical-schema/datalevin-schema)]
+        (try
+          (is (not (identical? conn second-conn)))
+          (let [second-client
+                (datalevin/make-client
+                 second-conn
+                 {:source-lifecycle "race-lifecycle"
+                  :revision-watermark watermark
+                  :advance-revision-watermark! #(swap! watermark max %)
+                  :security-key test-key})
+                rel (relationship system)
+                results
+                (run-at-same-commit-boundary
+                 relationship-transaction?
+                 #(eacl/create-relationship! client rel)
+                 #(eacl/create-relationship! second-client rel))]
+            (is (= 1 (count (filter nil? results))))
+            (is (= [:eacl/relationship-conflict]
+                   (keep :type results)))
+            (assert-paired! conn)
+            (is (= (:max-tx (d/db conn))
+                   (:viewer-version (coherence-state conn)))))
+          (finally
+            (d/close second-conn)))))))
 
 (deftest relation-removal-create-and-schema-schema-races-are-fenced-test
   (testing "relation removal and relationship creation cannot both commit"

--- a/modules/eacl-datalevin/test/eacl/datalevin/ordered_generation_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/ordered_generation_test.clj
@@ -1,0 +1,221 @@
+(ns eacl.datalevin.ordered-generation-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datalevin.core :as d]
+            [datalevin.util :as u]
+            [eacl.backend.source :as source]
+            [eacl.backend.v8 :as backend]
+            [eacl.core :as eacl]
+            [eacl.datalevin.core :as datalevin]
+            [eacl.proof-frame :as proof-frame]
+            [eacl.spicedb.consistency :as consistency]))
+
+(def ^:private test-key "01234567890123456789012345678901")
+
+(def ^:private logical-schema
+  "definition user {}
+   definition document {
+     relation viewer: user
+     relation editor: user
+     permission view = viewer
+   }")
+
+(defn- with-system
+  [f]
+  (let [dir (u/tmp-dir (str "eacl-datalevin-ordered-" (random-uuid)))
+        conn (datalevin/create-conn dir)
+        watermark (atom 0)
+        client
+        (datalevin/make-client
+         conn
+         {:security-key test-key
+          :source-lifecycle "ordered-generation-test"
+          :revision-watermark watermark
+          :advance-revision-watermark! #(swap! watermark max %)})]
+    (try
+      (eacl/write-schema! client logical-schema)
+      (d/transact!
+       conn
+       (mapv (fn [id] {:eacl/id id})
+             ["alice" "bob" "document-1" "document-2"]))
+      (f {:conn conn :client client :watermark watermark})
+      (finally
+        (d/close conn)
+        (u/delete-files dir)))))
+
+(defn- selected-adapter
+  [client f]
+  (let [selection (source/acquire! (:source client) :current)]
+    (try
+      (f (source/adapter selection))
+      (finally
+        (source/release! selection)))))
+
+(deftest exact-managed-and-invalidated-cache-paths-test
+  (with-system
+    (fn [{:keys [client]}]
+      (testing "schema generation is one exact EAV probe with no identity lookup"
+        (selected-adapter
+         client
+         (fn [adapter]
+           (with-redefs [d/entid
+                         (fn [& _]
+                           (throw
+                            (ex-info "unexpected schema identity lookup"
+                                     {:type :test/unexpected-entid})))]
+             (is (integer? (backend/invoke adapter
+                                            :schema-generation)))))))
+      (let [alice (eacl/spice-object :user "alice")
+            bob (eacl/spice-object :user "bob")
+            document-1 (eacl/spice-object :document "document-1")
+            document-2 (eacl/spice-object :document "document-2")
+            viewer (eacl/->Relationship alice :viewer document-1)
+            editor (eacl/->Relationship bob :editor document-2)
+            demand {:subject alice :permission :view :resource document-1}]
+        (eacl/create-relationship! client viewer)
+        (is (false? (:cached? (eacl/check-permission client demand))))
+
+        (testing "an identical-basis hit performs no proof-frame read"
+          (let [operations (atom {})
+                response
+                (binding [backend/*backend-op-stats* operations]
+                  (eacl/check-permission client demand))]
+            (is (true? (:cached? response)))
+            (is (zero? (get @operations :proof-frame 0)))))
+
+        (testing "an unrelated relation commit is a managed hit"
+          (let [before (:managed-hits (datalevin/cache-stats client))]
+            (eacl/create-relationship! client editor)
+            (let [operations (atom {})
+                  response
+                  (binding [backend/*backend-op-stats* operations]
+                    (eacl/check-permission client demand))]
+              (is (true? (:cached? response)))
+              (is (= 1 (get @operations :proof-frame 0)))
+              (is (= (inc before)
+                     (:managed-hits (datalevin/cache-stats client)))))))
+
+        (testing "a relevant relation commit invalidates the answer"
+          (eacl/delete-relationship! client viewer)
+          (let [response (eacl/check-permission client demand)]
+            (is (false? (:cached? response)))
+            (is (false? (:allowed? response)))))))))
+
+(deftest missing-and-above-ceiling-generations-are-distinguished-test
+  (with-system
+    (fn [{:keys [conn client]}]
+      (let [alice (eacl/spice-object :user "alice")
+            document (eacl/spice-object :document "document-1")
+            viewer (eacl/->Relationship alice :viewer document)]
+        (eacl/create-relationship! client viewer)
+        (selected-adapter
+         client
+         (fn [adapter]
+           (testing "a missing relation generation is typed unavailable"
+             (let [result
+                   (proof-frame/resolve!
+                    (proof-frame/request-frame adapter)
+                    [9007199254740000])]
+               (is (= :unavailable (:status result)))
+               (is (= :relation-generation-unavailable
+                      (:reason result)))))))
+
+        (let [db (d/db conn)
+              schema-generation
+              (:eacl.datalevin/schema-generation
+               (d/entity db [:eacl/id "schema-string"]))
+              relation-id
+              (selected-adapter
+               client
+               (fn [adapter]
+                 (:relation-id
+                  (first
+                   (backend/invoke adapter :relation-defs
+                                   :document :viewer)))))
+              original-revision-info d/read-snapshot-revision-info]
+          (with-redefs
+            [d/read-snapshot-revision-info
+             (fn [snapshot]
+               (assoc (original-revision-info snapshot)
+                      :max-tx schema-generation))]
+            (selected-adapter
+             client
+             (fn [adapter]
+               (testing "a relation generation above the selected ceiling is a contract violation"
+                 (let [result
+                       (proof-frame/resolve!
+                        (proof-frame/request-frame adapter)
+                        [relation-id])]
+                   (is (= :contract-violation (:status result)))
+                   (is (= :relation-generation-above-revision
+                          (:reason result)))))))))))))
+
+(deftest provider-restart-preserves-cursors-tokens-and-managed-state-test
+  (let [dir (u/tmp-dir (str "eacl-datalevin-restart-proof-"
+                            (random-uuid)))
+        watermark (atom 0)
+        options
+        {:security-key test-key
+         :source-lifecycle "ordered-restart-test"
+         :revision-watermark watermark
+         :advance-revision-watermark! #(swap! watermark max %)}
+        alice (eacl/spice-object :user "alice")
+        bob (eacl/spice-object :user "bob")
+        document-1 (eacl/spice-object :document "document-1")
+        document-2 (eacl/spice-object :document "document-2")
+        viewer-1 (eacl/->Relationship alice :viewer document-1)
+        viewer-2 (eacl/->Relationship alice :viewer document-2)
+        editor (eacl/->Relationship bob :editor document-2)
+        demand {:subject alice :permission :view :resource document-1}
+        page-query
+        {:subject alice
+         :permission :view
+         :resource/type :document
+         :first 1}
+        first-conn (datalevin/create-conn dir)]
+    (try
+      (let [first-client (datalevin/make-client first-conn options)]
+        (eacl/write-schema! first-client logical-schema)
+        (d/transact!
+         first-conn
+         (mapv (fn [id] {:eacl/id id})
+               ["alice" "bob" "document-1" "document-2"]))
+        (let [write-response
+              (eacl/create-relationships!
+               first-client [viewer-1 viewer-2])
+              token (:zed/token write-response)
+              _ (eacl/check-permission first-client demand)
+              first-page (eacl/lookup-resources first-client page-query)
+              cursor (get-in first-page [:page-info :end-cursor])]
+          (is (string? token))
+          (is (string? cursor))
+          (d/close first-conn)
+          (let [second-conn (datalevin/create-conn dir)]
+            (try
+              (let [second-client (datalevin/make-client second-conn options)]
+                (testing "the pre-restart causal token remains comparable"
+                  (is (true?
+                       (:allowed?
+                        (eacl/check-permission
+                         second-client alice :view document-1
+                         (consistency/at-least-as-fresh token))))))
+                (testing "the pre-restart cursor resumes on the same revision"
+                  (let [second-page
+                        (eacl/lookup-resources
+                         second-client (assoc page-query :after cursor))]
+                    (is (= 1 (count (:data second-page))))
+                    (is (not= (mapv :id (:data first-page))
+                              (mapv :id (:data second-page))))))
+                (testing "managed reuse remains enabled after reopen"
+                  (eacl/create-relationship! second-client editor)
+                  (let [before (:managed-hits
+                                (datalevin/cache-stats second-client))
+                        response (eacl/check-permission second-client demand)]
+                    (is (true? (:cached? response)))
+                    (is (= (inc before)
+                           (:managed-hits
+                            (datalevin/cache-stats second-client)))))))
+              (finally
+                (d/close second-conn))))))
+      (finally
+        (d/close first-conn)
+        (u/delete-files dir)))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/safe_retraction_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/safe_retraction_test.clj
@@ -31,9 +31,7 @@
              {:security-key test-key
               :source-lifecycle "safe-retraction-test"
               :revision-watermark watermark
-              :advance-revision-watermark! #(swap! watermark max %)
-              :datalevin-topology
-              backend/certified-topology-declaration})]
+              :advance-revision-watermark! #(swap! watermark max %)})]
         (eacl/write-schema! client logical-schema)
         (f conn client))
       (finally
@@ -44,6 +42,14 @@
   [db eid]
   {:forward (mapv :v (d/datoms db :eav eid storage/forward-attribute))
    :reverse (mapv :v (d/datoms db :eav eid storage/reverse-attribute))})
+
+(defn- error-type
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (:type (ex-data error)))))
 
 (deftest direct-safe-retraction-uses-the-transaction-database-schema-test
   (with-system
@@ -73,10 +79,19 @@
             unrelated (d/entid before [:eacl/id "other-folder"])]
         (is (seq (:reverse (halves before child))))
         (is (seq (:forward (halves before alice))))
-        (d/transact!
-         conn
-         (safe-retraction/direct-retract-entity-tx-data parent))
+        (is (= :datalevin/guarded-attribute-write
+               (error-type
+                #(d/transact!
+                  conn
+                  (safe-retraction/direct-retract-entity-tx-data parent)))))
+        (safe-retraction/transact-retract-entity! client parent)
         (let [after (d/db conn)]
+          (let [relation-id
+                (d/entid after
+                         [:eacl/id "eacl.relation::folder::viewer::user"])]
+            (is (= (:max-tx after)
+                   (:eacl.datalevin/relation-generation
+                    (d/entity after relation-id)))))
           (is (empty? (d/datoms after :eav parent)))
           (is (empty? (d/datoms after :eav child)))
           (is (empty? (:reverse (halves after child))))

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/.openspec.yaml
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/design.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/design.md
@@ -1,0 +1,139 @@
+## Context
+
+See `proposal.md`; the governing frame contract is `introduce-proof-carrying-semantic-equivalence`, the backend roles are `add-authorization-views`. Facts about the current Datalevin integration that shape this design:
+
+- The fork's contribution so far is the read side: explicit, thread-affine, cache-bypassing immutable read snapshots (`open-read-snapshot`, `read-snapshot-revision-info`, reader contexts, three-phase close). There is no pre-commit hook; transaction entry points are `with`, `transact!`, `transact-async`, `transact`, `with-transaction`, and `transact-tx-data`, all ungated. The only write rejection is the read-only guard on snapshot-wrapped storage.
+- `:db/current-tx` resolves at preparation to `(inc (:max-tx db-before))`; the commit independently calls `advance-max-tx` on a volatile store field and persists `:max-tx` in the meta DBI in the same LMDB batch as the datoms. The two agree under the connection lock. `:db/current-tx` is substituted only in entity position or in a ref-typed value position, and substitution calls `allocate-eid`.
+- Relationship tuples live on the endpoint entities as cardinality-many tuple attributes `[type relation type endpoint]`; the relation entity id is tuple position 1 in both the forward and reverse attribute. `:db/retractEntity` and `:db.fn/retractEntity` expand to the entity's own datoms, incoming reference datoms, and component children before the store commit; tuple components are not incoming references, so the peer half of a relationship is never implicitly retracted.
+- `make-client` requires `:source-lifecycle`, a derefable `:revision-watermark`, `:advance-revision-watermark!`, and `:datalevin-topology` equal to `certified-topology-declaration`; it rejects `:wal?`, `:ha-mode`, and the LMDB flags `:nosync :nometasync :mapasync :writemap`; it persists a source UUID and advances the watermark before readiness. `expire-cache!` throws because the lifecycle is shared persisted configuration.
+- Safe retraction is direct-invocation only (`:db.fn/call` with an inline function), because Datalevin cannot persist Clojure functions.
+- Two connections to one directory in one process share one store (`shared-local-stores`); a second process opening the same directory has its own volatile `max-tx`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Datalevin supplies a frame under the shared contract, read from the owned snapshot with one probe per requested relation plus one for the schema generation.
+- Mutation completeness is a property of the storage engine, not of who holds a connection: the store refuses an unstamped protected change and an unadmitted protected write.
+- The committed generation written into a stamp is the commit's `max-tx` by construction, and a foreign writer is detected at commit.
+- Lineage is durable: cursors, tokens, and managed state survive provider restart exactly as on Datomic.
+- The fork remains EACL-agnostic and the policy mechanism is reusable by any application that needs guarded attributes.
+
+**Non-Goals:**
+
+- Arbitrary historical selection (`at-exact-snapshot`), transaction-log scanning, or hidden snapshot retention.
+- Multi-process writers. LMDB serializes processes, but each Datalevin process allocates `max-tx` from its own volatile field; the continuity check rejects the second writer rather than coordinating it.
+- Protecting against raw KV writes to the datom DBIs, direct file modification, or a process that opens the directory with upstream Datalevin instead of the fork. These are outside the trusted boundary and are documented as such.
+- Guarding `:eacl/id`. Applications assert public identity on their own entities; identity mutation is neutralized by re-resolution and re-rendering, not by stamps.
+
+## Decisions
+
+### 1. Scalar stamps with commit-generation materialization
+
+Physical schema (replacing the ref attributes):
+
+```clojure
+{:eacl.datalevin/schema-generation  {:db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+ :eacl.datalevin/schema-write-fence {:db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+ :eacl.datalevin/relation-generation {:db/valueType :db.type/long :db/cardinality :db.cardinality/one}}
+```
+
+The writer emits `[:db/add relation-id :eacl.datalevin/relation-generation :db/current-tx]` exactly as today. The fork extends substitution: when the attribute is `:db.type/long` and the value is `:db/current-tx`, the prepared generation is substituted *without* `allocate-eid`, so `:max-eid` is untouched. At commit the store verifies that the generation it allocates (`advance-max-tx`) equals the prepared generation carried by those datoms and aborts the transaction otherwise. Equality is therefore enforced, not inferred from the connection lock.
+
+Why not a second transaction that patches stamps after the content commit: an intervening snapshot would read changed content with old evidence. Why not reinterpret the ref attributes: they alias entity ids and are retractable through `retractEntity` of an unrelated entity.
+
+### 2. `max-tx` continuity
+
+Inside the write transaction, before allocating, the store reads the persisted `:max-tx` from the meta DBI and requires it to equal the in-memory `max-tx` it is about to advance. LMDB's single-writer lock makes that read consistent; a second process that committed in between moves the persisted value and is detected with one KV get per commit. On mismatch the transaction aborts with `:datalevin/max-tx-continuity-violation` and the connection is marked unusable for writes until reopened. This replaces `:datalevin-topology` equality as the single-writer-process guarantee and costs nothing the commit was not already doing in the same batch.
+
+### 3. One write policy, enforced after expansion
+
+The fork gains a persisted, EACL-agnostic **write policy** in the meta DBI:
+
+```clojure
+{:guarded-attributes #{...}   ; datoms require the admission token
+ :frozen-attributes  #{...}   ; update-schema, clear-dbi, drop-dbi, re-index rejected for these
+ :commit-generation-attributes #{...} ; long attributes where :db/current-tx materializes
+ :stamp-rules
+ [{:when-attribute forward-tuple-attr :stamp-attribute relation-generation :stamp-entity [:tuple-position 1]}
+  {:when-attribute reverse-tuple-attr :stamp-attribute relation-generation :stamp-entity [:tuple-position 1]}
+  {:when-attribute :eacl.relation/... :stamp-attribute schema-generation :stamp-entity [:constant schema-eid]}
+  ...]}
+```
+
+Installation (`install-write-policy!`) is itself a guarded operation once a policy exists. Each open mints a random **admission token**; `transact!` callers supply it as `tx-meta {:datalevin/write-token token}`. `tx-meta` rather than a dynamic binding because it travels with the transaction through every entry point, including queued and asynchronous ones, and through transaction functions. Synchronous administrative APIs do not accept transaction metadata, so `with-write-policy-token` validates the same token and establishes a dynamic scope only around `update-schema`, `clear-dbi`, `drop-dbi`, and `re-index`. The dynamic scope is not used to admit datom transactions.
+
+Enforcement runs at the single point where every entry converges after expansion and before the store commit, over the complete datom list:
+
+1. any datom on a guarded attribute without the token → reject `:datalevin/guarded-attribute-write`;
+2. for each stamp rule, any datom on `:when-attribute` whose required `[stamp-entity stamp-attribute committing-generation]` datom is absent from the transaction → reject `:datalevin/missing-stamp`;
+3. any added datom on a commit-generation attribute whose value is not the committing generation → reject `:datalevin/stale-generation`.
+
+Definition rules use the exact persisted schema-singleton eid. A looser
+same-entity or wildcard selector would allow an admitted transaction to stamp
+an unrelated entity while changing the effective schema, creating a forged
+proof frame.
+
+Because expansion precedes enforcement, an application `retractEntity` of a permissioned object that would retract its tuple datoms is rejected (it carries no token), which is the desired outcome: the supported path is `delete-object!`, which retracts both halves and stamps every affected relation. A transaction that changes no protected datom requires nothing. A stamp without a matching change is allowed (over-stamping).
+
+Why a policy in the store rather than connection custody: custody constrains who may hold a handle, which another handle to the same directory ignores, and it forces a path-owning constructor that situated applications cannot use. Why not have the store derive stamps itself: the rule table is the minimum EACL-specific knowledge (which attributes, which tuple position); deriving is one more branch than verifying and would hide writer bugs rather than reject them.
+
+### 4. Writer role
+
+The Datalevin writer (`add-authorization-views` writer role) registers the policy in `ensure-physical-schema!`, holds the admission token for the lifetime of the connection, and passes it on every `transact!`. Planning is unchanged: endpoint identity guards, the write-fence CAS, `create-relationship-at-commit`, `delete-object-at-commit`, and `stamp-relation-versions` continue to produce the stamp set; the store now verifies it. Safe retraction remains the inline `:db.fn/call` form, but callers submit it through `eacl.datalevin.safe-retraction/transact-retract-entity!`, which uses the certified writer token and advances the external revision watermark.
+
+### 5. Frame and capabilities
+
+The basis adapter, bound to an owned read snapshot, implements:
+
+- `:schema-generation` — one EAVT probe on `[:eacl/id "schema-string"]` for `:eacl.datalevin/schema-generation`, returning `:v` (already memoized per adapter);
+- `:proof-frame` — for each requested relation id one EAVT probe for `:eacl.datalevin/relation-generation`, returning `[relation-id (:v datom)]`, realized eagerly; a missing datom yields `nil` (unavailable under the shared contract).
+
+Values are in the `max-tx` domain, the same as `:native-revision`, so the shared ceiling assertion applies unchanged. Capabilities add `:ordered-generations`; `:at-exact-snapshot` stays absent. No Datalevin-private comparison exists.
+
+### 6. Lineage and construction
+
+Lineage is `{:source-id <persisted UUID> :branch nil}` plus the required configured lifecycle — durable, as on Datomic. The revision watermark stays: a restored store whose `max-tx` is below the watermark fails construction. Construction first validates the public option shape, fork capabilities, unsafe flags/WAL/HA, and the pre-bootstrap watermark. Checking the watermark before any bootstrap mutation prevents a write from masking a rollback. It then installs or validates physical schema, source identity, schema singleton, policy, and complete initial generations; validates the resulting source identity; advances the watermark through every bootstrap commit; and only then becomes ready. `:datalevin-topology` is removed from the option map. The rejected LMDB flag set gains `:nolock`: without the environment writer lock, the continuity check's consistent read of the persisted `max-tx` is not guaranteed across processes.
+
+Fresh stores bootstrap in a deliberate order. Source identity and the schema
+singleton are written while no policy exists. The policy is then installed,
+and the first scalar generation datoms are submitted with its admission token.
+An existing protected store with missing generation evidence fails closed; it
+is never silently repaired because no operation can prove what an old
+unstamped mutation affected.
+
+Provider restart keeps every cursor and token valid and keeps managed lifting enabled; the sticky disablement from a contract violation (shared contract) is cleared by provider restart, since Datalevin's `expire-cache!` remains unavailable by design.
+
+### 7. Shared-store state adoption and bounded stale-wrapper recovery
+
+Several connection atoms in one process share a Datalevin `Store` but retain
+immutable DB wrappers. Every successful commit path, including the blind-map
+fast path, must adopt committed schema, giant-id, `max-tx`, and state-sync data
+into the original shared Store. Returning a wrapper over a detached transferred
+Store makes subsequent connections falsely appear foreign and breaks both
+performance and continuity.
+
+If another same-process connection commits after EACL prepared a transaction,
+the fork rejects the stale prepared generation before commit. The module
+refreshes that connection wrapper and retries the complete semantic operation
+at most eight times, and only for the typed
+`:eacl.datalevin/stale-connection-generation` condition. CAS contention,
+continuity violations, policy failures, foreign exceptions, deadlines, and
+cancellation are never included in that retry class.
+
+## Rejected alternatives
+
+- **Provider-owned path constructor with exclusive custody and alias rejection.** Does not prevent a second connection in the same or another process; forbids the situated topology (application writes its own data through its own connection); redundant once the store enforces the policy.
+- **Session-scoped lineage.** Strictly weaker than the persisted source id plus watermark Datalevin already has; would make every restart a cursor-invalidation event for an embedded database whose history is linear across restarts.
+- **Quiescent v2 migration keeping legacy ref stamps.** Nothing to migrate.
+- **Exact-vector and global-frontier "profiles".** The shared contract has one frame; Datalevin's scalar commit generation satisfies its global-ordering premise by construction (`advance-max-tx` under the writer lock plus the continuity check).
+- **A closed mutation algebra as a separate validator.** The writer's operations are the algebra; the store's stamp rules are the validator.
+
+## Risks / Trade-offs
+
+- **[Applications that today `retractEntity` permissioned objects directly will be rejected]** → the rejection names `delete-object!`; the README documents that Datalevin enforces what the other backends only document.
+- **[Policy enforcement adds per-transaction work]** → one set lookup per datom plus one meta read per commit; measured by the existing Datalevin write benchmark with a regression budget.
+- **[Upstream Datalevin can open the directory without the policy]** → documented as outside the boundary, with the same standing as direct file modification; the fork artifact is the only supported Datalevin.
+- **[Over-stamping on no-op writes invalidates equal-frame entries]** → unchanged from the other backends; telemetry reports stamp advances without content change.
+- **[Fork divergence from upstream grows]** → the policy and materialization are small, generic, and covered by fork-level contract tests; the build already pins `Datalevin-Upstream-Version`.
+- **[The maintained fork is bypassable below its public datom/admin APIs]** → raw KV writes, direct file mutation, and opening the directory with upstream Datalevin remain outside the certified boundary and are stated explicitly; no cache proof can compensate for that bypass.

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/proposal.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Datalevin is the only bundled backend without ordered-generation proofs, so its completed answers reuse only at an identical basis. Three facts cause that, none of them a missing "proof profile":
+
+1. **Read datoms carry no transaction.** The maintained fork's persistent datoms are reconstructed with `tx0` (`storage.clj` `retrieved->datom`), so the `:tx`-based frame Datomic, Datahike, and DataScript build cannot be read. A stamp must therefore be stored as a *value*.
+2. **The existing stamps are references into a shared id space.** `:eacl/schema-generation`, `:eacl/schema-write-fence`, and `:eacl/relation-version` are `:db.type/ref` populated by `:db/current-tx`, and in Datalevin `tx0 = 1` and `e0 = 0` share one numeric space: a stamp value aliases an entity id, `allocate-eid` advances `:max-eid` for it, and retracting an entity whose id equals a stamp retracts the stamp.
+3. **Nothing enforces the supported-writer contract.** `make-client` takes a caller-owned connection, the "certified sole-writer topology" is an equality check on a configuration map, and the fork has no pre-commit hook; any connection can write relationship tuples without a stamp.
+
+Datalevin does not need a session-scoped lineage. Its source identity is persisted, its lifecycle is required persisted configuration, and its external revision watermark already rejects a rolled-back store at construction — a stronger witness than the other durable backends have. Cursors and tokens must survive provider restart as they do on Datomic.
+
+## What Changes
+
+- **Scalar stamps.** Replace the three ref-typed attributes with `:db.type/long`, cardinality-one `:eacl.datalevin/schema-generation`, `:eacl.datalevin/schema-write-fence`, and `:eacl.datalevin/relation-generation`. No migration: the module is unpublished and v8 is unreleased; demo stores are reseeded.
+- **Commit-generation materialization in the fork.** `:db/current-tx` in the value position of a long attribute materializes to the committing `max-tx` without allocating an entity id, and the commit asserts that the prepared generation equals the generation it commits and that the store's persisted `max-tx` has not moved under it (foreign-writer detection).
+- **A generic write policy in the fork, enforced at the one point every transaction entry converges after expansion.** A persisted policy names guarded attributes (writes require a per-open admission token carried in `tx-meta`), frozen attributes (administrative mutation requires the same token), and exact stamp rules (a datom on a relationship tuple attribute requires a relation-generation datom for the relation at tuple position 1 in the same transaction; a datom on a definition attribute requires a schema-generation datom on the one persisted schema singleton). The fork stays EACL-agnostic: the policy is data registered by the Datalevin writer role at schema installation.
+- **Datalevin advertises `:ordered-generations`** with a `:proof-frame` that reads exactly the requested relation generations from the owned read snapshot; the certified `:schema-generation` operation reads the scalar attribute. Lineage remains persisted source id plus configured lifecycle; the revision watermark stays.
+- **Remove** the topology-declaration equality check (the fork's continuity check enforces the single-writer-process constraint at commit), the idea of a path-owning constructor, and the session nonce. Unsafe LMDB flags (now including `:nolock`), WAL, and HA modes remain rejected because they break owned read snapshots or the writer lock the continuity check relies on.
+- **Repair shared-store commit adoption and recover only safe same-process staleness.** Every commit path updates the original shared Store. A stale immutable connection wrapper is refreshed and the complete semantic write is retried under a fixed bound; CAS contention and every unsafe/unknown failure remain terminal.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `backend-native-revision-consistency`: Datalevin lineage is persisted source identity plus lifecycle, witnessed by the revision watermark; the write policy, not topology declarations, establishes mutation completeness.
+- `dependency-validated-authorization-cache`: Datalevin managed reuse under the shared lineage-scoped frame rule; storage-enforced atomic stamping.
+- `managed-reuse-certification`: Datalevin certification covers the fork write policy, scalar stamps, commit-generation equality, foreign-writer detection, and bounded frame reads.
+- `cross-backend-conformance`: Datalevin joins the ordered-generation conformance matrix, including restart survival of cursors and managed state.
+
+## Impact
+
+- Depends on `introduce-proof-carrying-semantic-equivalence` (frame contract: relation generations only, revision domain, ceiling assertion) and on `add-authorization-views` (writer role, Datalevin lifecycle and source acquisition).
+- Maintained fork (`dev.eacl/datalevin-embedded-eacl`): transaction pipeline (`:db/current-tx` for long attributes), commit path (generation equality, `max-tx` continuity), write policy (persisted in the meta DBI, admission token per open, enforcement before store commit), `update-schema` guard for frozen attributes, documentation, and contract tests.
+- `eacl-datalevin`: physical schema, `ensure-physical-schema!`, writer role (policy registration, admission token in `tx-meta`, stamp planning to scalar attributes), basis adapter (`:proof-frame`, `:schema-generation`, capabilities), construction validation, certification, benchmarks, README/PORTING.
+- Public authorization requests, revision tokens, and cursor formats are unchanged. The README capability table no longer states that Datalevin omits ordered-generation proofs.
+
+## Related changes
+
+Already applied or in progress; this change modifies their outcomes rather than their artifacts:
+
+- Workspace change `../../../openspec/changes/add-datalevin-backend-and-demo` (in progress, 93/153): introduced the Datalevin module, its ref-typed stamps, the `:datalevin-topology` declaration (design §5 "Limit the certified consistency topology"), the external revision watermark, and the exact-only capability policy. The declaration and the ref stamps are replaced here; the watermark, owned read snapshots, and unsafe-flag rejection are kept.
+- `eliminate-authorization-request-amplification` (applied): added Datalevin's certified `:schema-generation` operation and the revision-only `read-snapshot-revision-info` seam, both kept.
+- `add-authorization-views` (planned): the writer role that registers the write policy and carries the admission token; Datalevin's required persisted lifecycle.

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/backend-native-revision-consistency/spec.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/backend-native-revision-consistency/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Datalevin lineage is durable and storage-enforced
+The Datalevin basis source SHALL expose its persisted source identity and the configured persisted lifecycle as lineage, SHALL reject construction when the store's `max-tx` is below the external revision watermark, and SHALL advertise ordered generations only when the maintained fork reports commit-generation materialization, `max-tx` continuity, shared-store stale-generation recovery, and an installed write policy covering every physical EACL storage attribute except application identity `:eacl/id`. Cursors, tokens, and managed state SHALL remain valid across provider restart within one lineage. Topology declarations, connection custody, and advisory locks MUST NOT be accepted as evidence of mutation completeness.
+
+#### Scenario: Provider restarts
+- **WHEN** a Datalevin provider is closed and reopened on the same store with the same lifecycle
+- **THEN** cursors and tokens issued before the restart validate and managed lifting remains enabled
+
+#### Scenario: Store is rolled back
+- **WHEN** a restored store reports `max-tx` below the external watermark
+- **THEN** construction fails with `:eacl.datalevin/revision-regression` before acquisition or bootstrap mutation
+
+#### Scenario: Fork lacks the write policy
+- **WHEN** the fork artifact does not report write-policy support
+- **THEN** construction fails with a typed unsupported-capability error rather than advertising exact-only behaviour silently
+
+#### Scenario: Second writer process
+- **WHEN** another process commits to the same store between a transaction's preparation and commit
+- **THEN** the fork aborts the commit with `:datalevin/max-tx-continuity-violation` and the generations already committed remain consistent

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/cross-backend-conformance/spec.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/cross-backend-conformance/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Datalevin joins ordered-generation conformance
+The shared conformance suite SHALL run its ordered-generation cases — exact-hit precedence, unrelated-write reuse, relevant-write invalidation, lineage isolation, unavailable versus contract-violation classification, retained-basis reuse, and cursor continuation across unrelated writes — against Datalevin with the same expected results as the other ordered-generation backends, while exact historical selection remains reported as unsupported.
+
+#### Scenario: Equivalent fixtures
+- **WHEN** the suite runs the ordered-generation matrix on Datalevin
+- **THEN** every shared expectation passes without a Datalevin-specific acceptance path
+
+#### Scenario: Exact history remains unsupported
+- **WHEN** a changed-frame cursor needs exact reconstruction on Datalevin
+- **THEN** the suite expects the typed stale-cursor outcome, not a substituted snapshot

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/dependency-validated-authorization-cache/spec.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/dependency-validated-authorization-cache/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Datalevin managed reuse follows the shared frame rule
+After an exact-basis miss, EACL SHALL reuse a Datalevin completed answer or managed subproblem under the shared lineage-scoped frame rule: equal persisted source identity and lifecycle, equal certified schema generation, and equal scalar dependency frontier over the complete closure, in either revision direction. The frame SHALL be read from the owned immutable read snapshot with one probe per requested relation and one for the schema generation, in the `max-tx` domain, and SHALL be subject to the shared ceiling assertion.
+
+#### Scenario: Identical basis
+- **WHEN** an identical cacheable request repeats on the same selected basis
+- **THEN** EACL serves the exact entry without reading any relation generation
+
+#### Scenario: Unrelated forward commit
+- **WHEN** a later basis changes no relation in the answer's closure and no schema
+- **THEN** the frames are equal and the answer is reused
+
+#### Scenario: Relevant mutation
+- **WHEN** a guarded transaction changes a relation in the closure
+- **THEN** that relation's generation equals the committing `max-tx`, the frontier differs, and the old answer is not reused
+
+#### Scenario: Missing generation
+- **WHEN** a relation in the closure has no generation datom on the selected snapshot
+- **THEN** the frame is unavailable and the request evaluates exactly without disabling managed lifting
+
+### Requirement: Datalevin protected mutations are storage-enforced
+Every transaction reaching a Datalevin store with an installed EACL write policy SHALL be checked after expansion and before commit. A datom on a guarded attribute without the writer's admission token, a relationship tuple datom without a relation-generation datom for the relation at tuple position 1, a definition or schema-string datom without a schema-generation datom on the exact persisted schema singleton, or an added commit-generation datom carrying a value other than the committing generation SHALL abort the transaction atomically. Frozen schema or database administration SHALL require the same per-open token through the synchronous administrative scope. A transaction that changes no guarded datom SHALL require nothing; a stamp without a corresponding change SHALL be allowed.
+
+#### Scenario: Application retracts a permissioned object
+- **WHEN** application code submits `:db/retractEntity` for an entity holding relationship tuples through any connection
+- **THEN** the store rejects the transaction naming `delete-object!` and no tuple or stamp changes
+
+#### Scenario: Writer omits a stamp
+- **WHEN** an admitted transaction changes a tuple for a relation without stamping that relation
+- **THEN** the store rejects the transaction before commit
+
+#### Scenario: Writer stamps the wrong schema entity
+- **WHEN** an admitted transaction changes a definition but stamps a different entity
+- **THEN** the store rejects the transaction before commit
+
+#### Scenario: Administrative bypass is attempted
+- **WHEN** code calls schema update, clear, drop, or re-index against protected storage without the current open's token
+- **THEN** the fork rejects the administrative mutation atomically
+
+#### Scenario: Batch changes several relations
+- **WHEN** one admitted transaction adds or retracts tuples for several relations
+- **THEN** every affected relation's generation equals the committing `max-tx` on the resulting snapshot
+
+#### Scenario: Application writes its own data
+- **WHEN** a transaction touches only application attributes, including `:eacl/id` on a new entity
+- **THEN** the policy imposes no requirement and the transaction commits normally
+
+### Requirement: Datalevin stamps are scalar commit generations
+Datalevin SHALL store the schema generation, schema write fence, and relation generations as `:db.type/long` cardinality-one values materialized from `:db/current-tx` by the fork without allocating an entity id. Reference-typed stamps MUST NOT be installed or read.
+
+#### Scenario: Entity with a coinciding id is retracted
+- **WHEN** an entity whose id equals a previous generation value is retracted
+- **THEN** no stamp changes
+
+#### Scenario: Stamping does not allocate
+- **WHEN** a guarded transaction materializes generations
+- **THEN** `:max-eid` is unchanged by the stamp datoms
+
+### Requirement: Datalevin same-process stale connections recover narrowly
+When a distinct connection atom sharing the local Store prepares an EACL write
+from an older immutable wrapper, the module SHALL refresh that wrapper and
+retry the complete semantic operation under a fixed bound. Only the typed
+stale-connection-generation result SHALL be retryable; CAS contention,
+cross-process continuity failure, policy rejection, cancellation, deadline,
+and unknown storage errors SHALL remain terminal.
+
+#### Scenario: Another local connection commits first
+- **WHEN** one connection advances the shared Store before another submits a correctly planned EACL mutation
+- **THEN** the stale submission commits after bounded refresh without weakening stamp equality
+
+#### Scenario: Semantic CAS loses
+- **WHEN** the write-fence compare-and-set reports contention
+- **THEN** EACL returns the typed concurrent-schema-write outcome without retrying it as connection staleness

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/managed-reuse-certification/spec.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/specs/managed-reuse-certification/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Datalevin certification covers the storage-enforced boundary
+Executable certification SHALL establish, against the fork artifact and the Datalevin module: commit-generation materialization equal to the committed `max-tx`; `max-tx` continuity detection of a foreign writer; policy enforcement for unadmitted writes, missing stamps, wrong schema-stamp entities, stale generations, and frozen-schema/admin changes; shared-Store state adoption and bounded same-process stale-wrapper recovery; atomic stamp completeness for every writer operation including object-deletion batches, schema replacement, relation removal, and safe retraction; bounded frame acquisition proportional to the requested closure from one owned reader; and durable lineage across provider restart.
+
+#### Scenario: Controlled unstamped mutation
+- **WHEN** a control removes the relation stamp from an otherwise valid writer transaction
+- **THEN** the store rejects the transaction and certification records the rejection
+
+#### Scenario: Controlled stale generation
+- **WHEN** a control writes a literal generation below the committing `max-tx`
+- **THEN** the store rejects the transaction
+
+#### Scenario: Frame probe count
+- **WHEN** core requests `N` relation generations
+- **THEN** instrumentation observes `N` EAVT probes plus one schema-generation probe on the selected reader and no relationship-content scan
+
+#### Scenario: Restart preserves lineage
+- **WHEN** certification closes and reopens the provider between two requests
+- **THEN** the second request's lineage equals the first's and an equal frame reuses the first request's managed answer

--- a/openspec/changes/certify-datalevin-ordered-generation-proofs/tasks.md
+++ b/openspec/changes/certify-datalevin-ordered-generation-proofs/tasks.md
@@ -1,0 +1,38 @@
+## 1. Fork: Commit Generation and Continuity
+
+- [x] 1.1 Substitute `:db/current-tx` in the value position of `:db.type/long` attributes listed as commit-generation attributes without calling `allocate-eid`; reject the keyword for other value types.
+- [x] 1.2 Verify at commit that every commit-generation datom carries the generation the store allocates; abort with `:datalevin/stale-generation` otherwise.
+- [x] 1.3 Read the persisted `:max-tx` inside the write transaction before advancing; abort with `:datalevin/max-tx-continuity-violation` on mismatch and mark the connection write-unusable until reopen.
+- [x] 1.4 Add fork contract tests: materialized generation equals committed `max-tx`; `:max-eid` unchanged by stamping; a second process committing between prepare and commit is rejected; the read snapshot reports the same ceiling as the committed generation.
+
+## 2. Fork: Write Policy
+
+- [x] 2.1 Add a persisted write policy (guarded, frozen, commit-generation attributes; stamp rules) in the meta DBI with `install-write-policy!`, `write-policy`, and a per-open random admission token accepted through `tx-meta`.
+- [x] 2.2 Enforce the policy at the single post-expansion, pre-commit point that every committing entry reaches (`transact!`, `transact-async`, `transact`, `with-transaction`, `transact-tx-data`, and the blind-write fast path); speculative `with` results are not committed and are exempt; guarded writes without the token, missing stamps, and stale generations are rejected atomically.
+- [x] 2.3 Reject `update-schema`, `clear-dbi`, `drop-dbi`, and `re-index` for frozen attributes without the token.
+- [x] 2.4 Add fork contract tests: unadmitted tuple write, application `retractEntity` of an entity holding tuples, tuple change without its relation stamp, definition change without the schema stamp, stamp with the wrong generation, frozen schema change, admitted transaction with complete stamps, and a transaction touching no protected attribute; document the policy in `doc/write-policy.md`.
+
+## 3. Module: Schema and Writer
+
+- [x] 3.1 Replace the ref-typed stamp attributes with the three `:db.type/long` attributes; remove the ref attributes from the physical schema; reseed demo stores.
+- [x] 3.2 Register the write policy in `ensure-physical-schema!` (guarded: every `:eacl.*` and relationship storage attribute except `:eacl/id`; frozen: the same; commit-generation: the three stamp attributes; stamp rules for both tuple attributes at position 1 and for definition and schema-string attributes).
+- [x] 3.3 Implement the Datalevin writer role: hold the admission token, pass it in `tx-meta` on every submission, plan stamps to the scalar attributes, keep the write-fence CAS and commit-time functions unchanged.
+- [x] 3.4 Remove `:datalevin-topology`; keep unsafe-flag, WAL, and HA rejection and add `:nolock` to the rejected flags; validate fork capabilities and the native profile, reject watermark regression before bootstrap mutation, then validate/install policy, complete generations, and source identity before readiness.
+
+## 4. Module: Frame and Capabilities
+
+- [x] 4.1 Implement `:schema-generation` over `:eacl.datalevin/schema-generation` and `:proof-frame` as one EAVT probe per requested relation on the owned snapshot, eagerly realized, `nil` for a missing generation.
+- [x] 4.2 Advertise `:ordered-generations`; keep `:at-exact-snapshot` absent; confirm generations and `:native-revision` share the `max-tx` domain under the shared ceiling assertion.
+- [x] 4.3 Add tests: identical-basis exact hit with zero frame probes; unrelated forward commit reuses answers and managed subproblems; relevant commit invalidates; missing generation is unavailable, not a violation; an injected above-ceiling generation is a contract violation.
+
+## 5. Certification, Differentials, and Performance
+
+- [x] 5.1 Extend adapter certification v2 to Datalevin: domain, ceiling, atomic stamping after every writer operation (add, retract, touch, batch, compare-and-set, delete-object batches, schema replacement and relation removal, safe retraction), and durable lineage across provider restart.
+- [x] 5.2 Extend the randomized cached-versus-bypass differential and the mutation-race suite to the ordered-generation configuration, including writes from a second connection in the same process and restart between pages.
+- [x] 5.3 Add restart tests: cursors, tokens, and managed lifting remain valid after close and reopen; a watermark regression still fails construction.
+- [x] 5.4 Benchmark frame acquisition (zero, typical, maximum closures), exact hits, managed hits, and write commit latency with the policy active; record results and set a regression budget for the write path.
+
+## 6. Documentation and Gates
+
+- [x] 6.1 Update the README capability table, module README, PORTING.md, `docs/v8-backend-adapter-boundary.md`, and `docs/cache.md` for Datalevin ordered generations, the write policy, the rejected `retractEntity` path, and the trusted boundary.
+- [x] 6.2 Regenerate `public-source-closure.json`, update `backend-dispatch.edn` and the adapter-certification ledger, run the Datalevin module suite, fork contract tests, the CI-equivalent battery, and `openspec validate --strict`.

--- a/src-build/eacl/build/config.clj
+++ b/src-build/eacl/build/config.clj
@@ -9,7 +9,7 @@
 (def module-order
   [:eacl :eacl-datomic :eacl-datahike :eacl-datascript :eacl-datalevin])
 
-(def datalevin-fork-version "1.0.2-eacl.1")
+(def datalevin-fork-version "1.0.2-eacl.2")
 
 (def modules
   {:eacl

--- a/src-build/eacl/build/config_test.clj
+++ b/src-build/eacl/build/config_test.clj
@@ -36,7 +36,7 @@
                'com.rpl/specter
                'dev.eacl/datalevin-embedded-eacl}
              (set (keys dependencies))))
-      (is (= {:mvn/version "1.0.2-eacl.1"}
+      (is (= {:mvn/version "1.0.2-eacl.2"}
              (get dependencies
                   'dev.eacl/datalevin-embedded-eacl)))
       (is (not-any?


### PR DESCRIPTION
## Stack

- Base: #148 (`agent/introduce-proof-carrying-semantic-equivalence`)
- Storage dependency: [theronic/datalevin#2](https://github.com/theronic/datalevin/pull/2), stacked on the explicit-snapshot fork PR [theronic/datalevin#1](https://github.com/theronic/datalevin/pull/1)

## Summary

- replace Datalevin's ref-shaped cache stamps with persisted scalar `max-tx` generations and advertise certified `:ordered-generations`
- install a persisted storage write policy that freezes authorization schema, admits only token-bearing EACL writes, and atomically requires complete schema/relation stamps after transaction expansion
- close the per-open admission token into every EACL mutation path, fail closed on policy drift or missing generation evidence, and bound same-process stale-connection retries to typed generation contention
- implement relation proof frames as one exact EAV probe per requested relation and schema generation as one exact EAV probe against the bootstrap-resolved singleton, including direct public snapshots
- remove the caller-asserted topology option; qualify the actual embedded snapshot/durability profile and reject WAL, HA, and unsafe LMDB flags including `:nolock`
- certify safe retraction, restart continuity, independent same-process writers, randomized cache/bypass equivalence, and managed reuse across unrelated commits

## Correctness boundary

The storage fork is part of the trusted boundary. It materializes `:db/current-tx` without allocating an eid, checks persisted `max-tx` continuity inside the write transaction, enforces the persisted policy at the common post-expansion pre-commit boundary, rotates admission tokens per open, and makes a continuity-failed connection write-unusable until reopen. The EACL module refuses readiness unless those executable fork capabilities and the exact persisted policy are present.

## Verification

- module plus shared core: 253 tests, 8,605 assertions, 0 failures, 0 errors
- focused ordered-generation plus contract suites: 32 tests, 942 assertions, 0 failures, 0 errors
- ordered-generation suite: 3 tests, 20 assertions, 0 failures, 0 errors
- public-source closure: 70 roots, 80 source files, 1,673 reachable definitions; executable test 2/18 green
- build metadata: 3 tests, 43 assertions, 0 failures, 0 errors
- maintained fork: 74 tests, 398 assertions, 0 failures, 0 errors
- isolated Datalevin JAR build, Datalevin reflection compile gate, closure drift check, and strict OpenSpec validation all pass

## Measured regression gate

On the recorded Apple Silicon/JDK 26 host:

- 8-relation proof frame p95: 0.016875 ms
- 4,096-relation proof frame p95: 11.568875 ms
- identical-basis cache hit p95: 0.482708 ms
- managed cross-revision hit p95: 0.850792 ms
- policy-enforced write p50/p95: 4.719 / 5.633083 ms

The exact measurements and budgets are retained in `formal/verification/datalevin-ordered-generation-benchmark.edn`.