### PR TITLE
Refresh v8 source-closure assurance counts

### DIFF
--- a/formal/verification/assurance-matrix.edn
+++ b/formal/verification/assurance-matrix.edn
@@ -4,9 +4,9 @@
  :source-closure
  {:report "formal/verification/public-source-closure.json"
   :status :named-public-roots-enumerated
-  :source-files 102
-  :public-roots 72
-  :reachable-definitions 2146
+  :source-files 103
+  :public-roots 91
+  :reachable-definitions 2202
   :inline-defrecord-method-attribution :source-span-closed
   :backend-dispatch
   {:report "formal/verification/backend-dispatch.edn"
@@ -741,7 +741,7 @@
    :backend-certification [:datomic :datascript :datahike :datalevin]
    :production-mutations {:registered 10 :killed 10 :survived 0}
    :source-closure
-   {:source-files 102 :public-roots 72 :reachable-definitions 2146}
+   {:source-files 103 :public-roots 91 :reachable-definitions 2202}
    :production-authoritative
    :enabled-after-conformance-storage-and-performance-qualification
    :remaining []


### PR DESCRIPTION
## Summary
- reconcile the assurance matrix with the generated v8 public source-closure report
- record 103 source files, 91 public roots, and 2,202 reachable definitions in both matrix locations

## Verification
- `node bin/public-source-closure.mjs write` reports 91 roots and 2,202 definitions with no report diff
- `bin/formal source-closure` passes
- this fixes the post-merge formal failure that found the matrix still at 102/72/2,146