### PR TITLE
Build EACL with Java 25 by default

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1
@@ -496,11 +496,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Babashka
         uses: DeLaGuardo/setup-clojure@13.6.1
@@ -546,11 +546,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1
@@ -648,11 +648,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI and Node
         uses: DeLaGuardo/setup-clojure@13.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1
@@ -49,11 +49,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1
@@ -95,17 +95,17 @@ jobs:
     timeout-minutes: 120
     environment: clojars
     env:
-      EACL_JAVA_RELEASE: '26'
+      EACL_JAVA_RELEASE: '25'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -65,11 +65,11 @@ jobs:
           name: released-generated-runtimes
           path: target/formal
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1
@@ -171,11 +171,11 @@ jobs:
           name: released-generated-runtimes
           path: target/formal
 
-      - name: Set up Temurin JDK 26
+      - name: Set up Temurin JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '26'
+          java-version: '25'
 
       - name: Set up Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.6.1

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ clojure -T:build jar :java-release 17
 ```
 
 Pass the same `:java-release` to `prep` and `jar` or `install`. The generated
-kernel defaults to Java 26 bytecode and may be compiled for Java 8 through 26,
+kernel defaults to Java 25 bytecode and may be compiled for Java 8 through 26,
 but the complete JVM EACL module requires Java 11 or newer because its Caffeine
 cache dependency does. Java 17 is EACL's supported production runtime floor.
 See [formal/README.md](formal/README.md) for tool versions and the full

--- a/formal/smoke/java/run
+++ b/formal/smoke/java/run
@@ -7,7 +7,7 @@ generated="$repo_root/target/formal/java"
 classes="$generated/classes"
 dafny_runtime="$repo_root/target/formal-tools/dafny-4.11.0/dafny/DafnyRuntime.jar"
 clojure_classpath=$(clojure -Spath)
-java_release=${EACL_JAVA_RELEASE:-26}
+java_release=${EACL_JAVA_RELEASE:-25}
 
 case "$java_release" in
   ''|*[!0-9]*)

--- a/modules/eacl-datahike/README.md
+++ b/modules/eacl-datahike/README.md
@@ -162,7 +162,7 @@ client-level `:permission-tree-limits`.
 ```
 
 Its POM depends on `dev.eacl/eacl` at the exact same version, so consumers do
-not declare core separately. EACL targets Java 26 by default; explicit
+not declare core separately. EACL targets Java 25 by default; explicit
 source/custom builds can target older Java, subject to Datahike's own runtime
 requirements. Git and `:local/root` development must first follow the explicitly opt-in
 [core source preparation instructions](../../README.md#source-dependencies-and-formal-tooling).

--- a/modules/eacl-datascript/README.md
+++ b/modules/eacl-datascript/README.md
@@ -133,7 +133,7 @@ exact index probes. Use the integrity report when the old eid is unknown.
 ```
 
 Its POM depends on `dev.eacl/eacl` at the exact same version, so consumers do
-not declare core separately. EACL targets Java 26 by default; explicit
+not declare core separately. EACL targets Java 25 by default; explicit
 source/custom builds can target older Java, subject to DataScript's own runtime
 requirements. Build this module in isolation with `clojure -T:build jar`; Git and `:local/root`
 development must first follow the explicitly opt-in

--- a/modules/eacl-datomic/README.md
+++ b/modules/eacl-datomic/README.md
@@ -124,7 +124,7 @@ endpoint identity CAS. For high-degree targets, prefer batched
 ```
 
 Its POM depends on `dev.eacl/eacl` at the exact same version, so consumers do
-not declare core separately. EACL targets Java 26 by default; explicit
+not declare core separately. EACL targets Java 25 by default; explicit
 source/custom builds can target older Java, subject to Datomic's own runtime
 requirements. Build this module in isolation with `clojure -T:build jar`; Git and `:local/root`
 development must first follow the explicitly opt-in

--- a/openspec/specs/clojars-release-pipeline/spec.md
+++ b/openspec/specs/clojars-release-pipeline/spec.md
@@ -27,18 +27,18 @@ The core release artifact SHALL contain the Clojure and ClojureScript sources, `
 - **THEN** required core entries, POM coordinates, licence metadata, exact core dependency versions, and the absence of undeclared workspace paths are verified
 
 ### Requirement: Portable generated JVM bytecode
-The EACL 8 generated kernel build SHALL default to Java 26, the latest generally available Java feature release when this release contract was defined, and SHALL permit an explicit whole-number bytecode target from Java 8 through Java 26 for source and custom artifact builds. The artifact audit SHALL derive the expected class-file major version from the selected target. A generated artifact SHALL NOT vary by operating system, processor architecture, or installed JVM patch version, and SHALL run on its selected Java release and newer JVMs without requiring JVM-specific EACL classes.
+The EACL 8 generated kernel build SHALL default to Java 25 and SHALL permit an explicit whole-number bytecode target from Java 8 through Java 26 for source and custom artifact builds. The artifact audit SHALL derive the expected class-file major version from the selected target. A generated artifact SHALL NOT vary by operating system, processor architecture, or installed JVM patch version, and SHALL run on its selected Java release and newer JVMs without requiring JVM-specific EACL classes.
 
 #### Scenario: Default target execution
 - **WHEN** no bytecode override is supplied and the packaged core artifact is built and exercised
-- **THEN** its generated classes use Java 26 class-file major version 70 and produce the expected smoke result
+- **THEN** its generated classes use Java 25 class-file major version 69 and produce the expected smoke result
 
 #### Scenario: Newer-JVM execution
-- **WHEN** an artifact compiled for a selected Java target is exercised on a later supported JVM
+- **WHEN** an artifact compiled for a selected Java target is exercised on the same or a later supported JVM
 - **THEN** the generated kernel produces the same boundary result without recompilation
 
 #### Scenario: Explicit older target
-- **WHEN** a source or custom artifact build explicitly selects Java 8 through Java 25
+- **WHEN** a source or custom artifact build explicitly selects Java 8 through Java 26
 - **THEN** the generated sources are compiled and audited at that target and the artifact can run on that Java release or newer, subject to backend dependency requirements
 
 ### Requirement: Ordinary release provenance and gating
@@ -77,4 +77,3 @@ Only a job that references the GitHub `clojars` environment after satisfying rep
 #### Scenario: Unauthorized Maven group
 - **WHEN** the configured Clojars user cannot deploy the verified `dev.eacl` group
 - **THEN** a preflight fails before artifact upload and reports that group creation or authorization is required
-

--- a/src-build/eacl/build/config.clj
+++ b/src-build/eacl/build/config.clj
@@ -3,8 +3,9 @@
   (:require [clojure.string :as string]))
 
 (def default-version "8.0.0-SNAPSHOT")
-(def default-java-release 26)
+(def default-java-release 25)
 (def minimum-java-release 8)
+(def maximum-java-release 26)
 
 (def module-order
   [:eacl :eacl-datomic :eacl-datahike :eacl-datascript :eacl-datalevin])
@@ -120,7 +121,7 @@
     :else nil))
 
 (defn java-release
-  "Returns the bytecode release for generated Java. Java 26 is the pinned
+  "Returns the bytecode release for generated Java. Java 25 is the pinned
   default; source builds may explicitly target Java 8 through 26."
   [options]
   (let [candidate
@@ -129,14 +130,14 @@
             default-java-release)
         release (parse-java-release candidate)]
     (when-not (and release
-                   (<= minimum-java-release release default-java-release))
+                   (<= minimum-java-release release maximum-java-release))
       (throw
        (ex-info
         "EACL Java release must be an integer from 8 through 26."
         {:type :eacl.build/invalid-java-release
          :java-release candidate
          :minimum minimum-java-release
-         :maximum default-java-release})))
+         :maximum maximum-java-release})))
     release))
 
 (defn java-class-major-version

--- a/src-build/eacl/build/config_test.clj
+++ b/src-build/eacl/build/config_test.clj
@@ -55,12 +55,14 @@
          clojure.lang.ExceptionInfo
          #"MAJOR.MINOR.PATCH"
          (config/version {:version "8.0-SNAPSHOT"}))))
-  (testing "Java 26 is the default and older bytecode targets are explicit"
-    (is (= 26 config/default-java-release))
-    (is (= 26 (config/java-release {})))
+  (testing "Java 25 is the default and other bytecode targets are explicit"
+    (is (= 25 config/default-java-release))
+    (is (= 26 config/maximum-java-release))
+    (is (= 25 (config/java-release {})))
     (is (= 8 (config/java-release {:java-release 8})))
     (is (= 17 (config/java-release {:java-release "17"})))
     (is (= 52 (config/java-class-major-version {:java-release 8})))
+    (is (= 69 (config/java-class-major-version {})))
     (is (= 70 (config/java-class-major-version {:java-release 26})))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo

--- a/src-build/eacl/build/release_test.clj
+++ b/src-build/eacl/build/release_test.clj
@@ -11,7 +11,7 @@
     (is (string/includes? workflow "secrets.CLOJARS_DEPLOY_TOKEN"))
     (is (not (string/includes? workflow "secrets.CLOJURE_")))
     (is (string/includes? workflow "run: clojure -X:deploy"))
-    (is (string/includes? workflow "EACL_JAVA_RELEASE: '26'"))))
+    (is (string/includes? workflow "EACL_JAVA_RELEASE: '25'"))))
 
 (deftest release-build-propagates-one-explicit-java-target
   (let [builds (atom [])]

--- a/src-build/eacl/build/source_prep_test.clj
+++ b/src-build/eacl/build/source_prep_test.clj
@@ -37,7 +37,7 @@
       (is (re-find #"\(defn prep" build-source))
       (is (re-find #"Build and stage the generated JVM and browser runtimes"
                    build-source)))
-    (testing "Java 26 is the default but source preparation accepts an override"
-      (is (re-find #"EACL_JAVA_RELEASE:-26" java-build-script))
+    (testing "Java 25 is the default but source preparation accepts an override"
+      (is (re-find #"EACL_JAVA_RELEASE:-25" java-build-script))
       (is (re-find #"javac --release \"\$java_release\""
                    java-build-script)))))


### PR DESCRIPTION
## Summary
- make Java 25 the generated-kernel default while retaining explicit Java 8–26 targets
- run Core test, formal, and Clojars workflows on Temurin 25
- update release contracts and documentation for class-file major 69

## Verification
- 15 focused build tests, 119 assertions, 0 failures
- `clojure -T:build prep` verified the Dafny kernel and browser runtime
- all 652 generated JVM classes use class-file major 69