### PR TITLE
Cache unexpired cursor tokens without weakening TTL

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -426,6 +426,11 @@ constant lifecycle, and shared token keys. Restore, reset, purge, excision, or
 branch replacement requires lifecycle rotation.
 
 Cursors carry no expiry unless a positive `:cursor-ttl-seconds` is configured.
+The bounded client-private codec cache reuses an identical self-minted token
+only while its authenticated expiry remains in the future. A cache hit still
+checks the clock, the exact expiry instant is rejected, and the next encode
+mints a fresh token. Tokens not minted by that cache always traverse the full
+authenticated decoder.
 Cache TTL, answer eviction, page-navigation eviction, and checkpoint eviction
 do not limit cursor age; they only cause deterministic replay. An old cursor
 continues the original historical enumeration. Consumers that require current

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -201,7 +201,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/cursor.cljc",
-      "sha256": "68f9378fdebe0af5fcf69f0628c0fce5888dd4840c57bb86c65e7c5ab1d92a0e"
+      "sha256": "6b6d0563c9fbdd33401ce2551f3790959fa2b02dcefa96270d332f48665b8a8f"
     },
     {
       "path": "modules/eacl/src/eacl/engine/least_path.cljc",
@@ -257,7 +257,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "d26a42d82a16dc29b5ff6d76adccb2b613b2bf341d03a4f1a8cb203a358b467e"
+      "sha256": "8940eed3b986986ed6147b5c52e064ea5e5386d637952d2d0a572b53b516f2aa"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -408,7 +408,7 @@
     "rootCount": 70,
     "unionInternalDefinitionCount": 1691,
     "unionInternalDefinitionIdsSha256": "47726bbcfa3557bddf33d6096f863eae6012d5b134935024c8ddf148293a31a6",
-    "unionDefinitionLocationsSha256": "07ee2a483b48d1a4916ee6c3d44f56784f5caff9d761883d8ace8c86089a6df4",
+    "unionDefinitionLocationsSha256": "793cb64af8094e9fc0419a2c2a595b9eeb16ee13f22630d534664486cdfe8c9c",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 25,

--- a/formal/verification/public-source-closure.json
+++ b/formal/verification/public-source-closure.json
@@ -257,7 +257,7 @@
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel.clj",
-      "sha256": "8940eed3b986986ed6147b5c52e064ea5e5386d637952d2d0a572b53b516f2aa"
+      "sha256": "d26a42d82a16dc29b5ff6d76adccb2b613b2bf341d03a4f1a8cb203a358b467e"
     },
     {
       "path": "modules/eacl/src/eacl/formal/production_kernel_cljs.cljs",
@@ -408,7 +408,7 @@
     "rootCount": 70,
     "unionInternalDefinitionCount": 1691,
     "unionInternalDefinitionIdsSha256": "47726bbcfa3557bddf33d6096f863eae6012d5b134935024c8ddf148293a31a6",
-    "unionDefinitionLocationsSha256": "793cb64af8094e9fc0419a2c2a595b9eeb16ee13f22630d534664486cdfe8c9c",
+    "unionDefinitionLocationsSha256": "807b2246380390cc89372c19f47e09dc4b602e16f6f1c2884db4249ecd7631e6",
     "definitionsBySource": {
       "modules/eacl-datahike/src/eacl/datahike/backend.clj": {
         "count": 25,

--- a/modules/eacl/src/eacl/cursor.cljc
+++ b/modules/eacl/src/eacl/cursor.cljc
@@ -37,10 +37,11 @@
 (defrecord CursorCodecCache [state max-entries])
 
 (defn codec-cache
-  "Creates a bounded, client-private cache for non-expiring cursor codecs.
+  "Creates a bounded, client-private cache for cursor codecs.
 
   Tokens found here were authenticated when this exact client minted them.
-  Unknown tokens still pass through the authenticated decoder."
+  Expiring entries retain their authenticated expiry and are reused only while
+  unexpired. Unknown tokens still pass through the authenticated decoder."
   ([]
    (codec-cache {}))
   ([{:keys [max-entries]
@@ -461,29 +462,39 @@
   (let [{:keys [current-kid keyring]} (format-options options)
         kid (or current-kid :default)
         keyring (or keyring {:default secure/default-root-key})]
-    [kid (get keyring kid)]))
+    ;; TTL is part of the issuance policy. Keeping it in the private identity
+    ;; prevents a token minted under one policy from satisfying another
+    ;; policy's encode lookup, while authenticated decode remains compatible
+    ;; with retained keys and reads expiry from the protected payload.
+    [kid (get keyring kid) (:cursor-ttl-seconds options)]))
 
 (defn- memoizable-cache
-  [{:keys [cursor-codec-cache cursor-ttl-seconds]}]
-  (when (and cursor-codec-cache
-             (nil? cursor-ttl-seconds))
+  [{:keys [cursor-codec-cache]}]
+  (when cursor-codec-cache
     (when-not (instance? CursorCodecCache cursor-codec-cache)
       (throw (ex-info "Expected an EACL cursor codec cache."
                       {:type :eacl/invalid-config :eacl/error :eacl/invalid-config})))
     cursor-codec-cache))
 
 (defn- cached-token
-  [cache identity cursor]
-  (get-in @(:state cache) [:by-cursor [identity cursor]]))
+  [cache identity cursor now]
+  (let [state @(:state cache)
+        token (get-in state [:by-cursor [identity cursor]])
+        entry (get-in state [:by-token token])]
+    (when (and token
+               (= identity (:identity entry))
+               (or (nil? (:expires-at entry))
+                   (< now (:expires-at entry))))
+      token)))
 
 (defn- cached-cursor
   [cache identity token]
   (let [entry (get-in @(:state cache) [:by-token token])]
     (when (= identity (:identity entry))
-      (:cursor entry))))
+      entry)))
 
 (defn- remember-token!
-  [cache identity cursor token]
+  [cache identity cursor token issued-at expires-at]
   (swap!
    (:state cache)
    (fn [{:keys [order by-token by-cursor] :as state}]
@@ -494,7 +505,9 @@
              by-token'
              (assoc by-token token
                     {:identity identity
-                     :cursor cursor})
+                     :cursor cursor
+                     :issued-at issued-at
+                     :expires-at expires-at})
              by-cursor' (assoc by-cursor cursor-key token)
              overflow (- (count order') (:max-entries cache))
              evicted (when (pos? overflow)
@@ -509,11 +522,17 @@
               (let [{evicted-identity :identity
                      evicted-cursor :cursor}
                     (get-in current [:by-token evicted-token])]
-                (-> current
-                    (update :by-token dissoc evicted-token)
-                    (update :by-cursor
-                            dissoc
-                            [evicted-identity evicted-cursor]))))
+                (cond-> (update current :by-token dissoc evicted-token)
+                  ;; A later token for the same cursor may have replaced this
+                  ;; reverse entry before the older token reached FIFO
+                  ;; eviction. Never evict the newer mapping with the old one.
+                  (= evicted-token
+                     (get-in current
+                             [:by-cursor
+                              [evicted-identity evicted-cursor]]))
+                  (update :by-cursor
+                          dissoc
+                          [evicted-identity evicted-cursor]))))
             (assoc state
                    :order (vec (drop overflow order'))
                    :by-token by-token'
@@ -530,10 +549,14 @@
      (when-not (map? cursor)
        (cursor-error! :malformed {}))
      (let [cache (memoizable-cache options)
-           identity (when cache (codec-identity options))]
+           identity (when cache (codec-identity options))
+           ;; A TTL-bearing hit needs one clock read to prove the cached token
+           ;; remains inside the expiry protected by its payload. Preserve the
+           ;; clock-free non-expiring hit path.
+           current-time (when cursor-ttl-seconds (now-seconds options))]
        (or (when cache
-             (cached-token cache identity cursor))
-           (let [issued-at (now-seconds options)
+             (cached-token cache identity cursor current-time))
+           (let [issued-at (or current-time (now-seconds options))
                  expires-at (when cursor-ttl-seconds
                               (+ issued-at cursor-ttl-seconds))
                  token
@@ -545,7 +568,7 @@
                    :expires-at expires-at})]
              (if cache
                (remember-token!
-                cache identity cursor token)
+                cache identity cursor token issued-at expires-at)
                token)))))))
 
 (defn expired-cursor-error
@@ -577,13 +600,17 @@
      (let [cache (memoizable-cache options)
            identity (when cache (codec-identity options))]
        (or (when cache
-             ;; The codec cache holds only non-expiring tokens this client
-             ;; minted itself, so a hit is authenticated and unexpired.
-             (when-let [cursor (cached-cursor cache identity token)]
+             ;; The codec cache holds only tokens this client minted itself.
+             ;; Expiry is protected by the token payload and retained in the
+             ;; entry, so a hit skips crypto without skipping the TTL decision.
+             (when-let [{:keys [cursor expires-at]}
+                        (cached-cursor cache identity token)]
                {:cursor cursor
                 :authenticated? true
-                :expired? false
-                :expired-at nil}))
+                :expired? (boolean
+                           (and expires-at
+                                (>= (now-seconds options) expires-at)))
+                :expired-at expires-at}))
            (let [payload
                  (try
                    (decode-aead options token)

--- a/modules/eacl/test/eacl/secure_format_test.cljc
+++ b/modules/eacl/test/eacl/secure_format_test.cljc
@@ -463,6 +463,69 @@
                  (tamper-compact-authenticator encoded)
                  cached-options))))))))
 
+(deftest private-cursor-codec-cache-retains-exact-ttl-semantics-test
+  (let [value {:v 12
+               :scope [:lookup {:subject/id "ttl-user"}]
+               :edge {:kind :stable-edge :position [1 "document-1"]}}
+        codec-cache (cursor/codec-cache {:max-entries 2})
+        cached-options
+        (assoc options
+               :cursor-codec-cache codec-cache
+               :cursor-ttl-seconds 10)
+        encode-work (atom {})
+        token-1
+        (binding [cursor/*codec-work* encode-work]
+          (let [minted
+                (cursor/cursor->token
+                 value (assoc cached-options :now-seconds 100))
+                reused
+                (cursor/cursor->token
+                 value (assoc cached-options :now-seconds 109))]
+            (is (= minted reused)
+                "an identical payload reuses its still-valid authenticated token")
+            (is (= 1 (:encode-calls @encode-work)))
+            minted))]
+    (testing "a cached decode still enforces the protected expiry"
+      (let [decode-work (atom {})
+            authenticated
+            (binding [cursor/*codec-work* decode-work]
+              (cursor/token->authenticated-cursor
+               token-1 (assoc cached-options :now-seconds 110)))]
+        (is (true? (:authenticated? authenticated)))
+        (is (true? (:expired? authenticated)))
+        (is (= 110 (:expired-at authenticated)))
+        (is (empty? @decode-work)
+            "self-minted tokens need neither decryption nor re-authentication"))
+      (is (= :expired
+             (:reason
+              (error-data
+               #(cursor/token->cursor
+                 token-1 (assoc cached-options :now-seconds 110)))))))
+    (testing "expiry remints without corrupting the newer reverse mapping"
+      (let [token-2
+            (cursor/cursor->token
+             value (assoc cached-options :now-seconds 110))
+            other-token
+            (cursor/cursor->token
+             {:v 12 :scope :other}
+             (assoc cached-options :now-seconds 110))]
+        (is (not= token-1 token-2))
+        ;; max-entries=2 evicts token-1 here. Its eviction must not delete the
+        ;; token-2 reverse lookup for the same cursor.
+        (is (string? other-token))
+        (is (= token-2
+               (cursor/cursor->token
+                value (assoc cached-options :now-seconds 111))))))
+    (testing "issuance policies never share an encode lookup"
+      (is (not=
+           (cursor/cursor->token
+            value (assoc cached-options :now-seconds 111))
+           (cursor/cursor->token
+            value
+            (assoc cached-options
+                   :cursor-ttl-seconds 20
+                   :now-seconds 111)))))))
+
 (deftest private-cursor-construction-context-cache-is-bounded-test
   (let [codec-cache (cursor/codec-cache {:max-entries 2})
         builds (atom {})


### PR DESCRIPTION
## Summary

- allow the bounded client-private cursor codec cache to reuse self-minted TTL-bearing tokens only before their authenticated expiry
- retain issued-at and expires-at in cache entries and enforce the exact expiry boundary on cached decode
- include cursor TTL in issuance-policy identity and preserve newer reverse mappings when an older token is evicted
- document the bounded behavior and add JVM/CLJS regression coverage

## Stack

This PR is based on #151 and contains only the TTL cursor-token cache optimization.

## Verification

- core + DataScript JVM: 473 tests, 16,061 assertions
- DataScript CLJS: 315 tests, 8,637 assertions
- public source closure: 70 roots, 1,691 reachable definitions
- verification manifest counts consistent; assurance remains conditionally verified because of the repository predeclared external/mechanized obligations