### PR TITLE
Scope the Clojars release gate to the release branch's push runs (v8.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,28 +60,37 @@ jobs:
         with:
           cli: latest
 
-      - name: Wait for exact-SHA Tests and Formal verification checks
+      - name: Wait for this branch's exact-SHA Tests and Formal verification checks
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p target/release
-          deadline=$((SECONDS + 5400))
-          while [ "$SECONDS" -lt "$deadline" ]; do
+          # GitHub attaches every check run to its commit, so the release
+          # commit can also carry pull-request runs (which verified a merge
+          # commit) and the runs of other branches pushed to the same commit.
+          # Only this branch's own push-event workflow runs are release
+          # evidence; the guard correlates check runs with them by check suite.
+          fetch_listings() {
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&event=push&branch=$GITHUB_REF_NAME&per_page=100" \
+              > target/release/workflow-runs.json
             gh api \
               -H 'Accept: application/vnd.github+json' \
               "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
               > target/release/check-runs.json
-            status="$(clojure -M:release-guard checks target/release/check-runs.json false)"
+          }
+          deadline=$((SECONDS + 5400))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            fetch_listings
+            status="$(clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json false)"
             if [ "$status" = ready ]; then
               exit 0
             fi
             sleep 30
           done
-          gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
-            > target/release/check-runs.json
-          clojure -M:release-guard checks target/release/check-runs.json true
+          fetch_listings
+          clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json true
 
   deploy:
     if: >-
@@ -138,7 +147,7 @@ jobs:
           bin/formal build-java
           bin/formal browser-bundle
 
-      - name: Build, audit, cold-smoke, and deploy the four artifacts
+      - name: Build, audit, cold-smoke, and deploy the release set
         env:
           EACL_VERSION: ${{ needs.provenance.outputs.version }}
           CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/design.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`eacl.release-guard/evaluate-checks` read
+`GET /repos/{owner}/{repo}/commits/{sha}/check-runs` and grouped the required
+check names by name. GitHub Actions creates one check suite per workflow run
+and attaches every check run to the run's head commit, so a commit carries one
+set of check runs per (workflow, event, ref) that ran on it:
+
+- push runs of the release branch: the evidence the gate wants;
+- `pull_request` runs when the release branch heads an open pull request:
+  these check out `refs/pull/N/merge`, a synthetic merge with the base branch;
+- push runs of any other branch pointing at the same commit, for example
+  `main` when a release branch is cut from its head.
+
+## Decisions
+
+### 1. Correlate through the check suites of branch push runs
+
+`GET /repos/{owner}/{repo}/actions/runs?head_sha=SHA&event=push&branch=BRANCH`
+returns the workflow runs of the release branch's own push, each with its
+`check_suite_id`. A check run whose `check_suite.id` is outside that set is
+not release evidence. The guard re-applies the event, branch, and commit
+filter itself, so the shell query is not load-bearing.
+
+Alternative considered: skip every job on same-repo `pull_request` events in
+`test.yml` and `formal.yml`. That removes one duplicate source, still leaves
+`skipped` check runs with required names on the commit, and does nothing for
+a second branch at the same commit.
+
+Alternative considered: accept duplicates when every copy succeeded. That
+admits pull-request results that verified a different tree and hides a real
+disagreement between runs of the same commit.
+
+### 2. Keep the exactness rules inside the admitted suites
+
+Within the admitted suites, duplicates, wrong-commit runs, non-success
+conclusions (including `skipped`), and results absent or pending past the
+deadline reject exactly as before.
+
+### 3. Refuse truncated listings
+
+Both listing endpoints report `total_count`. A page holding fewer items than
+GitHub counted is rejected rather than judged, so a busy commit cannot pass by
+omission.
+
+## Verification
+
+- `eacl.release-guard-test` covers the failing shape (pull-request and
+  other-branch results on the release commit, including a skipped and a failed
+  foreign copy), branch-scoped suite derivation, pending-until-runs-exist,
+  truncation, and the workflow's query strings.
+- The new guard evaluates the recorded GitHub payloads of commit `87fc228e`
+  to `ready`; the previous guard rejects them with the duplicate error.
+- The `v8.0.0` release run exercises the fix under the conditions that failed.

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/proposal.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/proposal.md
@@ -1,0 +1,43 @@
+# Scope the Clojars release gate to the release branch's push runs
+
+## Why
+
+The Clojars release run for `v8.0.0-SNAPSHOT` commit `87fc228e` failed in
+`required_checks` with "Required checks have duplicate ambiguous results"
+although every Tests and Formal verification job for that commit had
+succeeded. The release guard judges every check run GitHub attaches to the
+release commit. GitHub attaches check runs to a commit regardless of the ref
+or event that produced them, so the commit carried a second set of Tests and
+Formal check runs from the `pull_request` event of PR #189, which was open from
+the release branch at the time. Those runs verify a synthetic merge commit,
+not the pushed tree, and the guard could not tell the two sets apart.
+
+The same defect blocks the intended `8.0.0` release: a `v8.0.0` branch cut
+from the head of `main` shares its commit with `main`, so `main`'s push runs
+also attach to the release commit and the gate reports duplicates again.
+
+## What Changes
+
+- Correlate required check runs with the push-event workflow runs whose head
+  branch and head commit are exactly the release branch and release commit,
+  through each workflow run's check-suite id. Check runs the commit carries
+  from pull-request events or from other branches are ignored: they never
+  count as evidence and are never reported as ambiguous duplicates.
+- Reject a truncated GitHub listing page instead of judging a partial view.
+- Query both listings in the release workflow; the credential-free guard
+  remains the only judge.
+- Record the current five-module release set in the pipeline specification
+  (`dev.eacl/eacl-caveats-jvm` joined the coordinated set with the v9 Caveat
+  foundation).
+
+## Capabilities
+
+### Modified Capabilities
+- `clojars-release-pipeline`: ordinary gating judges only the release
+  branch's own push-event runs at the release commit; the coordinated
+  release set lists all five published modules.
+
+## Impact
+
+`src-build/eacl/release_guard.clj`, its tests, and
+`.github/workflows/release.yml`. No published artifact source changes.

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/specs/clojars-release-pipeline/spec.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/specs/clojars-release-pipeline/spec.md
@@ -1,0 +1,40 @@
+## REMOVED Requirements
+
+### Requirement: Coordinated module publication
+**Reason**: The coordinated release set gained `dev.eacl/eacl-caveats-jvm` with the v9 Caveat foundation; the four-artifact wording no longer describes the pipeline.
+**Migration**: Replaced by the five-module requirement "Coordinated release-set publication" below.
+
+## ADDED Requirements
+
+### Requirement: Coordinated release-set publication
+The release pipeline SHALL build and publish `dev.eacl/eacl`, `dev.eacl/eacl-caveats-jvm`, `dev.eacl/eacl-datomic`, `dev.eacl/eacl-datahike`, and `dev.eacl/eacl-datascript` at one identical Maven version. Each dependent POM SHALL depend on `dev.eacl/eacl` at that exact version and SHALL declare its own runtime dependencies.
+
+#### Scenario: Coordinated release set
+- **WHEN** a release candidate is prepared for publication
+- **THEN** all five JARs and POMs are built and validated before the first remote upload
+- **AND** core is deployed before the artifacts that depend on it
+
+#### Scenario: Backend-only consumer
+- **WHEN** a consumer resolves one backend artifact from Clojars
+- **THEN** Maven dependency resolution brings in the matching core artifact and only that adapter's declared runtime dependencies
+
+## MODIFIED Requirements
+
+### Requirement: Ordinary release provenance and gating
+Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-SNAPSHOT`, SHALL derive the Maven version from that branch name, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. Release evidence SHALL consist only of the check runs produced by the release branch's own push-event workflow runs at the release commit, correlated through their check suites. Check runs the same commit carries from pull-request events or from other branches SHALL be ignored: they SHALL neither satisfy a required gate nor be reported as ambiguous duplicates. A listing page that omits results GitHub counted SHALL be rejected rather than judged. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
+
+#### Scenario: Green version branch
+- **WHEN** branch `v8.1.0` completes every required gate successfully for a commit
+- **THEN** the release pipeline is eligible to publish that commit only as version `8.1.0`
+
+#### Scenario: Same commit verified by other refs
+- **WHEN** the release commit also carries Tests and Formal verification results from an open pull request headed by the release branch, or from another branch pushed to the same commit
+- **THEN** the gate judges only the release branch's push-event results and publishes once those succeed
+
+#### Scenario: Main or arbitrary branch
+- **WHEN** CI runs on `main`, `release/v8.0`, `feature/example`, or another non-matching ref
+- **THEN** no job with Clojars credentials can upload an artifact
+
+#### Scenario: Failed or mismatched CI
+- **WHEN** any required gate fails, times out, is cancelled, or reports a different source commit
+- **THEN** ordinary publication is rejected before Clojars credentials are used

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/tasks.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/tasks.md
@@ -1,0 +1,13 @@
+## 1. Reproduce
+- [x] Reproduce the `required_checks` rejection of commit `87fc228e` locally from the recorded check-run payload.
+
+## 2. Correlate release evidence with the branch push runs
+- [x] Derive admitted check-suite ids from push-event workflow runs of exactly the release branch and commit.
+- [x] Judge only check runs inside admitted suites; keep duplicate, wrong-commit, non-success, and deadline rejections within them.
+- [x] Reject truncated listing pages.
+- [x] Query workflow runs and check runs in `release.yml` and pass both listings to the guard.
+
+## 3. Verify and record
+- [x] Cover the failing shape and the new rules in `eacl.release-guard-test`; run it and `eacl.build.release-test` through nREPL.
+- [x] Evaluate the recorded payloads of commit `87fc228e` to `ready` with the new guard.
+- [x] Update the `clojars-release-pipeline` specification, including the five-module release set.

--- a/openspec/specs/clojars-release-pipeline/spec.md
+++ b/openspec/specs/clojars-release-pipeline/spec.md
@@ -2,18 +2,8 @@
 
 ## Purpose
 Define a secure, coordinated Clojars publication contract for EACL's core and backend artifacts, including version provenance, generated-runtime integrity, and exceptional snapshot handling.
+
 ## Requirements
-### Requirement: Coordinated module publication
-The release pipeline SHALL build and publish `dev.eacl/eacl`, `dev.eacl/eacl-datomic`, `dev.eacl/eacl-datahike`, and `dev.eacl/eacl-datascript` at one identical Maven version. Each backend POM SHALL depend on `dev.eacl/eacl` at that exact version and SHALL declare its own runtime dependencies.
-
-#### Scenario: Four-artifact release set
-- **WHEN** a release candidate is prepared for publication
-- **THEN** all four JARs and POMs are built and validated before the first remote upload
-- **AND** core is deployed before the backend artifacts that depend on it
-
-#### Scenario: Backend-only consumer
-- **WHEN** a consumer resolves one backend artifact from Clojars
-- **THEN** Maven dependency resolution brings in the matching core artifact and only that adapter's declared runtime dependencies
 
 ### Requirement: Publish complete verifiable artifacts
 The core release artifact SHALL contain the Clojure and ClojureScript sources, `deps.cljs`, the generated JVM kernel classes and their Dafny runtime classes, and the generated browser runtime. Every release POM SHALL contain valid coordinates, project metadata, source-control information, and the EPL-2.0 licence declaration required by Clojars.
@@ -42,11 +32,15 @@ The EACL 8 generated kernel build SHALL default to Java 25 and SHALL permit an e
 - **THEN** the generated sources are compiled and audited at that target and the artifact can run on that Java release or newer, subject to backend dependency requirements
 
 ### Requirement: Ordinary release provenance and gating
-Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH`, SHALL derive Maven version `MAJOR.MINOR.PATCH` from that branch, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
+Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-SNAPSHOT`, SHALL derive the Maven version from that branch name, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. Release evidence SHALL consist only of the check runs produced by the release branch's own push-event workflow runs at the release commit, correlated through their check suites. Check runs the same commit carries from pull-request events or from other branches SHALL be ignored: they SHALL neither satisfy a required gate nor be reported as ambiguous duplicates. A listing page that omits results GitHub counted SHALL be rejected rather than judged. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
 
 #### Scenario: Green version branch
 - **WHEN** branch `v8.1.0` completes every required gate successfully for a commit
 - **THEN** the release pipeline is eligible to publish that commit only as version `8.1.0`
+
+#### Scenario: Same commit verified by other refs
+- **WHEN** the release commit also carries Tests and Formal verification results from an open pull request headed by the release branch, or from another branch pushed to the same commit
+- **THEN** the gate judges only the release branch's push-event results and publishes once those succeed
 
 #### Scenario: Main or arbitrary branch
 - **WHEN** CI runs on `main`, `release/v8.0`, `feature/example`, or another non-matching ref
@@ -77,3 +71,15 @@ Only a job that references the GitHub `clojars` environment after satisfying rep
 #### Scenario: Unauthorized Maven group
 - **WHEN** the configured Clojars user cannot deploy the verified `dev.eacl` group
 - **THEN** a preflight fails before artifact upload and reports that group creation or authorization is required
+
+### Requirement: Coordinated release-set publication
+The release pipeline SHALL build and publish `dev.eacl/eacl`, `dev.eacl/eacl-caveats-jvm`, `dev.eacl/eacl-datomic`, `dev.eacl/eacl-datahike`, and `dev.eacl/eacl-datascript` at one identical Maven version. Each dependent POM SHALL depend on `dev.eacl/eacl` at that exact version and SHALL declare its own runtime dependencies.
+
+#### Scenario: Coordinated release set
+- **WHEN** a release candidate is prepared for publication
+- **THEN** all five JARs and POMs are built and validated before the first remote upload
+- **AND** core is deployed before the artifacts that depend on it
+
+#### Scenario: Backend-only consumer
+- **WHEN** a consumer resolves one backend artifact from Clojars
+- **THEN** Maven dependency resolution brings in the matching core artifact and only that adapter's declared runtime dependencies

--- a/src-build/eacl/release_guard.clj
+++ b/src-build/eacl/release_guard.clj
@@ -52,10 +52,47 @@
     (assert-branch-head! context)
     version))
 
+(defn branch-name
+  "Branch name of a refs/heads/* ref. Tags and pull-request refs are rejected
+  because required checks are correlated with branch push runs only."
+  [ref]
+  (let [[_ branch] (re-matches #"refs/heads/(.+)" (str ref))]
+    (when (string/blank? branch)
+      (reject! "Release checks are scoped to a branch ref."
+               :eacl.release/invalid-ref-type
+               {:ref ref}))
+    branch))
+
+(defn release-check-suites
+  "Check-suite ids of the push-event workflow runs for exactly this branch and
+  commit. GitHub attaches every check run to its commit, so one SHA also
+  carries pull-request runs (which verify a synthetic merge commit rather than
+  the pushed tree) and the runs of any other branch pushed to the same commit.
+  Only the release branch's own push runs verify the release commit as pushed,
+  and only their check suites are admitted as release evidence."
+  [{:keys [sha branch]} workflow-runs]
+  (into #{}
+        (comp (filter (fn [{:keys [event head_branch head_sha]}]
+                        (and (= "push" event)
+                             (= branch head_branch)
+                             (= sha head_sha))))
+              (map :check_suite_id)
+              (remove nil?))
+        workflow-runs))
+
 (defn evaluate-checks
-  "Return :ready or :pending; reject ambiguity, wrong SHA, or bad conclusions."
-  [sha check-runs final?]
-  (let [relevant (filter #(contains? required-checks (:name %)) check-runs)
+  "Return :ready or :pending; reject ambiguity, wrong SHA, or bad conclusions.
+  Only check runs that belong to the release branch's push-event workflow runs
+  for this commit are judged; results the same commit carries from other refs
+  or events are ignored rather than treated as ambiguous duplicates."
+  [{:keys [sha] :as context} workflow-runs check-runs final?]
+  (let [suites (release-check-suites context workflow-runs)
+        relevant
+        (filter
+         (fn [{:keys [name check_suite]}]
+           (and (contains? required-checks name)
+                (contains? suites (:id check_suite))))
+         check-runs)
         by-name (group-by :name relevant)
         duplicates
         (vec
@@ -94,6 +131,18 @@
                  {:checks (vec (sort pending))})
         :else :pending))))
 
+(defn listing
+  "Items of one GitHub listing payload. A page that does not hold every item
+  GitHub counted is rejected: the gate must never judge a partial view."
+  [{:keys [total_count] :as payload} key]
+  (let [items (vec (get payload key))]
+    (when (and (integer? total_count)
+               (not= total_count (count items)))
+      (reject! "GitHub listing was truncated to one page."
+               :eacl.release/truncated-listing
+               {:key key :total-count total_count :returned (count items)}))
+    items))
+
 (defn- environment-context
   []
   {:event-name (System/getenv "GITHUB_EVENT_NAME")
@@ -103,22 +152,25 @@
    :branch-sha (System/getenv "EACL_BRANCH_SHA")
    :supplied-version (System/getenv "EACL_VERSION")})
 
-(defn- read-check-runs
-  [path]
+(defn- read-listing
+  [path key]
   (let [read-json (requiring-resolve 'clojure.data.json/read-str)]
-    (:check_runs (read-json (slurp path) :key-fn keyword))))
+    (listing (read-json (slurp path) :key-fn keyword) key)))
 
 (defn -main
-  [& [operation argument final-argument]]
+  [& [operation & arguments]]
   (case operation
     "ordinary" (println (ordinary-version (environment-context)))
     "checks"
-    (println
-     (name
-      (evaluate-checks
-       (System/getenv "GITHUB_SHA")
-       (read-check-runs argument)
-       (= "true" final-argument))))
+    (let [[workflow-runs-path check-runs-path final-argument] arguments
+          {:keys [sha ref]} (environment-context)]
+      (println
+       (name
+        (evaluate-checks
+         {:sha sha :branch (branch-name ref)}
+         (read-listing workflow-runs-path :workflow_runs)
+         (read-listing check-runs-path :check_runs)
+         (= "true" final-argument)))))
     (reject! "Unknown EACL release-guard operation."
              :eacl.release/unknown-guard-operation
              {:operation operation})))

--- a/src-build/eacl/release_guard_test.clj
+++ b/src-build/eacl/release_guard_test.clj
@@ -1,5 +1,6 @@
 (ns eacl.release-guard-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as string]
+            [clojure.test :refer [deftest is testing]]
             [eacl.release-guard :as guard]))
 
 (def ordinary-context
@@ -21,42 +22,152 @@
            (assoc ordinary-context :ref "refs/heads/feature/v8.1.0")
            (assoc ordinary-context :ref "refs/heads/v8.0-SNAPSHOT")
            (assoc ordinary-context :ref "refs/tags/v8.1.0"
-                                   :ref-type "tag")
+                  :ref-type "tag")
            (assoc ordinary-context :event-name "pull_request")
            (assoc ordinary-context :supplied-version "8.1.0")
            (assoc ordinary-context :branch-sha "newer")]]
     (is (thrown? clojure.lang.ExceptionInfo
                  (guard/ordinary-version context)))))
 
+(deftest checks-are-scoped-to-a-branch-ref
+  (is (= "v8.1.0" (guard/branch-name "refs/heads/v8.1.0")))
+  (is (= "release/v8.0" (guard/branch-name "refs/heads/release/v8.0")))
+  (doseq [ref ["refs/tags/v8.1.0" "refs/pull/189/merge" "" nil]]
+    (is (thrown? clojure.lang.ExceptionInfo (guard/branch-name ref)))))
+
+(def check-context
+  {:sha "release-sha" :branch "v8.1.0"})
+
+(def tests-suite 11)
+(def formal-suite 12)
+
+(defn- workflow-run
+  [event branch sha suite]
+  {:event event
+   :head_branch branch
+   :head_sha sha
+   :check_suite_id suite})
+
+(def release-workflow-runs
+  [(workflow-run "push" "v8.1.0" "release-sha" tests-suite)
+   (workflow-run "push" "v8.1.0" "release-sha" formal-suite)])
+
+(def formal-check-names
+  #{"dafny-and-generated-boundaries"
+    "temporal-models"
+    "parity-corpus-and-mutations"})
+
+(defn- check-run
+  ([name sha suite]
+   (check-run name sha suite "completed" "success"))
+  ([name sha suite status conclusion]
+   {:name name
+    :head_sha sha
+    :status status
+    :conclusion conclusion
+    :check_suite {:id suite}}))
+
 (defn- successful-checks
   [sha]
   (mapv
    (fn [name]
-     {:name name
-      :head_sha sha
-      :status "completed"
-      :conclusion "success"})
-   guard/required-checks))
+     (check-run name sha (if (formal-check-names name) formal-suite tests-suite)))
+   (sort guard/required-checks)))
+
+(deftest only-the-release-branch-push-runs-are-release-evidence
+  (is (= #{tests-suite formal-suite}
+         (guard/release-check-suites check-context release-workflow-runs)))
+  (testing "pull-request, other-branch, other-commit, and suite-less runs are ignored"
+    (is (= #{tests-suite}
+           (guard/release-check-suites
+            check-context
+            [(workflow-run "push" "v8.1.0" "release-sha" tests-suite)
+             (workflow-run "pull_request" "v8.1.0" "release-sha" 21)
+             (workflow-run "push" "main" "release-sha" 22)
+             (workflow-run "push" "v8.1.0" "older-sha" 23)
+             (workflow-run "workflow_dispatch" "v8.1.0" "release-sha" 24)
+             (dissoc (workflow-run "push" "v8.1.0" "release-sha" 25)
+                     :check_suite_id)])))))
+
+(deftest same-commit-results-from-other-refs-do-not-make-the-gate-ambiguous
+  (let [sha "release-sha"
+        checks (successful-checks sha)
+        pull-request-suite 21
+        main-suite 22
+        foreign-runs
+        (into release-workflow-runs
+              [(workflow-run "pull_request" "v8.1.0" sha pull-request-suite)
+               (workflow-run "push" "main" sha main-suite)])
+        foreign-checks
+        (into checks
+              (concat
+               ;; The pull-request event verified a synthetic merge commit.
+               (map #(assoc % :check_suite {:id pull-request-suite}) checks)
+               ;; A same-repo pull request skips its duplicate test job.
+               [(check-run "test" sha pull-request-suite "completed" "skipped")]
+               ;; main was pushed to the same commit and one of its jobs failed.
+               (map #(assoc % :check_suite {:id main-suite}) checks)
+               [(check-run "test" sha main-suite "completed" "failure")]))]
+    (is (= :ready (guard/evaluate-checks check-context foreign-runs foreign-checks false)))
+    (is (= :ready (guard/evaluate-checks check-context foreign-runs foreign-checks true)))
+    (testing "the foreign results also never stand in for absent release evidence"
+      (is (= :pending
+             (guard/evaluate-checks
+              check-context foreign-runs
+              (remove #(= tests-suite (get-in % [:check_suite :id]))
+                      foreign-checks)
+              false))))))
 
 (deftest exact-sha-check-gate-rejects-every-ambiguous-state
   (let [sha "release-sha"
         checks (successful-checks sha)]
-    (is (= :ready (guard/evaluate-checks sha checks false)))
+    (is (= :ready (guard/evaluate-checks check-context release-workflow-runs checks false)))
     (is (= :pending
-           (guard/evaluate-checks sha (pop checks) false)))
+           (guard/evaluate-checks check-context release-workflow-runs (pop checks) false)))
     (is (thrown? clojure.lang.ExceptionInfo
-                 (guard/evaluate-checks sha (pop checks) true)))
-    (is (thrown?
-         clojure.lang.ExceptionInfo
-         (guard/evaluate-checks sha (conj checks (first checks)) false)))
+                 (guard/evaluate-checks check-context release-workflow-runs (pop checks) true)))
+    (testing "release evidence is pending until the branch push runs exist"
+      (is (= :pending (guard/evaluate-checks check-context [] checks false)))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (guard/evaluate-checks check-context [] checks true)))
+      (is (= :pending
+             (guard/evaluate-checks
+              (assoc check-context :branch "v8.2.0") release-workflow-runs checks false))))
+    (testing "a duplicate inside the release branch's own runs stays ambiguous"
+      (is (thrown?
+           clojure.lang.ExceptionInfo
+           (guard/evaluate-checks
+            check-context release-workflow-runs (conj checks (first checks)) false))))
     (doseq [changed [(assoc-in checks [0 :head_sha] "wrong-sha")
                      (assoc-in checks [0 :status] "in_progress")
                      (assoc-in checks [0 :conclusion] "failure")
                      (assoc-in checks [0 :conclusion] "cancelled")
-                     (assoc-in checks [0 :conclusion] "timed_out")]]
+                     (assoc-in checks [0 :conclusion] "timed_out")
+                     (assoc-in checks [0 :conclusion] "skipped")]]
       (testing (str "rejected check state " (first changed))
         (if (= "in_progress" (:status (first changed)))
           (is (thrown? clojure.lang.ExceptionInfo
-                       (guard/evaluate-checks sha changed true)))
+                       (guard/evaluate-checks
+                        check-context release-workflow-runs changed true)))
           (is (thrown? clojure.lang.ExceptionInfo
-                       (guard/evaluate-checks sha changed false))))))))
+                       (guard/evaluate-checks
+                        check-context release-workflow-runs changed false))))))))
+
+(deftest truncated-github-listings-are-never-judged
+  (is (= [{:id 1} {:id 2}]
+         (guard/listing {:total_count 2 :check_runs [{:id 1} {:id 2}]}
+                        :check_runs)))
+  (is (= [] (guard/listing {:total_count 0 :workflow_runs []} :workflow_runs)))
+  (is (thrown? clojure.lang.ExceptionInfo
+               (guard/listing {:total_count 3 :check_runs [{:id 1} {:id 2}]}
+                              :check_runs))))
+
+(deftest release-workflow-correlates-branch-push-runs
+  (let [workflow (slurp ".github/workflows/release.yml")]
+    (is (string/includes?
+         workflow
+         "actions/runs?head_sha=$GITHUB_SHA&event=push&branch=$GITHUB_REF_NAME"))
+    (is (string/includes? workflow "commits/$GITHUB_SHA/check-runs"))
+    (is (string/includes?
+         workflow
+         "clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json"))))


### PR DESCRIPTION
Release branch for `dev.eacl/*` **8.0.0**: `main` at 6328d67d plus the release-gate fix below. Merging keeps `main` at parity with the published commit, as #189 did for the snapshot branch.

## Why the last release run failed

Run [34372797620](https://github.com/theronic/eacl/actions/runs/34372797620) (`v8.0.0-SNAPSHOT` at 87fc228e) rejected the release with "Required checks have duplicate ambiguous results" while every Tests and Formal verification job had succeeded. `eacl.release-guard` judged every check run GitHub attaches to the commit, and GitHub attaches check runs to a commit regardless of the ref or event that produced them. #189 was open from the release branch, so the commit also carried the `pull_request` runs of that PR, which verify a synthetic merge commit rather than the pushed tree. A `v8.0.0` branch cut from the head of `main` would have failed the same way, because `main`'s own push runs attach to that commit too.

## Fix

- The guard correlates required check runs with the push-event workflow runs whose head branch and head commit are exactly the release branch and release commit, through each run's check suite. Results the commit carries from pull-request events or other branches are ignored instead of being reported as duplicates.
- A truncated GitHub listing page is rejected rather than judged.
- `release.yml` queries both listings and passes them to the guard. The deploy step name no longer hard-codes "four artifacts": the coordinated set has five modules since `eacl-caveats-jvm` joined it.
- `clojars-release-pipeline` spec updated; archived OpenSpec change `2026-09-10-scope-release-gate-to-branch-push-runs`.

## Verification

- `eacl.release-guard-test` (7 tests, 40 assertions) and `eacl.build.release-test` (6 tests, 38 assertions) pass through nREPL.
- The previous guard rejects the recorded GitHub payloads of 87fc228e; the new guard evaluates them to `ready`, and reports `pending` then a deadline rejection for a branch with no push runs at that commit.
- This PR deliberately recreates the failing condition on the release commit (pull-request check runs attached to the `v8.0.0` head). The live check is Clojars release run [34502331066](https://github.com/theronic/eacl/actions/runs/34502331066).
