### PR TITLE
Protect qualified retraction and add certified cleanup sweeps

### DIFF
--- a/bin/public-source-closure.mjs
+++ b/bin/public-source-closure.mjs
@@ -30,6 +30,7 @@ const roots = [
   "eacl.relationships.qualifier-integrity/report",
   "eacl.relationships.qualifier-integrity/repair-pair!",
   "eacl.relationships.qualifier-integrity/cleanup-orphans!",
+  "eacl.relationships.qualifier-integrity/cleanup-sweep!",
   "eacl.relationships.staged/prepare!",
   "eacl.relationships.staged/plan-current",
   "eacl.relationships.staged/write!",

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -273,6 +273,38 @@ authorization hot path. Corrupt data blocks collection. An exact native head
 guard rejects any write after the scan, including a concurrent attachment;
 retry by taking a fresh snapshot. Collection never supplies expiration semantics.
 
+`eacl.relationships.qualifier-integrity/cleanup-sweep!` drains multiple batches
+using one global capture. Pass a native staged writer from Datomic, DataScript,
+or a direct Datahike writer, with optional `:batch-size`, `:max-qualifiers`,
+`:max-capture-units`, and a zero-argument `:cancelled?` predicate. Datalevin
+continues to support the single-batch operation; its leased snapshot and commit
+result boundary is not certified for sweeps.
+
+Repeated single-batch calls rescan active data and remaining orphans each time.
+A quiescent sweep scans O(A+Q) data, sorts O(Q log Q), and makes O(Q/B) commits,
+where A is active scanned data, Q is captured qualifier data, and B is batch size.
+Each commit still contains an exact head guard and one fact assertion and
+retraction per candidate. Operation-count contracts verify this work bound;
+these are not latency improvement claims.
+
+Capture retains O(A+Q) proof data; draining retains O(Q) candidate facts and ids.
+The defaults limit capture to 100,000 distinct qualifiers and 2,000,000 data
+cells/string code units. Accounting occurs on native streams before building
+proof entity maps and fact vectors. These are data-volume limits, not a byte
+limit on backend snapshots, native index buffers, or the entire JVM heap.
+Exceeding a limit fails before any cleanup commits.
+
+The sweep certificate advances only from its own transaction's `db-before` and
+`db-after` evidence. A foreign write, source change, failed guard, or absent
+commit result stops the sweep. The result reports `:status` (`:complete`,
+`:cancelled`, or `:restart-required`), confirmed `:qualifiers`,
+`:committed-batches`, and `:remaining-count`. A missing transaction response may
+mean the last batch committed; that batch is unconfirmed and is not counted.
+Restart by calling the sweep again for a fresh capture. Successful earlier
+batches remain committed; no serialized continuation or automatic rebasing is
+supported. Source/lifecycle resets retain the backend's existing quiescence and
+lifecycle-rotation requirements.
+
 Install the additive Caveat and qualifier attributes through each backend's
 explicit schema installation/preparation API before using staged persistence.
 Existing storage migration remains explicit; startup does not scan or migrate

--- a/docs/v8-backend-modules-and-upgrade.md
+++ b/docs/v8-backend-modules-and-upgrade.md
@@ -188,6 +188,20 @@ peer-only ghost; a missing lookup ref cannot recover the former eid.
 | Datalevin qualified embedded profile | call `eacl.datalevin.safe-retraction/prepare!`, then submit through `eacl.datalevin.safe-retraction/transact-retract-entity!` |
 | Function-unsafe remote topology | use `delete-object!`, then native entity deletion |
 
+Safe-retraction function compatibility version 5 protects all declared Caveat
+and qualifier facts, including partial records and component descendants. It
+also stamps Relations affected only by self-loops. Attempts to delete qualified
+control entities fail atomically with `:protected-control-entity`. Dedicated
+schema writers and admitted orphan cleanup remain available.
+
+After upgrading the library, explicitly rerun the preparation/installation
+operation above. In particular, Datomic persists its function body: a library
+upgrade alone does not replace it. Installation replaces recognized older EACL
+bodies, is idempotent for the current body, and rejects unrelated occupants.
+The backend digest markers identify this combined function compatibility
+contract. The relationship storage ABI stays at v8; no storage migration is
+required by these fixes.
+
 Do not combine relationship additions involving a target with safe retraction
 of that target in the same application transaction. Use batched
 `delete-object!` for very high-degree targets and backend integrity reports for

--- a/formal/assurance_contract.clj
+++ b/formal/assurance_contract.clj
@@ -204,6 +204,17 @@
     :runtime-targets [:clj-java :cljs-javascript]
     :remaining [:phase-3-serving-activation
                 :independent-review]}
+   {:operation :qualifier-cleanup-sweep
+    :entry-points ['eacl.relationships.qualifier-integrity/cleanup-sweep!]
+    :theorems [:own-cleanup-preserves-remaining-absence
+               :foreign-attachment-invalidates-certificate]
+    :dafny ["formal/dafny/QualifierCleanupSweep.dfy"]
+    :adapter-obligations [:authoritative-own-commit-before-and-after
+                          :exact-source-and-native-head-guard
+                          :candidate-fact-assertions
+                          :bounded-streaming-proof-capture]
+    :runtime-targets [:clj-java :cljs-javascript]
+    :remaining [:independent-review]}
    {:operation :execution-contract
     :entry-points
     ['eacl.execution/normalize 'eacl.engine.v8/lookup-resources]

--- a/formal/baselines/qualifier-cleanup-sweep.edn
+++ b/formal/baselines/qualifier-cleanup-sweep.edn
@@ -1,0 +1,7 @@
+{:description "Authored before timing/allocation sampling; caller-thread allocation excludes native writer threads and backend resident snapshots."
+ :orphans [16 64 128]
+ :active 5
+ :batch-size 2
+ :max-elapsed-ms 30000
+ :max-caller-allocated-bytes 268435456
+ :global-streams 6}

--- a/formal/dafny/QualifierCleanupSweep.dfy
+++ b/formal/dafny/QualifierCleanupSweep.dfy
@@ -1,0 +1,44 @@
+module QualifierCleanupSweep {
+  datatype Snapshot = Snapshot(
+    source: nat,
+    lifecycle: nat,
+    revision: nat,
+    qualifiers: set<nat>,
+    attached: set<nat>
+  )
+
+  predicate Certified(snapshot: Snapshot, candidates: set<nat>) {
+    candidates <= snapshot.qualifiers && candidates !! snapshot.attached
+  }
+
+  predicate OwnCleanup(before: Snapshot, after: Snapshot, deleted: set<nat>) {
+    after.source == before.source &&
+    after.lifecycle == before.lifecycle &&
+    after.revision > before.revision &&
+    after.qualifiers == before.qualifiers - deleted &&
+    after.attached == before.attached
+  }
+
+  lemma OwnCommitPreservesRemainingAbsence(
+    before: Snapshot, after: Snapshot,
+    candidates: set<nat>, deleted: set<nat>
+  )
+    requires Certified(before, candidates)
+    requires deleted <= candidates
+    requires OwnCleanup(before, after, deleted)
+    ensures Certified(after, candidates - deleted)
+    ensures deleted !! after.attached
+  {
+  }
+
+  lemma ForeignAttachmentCannotExtendCertificate(
+    before: Snapshot, after: Snapshot, candidates: set<nat>, qid: nat
+  )
+    requires Certified(before, candidates)
+    requires qid in candidates
+    requires qid in after.attached
+    ensures !OwnCleanup(before, after, {})
+    ensures !Certified(after, candidates)
+  {
+  }
+}

--- a/modules/eacl-datahike/src/eacl/datahike/qualifiers.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/qualifiers.clj
@@ -38,6 +38,9 @@
   {:backend :datahike :entity entity :facts facts :rows db/relationship-identity-datoms
    :source backend/database-source-scope :generation schema/current-schema-generation
    :all-rows (fn [database attribute] (when (db/entid database attribute) (d/datoms database {:index :aevt :components [attribute]})))
+   :fact-rows (fn [database eid] (d/datoms database {:index :eavt :components [eid]}))
+   :attribute-ident (fn [database a] (if (keyword? a) a (:db/ident (d/entity database a))))
+   :cleanup-token (juxt :schema :config)
    :relation-version-attribute :eacl/relation-version
    :revision :max-tx
    :head-guard (fn [database]
@@ -74,7 +77,10 @@
    (merge (planner-api)
           (let [scope (backend/connection-source-scope conn)]
             {:source #(or (backend/database-source-scope %) scope)})
-          {:snapshot #(d/db conn) :transact! #(d/transact conn %)})))
+          {:cleanup-commit-snapshots (fn [report]
+                                      (when (and (:db-before report) (:db-after report))
+                                        [(:db-before report) (:db-after report)]))
+           :snapshot #(d/db conn) :transact! #(d/transact conn %)})))
 
 (defn publication-capability [database]
   (when (db/direct-writer? database)

--- a/modules/eacl-datahike/src/eacl/datahike/safe_retraction.clj
+++ b/modules/eacl-datahike/src/eacl/datahike/safe_retraction.clj
@@ -12,7 +12,7 @@
             [eacl.relationships.storage :as storage]))
 
 (def function-digest
-  "99ec0f983ea09eea439583e22297f55611ca55d8114f4b9230954834efc42bbc")
+  "fd4f181fbe62c484b3dce6e41b30e9a1330e17a241137a039439560ee0a44602")
 
 (def function-doc
   (str safe/function-doc-prefix " v" safe/function-version

--- a/modules/eacl-datahike/test/eacl/datahike/qualifier_storage_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/qualifier_storage_test.clj
@@ -1,5 +1,7 @@
 (ns eacl.datahike.qualifier-storage-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [eacl.datahike.qualifiers :as qualifiers]
+            [eacl.relationships.qualifier-sweep-contract :as sweep]
+            [clojure.test :refer [deftest is]]
             [datahike.api :as d]
             [eacl.datahike.core :as api]
             [eacl.datahike.impl :as impl]
@@ -41,3 +43,17 @@
         :evidence #(admission/evidence (d/db conn))
         :transact! #(d/transact conn %)})
       (finally (d/release conn) (d/delete-database config)))))
+
+(defn with-sweep-fixture [f]
+  (doseq [options [nil {:attribute-refs? true} {:schema-flexibility :read}]]
+    (let [conn (schema/create-conn nil options) config (:config (d/db conn))]
+      (try
+        (f {:client (api/make-client conn {}) :snapshot #(d/db conn)
+            :transact! #(d/transact conn %) :entid ddb/entid
+            :writer #(qualifiers/writer conn) :rows (:all-rows (qualifiers/read-api))})
+        (finally (d/release conn) (d/delete-database config))))))
+
+(deftest cleanup-sweep-native-work-and-transition-contract
+  (sweep/exercise-work! with-sweep-fixture)
+  (sweep/exercise-hostile! with-sweep-fixture)
+  (sweep/exercise-budgets! with-sweep-fixture))

--- a/modules/eacl-datahike/test/eacl/datahike/safe_retraction_test.clj
+++ b/modules/eacl-datahike/test/eacl/datahike/safe_retraction_test.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [datahike.api :as d]
             [eacl.contract-support :as contract]
+            [eacl.authorization.qualification-test :as qualification]
+            [eacl.relationships.safe-retraction-contract :as control-contract]
             [eacl.core :as eacl]
             [eacl.datahike.core :as core]
             [eacl.datahike.db :as ddb]
@@ -294,3 +296,21 @@
      client
      (mapv (fn [[u a]] (eacl/->Relationship u :owner a)) unrelated))
     (is (= before (expansion-size)))))
+
+(deftest qualified-control-roles-are-protected-in-every-mode-test
+  (doseq [[label config _] modes]
+    (testing label
+      (let [conn (schema/create-conn nil config)
+            config (:config (d/db conn))]
+        (try
+          (d/transact conn [{:db/ident :test/component :db/valueType :db.type/ref
+                            :db/cardinality :db.cardinality/one :db/isComponent true}])
+          (safe-datahike/prepare! conn)
+          (control-contract/exercise!
+           {:client (core/make-client conn {:clock (constantly 99)
+                                           :caveat-evaluator (qualification/portable-evaluator (atom 0))})
+            :snapshot #(d/db conn) :transact! #(d/transact conn %)
+            :entid ddb/entid :rows #(ddb/avet-datoms %1 %2)
+            :facts ddb/entity-facts :revision :max-tx
+            :retract! #(d/transact conn (safe-datahike/retract-entity-tx-data (d/db conn) %))})
+          (finally (d/release conn) (d/delete-database config)))))))

--- a/modules/eacl-datalevin/test/eacl/datalevin/safe_retraction_test.clj
+++ b/modules/eacl-datalevin/test/eacl/datalevin/safe_retraction_test.clj
@@ -3,6 +3,8 @@
             [datalevin.core :as d]
             [datalevin.util :as u]
             [eacl.core :as eacl]
+            [eacl.authorization.qualification-test :as qualification]
+            [eacl.relationships.safe-retraction-contract :as control-contract]
             [eacl.datalevin.backend :as backend]
             [eacl.datalevin.core :as datalevin]
             [eacl.datalevin.safe-retraction :as safe-retraction]
@@ -121,3 +123,29 @@
            conn
            (safe-retraction/retract-entity-tx-data [:eacl/id "victim"]))
           (is (empty? (d/datoms (d/db conn) :eav eid))))))))
+
+(deftest qualified-control-roles-are-protected-through-the-admitted-writer
+  (let [dir (u/tmp-dir (str "qualified-control-" (random-uuid)))
+        conn (datalevin/create-conn dir {:test/component {:db/valueType :db.type/ref :db/isComponent true}})
+        watermark (atom 0)]
+    (try
+      (let [client (datalevin/make-client
+                    conn {:security-key test-key
+                          :source-lifecycle (random-uuid)
+                          :revision-watermark watermark
+                          :advance-revision-watermark! #(swap! watermark max %)
+                          :clock (constantly 99)
+                          :caveat-evaluator (qualification/portable-evaluator (atom 0))})
+            token (:write-token (d/install-write-policy! conn (d/write-policy conn)))]
+        (control-contract/exercise!
+         {:client client :snapshot #(d/db conn) :entid d/entid
+          :transact! (fn [tx]
+                       (d/transact! conn
+                                    (conj (vec tx) [:db/add
+                                                    (d/entid (d/db conn) [:eacl/id "schema-string"])
+                                                    :eacl.datalevin/schema-generation :db/current-tx])
+                                    {:datalevin/write-token token}))
+          :rows #(d/datoms %1 :ave %2)
+          :facts (fn [db eid] (mapv (juxt :a :v) (d/datoms db :eav eid)))
+          :revision :max-tx :retract! #(safe-retraction/transact-retract-entity! client %)}))
+      (finally (d/close conn) (u/delete-files dir)))))

--- a/modules/eacl-datascript/src/eacl/datascript/qualifiers.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/qualifiers.cljc
@@ -47,6 +47,9 @@
   {:backend :datascript :entity entity :facts facts :rows identity-rows
    :source backend/database-source-scope :generation schema/current-schema-generation
    :all-rows (fn [database attribute] (ds/datoms database :aevt attribute))
+   :fact-rows (fn [database eid] (ds/datoms database :eavt eid))
+   :attribute-ident (fn [_database a] a)
+   :cleanup-token :schema
    :relation-version-attribute :eacl/relation-version
    :revision :max-tx
    :head-guard (fn [database]
@@ -80,7 +83,10 @@
    (merge (planner-api)
           (let [scope {:source-id {:connection-id (backend/connection-source-id conn)} :branch nil}]
             {:source #(or (backend/database-source-scope %) scope)})
-          {:snapshot #(ds/db conn) :transact! #(ds/transact! conn %)})))
+          {:cleanup-commit-snapshots (fn [report]
+                                      (when (and (:db-before report) (:db-after report))
+                                        [(:db-before report) (:db-after report)]))
+           :snapshot #(ds/db conn) :transact! #(ds/transact! conn %)})))
 
 (defn publication-capability [database]
   (admission/publication-descriptor :prepared))

--- a/modules/eacl-datascript/src/eacl/datascript/safe_retraction.cljc
+++ b/modules/eacl-datascript/src/eacl/datascript/safe_retraction.cljc
@@ -9,7 +9,7 @@
             [eacl.relationships.storage :as storage]))
 
 (def function-digest
-  "b95f310357fa216e59435c6d15a8adaea910650b0ee5d602f9d98e5cbeed4361")
+  "c8dad3f368de21e3785a35e0f2494a9c2a72135cc3f4e304a70deddc710fe03e")
 
 (def function-doc
   (str safe/function-doc-prefix " v" safe/function-version

--- a/modules/eacl-datascript/test/eacl/datascript/qualifier_storage_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/qualifier_storage_test.cljc
@@ -1,5 +1,7 @@
 (ns eacl.datascript.qualifier-storage-test
-  (:require [#?(:clj clojure.test :cljs cljs.test) :refer [deftest is]]
+  (:require [eacl.datascript.qualifiers :as qualifiers]
+            [eacl.relationships.qualifier-sweep-contract :as sweep]
+            [#?(:clj clojure.test :cljs cljs.test) :refer [deftest is]]
             [datascript.core :as d]
             [eacl.datascript.core :as api]
             [eacl.datascript.impl :as impl]
@@ -58,3 +60,14 @@
         :evidence #(admission/evidence (d/db conn))
         :transact! #(d/transact! conn %)})
       (finally nil))))
+
+(defn with-sweep-fixture [f]
+  (let [conn (schema/create-conn)]
+    (f {:client (api/make-client conn {}) :snapshot #(d/db conn)
+        :transact! #(d/transact! conn %) :entid d/entid
+        :writer #(qualifiers/writer conn) :rows #(d/datoms %1 :aevt %2)})))
+
+(deftest cleanup-sweep-native-work-and-transition-contract
+  (sweep/exercise-work! with-sweep-fixture)
+  (sweep/exercise-hostile! with-sweep-fixture)
+  (sweep/exercise-budgets! with-sweep-fixture))

--- a/modules/eacl-datascript/test/eacl/datascript/qualifier_sweep_mutation_test.clj
+++ b/modules/eacl-datascript/test/eacl/datascript/qualifier_sweep_mutation_test.clj
@@ -1,0 +1,32 @@
+(ns eacl.datascript.qualifier-sweep-mutation-test
+  (:require [clojure.test :refer [deftest is]]
+            [eacl.datascript.qualifier-storage-test :as native]
+            [eacl.relationships.qualifier-integrity :as integrity]
+            [eacl.relationships.qualifier-sweep-contract :as contract]))
+
+(deftest native-work-contract-kills-repeated-global-capture
+  (let [original @#'integrity/sweep-chunk!]
+    (with-redefs-fn
+      {#'integrity/sweep-chunk!
+       (fn [native certificate chunk]
+         ((:with-snapshot native) #(integrity/proof-input native %))
+         (original native certificate chunk))}
+      #(native/with-sweep-fixture
+        (fn [fixture]
+          (let [{:keys [result counts expected]} (contract/work-outcome fixture)]
+            (is (= expected (set (:qualifiers result))))
+            (is (> (:streams counts) 6) "the native work contract detects per-chunk recapture")))))))
+
+(deftest native-attachment-contract-kills-unproved-rebase
+  (let [original @#'integrity/sweep-chunk!]
+    (with-redefs-fn
+      {#'integrity/sweep-chunk!
+       (fn [native _certificate chunk]
+         (let [unproved ((:with-snapshot native) #(@#'integrity/sweep-certificate native %))]
+           (original native unproved chunk)))}
+      #(native/with-sweep-fixture
+        (fn [fixture]
+          (let [{:keys [attached attached-survives?]}
+                (contract/hostile-outcome fixture :attachment)]
+            (is (= 1 (count attached)))
+            (is (false? attached-survives?) "unproved rebasing deletes a newly attached qualifier")))))))

--- a/modules/eacl-datascript/test/eacl/datascript/safe_retraction_test.cljc
+++ b/modules/eacl-datascript/test/eacl/datascript/safe_retraction_test.cljc
@@ -3,6 +3,8 @@
              :refer [deftest is testing]]
             [datascript.core :as ds]
             [eacl.contract-support :as contract]
+            [eacl.authorization.qualification-test :as qualification]
+            [eacl.relationships.safe-retraction-contract :as control-contract]
             [eacl.core :as eacl]
             [eacl.datascript.core :as core]
             [eacl.datascript.impl :as impl]
@@ -247,3 +249,19 @@
      client
      (mapv (fn [[u a]] (eacl/->Relationship u :owner a)) unrelated))
     (is (= before (expansion-size)))))
+
+(deftest qualified-control-roles-are-protected-in-every-mode-test
+  (doseq [mode [:named :direct]]
+    (let [conn (schema/create-conn {:test/component
+                                    {:db/valueType :db.type/ref :db/isComponent true}})
+          client (core/make-client conn {:clock (constantly 99)
+                                        :caveat-evaluator (qualification/portable-evaluator (atom 0))})]
+      (safe-datascript/install! conn)
+      (control-contract/exercise!
+       {:client client :snapshot #(ds/db conn) :transact! #(ds/transact! conn %)
+        :entid ds/entid :rows #(ds/datoms %1 :aevt %2)
+        :facts (fn [db eid] (mapv (juxt :a :v) (ds/datoms db :eavt eid)))
+        :revision :max-tx
+        :retract! #(ds/transact! conn ((if (= mode :named)
+                                        safe-datascript/retract-entity-tx-data
+                                        safe-datascript/direct-retract-entity-tx-data) %))}))))

--- a/modules/eacl-datomic/src/eacl/datomic/qualifiers.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/qualifiers.clj
@@ -34,6 +34,9 @@
   {:backend :datomic :entity entity :facts facts :rows db/relationship-identity-datoms
    :source (fn [database] (str (.id ^datomic.Database database))) :generation generation
    :all-rows (fn [database attribute] (when (d/entid database attribute) (d/datoms database :aevt attribute)))
+   :fact-rows (fn [database eid] (d/datoms database :eavt eid))
+   :attribute-ident (fn [database a] (d/ident database a))
+   :cleanup-token (constantly nil)
    :relation-version-attribute :eacl/relation-version
    :revision d/basis-t
    :head-guard (fn [database] [:eacl.fn/assert-storage-basis (d/basis-t database)])
@@ -60,7 +63,10 @@
   (when-not (d/entid (d/db conn) :eacl.fn/assert-qualifier-facts) (staged/error! :schema-unprepared))
   (staged/native-writer
    (merge (planner-api)
-          {:snapshot #(d/db conn)
+          {:cleanup-commit-snapshots (fn [report]
+                                      (when (and (:db-before report) (:db-after report))
+                                        [(:db-before report) (:db-after report)]))
+           :snapshot #(d/db conn)
            :generation-after-reference #(generation (:db-after %))
            :transact! #(deref (d/transact conn %))})))
 

--- a/modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj
+++ b/modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj
@@ -8,7 +8,7 @@
             [eacl.relationships.safe-retraction :as safe]))
 
 (def function-digest
-  "79faf08f6f5f1c1b1e45c089fa754dda73eb8f75fab5ad5e2a9958a368ac6106")
+  "00c50c459a2b8bc69d103c0a4a03a5b0a6950fe76f9c2c9b32c376715c1530ba")
 
 (def function-doc
   (str safe/function-doc-prefix " v" safe/function-version
@@ -26,7 +26,9 @@
      :params '[db target]
      :code
      (walk/postwalk-replace
-      {'endpoint-value-constructor endpoint-pair/constructor-form}
+      {'endpoint-value-constructor endpoint-pair/constructor-form
+       'qualified-control-attributes safe/qualified-control-attributes
+       'qualified-schema-idents safe/qualified-schema-idents}
       '(let [endpoint-value endpoint-value-constructor
              invalid!
             (fn [reason data]
@@ -102,6 +104,8 @@
                         (some? (:eacl/schema-string entity))
                         (some? (:eacl.relation/relation-name entity))
                         (some? (:eacl.permission/permission-name entity))
+                        (some #(some? (% entity)) qualified-control-attributes)
+                        (contains? qualified-schema-idents ident)
                         (and (keyword? ident)
                              (contains? #{"eacl" "eacl.fn"}
                                         (namespace ident))))))
@@ -189,9 +193,8 @@
                              :op [:db/retract (:e peer)
                                   forward-attr (:v peer)]}))))
                      (datomic.api/datoms db :aevt relation-key-attr)))
-                  halves (remove #(nil? (:op %))
-                                 (or local-halves repair-halves))
-                  peer-retractions (distinct (map :op halves))
+                  halves (or local-halves repair-halves)
+                  peer-retractions (distinct (keep :op halves))
                   relation-eids (distinct (map :relation-eid halves))]
               (vec
                (concat

--- a/modules/eacl-datomic/test/eacl/datomic/adversarial_v8_review_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/adversarial_v8_review_test.clj
@@ -1,0 +1,298 @@
+(ns eacl.datomic.adversarial-v8-review-test
+  "Native regressions for qualified control protection and complete Relation stamps."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
+            [datomic.api :as d]
+            [eacl.authorization.qualification-test :as qualification-fixtures]
+            [eacl.core :as eacl]
+            [eacl.datomic.core :as core]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
+            [eacl.datomic.safe-retraction :as safe-datomic]
+            [eacl.datomic.schema :as schema]
+            [eacl.relationships.safe-retraction :as safe]
+            [eacl.relationships.storage :as storage]))
+
+(def qualified-schema
+  "caveat enabled(flag bool) { flag }
+   caveat standby(flag bool) { flag }
+   definition user {}
+   definition doc {
+     relation viewer: user | user with enabled | user with standby
+     permission view = viewer
+   }")
+
+(def loop-schema
+  "definition node {
+     relation loop: node
+     relation unrelated: node
+     permission view = loop
+   }")
+
+(defn with-review-client [schema-source f]
+  (with-mem-conn [conn schema/v8-schema]
+    (let [client (core/make-client
+                  conn
+                  {:clock (constantly 99)
+                   :caveat-evaluator
+                   (qualification-fixtures/portable-evaluator (atom 0))})]
+      ;; Use the public writer: unlike the low-level schema facade it selects
+      ;; the qualified relation-allowance feature through orchestration.
+      (eacl/write-schema! client {:schema schema-source})
+      (safe-datomic/install! conn)
+      (f conn client))))
+
+(defn throwable-reasons [error]
+  (loop [cause error result #{}]
+    (if (nil? cause)
+      result
+      (recur (.getCause ^Throwable cause)
+             (cond-> result
+               (:reason (ex-data cause))
+               (conj (:reason (ex-data cause))))))))
+
+(defn retract-outcome! [conn target]
+  (try
+    {:report @(d/transact conn (safe-datomic/retract-entity-tx-data target))}
+    (catch Exception error
+      {:error error :reasons (throwable-reasons error)})))
+
+(defn seed-qualified! [conn client]
+  @(d/transact conn [{:eacl/id "review/u"} {:eacl/id "review/d"}])
+  (let [subject (eacl/spice-object :user "review/u")
+        resource (eacl/spice-object :doc "review/d")
+        relationship (assoc (eacl/->Relationship subject :viewer resource)
+                            :caveat "enabled"
+                            :valid-until-ms 100)]
+    ;; No bound Caveat context: its absence is essential to the minimal
+    ;; false -> true witness when the ordinary Caveat reference disappears.
+    (eacl/create-relationship! client relationship)
+    (let [db (d/db conn)
+          subject-eid (d/entid db [:eacl/id "review/u"])
+          qid (nth (:v (first (d/datoms db :eavt subject-eid
+                                        storage/forward-attribute))) 4)]
+      {:caveat-eid (d/entid db [:eacl.caveat/name "enabled"])
+       :qualifier-eid qid
+       :request {:subject subject :resource resource :permission :view
+                 :caveat-context {"flag" false} :cache? false}})))
+
+(deftest safe-retraction-must-not-weaken-a-caveat-into-expiry-only
+  (with-review-client
+    qualified-schema
+    (fn [conn client]
+      (let [{:keys [caveat-eid qualifier-eid request]} (seed-qualified! conn client)
+            before (d/db conn)
+            before-result (eacl/check-permission client request)]
+        (is (some? caveat-eid))
+        (is (some? qualifier-eid))
+        (is (= :no-permission (:permissionship before-result)))
+        (let [outcome (retract-outcome! conn caveat-eid)
+              after (d/db conn)
+              after-result (eacl/check-permission client request)]
+          (is (:error outcome) "Caveat definitions are not object-deletion targets")
+          (is (contains? (:reasons outcome) :protected-control-entity))
+          (is (= (d/basis-t before) (d/basis-t after))
+              "a rejected deletion must not commit any ref cleanup")
+          (is (= caveat-eid (d/entid after [:eacl.caveat/name "enabled"])))
+          (is (= :no-permission (:permissionship after-result))
+              (str "Native result after attempted deletion: " (pr-str after-result))))))))
+
+(deftest safe-retraction-must-reject-qualifier-entity-targets
+  (with-review-client
+    qualified-schema
+    (fn [conn client]
+      (let [{:keys [qualifier-eid]} (seed-qualified! conn client)
+            before (d/db conn)
+            outcome (retract-outcome! conn qualifier-eid)]
+        (is (:error outcome))
+        (is (contains? (:reasons outcome) :protected-control-entity))
+        (is (= (d/basis-t before) (d/basis-t (d/db conn))))
+        (is (seq (d/datoms (d/db conn) :eavt qualifier-eid)))))))
+
+(deftest component-closure-must-not-delete-a-caveat-definition
+  (with-review-client
+    qualified-schema
+    (fn [conn client]
+      (let [{:keys [caveat-eid request]} (seed-qualified! conn client)]
+        @(d/transact conn [{:db/ident :review/component
+                            :db/valueType :db.type/ref
+                            :db/cardinality :db.cardinality/one
+                            :db/isComponent true}])
+        @(d/transact conn [{:eacl/id "review/parent"
+                            :review/component caveat-eid}])
+        (let [before (d/db conn)
+              outcome (retract-outcome! conn [:eacl/id "review/parent"])]
+          (is (:error outcome))
+          (is (contains? (:reasons outcome) :protected-control-entity))
+          (is (= (d/basis-t before) (d/basis-t (d/db conn))))
+          (is (some? (d/entid (d/db conn) [:eacl/id "review/parent"])))
+          (is (= :no-permission
+                 (:permissionship (eacl/check-permission client request)))))))))
+
+(defn relation-id [db name]
+  (d/entid db [:eacl.relation/resource-type+relation-name+subject-type
+               [:node name :node]]))
+
+(defn generation [db relation]
+  (:v (first (d/datoms db :eavt relation :eacl/relation-version))))
+
+(deftest deleting-an-isolated-self-loop-must-advance-its-relation-generation
+  (with-review-client
+    loop-schema
+    (fn [conn client]
+      @(d/transact conn [{:eacl/id "review/loop"}
+                         {:eacl/id "review/other-a"}
+                         {:eacl/id "review/other-b"}])
+      (let [node (eacl/spice-object :node "review/loop")
+            other-a (eacl/spice-object :node "review/other-a")
+            other-b (eacl/spice-object :node "review/other-b")]
+        (eacl/create-relationship! client (eacl/->Relationship node :loop node))
+        (eacl/create-relationship! client (eacl/->Relationship other-a :unrelated other-b))
+        (let [before (d/db conn)
+              eid (d/entid before [:eacl/id "review/loop"])
+              loop-id (relation-id before :loop)
+              unrelated-id (relation-id before :unrelated)
+              expansion (d/invoke before safe/function-ident before eid)
+              stamped (into #{}
+                            (keep (fn [op]
+                                    (when (and (= :db/add (first op))
+                                               (= :eacl/relation-version (nth op 2 nil)))
+                                      (second op))))
+                            expansion)]
+          (is (= #{loop-id} stamped)
+              "zero peer retractions does not mean zero affected relations")
+          @(d/transact conn (safe-datomic/retract-entity-tx-data eid))
+          (let [after (d/db conn)]
+            (is (empty? (d/datoms after :eavt eid)))
+            (is (not= (generation before loop-id) (generation after loop-id)))
+            (is (= (generation before unrelated-id)
+                   (generation after unrelated-id)))))))))
+
+(defn stamp-set [expansion]
+  (into #{} (keep (fn [[op eid attribute]]
+                    (when (and (= :db/add op) (= :eacl/relation-version attribute)) eid))) expansion))
+
+(defn affected-relations
+  "Independent projection of both physical indexes; self edges stay in scope."
+  [db closure]
+  (into #{}
+        (for [attribute storage/attributes
+              datom (d/datoms db :aevt attribute)
+              :let [[_ relation _ peer] (:v datom)]
+              :when (or (closure (:e datom)) (closure peer))]
+          relation)))
+
+(deftest native-stamps-refine-incident-edges-in-small-graphs
+  (with-review-client
+    loop-schema
+    (fn [conn _client]
+      @(d/transact conn [{:eacl/id "graph/a"} {:eacl/id "graph/b"}
+                         {:eacl/id "graph/parent"}
+                         {:db/ident :review/children :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/many :db/isComponent true}])
+      (let [base (d/db conn)
+            a (d/entid base [:eacl/id "graph/a"])
+            b (d/entid base [:eacl/id "graph/b"])
+            parent (d/entid base [:eacl/id "graph/parent"])
+            r (relation-id base :loop)
+            u (relation-id base :unrelated)
+            edges [[a r a] [b u b] [a u b] [b r a]]]
+        (doseq [mask (range 16)
+                direction [:forward :reverse :both]
+                closure [#{a} #{a b}]]
+          (let [edge-ops (for [index (range 4)
+                               :when (bit-test mask index)
+                               half [:forward :reverse]
+                               :let [[s rel o] (nth edges index)]
+                               :when (or (not= s o) (= :both direction) (= half direction))]
+                           (if (= half :forward)
+                             [:db/add s storage/forward-attribute [:node rel :node o nil]]
+                             [:db/add o storage/reverse-attribute [:node rel :node s nil]]))
+                ops (into (mapv #(vector :db/add parent :review/children %) closure) edge-ops)
+                db (:db-after (d/with base ops))
+                expected (affected-relations db (conj closure parent))
+                expansion (d/invoke db safe/function-ident db parent)]
+            (is (= expected (stamp-set expansion)))
+            (is (= (count expected)
+                   (count (filter #(= :eacl/relation-version (nth % 2 nil)) expansion))))))))))
+
+(deftest component-self-loop-and-mixed-closure-advance-exactly
+  (with-review-client
+    loop-schema
+    (fn [conn client]
+      @(d/transact conn [{:db/ident :review/child
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/one
+                          :db/isComponent true}])
+      @(d/transact conn [{:db/id -1 :eacl/id "child"}
+                         {:eacl/id "parent" :review/child -1}
+                         {:eacl/id "peer"}])
+      (let [child (eacl/spice-object :node "child")
+            parent (eacl/spice-object :node "parent")
+            peer (eacl/spice-object :node "peer")]
+        (eacl/create-relationship! client (eacl/->Relationship child :loop child))
+        (eacl/create-relationship! client (eacl/->Relationship parent :unrelated peer))
+        (let [before (d/db conn)
+              p (d/entid before [:eacl/id "parent"])
+              c (d/entid before [:eacl/id "child"])
+              expected (affected-relations before #{p c})]
+          (is (= expected (stamp-set (d/invoke before safe/function-ident before p))))
+          @(d/transact conn [[safe/function-ident p] [safe/function-ident p]])
+          (let [after (d/db conn)]
+            (is (empty? (d/datoms after :eavt p)))
+            (is (empty? (d/datoms after :eavt c)))
+            (doseq [r expected] (is (< (generation before r) (generation after r))))
+            (is (empty? (affected-relations after #{p c})))
+            (is (empty? (stamp-set (d/invoke after safe/function-ident after p))))))))))
+
+(defn mutated-definition [mutation]
+  (let [definition safe-datomic/function-definition
+        body (:db/fn definition)
+        original (read-string (:code body))
+        code (case mutation
+               :control (walk/postwalk-replace {safe/qualified-control-attributes #{}} original)
+               :self-loop (walk/postwalk-replace
+                           {'(or local-halves repair-halves)
+                            '(remove (fn [half] (nil? (:op half))) (or local-halves repair-halves))}
+                           original))]
+    (is (not= code original) "mutation must reach the production body")
+    (assoc definition :db/fn (d/function {:lang (:lang body) :params (:params body) :code code}))))
+
+(deftest native-witness-kills-missing-control-protection
+  (with-review-client
+    qualified-schema
+    (fn [conn client]
+      (let [{:keys [caveat-eid qualifier-eid request]} (seed-qualified! conn client)
+            before (d/db conn)]
+        (is (= :no-permission (:permissionship (eacl/check-permission client request))))
+        @(d/transact conn [(mutated-definition :control)])
+        @(d/transact conn (safe-datomic/retract-entity-tx-data caveat-eid))
+        (is (some? (:eacl.relationship-qualifier/caveat (d/entity before qualifier-eid))))
+        (is (nil? (:eacl.relationship-qualifier/caveat (d/entity (d/db conn) qualifier-eid))))
+        (is (= :has-permission (:permissionship (eacl/check-permission client request))))))))
+
+(deftest native-oracle-kills-premature-nil-op-filter
+  (with-review-client
+    loop-schema
+    (fn [conn client]
+      @(d/transact conn [{:eacl/id "self"}])
+      (let [object (eacl/spice-object :node "self")]
+        (eacl/create-relationship! client (eacl/->Relationship object :loop object))
+        @(d/transact conn [(mutated-definition :self-loop)])
+        (let [db (d/db conn) eid (d/entid db [:eacl/id "self"])]
+          (is (not= (affected-relations db #{eid})
+                    (stamp-set (d/invoke db safe/function-ident db eid)))))))))
+
+(deftest recognized-v4-body-is-replaced-before-native-invocation
+  (with-review-client
+    qualified-schema
+    (fn [conn client]
+      (let [{:keys [caveat-eid request]} (seed-qualified! conn client)
+            old (assoc (mutated-definition :control)
+                       :db/doc (str safe/function-doc-prefix " v4; previous qualified guard"))]
+        @(d/transact conn [old])
+        (is (some #(= :db.fn/retractEntity (first %))
+                  (d/invoke (d/db conn) safe/function-ident (d/db conn) caveat-eid)))
+        (is (= :upgradeable (:state (safe-datomic/install! conn))))
+        (is (= :current (:state (safe-datomic/install! conn))))
+        (is (contains? (:reasons (retract-outcome! conn caveat-eid)) :protected-control-entity))
+        (is (= :no-permission (:permissionship (eacl/check-permission client request))))))))

--- a/modules/eacl-datomic/test/eacl/datomic/qualifier_storage_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/qualifier_storage_test.clj
@@ -1,6 +1,9 @@
 (ns eacl.datomic.qualifier-storage-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [eacl.datomic.qualifiers :as qualifiers]
+            [eacl.relationships.qualifier-sweep-contract :as sweep]
+            [clojure.test :refer [deftest is]]
             [datomic.api :as d]
+            [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
             [eacl.datomic.core :as api]
             [eacl.datomic.impl :as impl]
             [eacl.datomic.db :as db]
@@ -44,3 +47,14 @@
         :evidence #(admission/evidence (d/db conn))
         :transact! #(deref (d/transact conn %))})
       (finally (d/release conn) (d/delete-database uri)))))
+
+(defn with-sweep-fixture [f]
+  (with-mem-conn [conn schema/v8-schema]
+    (f {:client (api/make-client conn {}) :snapshot #(d/db conn)
+        :transact! #(deref (d/transact conn %)) :entid d/entid
+        :writer #(qualifiers/writer conn) :rows #(d/datoms %1 :aevt %2)})))
+
+(deftest cleanup-sweep-native-work-and-transition-contract
+  (sweep/exercise-work! with-sweep-fixture)
+  (sweep/exercise-hostile! with-sweep-fixture)
+  (sweep/exercise-budgets! with-sweep-fixture))

--- a/modules/eacl-datomic/test/eacl/datomic/safe_retraction_test.clj
+++ b/modules/eacl-datomic/test/eacl/datomic/safe_retraction_test.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [datomic.api :as d]
             [eacl.contract-support :as contract]
+            [eacl.authorization.qualification-test :as qualification]
+            [eacl.relationships.safe-retraction-contract :as control-contract]
             [eacl.core :as eacl]
             [eacl.datomic.core :as core]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
@@ -261,3 +263,17 @@
          client
          (mapv (fn [[u a]] (eacl/->Relationship u :owner a)) unrelated)))
       (is (= before (expansion-size))))))
+
+(deftest qualified-control-roles-are-protected-in-the-installed-body-test
+  (with-mem-conn [conn (conj schema/v8-schema
+                            {:db/ident :test/component :db/valueType :db.type/ref
+                             :db/cardinality :db.cardinality/one :db/isComponent true})]
+    (safe-datomic/install! conn)
+    (control-contract/exercise!
+     {:client (core/make-client conn {:clock (constantly 99)
+                                     :caveat-evaluator (qualification/portable-evaluator (atom 0))})
+      :snapshot #(d/db conn) :transact! #(deref (d/transact conn %))
+      :entid d/entid :rows #(d/datoms %1 :aevt %2)
+      :facts (fn [db eid] (mapv (fn [datom] [(d/ident db (:a datom)) (:v datom)]) (d/datoms db :eavt eid)))
+      :revision d/basis-t
+      :retract! #(deref (d/transact conn (safe-datomic/retract-entity-tx-data %)))})))

--- a/modules/eacl/src/eacl/relationships/qualifier_capture.cljc
+++ b/modules/eacl/src/eacl/relationships/qualifier_capture.cljc
@@ -1,0 +1,59 @@
+(ns eacl.relationships.qualifier-capture
+  "Resource accounting before retaining offline proof data. Native snapshots
+   and backend index buffers are owned by the caller, outside these budgets."
+  (:require [eacl.relationships.qualifier :as qualifier]))
+
+(def default-budgets {:max-capture-units 2000000 :max-qualifiers 100000})
+
+(defn bounded-native
+  "Bounds captured data cells and string code units, and distinct qualifier ids.
+   Fact streams are checked before building entity maps or fact vectors."
+  [native options]
+  (let [{:keys [max-capture-units max-qualifiers]} (merge default-budgets options)
+        _ (when-not (and (pos-int? max-capture-units) (pos-int? max-qualifiers))
+            (throw (ex-info "Invalid qualifier capture budgets."
+                            {:type :eacl.integrity/invalid-options})))
+        units (volatile! 0)
+        qids (volatile! #{})
+        limit! (fn [budget]
+                 (throw (ex-info "Qualifier sweep capture budget exceeded."
+                                 {:type :eacl.integrity/capture-budget-exceeded :budget budget})))
+        charge! (fn [value]
+                  (loop [pending (list value)]
+                    (when-let [items (seq pending)]
+                      (let [v (first items)
+                            cost (if (string? v) (inc (count v)) 1)]
+                        (when (> (+ @units cost) max-capture-units) (limit! :max-capture-units))
+                        (vswap! units + cost)
+                        (recur (if (coll? v) (concat v (rest items)) (rest items)))))))
+        track! (fn [qid]
+                 (when (and (qualifier/concrete-eid? qid) (not (contains? @qids qid)))
+                   (when (>= (count @qids) max-qualifiers) (limit! :max-qualifiers))
+                   (vswap! qids conj qid)))
+        checked-row (fn [row] (charge! [(:e row) (:a row) (:v row) (:tx row)]) row)
+        facts (fn [db eid]
+                (into [] (map (fn [row]
+                                (checked-row row)
+                                [(:a row) (:v row) (:tx row)]))
+                      ((:fact-rows native) db eid)))
+        entity (fn [db eid]
+                 (let [rows (facts db eid)]
+                   (when (seq rows)
+                     (reduce (fn [result [a v]]
+                               (let [attribute ((:attribute-ident native) db a)]
+                                 (if (= :eacl.relation/caveats attribute)
+                                   (update result attribute (fnil conj #{}) v)
+                                   (assoc result attribute v))))
+                             {:db/id eid} rows))))]
+    (assoc native
+           :entity entity :facts facts
+           :all-rows (fn [db attribute]
+                       (map (fn [row]
+                              (checked-row row)
+                              (track! (if (contains? qualifier/attributes attribute)
+                                        (:e row)
+                                        (when (and (vector? (:v row)) (= 5 (count (:v row))))
+                                          (nth (:v row) 4))))
+                              row)
+                            ((:all-rows native) db attribute)))
+           :rows (fn [& args] (map checked-row (apply (:rows native) args))))))

--- a/modules/eacl/src/eacl/relationships/qualifier_integrity.cljc
+++ b/modules/eacl/src/eacl/relationships/qualifier_integrity.cljc
@@ -3,6 +3,7 @@
   (:require [eacl.caveats.definition :as definition]
             [eacl.relationships.endpoint-pair :as pair]
             [eacl.relationships.qualifier :as qualifier]
+            [eacl.relationships.qualifier-capture :as capture]
             [eacl.relationships.storage :as storage]))
 
 (defn- identity-of [decoded]
@@ -215,3 +216,94 @@
                       {:type :eacl.integrity/source-mismatch :eacl/error :eacl.integrity/source-mismatch})))
     ((:transact! native) (:tx-data plan))
     (dissoc plan :tx-data)))
+
+(defn- sweep-certificate [native db]
+  {:source ((:source native) db)
+   :revision ((:revision native) db)
+   :token ((:cleanup-token native) db)})
+
+(defn- capture-sweep [writer options]
+  (let [native (:native writer)]
+    ((:with-snapshot native)
+     (fn [db]
+       (when-not (= (:source writer) ((:source native) db))
+         (throw (ex-info "Qualifier cleanup source changed."
+                         {:type :eacl.integrity/source-mismatch})))
+       (let [frame (proof-input (capture/bounded-native native options) db)
+             diagnosis (report frame {:sample-size 0})]
+         (when-not (= :healthy (:status diagnosis))
+           (throw (ex-info "Repair corrupt qualifier data before collecting orphans."
+                           {:type :eacl.integrity/corrupt-qualifiers :counts (:counts diagnosis)})))
+         {:certificate (sweep-certificate native db)
+          :candidates (into []
+                            (comp (remove #(seq (get-in frame [:references (key %)])))
+                                  (map (fn [[qid record]] [qid (:facts record)])))
+                            (sort-by key (:qualifiers frame)))})))))
+
+(defn- sweep-chunk! [native certificate chunk]
+  (let [tx-data
+        ((:with-snapshot native)
+         (fn [db]
+           (when-not (= certificate (sweep-certificate native db))
+             (throw (ex-info "Qualifier sweep requires a new capture."
+                             {:type :eacl.integrity/stale-sweep})))
+           (into [((:head-guard native) db)]
+                 (mapcat (fn [[qid facts]]
+                           [((:assert-entity native) qid facts) [:db/retractEntity qid]]))
+                 chunk)))
+        report ((:transact! native) tx-data)
+        [before after] ((:cleanup-commit-snapshots native) report)
+        previous (when before (sweep-certificate native before))
+        next (when after (sweep-certificate native after))]
+    ;; A later current-db sample cannot certify which transaction committed.
+    (when-not (and (= certificate previous)
+                   (= (:source certificate) (:source next))
+                   (= (:token certificate) (:token next))
+                   (number? (:revision next))
+                   (> (:revision next) (:revision certificate)))
+      (throw (ex-info "Cleanup commit evidence is missing or inconsistent."
+                      {:type :eacl.integrity/unproved-cleanup-commit})))
+    next))
+
+(defn cleanup-sweep!
+  "Collects captured orphans in bounded, individually atomic transactions.
+
+   Options: :batch-size (1..1000, default 100), :max-capture-units (default
+   2,000,000 data cells/string code units), :max-qualifiers (default 100,000),
+   and :cancelled? (zero-argument predicate). One capture takes O(A+Q) data
+   work and O(Q log Q) sorting, with O(A+Q) bounded capture memory; draining
+   retains O(Q) candidate facts. Native snapshot/index memory is additional.
+
+   Returns :status :complete, :cancelled, or :restart-required, confirmed
+   :qualifiers, :committed-batches, and :remaining-count. A failed/ambiguous
+   transaction is never counted. Restart always captures fresh evidence.
+   Datomic, DataScript, and direct Datahike writers certify own commit reports;
+   other writers retain the single-batch API."
+  ([writer] (cleanup-sweep! writer {}))
+  ([writer {:keys [batch-size cancelled?] :or {batch-size 100 cancelled? (constantly false)} :as options}]
+   (when-not (and (integer? batch-size) (<= 1 batch-size 1000) (ifn? cancelled?))
+     (throw (ex-info "Invalid qualifier sweep options." {:type :eacl.integrity/invalid-options})))
+   (let [native (:native writer)]
+     (when-not (every? #(ifn? (get native %))
+                      [:cleanup-commit-snapshots :cleanup-token :fact-rows :attribute-ident])
+       (throw (ex-info "This backend does not certify cleanup sweep commits."
+                       {:type :eacl.integrity/unsupported-sweep :backend (:backend native)})))
+     (let [{:keys [certificate candidates]} (capture-sweep writer options)]
+       (loop [certificate certificate candidates candidates collected [] batches 0]
+         (let [result {:qualifiers collected :committed-batches batches
+                       :remaining-count (count candidates) :source (:source certificate)}]
+           (cond
+             (empty? candidates) (assoc result :status :complete)
+             (cancelled?) (assoc result :status :cancelled)
+             :else
+             (let [n (min batch-size (count candidates))
+                   chunk (subvec candidates 0 n)
+                   outcome (try {:certificate (sweep-chunk! native certificate chunk)}
+                                (catch #?(:clj Exception :cljs :default) error
+                                  {:error error}))]
+               (if-let [error (:error outcome)]
+                 (assoc result :status :restart-required :error error)
+                 (recur (:certificate outcome)
+                        (subvec candidates n)
+                        (into collected (map first) chunk)
+                        (inc batches)))))))))))

--- a/modules/eacl/src/eacl/relationships/safe_retraction.cljc
+++ b/modules/eacl/src/eacl/relationships/safe_retraction.cljc
@@ -5,16 +5,23 @@
   installation. The public transaction function deliberately takes only the
   native retractEntity target; it carries no EACL mutation envelope or journal
   state."
-  (:require [eacl.relationships.endpoint-pair :as endpoint-pair]
+  (:require [eacl.caveats.schema :as caveat-schema]
+            [eacl.relationships.qualifier :as qualifier]
+            [eacl.relationships.endpoint-pair :as endpoint-pair]
             [eacl.relationships.storage :as storage]))
 
 (def function-ident :eacl.fn/retractEntity)
-(def function-version 4)
+(def function-version 5)
 (def function-doc-prefix "EACL safe entity retraction function")
 (def supported-modes #{:named :direct :unsupported})
 
 (def relation-version-attribute :eacl/relation-version)
 (def current-transaction-value :db/current-tx)
+(def qualified-control-attributes
+  "Owned facts also identify partially populated qualified control records."
+  (into caveat-schema/caveat-attributes qualifier/attributes))
+(def qualified-schema-idents
+  (into #{} (map :db/ident) caveat-schema/datom-schema))
 (def ^:no-doc empty-plan
   {:peer-retractions [] :relation-ids [] :local-half-count 0})
 
@@ -63,11 +70,14 @@
   Safe retraction is an object operation. Definitions and installed EACL
   functions must be changed through their dedicated writers so the schema
   generation remains authoritative."
-  [{:keys [db-ident eacl-id relation-name permission-name schema-string]}]
+  [{:keys [db-ident eacl-id relation-name permission-name schema-string
+           qualified-control?]}]
   (or (= "schema-string" eacl-id)
       (some? relation-name)
       (some? permission-name)
       (some? schema-string)
+      (true? qualified-control?)
+      (contains? qualified-schema-idents db-ident)
       (and (keyword? db-ident)
            (contains? #{"eacl" "eacl.fn"} (namespace db-ident)))))
 
@@ -80,6 +90,9 @@
                        (when
                         (protected-control-entity?
                          {:db-ident (:db/ident native)
+                          :qualified-control?
+                          (boolean (some #(some? (% native))
+                                         qualified-control-attributes))
                           :eacl-id (:eacl/id native)
                           :schema-string (:eacl/schema-string native)
                           :relation-name (:eacl.relation/relation-name native)

--- a/modules/eacl/test/eacl/bench/qualifier_cleanup_test.clj
+++ b/modules/eacl/test/eacl/bench/qualifier_cleanup_test.clj
@@ -1,0 +1,42 @@
+(ns eacl.bench.qualifier-cleanup-test
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [eacl.datomic.qualifier-storage-test :as datomic]
+            [eacl.datascript.qualifier-storage-test :as datascript]
+            [eacl.datahike.qualifier-storage-test :as datahike]
+            [eacl.relationships.qualifier-integrity :as integrity]
+            [eacl.relationships.qualifier-sweep-contract :as contract])
+  (:import [java.lang.management ManagementFactory]
+           [com.sun.management ThreadMXBean]))
+
+(deftest ^:benchmark cleanup-sweep-native-resource-budgets
+  (let [budget (edn/read-string (slurp "formal/baselines/qualifier-cleanup-sweep.edn"))
+        bean ^ThreadMXBean (ManagementFactory/getThreadMXBean)
+        tid (.threadId (Thread/currentThread))
+        samples (atom [])]
+    (doseq [[backend with-fixture] [[:datomic datomic/with-sweep-fixture]
+                                   [:datascript datascript/with-sweep-fixture]
+                                   [:datahike datahike/with-sweep-fixture]]
+            q (:orphans budget)]
+      (with-fixture
+        (fn [fixture]
+          (let [fixture (contract/seed! fixture q (:active budget))
+                counts (atom {})
+                writer (contract/traced-writer (:writer fixture) counts)
+                allocated-before (.getThreadAllocatedBytes bean tid)
+                start (System/nanoTime)
+                result (integrity/cleanup-sweep! writer {:batch-size (:batch-size budget)})
+                elapsed-ms (/ (- (System/nanoTime) start) 1e6)
+                allocated (- (.getThreadAllocatedBytes bean tid) allocated-before)]
+            (is (= :complete (:status result)))
+            (is (= q (count (:qualifiers result))))
+            (is (= (:global-streams budget) (:streams @counts)))
+            (is (< elapsed-ms (:max-elapsed-ms budget)))
+            (is (<= 0 allocated (:max-caller-allocated-bytes budget)))
+            (swap! samples conj {:backend backend :orphans q :active (:active budget)
+                                 :elapsed-ms elapsed-ms :caller-allocated-bytes allocated :work @counts})))))
+    (io/make-parents "target/benchmarks/adversarial-review/cleanup-sweep.edn")
+    (spit "target/benchmarks/adversarial-review/cleanup-sweep.edn"
+          (pr-str {:java (System/getProperty "java.version") :os (System/getProperty "os.name")
+                   :arch (System/getProperty "os.arch") :samples @samples}))))

--- a/modules/eacl/test/eacl/relationships/qualifier_sweep_contract.cljc
+++ b/modules/eacl/test/eacl/relationships/qualifier_sweep_contract.cljc
@@ -1,0 +1,141 @@
+(ns eacl.relationships.qualifier-sweep-contract
+  (:require [#?(:clj clojure.test :cljs cljs.test) :refer [is testing]]
+            [eacl.core :as eacl]
+            [eacl.relationships.qualifier :as qualifier]
+            [eacl.relationships.qualifier-integrity :as integrity]
+            [eacl.relationships.staged :as staged]
+            [eacl.relationships.storage :as storage]))
+
+(def schema-source
+  "definition user {}\ndefinition doc {\n relation viewer: user\n permission view = viewer\n}")
+
+(defn seed! [{:keys [client snapshot transact! writer entid rows] :as fixture} q active]
+  (eacl/write-schema! client {:schema schema-source})
+  (transact! [{:db/id -1 :eacl/id "u"} {:db/id -2 :eacl/id "d"}])
+  (let [db (snapshot)
+        writer (writer)
+        rid (:e (first (rows db :eacl.relation/relation-name)))
+        identity [:user (entid db [:eacl/id "u"]) rid :doc (entid db [:eacl/id "d"])]]
+    (dotimes [i active]
+      (let [id (str "active-" i)]
+        (transact! [{:db/id -1 :eacl/id id}])
+        (eacl/create-relationship! client
+                                   (assoc (eacl/->Relationship (eacl/spice-object :user "u") :viewer (eacl/spice-object :doc id))
+                                          :valid-until-ms 100))))
+    (assoc fixture :writer writer :identity identity
+           :handles (mapv (fn [_] (staged/prepare! writer identity {:valid-until-ms 100})) (range q)))))
+
+(defn orphan-oracle [{:keys [snapshot rows]}]
+  (let [db (snapshot)
+        qualifiers (set (map :e (rows db qualifier/marker-attribute)))
+        attached (into #{} (keep #(nth (:v %) 4 nil))
+                       (mapcat #(rows db %) storage/attributes))]
+    (into #{} (remove attached) qualifiers)))
+
+(defn traced-writer [writer counts]
+  (let [native (:native writer)]
+    (assoc writer :native
+           (assoc native
+                  :all-rows (fn [& args]
+                              (swap! counts update :streams (fnil inc 0))
+                              (map (fn [row] (swap! counts update :rows (fnil inc 0)) row)
+                                   (apply (:all-rows native) args)))
+                  :fact-rows (fn [& args]
+                               (swap! counts update :fact-reads (fnil inc 0))
+                               (map (fn [row] (swap! counts update :facts (fnil inc 0)) row)
+                                    (apply (:fact-rows native) args)))
+                  :transact! (fn [tx]
+                               (swap! counts update :tx-sizes (fnil conj []) (count tx))
+                               ((:transact! native) tx))))))
+
+(defn work-outcome [fixture]
+  (let [fixture (seed! fixture 8 5)
+        expected (orphan-oracle fixture)
+        counts (atom {})
+        result (integrity/cleanup-sweep! (traced-writer (:writer fixture) counts) {:batch-size 2})]
+    {:result result :counts @counts :expected expected :remaining (orphan-oracle fixture)}))
+
+(defn exercise-work! [with-fixture]
+  (doseq [q [4 8 16] active [0 5]]
+    (with-fixture
+      (fn [fixture]
+        (let [fixture (seed! fixture q active)
+              before (orphan-oracle fixture)
+              counts (atom {})
+              result (integrity/cleanup-sweep! (traced-writer (:writer fixture) counts) {:batch-size 2})]
+          (is (= :complete (:status result)))
+          (is (= before (set (:qualifiers result))))
+          (is (empty? (orphan-oracle fixture)))
+          (is (= 6 (:streams @counts)) "one pass through each of six global index streams")
+          (is (= (+ (* 2 q) (* 4 active)) (:rows @counts)))
+          (is (= (/ q 2) (:committed-batches result)))
+          (is (= (repeat (/ q 2) 5) (:tx-sizes @counts)))
+          (is (pos? (:fact-reads @counts)))
+          (is (= active (count (seq ((:rows fixture) ((:snapshot fixture)) storage/forward-attribute))))))))))
+
+(defn hostile-outcome [fixture transition]
+  (let [{:keys [writer identity handles transact!] :as fixture} (seed! fixture 6 0)
+        native (:native writer)
+        attempts (atom 0)
+        changed-source (atom false)
+        source (:source native)
+        attach! #(staged/write! writer :create identity (last handles))
+        writer (assoc writer :native
+                      (assoc native
+                             :source (fn [db] (if @changed-source :reopened (source db)))
+                             :transact!
+                             (fn [tx]
+                               (let [attempt (swap! attempts inc)]
+                                 (when (and (= transition :failed-chunk) (= attempt 2))
+                                   (throw (ex-info "injected native failure" {})))
+                                 (when (and (= transition :attachment-at-commit) (= attempt 1)) (attach!))
+                                 (let [report ((:transact! native) tx)]
+                                   (when (= attempt 1)
+                                     (case transition
+                                       :attachment (attach!)
+                                       :unrelated-write (transact! [{:db/id -1 :eacl/id "foreign"}])
+                                       nil))
+                                   (when-not (= transition :lost-result) report))))))
+        polls (atom 0)
+        cancelled? (fn []
+                     (let [poll (swap! polls inc)]
+                       (when (and (= transition :source-change) (= poll 2)) (reset! changed-source true))
+                       (and (= transition :cancel) (= poll 2))))
+        result (integrity/cleanup-sweep! writer {:batch-size 2 :cancelled? cancelled?})
+        db ((:snapshot fixture))
+        attached (keep #(nth (:v %) 4 nil) ((:rows fixture) db storage/forward-attribute))
+        attached-survives? (every? #(seq ((:facts native) db %)) attached)]
+    {:result result :attached-survives? attached-survives? :attached (vec attached)
+     :fixture fixture}))
+
+(defn exercise-hostile! [with-fixture]
+  (doseq [transition (list :attachment :attachment-at-commit :unrelated-write :lost-result
+                           :source-change :cancel :failed-chunk)]
+    (testing (str transition)
+      (with-fixture
+        (fn [fixture]
+          (let [{:keys [result attached-survives? attached fixture]} (hostile-outcome fixture transition)
+                confirmed (if (contains? #{:lost-result :attachment-at-commit} transition) 0 2)]
+            (is (= (if (= :cancel transition) :cancelled :restart-required) (:status result)))
+            (is (= confirmed (count (:qualifiers result))))
+            (is (= (- 6 confirmed) (:remaining-count result)))
+            (is attached-survives?)
+            (when (contains? #{:attachment :attachment-at-commit} transition) (is (= 1 (count attached))))
+            (let [expected (orphan-oracle fixture)
+                  restarted (integrity/cleanup-sweep! (:writer fixture) {:batch-size 2})]
+              (is (= :complete (:status restarted)))
+              (is (= expected (set (:qualifiers restarted)))))))))))
+
+(defn exercise-budgets! [with-fixture]
+  (doseq [options [{:max-qualifiers 2} {:max-capture-units 1}]]
+    (with-fixture
+      (fn [fixture]
+        (let [fixture (seed! fixture 6 2)
+              before (orphan-oracle fixture)
+              counts (atom {})
+              error (try (integrity/cleanup-sweep! (traced-writer (:writer fixture) counts) options) nil
+                         (catch #?(:clj Exception :cljs :default) e e))]
+          (is (= :eacl.integrity/capture-budget-exceeded (:type (ex-data error))))
+          (is (empty? (:tx-sizes @counts)))
+          (is (= before (orphan-oracle fixture)))
+          (is (nil? (:fact-reads @counts)) "budget fails before materializing entity/fact maps"))))))

--- a/modules/eacl/test/eacl/relationships/safe_retraction_contract.cljc
+++ b/modules/eacl/test/eacl/relationships/safe_retraction_contract.cljc
@@ -1,0 +1,82 @@
+(ns eacl.relationships.safe-retraction-contract
+  "Native control-role refinement contract, shared by every supported mode."
+  (:require [#?(:clj clojure.test :cljs cljs.test) :refer [is testing]]
+            [eacl.core :as eacl]
+            [eacl.relationships.qualifier :as qualifier]
+            [eacl.relationships.safe-retraction :as safe]
+            [eacl.relationships.storage :as storage]))
+
+(def schema-source
+  "caveat enabled(flag bool) { flag }
+   caveat standby(flag bool) { flag }
+   definition user {}
+   definition doc {
+     relation viewer: user | user with enabled | user with standby
+     permission view = viewer
+   }")
+
+(defn reasons [error]
+  (loop [error error found #{}]
+    (if error
+      (recur #?(:clj (ex-cause error) :cljs (.-cause error))
+             (conj found (:reason (ex-data error))))
+      found)))
+
+(defn exercise!
+  [{:keys [client snapshot transact! entid rows facts revision retract!]}]
+  (eacl/write-schema! client {:schema schema-source})
+  (transact! [{:db/id -1 :eacl/id "control/u"} {:db/id -2 :eacl/id "control/d"}])
+  (let [subject (eacl/spice-object :user "control/u")
+        resource (eacl/spice-object :doc "control/d")
+        request {:subject subject :resource resource :permission :view
+                 :caveat-context {"flag" false} :cache? false}]
+    (eacl/create-relationship! client
+      (assoc (eacl/->Relationship subject :viewer resource)
+             :caveat "enabled" :valid-until-ms 100))
+    (let [db (snapshot)
+          caveat (entid db [:eacl.caveat/name "enabled"])
+          qid (nth (:v (first (rows db storage/forward-attribute))) 4)
+          reject! (fn [target]
+                    (let [before (snapshot)
+                          error (try (retract! target) nil
+                                     (catch #?(:clj Exception :cljs :default) e e))
+                          after (snapshot)]
+                      (is (contains? (reasons error) :protected-control-entity))
+                      (is (= (revision before) (revision after)))
+                      (is (= (facts before caveat) (facts after caveat)))
+                      (is (= (facts before qid) (facts after qid)))
+                      (is (= :no-permission (:permissionship (eacl/check-permission client request))))))
+          partial-facts {:eacl.caveat/name "partial"
+                         :eacl.caveat/parameters-payload "[]"
+                         :eacl.caveat/expression-source "false"
+                         :eacl.caveat/profile-version "damaged"
+                         :eacl.relationship-qualifier/format-version 1
+                         :eacl.relationship-qualifier/caveat caveat
+                         :eacl.relationship-qualifier/caveat-context "{}"
+                         :eacl.relationship-qualifier/valid-until-ms 100}]
+      (is (= (set (keys partial-facts)) safe/qualified-control-attributes))
+      (is (some? (entid db [:eacl.caveat/name "standby"])))
+      (is (not-any? #(= qualifier/context-attribute (first %)) (facts db qid)))
+      (is (= :no-permission (:permissionship (eacl/check-permission client request))))
+      (reject! caveat)
+      (reject! qid)
+      (doseq [[attribute value] partial-facts]
+        (testing (str "partially populated " attribute)
+          (transact! [{:db/id -1 :eacl/id (str attribute) attribute value}])
+          (reject! [:eacl/id (str attribute)])))
+      (doseq [child [caveat qid]]
+        (transact! [{:db/id -1 :eacl/id "control/parent" :test/component child}])
+        (reject! [:eacl/id "control/parent"])
+        (is (some? (entid (snapshot) [:eacl/id "control/parent"])))
+        (transact! [[:db/retract [:eacl/id "control/parent"] :test/component child]]))
+      (doseq [ident safe/qualified-schema-idents
+              :let [eid (entid (snapshot) [:db/ident ident])]
+              :when eid]
+        (reject! eid))
+      (transact! [{:db/id -1 :db/ident :review/application}])
+      (let [eid (entid (snapshot) [:db/ident :review/application])]
+        (retract! [:db/ident :review/application])
+        (is (empty? (facts (snapshot) eid))))
+      (retract! [:db/ident :review/missing])
+      (retract! [:eacl/id "control/parent"])
+      (is (nil? (entid (snapshot) [:eacl/id "control/parent"]))))))

--- a/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/design.md
+++ b/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/design.md
@@ -1,0 +1,112 @@
+## Context
+
+`cleanup-plan` performs `proof-input` before `report` limits its candidates.
+`proof-input` explicitly scans the complete database view and materializes
+qualifier facts, versions, references, and selected definitions. Calling the
+single-batch function repeatedly reconstructs that proof after every deletion.
+Source: [modules/eacl/src/eacl/relationships/qualifier_integrity.cljc — proof-input, cleanup-plan, cleanup-orphans!](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl/src/eacl/relationships/qualifier_integrity.cljc).
+
+For Q=mB, the qualifier visits are `B*m*(m+1)/2`, even without active qualifiers.
+At Q=1,000,000 and B=100 this is 5,000,500,000 visits. These are arithmetic lower
+bounds under a quiescent drain workload, not measured runtime figures.
+
+## Goals / Non-Goals
+
+Amortize one valid global proof over the sweep's own bounded cleanup commits.
+Preserve orphan ownership safety, source isolation, exact head guards, native
+entity-fact assertions, and maximum transaction size. Make partial progress and
+restart requirements explicit. Preserve the existing single-batch API.
+
+Do not remove guards, introduce stale read-side repair, assume all native
+transaction reports have the same shape, or add a per-qualifier owner sidecar in
+this change. Do not claim constant memory simply because commit batches are small.
+
+## Decisions
+
+### 1. Separate capture from draining
+
+Introduce a dedicated sweep runner or an opaque in-process sweep session. At
+capture, select one native snapshot, validate healthy qualifier data, and produce
+plain candidate ids plus the facts needed for conditional deletion. Retain a
+complete source/lifecycle identity and exact selected revision.
+
+Do not retain a borrowed backend snapshot beyond its allowed lifetime. Materialize
+only the necessary plain proof/candidate data or keep a legitimately owned lease.
+Expose and enforce an explicit sweep memory/candidate budget while scanning;
+checking only after full allocation is not a bound. Large captures can use a
+bounded spool or a separately designed streaming strategy. The first implementation
+must state its retained-memory complexity rather than hiding it behind batch size.
+
+### 2. Carry authority forward only through self commits
+
+Let the initial proof certify candidate set C as unattached at exact revision t0.
+For each candidate chunk D:
+
+1. Select a current native snapshot and require its exact source and revision to
+   equal the sweep certificate's expected source and revision.
+2. Submit the same exact-head and candidate-fact guards as the existing safe
+   cleanup, plus deletion of D, within the configured transaction-size limit.
+3. Obtain an authoritative commit result identifying the exact revision produced
+   by **this** transaction. The sweep may replace its expected revision only with
+   that result, not a later `current-db` sample.
+4. Remove D from C. All remaining candidates remain unattached because the only
+   intervening certified transition was deletion of unattached qualifier data.
+
+A foreign write, failed guard, unexpected source/lifecycle, unsupported commit
+revision evidence, or transport ambiguity invalidates the sweep certificate.
+Return explicit restart-required/partial-progress state or capture a new proof.
+Never blindly rebase an old candidate list onto a new current revision.
+
+If a backend cannot provide a trustworthy own-commit revision, retain its current
+single-batch behavior until that evidence is implemented; do not claim the
+optimized contract for that backend.
+
+### 3. Preserve successful partial progress
+
+A sweep consists of several individually atomic commits, not one giant atomic
+transaction. On interruption, already committed orphan deletions remain valid.
+Return their count and explicit continuation/restart status. Cancelled or failed
+chunks must not be counted as committed. Release any owned snapshot/session
+resources. Restart after process loss requires fresh ownership evidence, not an
+unauthenticated serialized candidate list.
+
+### 4. Use operation-count acceptance before timing
+
+Instrument complete proof captures, both endpoint scan streams, qualifier entity
+and fact reads, candidate materialization, and transaction sizes. On an otherwise
+quiescent sweep within configured budgets, the number of global captures is one
+rather than proportional to Q/B. Total qualifying/candidate work should be
+O(A+Q) plus O(Q/B) guarded commits, where A is the stable scanned active data.
+Any chosen sort adds its separately reported term.
+
+Exercise several increasing Q values at a fixed B and a fixed nonzero active
+background. Repeated single-batch behavior is the baseline. Use actual native
+adapters; a counter over returned candidate counts is not enough. Author latency
+and allocation budgets before sampling. Keep raw outputs under ignored target.
+
+## Formal invariant
+
+At each certified sweep state, all remaining candidate qids are unattached in the
+exact expected snapshot. A successful own cleanup step only deletes a subset of
+those qids and cannot attach the remainder. A non-cleanup transition requires a
+new global absence proof or an independently justified per-candidate proof.
+
+Retain hostile traces: publish a candidate between batches; prepare a new qualifier;
+change a source/lifecycle; fail a head guard; lose the commit result; cancel after a
+successful batch; restore an old session against a new database. No trace may
+delete a qualifier attached to a surviving Relationship.
+
+## Alternatives considered
+
+Increasing B only reduces the coefficient and can violate transaction budgets.
+Dropping head guards permits deleting concurrently attached qualifiers. Rescanning
+only requested qid facts does not prove global absence of endpoint references.
+A new ownership index could make point proofs possible, but would expand storage,
+writer, and formal obligations and is intentionally not the release-local remedy.
+
+## Open questions to resolve during implementation
+
+Choose a synchronous sweep runner versus an opaque resumable session based on
+actual writer/lease capabilities. Establish memory/spool budgets and exact commit
+revision evidence per backend. Treat these as implementation decisions, not
+reasons to ship a guardless optimization or advertise unmeasured performance.

--- a/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/proposal.md
+++ b/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/proposal.md
@@ -1,0 +1,40 @@
+# Avoid repeated full scans in qualifier cleanup
+
+## Why
+
+Each `cleanup-orphans!` batch rebuilds a whole-database `proof-input` before
+limiting deletion candidates. Draining Q orphans in batches of B revisits
+`Q + (Q-B) + ...` qualifier records, even with no active data or concurrent writes.
+With stable active data, every batch scans that background again. Bounded
+transaction size therefore does not imply bounded work or a scalable sweep.
+
+This is a source-derived maintenance complexity finding, not an observed
+latency regression or a hot-path authorization defect.
+
+## What Changes
+
+Add an explicit sweep operation/session that captures one global proof, then
+commits bounded candidate batches while advancing its certificate only through
+its own verified cleanup commits. Foreign writes and source changes invalidate
+the certificate. Preserve existing single-batch behavior and all native guards.
+Instrument scan counts and distinguish scan/materialization cost from commit size.
+
+## Capabilities
+
+### New Capabilities
+- `qualifier-cleanup-sweeps`: source-scoped, exact-revision-certified orphan
+  collection that does not rebuild a full proof after each own deletion batch.
+
+### Modified Capabilities
+
+No existing specification file is edited by this proposal.
+
+## Impact
+
+Primary implementation: `modules/eacl/src/eacl/relationships/qualifier_integrity.cljc`
+and the native staged-writer result/proof boundary needed to identify the exact
+revision of a successful cleanup commit. Add operation-count and interleaving
+contracts. No required relationship storage ABI change or ownership sidecar.
+
+This change is independent of the safe-retraction safety fixes. A sweep must
+not weaken head guards merely to avoid work.

--- a/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/specs/qualifier-cleanup-sweeps/spec.md
+++ b/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/specs/qualifier-cleanup-sweeps/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: A quiescent cleanup sweep amortizes global proof capture
+A supported sweep SHALL capture a global orphan proof once and SHALL NOT rebuild
+that proof after every own successful cleanup batch while its certificate remains
+valid. Every commit SHALL remain within configured transaction-size bounds.
+
+#### Scenario: Many orphan batches with no foreign writes
+- **GIVEN** a healthy source with Q orphans exceeding one deletion batch, within sweep capture budgets
+- **WHEN** the sweep drains those orphans without foreign writes
+- **THEN** it performs one global proof capture and multiple guarded bounded commits
+- **AND** it does not rescan the stable active relationship background per batch
+
+### Requirement: Only proved own commits extend a sweep certificate
+A sweep SHALL bind candidate absence to an exact source/lifecycle/revision and
+SHALL advance that revision only using an authoritative result of its own
+successful cleanup transaction.
+
+#### Scenario: A candidate is attached between batches
+- **WHEN** another writer attaches a remaining candidate before the next cleanup commit
+- **THEN** the old sweep certificate is rejected or freshly revalidated
+- **AND** the attached qualifier is not deleted
+
+#### Scenario: A later current snapshot is not the sweep's own commit result
+- **WHEN** the current revision includes an unproved foreign write
+- **THEN** the sweep does not treat that revision as a valid continuation certificate
+
+### Requirement: Budgets and partial progress are explicit
+A sweep SHALL enforce capture resource budgets, release owned resources, and
+report only successfully committed deletions. It SHALL distinguish partial
+progress requiring restart from complete collection.
+
+#### Scenario: Interruption after one committed batch
+- **WHEN** cancellation or a conflict occurs after an earlier successful batch
+- **THEN** the result identifies committed progress and the remaining work requires valid continuation evidence
+- **AND** no uncommitted deletion is reported as successful

--- a/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/tasks.md
+++ b/openspec/changes/2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/tasks.md
@@ -1,0 +1,26 @@
+## 1. Characterize the current work
+- [x] Load `regressions/eacl/cleanup_characterization.clj` in a test-enabled nREPL and use disposable native fixtures.
+- [x] Seed controlled orphan counts through preparation APIs and measure complete scans, rows realized, entity/fact reads, and committed batch sizes.
+- [x] Compare several Q values at fixed B, with and without a stable active relationship background.
+- [x] Record baseline counts separately from latency; author timing/allocation budgets before sampling.
+
+## 2. Add the sweep proof boundary
+- [x] Choose a synchronous runner or opaque session without changing existing single-batch semantics.
+- [x] Capture candidate/fact/source/revision evidence once under an owned valid snapshot.
+- [x] Define and enforce capture memory/candidate budgets before exceeding them; state retained-memory complexity explicitly.
+- [x] Add or certify authoritative own-commit revision evidence for each participating backend.
+- [x] Preserve exact head guards, candidate-fact guards, and configured transaction-size limits for every chunk.
+- [x] Advance the certificate only through successful own cleanup commits and invalidate it on any unproved transition.
+
+## 3. Add hostile transition and work contracts
+- [x] Race attachment of a candidate between batches and prove no attached qualifier is deleted.
+- [x] Cover unrelated writes, source/lifecycle changes, lost commit results, cancellation, partial success, and stale-session restart.
+- [x] Assert one global capture for a quiescent sweep within budgets, rather than one capture per batch.
+- [x] Compare final state and collected ids with an independent single-snapshot orphan oracle.
+- [x] Add a mutation restoring per-batch full capture and a mutation accepting an unproved current revision; both must fail their respective tests.
+
+## 4. Validate and document
+- [x] Run actual native backend contracts and applicable formal/refinement gates.
+- [x] Run `bin/formal source-closure` and the installed OpenSpec validator.
+- [x] Document single-batch versus sweep complexity, memory bounds, restart semantics, and backend eligibility.
+- [x] Keep benchmark data and generated verification reports under ignored target; do not advertise unmeasured latency improvements.

--- a/openspec/changes/2026-09-09-eacl-v8-adversarial-review/implementation.md
+++ b/openspec/changes/2026-09-09-eacl-v8-adversarial-review/implementation.md
@@ -1,0 +1,28 @@
+# Applied change pack
+
+The imported review bundle is a container, not a standalone OpenSpec change.
+Its three child changes were copied to the project change root as directed by
+its README. These are the canonical implementation task lists:
+
+- [Qualified control protection](../2026-09-09-protect-qualified-control-plane-from-safe-retraction/tasks.md)
+- [Datomic self-loop generation stamps](../2026-09-09-stamp-datomic-self-loop-retractions/tasks.md)
+- [Qualifier cleanup sweeps](../2026-09-09-avoid-repeated-full-scans-in-qualifier-cleanup/tasks.md)
+
+The original review and proposed regressions remain intact. Maintained native
+regressions now live in the backend test roots. The shared safe-retraction
+contract covers all owned control fields and supported backend modes; Datomic
+native mutation controls retain the false-Caveat/expiry witness and the
+self-loop stamp obligation.
+
+The cleanup API uses a synchronous sweep with data-volume budgets and exact
+own-commit evidence. Datomic, DataScript, and direct Datahike writers support
+sweeps. Datalevin keeps single-batch cleanup until its leased commit evidence is
+certified. Native work/race contracts and `QualifierCleanupSweep.dfy` express
+the certificate invariant. Timing/allocation acceptance budgets live in
+`formal/baselines/qualifier-cleanup-sweep.edn`, consumed by the native benchmark.
+
+See `docs/caveats.md` for budgets and restart semantics, and
+`docs/v8-backend-modules-and-upgrade.md` for the required explicit function-v5
+installation. Storage remains v8. Generated verification output belongs under
+`target/formal/verification/adversarial-review/`; benchmark observations belong
+under `target/benchmarks/adversarial-review/`.

--- a/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/design.md
+++ b/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/design.md
@@ -1,0 +1,107 @@
+## Context
+
+The shared guard projects a small list of Relation/Permission/schema fields.
+Datomic independently embeds the same incomplete role check in a transaction
+function. Named Caveats use `:eacl.caveat/*`; qualifiers use
+`:eacl.relationship-qualifier/*`. Neither is currently identified as protected.
+
+Sources: [modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj — function-definition](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj); [modules/eacl/src/eacl/relationships/safe_retraction.cljc — protected-control-entity?, ensure-unprotected!, plan-local-halves](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl/src/eacl/relationships/safe_retraction.cljc); [modules/eacl/src/eacl/caveats/schema.cljc — datom-schema](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl/src/eacl/caveats/schema.cljc); [modules/eacl/src/eacl/caveats/definition.cljc — validate-replacements!](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl/src/eacl/caveats/definition.cljc); [modules/eacl/src/eacl/relationships/qualifier.cljc — decode, normalize, relation-allowance](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl/src/eacl/relationships/qualifier.cljc).
+
+## Goals / Non-Goals
+
+Prevent unsupported object deletion from changing any qualified control record.
+Reject the entire mutation before peer retractions or native component deletion.
+Keep ordinary object deletion and explicit admitted qualifier cleanup working.
+
+Do not change valid expiry-only semantics, introduce a storage migration, add
+read-time repair, or broaden this change into generic protection against arbitrary
+raw database transactions. Do not claim the helper authorizes its caller.
+
+## Decisions
+
+### 1. Classify owned roles by present facts
+
+The protected set includes all currently declared Caveat and qualifier facts:
+
+```clojure
+#{:eacl.caveat/name
+   :eacl.caveat/parameters-payload
+   :eacl.caveat/expression-source
+   :eacl.caveat/profile-version
+   :eacl.relationship-qualifier/format-version
+   :eacl.relationship-qualifier/caveat
+   :eacl.relationship-qualifier/caveat-context
+   :eacl.relationship-qualifier/valid-until-ms}
+```
+
+A non-nil value for any owned fact identifies a protected data record. Using
+only Caveat name or qualifier format would omit partially populated records.
+Native entity wrappers need not implement `contains?`; use the adapter's known
+lookup semantics or a normalized owned-role flag. Extend the projection passed
+to `protected-control-entity?`, not just that predicate's destructuring.
+
+Preserve the existing Relation, Permission, schema-string, and function checks.
+Recognize owned qualification schema idents where the backend represents them as
+entities. Keep the role list synchronized with actual storage declarations.
+
+### 2. Check the entire native deletion closure atomically
+
+Resolve the target and its cycle-safe component closure against the transaction's
+selected native database. Reject with `:eacl.safe-retraction/invalid` and
+`:reason :protected-control-entity` if any member is protected. No partial peer
+cleanup, qualifier mutation, generation stamp, or entity deletion may commit.
+An ordinary parent whose component points to a control entity must also fail.
+
+### 3. Align native and portable implementations
+
+Prefer a small portable role specification or quoted predicate form that can be
+embedded in Datomic without adding an EACL transactor classpath dependency. A
+shared Clojure helper alone does not fix the already-embedded Datomic body.
+Exercise the actual installed/native function, not just a helper mock.
+
+### 4. Preserve decoder and schema-writer semantics
+
+Expiry-only qualifiers remain valid. The remedy is to prohibit the destructive
+transition, not to make nil Caveats always fail. Dedicated schema replacement
+continues rejecting removal of referenced definitions. Explicit admitted orphan
+cleanup may still retract an unattached qualifier; object safe-retraction is not
+that cleanup API.
+
+### 5. Upgrade installed functions explicitly
+
+Change the installed-function compatibility identity using the repository's
+existing version/marker mechanism and update its digest representation according
+to the project's established contract. Verify that `install!` replaces a
+recognized old body and rejects an unrelated occupant. Coordinate one update
+with the self-loop change. Do not pin arbitrary repository source hashes as a
+substitute for behavioral tests. Keep storage version 8 unchanged.
+
+## Counterexample and acceptance
+
+Use two named Caveat alternatives plus a plain alternative, one expiring
+Relationship, no bound context, and a false request-context flag. Both named
+alternatives must exist before the test. At time 99 with expiry 100, deleting the
+used Caveat is rejected and a fresh uncached check remains `:no-permission`.
+With the old guard it can become `:has-permission`; that native outcome remains
+to be executed. Also test qualifier targets and component cascades.
+
+The supplied native test file follows the current public writer and test fixture
+APIs. Repeat it on supported DataScript CLJ/CLJS and Datahike named/direct modes.
+Inspect any additional backend mode before claiming parity.
+
+## Risks / Trade-offs
+
+Classifying only the normal marker is too weak; classifying every arbitrary
+application namespace is unnecessarily broad. Derive a narrow owned-role set.
+Rejecting a formerly admitted Caveat deletion is an intentional correctness
+restriction. Existing installed Datomic code remains unsafe until replaced.
+
+## Verification and formal refinement
+
+Extend the native mutation contract so accepted object deletion preserves all
+Caveat definitions and all qualifiers not legitimately removed by the operation's
+specified ownership cleanup. Model ordinary incoming-ref retraction explicitly.
+Retain the two-Caveat, plain-allowed, future-expiry, empty-bound-context witness.
+A mutation control that removes the new role guard must fail a **native** test.
+Existing Boolean evidence theorems are not evidence that the writer preserves
+those definitions.

--- a/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/proposal.md
+++ b/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/proposal.md
@@ -1,0 +1,42 @@
+# Protect qualified control-plane data from safe retraction
+
+## Why
+
+The optional native safe-retraction operation rejects Relations and Permissions
+but admits named Caveats and qualifier entities. Deleting a Caveat may remove an
+ordinary ref from a combined Caveat+expiration qualifier, leaving a valid
+expiry-only grant. Component cascades can perform the same unsupported mutation.
+This bypasses the dedicated schema writer's retained-Caveat guard.
+
+The failure is source-confirmed at `6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56`; a native regression is supplied
+but has not been executed by the reviewer. See F1 in the accompanying review.
+
+## What Changes
+
+Reject Caveat/qualifier control entities and component closures containing them
+at the native safe-retraction boundary. Align the portable guard with Datomic's
+embedded body, including partially populated owned records. Preserve atomic
+failure, existing application-object behavior, and supported explicit qualifier
+cleanup/preparation APIs. Version and replace installed function bodies.
+
+## Capabilities
+
+### New Capabilities
+- `safe-retraction-control-plane`: application object deletion cannot mutate
+  qualified authorization control data directly or through a component cascade.
+
+### Modified Capabilities
+
+None of the existing specification files is modified by this proposal; this
+change adds an explicit cross-backend contract for the affected operation.
+
+## Impact
+
+Primary implementation: `modules/eacl/src/eacl/relationships/safe_retraction.cljc`
+and `modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj`. DataScript and
+Datahike wrappers and their installed/direct modes require contract tests.
+Datalevin support must be inspected before asserting applicability; it was not
+reviewed for this operation. No relationship storage ABI or tuple shape change.
+
+Coordinate the installed-function compatibility update with the self-loop fix;
+one release must not leave either old persisted function body active.

--- a/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/specs/safe-retraction-control-plane/spec.md
+++ b/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/specs/safe-retraction-control-plane/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Object retraction excludes qualified control entities
+The safe-retraction operation SHALL reject a target containing any owned Caveat
+or Relationship qualifier fact, including partially populated control records.
+It SHALL preserve existing Relation, Permission, schema, and function protection.
+
+#### Scenario: A referenced Caveat is the explicit target
+- **GIVEN** a Relationship with a false Caveat, no bound context, and future expiration, on a Relation admitting plain and two named alternatives
+- **WHEN** safe retraction targets the used Caveat entity
+- **THEN** the operation fails with reason `:protected-control-entity`
+- **AND** no database mutation commits and a fresh permission check remains denied
+
+#### Scenario: A qualifier entity is the explicit target
+- **WHEN** safe retraction targets an attached or unattached qualifier entity
+- **THEN** it rejects the object operation without deleting that entity
+- **AND** an independently authorized explicit orphan-cleanup operation remains available
+
+### Requirement: Protection covers native component cascades
+The operation SHALL inspect the entire native component closure and SHALL abort
+the complete transaction if any member is qualified control data.
+
+#### Scenario: An application parent owns a Caveat as a component
+- **WHEN** safe retraction targets the parent
+- **THEN** neither the parent, the Caveat, nor incoming qualifier references are retracted
+
+### Requirement: Installed bodies implement the same protection
+Every supported native safe-retraction mode SHALL enforce the same protected-role
+contract, and an explicit install/upgrade SHALL replace a recognized older body.
+
+#### Scenario: A recognized previous Datomic body is installed
+- **WHEN** the corrected function is installed
+- **THEN** subsequent native invocations enforce control-plane protection
+- **AND** repeating installation is idempotent and an unrelated occupant remains a conflict

--- a/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/tasks.md
+++ b/openspec/changes/2026-09-09-protect-qualified-control-plane-from-safe-retraction/tasks.md
@@ -1,0 +1,26 @@
+## 1. Reproduce the native defect
+- [x] Load `regressions/eacl/datomic/adversarial_v8_review_test.clj` in the test-enabled nREPL.
+- [x] Confirm the direct Caveat deletion is admitted on the pinned code and record the fresh false-to-true permission result.
+- [x] Confirm the qualifier-target and component-closure guard regressions fail for the intended reason, not fixture admission.
+- [x] Retain the second named alternative and absent bound context; do not simplify away the witness.
+
+## 2. Implement the mutation boundary
+- [x] Inventory current Caveat/qualifier owned fields from their declarations.
+- [x] Extend the portable guard and its native-entity field projection.
+- [x] Extend the self-contained Datomic transaction-function predicate.
+- [x] Reject protected members anywhere in the native component closure before any mutation commits.
+- [x] Preserve ordinary object deletion, typed errors, and explicit admitted qualifier cleanup.
+
+## 3. Cross-backend and installation coverage
+- [x] Exercise actual installed Datomic, DataScript CLJ/CLJS named/direct, and Datahike supported modes.
+- [x] Inspect Datalevin's actual capability before deciding whether additional coverage applies.
+- [x] Coordinate a function compatibility/version update with `2026-09-09-stamp-datomic-self-loop-retractions`; verify an old installed body is replaced.
+- [x] Verify conflict-safe installation, idempotent reinstallation, and ordinary application-object regressions.
+- [x] Add partial-control-record, qualifier-target, parent-component, missing-target, and unknown-ident cases.
+
+## 4. Refine and release
+- [x] Add a model transition or native refinement check for incoming Caveat-ref removal and protected control roles.
+- [x] Add a killed production mutation that removes the protection and recreates the native witness.
+- [x] Run relevant JVM/CLJS/native suites and the applicable formal gates via the repository's prescribed workflow.
+- [x] Run `bin/formal source-closure` after public source changes and validate this OpenSpec change with the installed CLI.
+- [x] Document the required installed-function upgrade; keep storage ABI v8 and generated verification output out of Git.

--- a/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/design.md
+++ b/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The Datomic implementation intentionally omits peer retractions for a
+self-relationship because native retractEntity removes both local halves. It
+incorrectly uses that physical optimization to erase logical invalidation data.
+Sources: [modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj — function-definition](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj); [modules/eacl/src/eacl/relationships/safe_retraction.cljc — protected-control-entity?, ensure-unprotected!, plan-local-halves](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl/src/eacl/relationships/safe_retraction.cljc); [modules/eacl-datomic/test/eacl/datomic/safe_retraction_test.clj](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/modules/eacl-datomic/test/eacl/datomic/safe_retraction_test.clj); [formal/dafny/NativeGenerationCoherence.dfy — ForwardStep, SafeRetraction](https://github.com/theronic/eacl/blob/6c3f33f2449ea10ba56b88b3e9d9f076b1ab2d56/formal/dafny/NativeGenerationCoherence.dfy).
+
+## Goals / Non-Goals
+
+Restore exact affected-Relation coverage without adding native scans or global
+cache invalidation. Preserve idempotent current-transaction stamps and existing
+missing-target/ghost-repair behavior. Do not change the shared planner, which
+already derives all affected Relation ids. Do not broaden managed qualified
+cache reuse as part of this fix.
+
+## Decisions
+
+### 1. Separate the two projections
+
+Use all half records for logical invalidation and only non-nil operations for
+physical peer cleanup:
+
+```clojure
+halves (or local-halves repair-halves)
+peer-retractions (distinct (keep :op halves))
+relation-eids (distinct (map :relation-eid halves))
+```
+
+Emit one idempotent current-transaction stamp for each distinct Relation id,
+including Relations with only self-relationships in the deletion closure. A
+non-self incident edge on the same Relation can mask the old defect, so the
+minimal regression must isolate a Relation used only by the self-loop.
+
+### 2. Preserve the asymptotic behavior
+
+For H inspected local half records, this remains linear projection work with
+set-based distinctness and O(number of distinct affected Relations) stamps.
+There is no reason to scan all Relation definitions, all relationships, or flush
+unrelated cache entries to compensate. Non-nil qualifier slots must be preserved
+in any actual peer retraction as before.
+
+### 3. Test the installed native body
+
+The regression calls `d/invoke` on the installed function to assert the stamp set,
+then transacts it and compares actual generation values. Assert entity and tuple
+removal as well. Include a separate unrelated Relation whose generation must not
+change. Repeat the essential case for a self-loop-bearing component child.
+
+Do not satisfy the test solely by changing `plan-local-halves`: Datomic executes
+its own embedded body. Update the compatibility identity together with the
+control-plane fix so persisted old functions are upgraded.
+
+## Formal refinement
+
+The required affected set is exactly:
+
+```text
+{ r | exists edge in before.forward union before.reverse:
+         edge.relation = r and
+         (edge.subject in closure or edge.resource in closure) }
+```
+
+Nothing excludes `edge.subject = edge.resource`. Check equality between the
+native expansion's stamp set and this independent relation projection. Test
+both physical directions, repeated invocations, and component closures.
+
+The supplied Python branch model enumerates 768 small cases and detects 207
+violations in the old algorithm versus zero in the correction. It is a finite
+independent check, not proof that the actual native implementation ran correctly.
+The native regression and production mutation control remain required.
+
+## Risks / Trade-offs
+
+Generation advances may cause previously incorrect proof hits to become misses;
+that is necessary invalidation. Extra stamps are not needed for unaffected
+Relations. Do not infer that this witness proves a stale default public answer:
+the currently inspected qualification path uses exact completed-answer reuse.
+
+## Deployment
+
+No storage ABI change. Upgrade the optional installed function explicitly;
+changing the in-process library does not change an existing Datomic database
+function. A combined F1/F2 release should use one coordinated compatibility bump.

--- a/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/proposal.md
+++ b/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/proposal.md
@@ -1,0 +1,39 @@
+# Stamp Datomic self-loop retractions
+
+## Why
+
+Datomic's embedded safe-retraction function filters local-half records whose
+peer operation is nil before deriving affected Relation ids. Self-relationships
+have no peer operation, but native entity retraction still deletes them. Their
+Relation generations therefore fail to advance, violating the writer condition
+used by `NativeGenerationCoherence`.
+
+The shared planner already handles this correctly. The defect is an embedded
+implementation/refinement gap, not a proposed change to the proof's semantics.
+
+## What Changes
+
+Derive Relation ids from all affected half records. Filter nil only in the
+peer-retraction projection. Add installed-native generation assertions for
+self-loops, component closures, and mixed affected/unaffected Relations. Replace
+previous installed function bodies using the coordinated compatibility update.
+
+## Capabilities
+
+### New Capabilities
+- `safe-retraction-generation-coverage`: every changed relationship partition,
+  including a self-loop-only partition, advances its generation atomically.
+
+### Modified Capabilities
+
+No existing specification files are edited by this proposal.
+
+## Impact
+
+Change the embedded body in `modules/eacl-datomic/src/eacl/datomic/safe_retraction.clj`.
+Retain parity with `plan-local-halves` in the shared safe-retraction namespace.
+Update native tests and refinement/mutation evidence. No tuple/storage migration.
+Coordinate the function installation identity with the control-plane fix.
+
+A stale default v8 `can?` answer is not claimed by this finding; the concrete
+release defect is violation of the supported writer's generation invariant.

--- a/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/specs/safe-retraction-generation-coverage/spec.md
+++ b/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/specs/safe-retraction-generation-coverage/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Every changed Relation slice advances its generation
+An accepted safe retraction SHALL atomically advance the generation of every
+Relation whose forward or reverse relationship slice changes, including a
+Relation affected only by a self-relationship.
+
+#### Scenario: An isolated self-loop is deleted
+- **GIVEN** entity x has Relationship x-r-x and no other edge on Relation r is incident to the deletion closure
+- **WHEN** native safe retraction deletes x
+- **THEN** both stored halves disappear and r's generation advances in the same commit
+
+#### Scenario: A component owns a self-loop
+- **WHEN** safe retraction deletes a parent whose component child has a self-loop
+- **THEN** the child's self-loop Relation is included in the affected stamp set
+
+### Requirement: Physical peer optimization does not erase logical effects
+The affected Relation set SHALL be derived independently of whether a peer
+retraction operation is required. Unaffected Relation generations SHALL remain
+unchanged, and duplicate affected Relations SHALL produce idempotent stamps.
+
+#### Scenario: No peer retraction is needed
+- **GIVEN** all affected halves are local self-relationship halves
+- **WHEN** the native transaction function expands the deletion
+- **THEN** it emits the required Relation stamps even though its peer-retraction list is empty
+
+#### Scenario: An unrelated Relation is present
+- **WHEN** another Relation has no edge incident to the deletion closure
+- **THEN** its generation is not changed by the safe retraction

--- a/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/tasks.md
+++ b/openspec/changes/2026-09-09-stamp-datomic-self-loop-retractions/tasks.md
@@ -1,0 +1,22 @@
+## 1. Establish the failing invariant
+- [x] Run the supplied isolated-self-loop native regression on the pinned commit.
+- [x] Assert the `d/invoke` stamp set, actual generation advance, removed entity/halves, and unchanged unrelated generation.
+- [x] Add a component-child self-loop case and a mixed closure case that cannot mask the missing stamp.
+
+## 2. Correct the embedded projection
+- [x] Keep all local/repair records in `halves`.
+- [x] Derive peer retractions using `keep :op` and Relation ids independently from all records.
+- [x] Preserve exact qualifier-bearing tuple values and one idempotent stamp per affected Relation.
+- [x] Coordinate installed-function replacement with `2026-09-09-protect-qualified-control-plane-from-safe-retraction`.
+
+## 3. Strengthen implementation/model correspondence
+- [x] Compare native stamp sets against an independent affected-edge oracle over small generated graphs and closures.
+- [x] Cover self-loops in both tuple halves, repeated calls, missing numeric targets, and ordinary non-self cases.
+- [x] Add a production mutation that restores the premature nil-op filter and confirm a native test kills it.
+- [x] Keep the formal affected set inclusive of self-loops; do not weaken the writer obligation to match the bug.
+
+## 4. Validate and release
+- [x] Run native safe-retraction, generation/cache, and backend contract suites in nREPL.
+- [x] Run relevant Dafny/refinement gates and `bin/formal source-closure`.
+- [x] Validate this OpenSpec change and document the explicit installed-function upgrade.
+- [x] Keep storage ABI v8; do not commit generated solver output or source-hash refresh pins.


### PR DESCRIPTION
Safe entity retraction could remove Caveat or qualifier control records and turn a denied request into a grant. Datomic also omitted Relation generation stamps when only self-loops were removed, and repeated orphan cleanup rescanned the whole graph for every batch.

This change:

- Rejects qualified control entities, partial control records, and component descendants atomically across the supported safe-retraction backends.
- Preserves Datomic self-loop Relation ids for exact generation stamping while filtering only absent peer-retraction operations.
- Adds `cleanup-sweep!` for Datomic, DataScript, and direct Datahike: one bounded capture, bounded deletion batches, exact head guards, and authoritative own-commit evidence. Foreign writes or ambiguous reports require a fresh capture; cancellation preserves confirmed progress.
- Adds native regressions, mutation controls, resource budgets, a Dafny cleanup invariant, and the three completed OpenSpec change plans (53/53 tasks).

Safe-retraction function compatibility advances to v5. Applications must rerun the documented installation/preparation operation to replace persisted functions. The storage ABI remains v8. Datalevin retains single-batch qualifier cleanup.

Validation passed on the final source tree:

- JVM CI suite via nREPL: 1,517 tests / 153,761 assertions.
- DataScript ClojureScript: 844 tests / 113,279 assertions.
- Datalevin: 70 tests / 8,282 assertions using the maintained local sibling dependency.
- Targeted native retraction/generation, cleanup race/mutation, and resource-budget suites.
- `bin/formal fast`, native-generation and cleanup-sweep Dafny proofs, and `bin/formal source-closure`.
- Strict OpenSpec validation for all three child changes and `git diff --check`.

Generated verification and benchmark reports remain under ignored `target/` paths.
