### PR TITLE
Publish EACL snapshots and release candidates from green version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Clojars release
 
 on:
   push:
-    branches:
-      - 'v*'
+    tags: ['v[0-9]*']
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,136 +16,71 @@ concurrency:
 jobs:
   provenance:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.guard.outputs.version }}
+      tests-run-id: ${{ steps.guard.outputs.tests-run-id }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ github.sha }}
+          fetch-depth: 0
 
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '25'
 
-      - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.6.1
+      - uses: DeLaGuardo/setup-clojure@13.6.1
         with:
           cli: latest
 
-      - name: Derive and guard release version
+      - name: Require a merged version tag and existing green source CI
         id: guard
-        run: |
-          branch_sha="$(git ls-remote origin "$GITHUB_REF" | cut -f1)"
-          test -n "$branch_sha"
-          version="$(EACL_BRANCH_SHA="$branch_sha" clojure -M:release-guard ordinary)"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-  required_checks:
-    needs: provenance
-    runs-on: ubuntu-latest
-    timeout-minutes: 95
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.6.1
-        with:
-          cli: latest
-
-      - name: Wait for this branch's exact-SHA Tests and Formal verification checks
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p target/release
-          # GitHub attaches every check run to its commit, so the release
-          # commit can also carry pull-request runs (which verified a merge
-          # commit) and the runs of other branches pushed to the same commit.
-          # Only this branch's own push-event workflow runs are release
-          # evidence; the guard correlates check runs with them by check suite.
-          fetch_listings() {
-            gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&event=push&branch=$GITHUB_REF_NAME&per_page=100" \
-              > target/release/workflow-runs.json
-            gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
-              > target/release/check-runs.json
-          }
-          deadline=$((SECONDS + 5400))
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            fetch_listings
-            status="$(clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json false)"
-            if [ "$status" = ready ]; then
-              exit 0
-            fi
-            sleep 30
-          done
-          fetch_listings
-          clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json true
+        run: bash bin/release-preflight
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-ci-provenance
+          path: target/release
 
   deploy:
-    if: >-
-      always() &&
-      needs.provenance.result == 'success' &&
-      needs.required_checks.result == 'success'
-    needs:
-      - provenance
-      - required_checks
+    needs: provenance
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 60
     environment: clojars
     env:
       EACL_JAVA_RELEASE: '25'
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ github.sha }}
+          fetch-depth: 0
 
-      - name: Set up Temurin JDK 25
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '25'
 
-      - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.6.1
+      - uses: DeLaGuardo/setup-clojure@13.6.1
         with:
           cli: latest
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - name: Recheck tag, release branch, and CI after approval
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash bin/release-preflight
+
+      - name: Reuse the generated runtimes from the verified Tests run
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
-
-      - name: Repeat release provenance guard
-        run: |
-          branch_sha="$(git ls-remote origin "$GITHUB_REF" | cut -f1)"
-          test -n "$branch_sha"
-          actual="$(EACL_BRANCH_SHA="$branch_sha" clojure -M:release-guard ordinary)"
-          test "$actual" = "${{ needs.provenance.outputs.version }}"
-
-      - name: Cache checksum-locked formal tools and JavaScript dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            target/formal-tools
-            ~/.npm
-          key: release-formal-${{ runner.os }}-${{ hashFiles('formal/toolchain.lock.json', 'formal/smoke/js/package-lock.json') }}
-
-      - name: Build generated release runtimes explicitly
-        run: |
-          bin/formal bootstrap
-          bin/formal build-java
-          bin/formal browser-bundle
+          name: released-generated-runtimes
+          path: target/formal
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.guard.outputs.tests-run-id }}
 
       - name: Build, audit, cold-smoke, and deploy the release set
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,28 +60,37 @@ jobs:
         with:
           cli: latest
 
-      - name: Wait for exact-SHA Tests and Formal verification checks
+      - name: Wait for this branch's exact-SHA Tests and Formal verification checks
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p target/release
-          deadline=$((SECONDS + 5400))
-          while [ "$SECONDS" -lt "$deadline" ]; do
+          # GitHub attaches every check run to its commit, so the release
+          # commit can also carry pull-request runs (which verified a merge
+          # commit) and the runs of other branches pushed to the same commit.
+          # Only this branch's own push-event workflow runs are release
+          # evidence; the guard correlates check runs with them by check suite.
+          fetch_listings() {
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&event=push&branch=$GITHUB_REF_NAME&per_page=100" \
+              > target/release/workflow-runs.json
             gh api \
               -H 'Accept: application/vnd.github+json' \
               "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
               > target/release/check-runs.json
-            status="$(clojure -M:release-guard checks target/release/check-runs.json false)"
+          }
+          deadline=$((SECONDS + 5400))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            fetch_listings
+            status="$(clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json false)"
             if [ "$status" = ready ]; then
               exit 0
             fi
             sleep 30
           done
-          gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
-            > target/release/check-runs.json
-          clojure -M:release-guard checks target/release/check-runs.json true
+          fetch_listings
+          clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json true
 
   deploy:
     if: >-
@@ -138,7 +147,7 @@ jobs:
           bin/formal build-java
           bin/formal browser-bundle
 
-      - name: Build, audit, cold-smoke, and deploy the four artifacts
+      - name: Build, audit, cold-smoke, and deploy the release set
         env:
           EACL_VERSION: ${{ needs.provenance.outputs.version }}
           CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This README is too long & too technical, so I am working to simplify it and brea
 
 > [!WARNING]
 > EACL is used in production, but under active development.
-> This branch targets `8.0.0-SNAPSHOT`. Build it locally until the coordinated release is published; see [Clojars](https://clojars.org/dev.eacl/) for published versions.
+> This branch targets `8.0.0-SNAPSHOT`; see [Clojars](https://clojars.org/dev.eacl/eacl) for published versions and [Publishing EACL](docs/publishing.md) for the version-tag release process.
 
 ## Real-Time UI Maintenance
 

--- a/bin/release-preflight
+++ b/bin/release-preflight
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Credential-free checks; repeat after environment approval to catch stale tags/CI.
+set -euo pipefail
+mkdir -p target/release
+clojure -M:release-guard tag > target/release/version.env
+branch=$(sed -n 's/^branch=//p' target/release/version.env)
+test -n "$branch"
+git fetch --no-tags origin \
+  "+$GITHUB_REF:refs/eacl-release/tag" \
+  "+refs/heads/$branch:refs/remotes/origin/$branch"
+test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+export EACL_TAG_SHA EACL_SOURCE_TREE EACL_BRANCH_TREE EACL_ANCESTOR
+EACL_TAG_SHA=$(git rev-parse 'refs/eacl-release/tag^{commit}')
+EACL_SOURCE_TREE=$(git rev-parse 'HEAD^{tree}')
+EACL_BRANCH_TREE=$(git rev-parse "refs/remotes/origin/$branch^{tree}")
+EACL_ANCESTOR=false
+if git merge-base --is-ancestor "$GITHUB_SHA" "refs/remotes/origin/$branch"; then
+  EACL_ANCESTOR=true
+fi
+clojure -M:release-guard provenance
+
+# Tagging never launches Tests/Formal. Reuse push CI on this exact commit,
+# including a PR head already merged into the release branch with the same tree.
+gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&event=push&per_page=100" \
+  > target/release/workflow-runs.json
+gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
+  > target/release/check-runs.json
+clojure -M:release-guard tag-checks \
+  target/release/workflow-runs.json target/release/check-runs.json
+
+tests_run_id=$(jq '[.workflow_runs[] | select(.path == ".github/workflows/test.yml" and .event == "push")] | max_by(.id) | .id' target/release/workflow-runs.json)
+cat target/release/version.env >> "$GITHUB_OUTPUT"
+echo "tests-run-id=$tests_run_id" >> "$GITHUB_OUTPUT"
+{
+  echo "Tag: $GITHUB_REF"
+  echo "Source commit: $GITHUB_SHA"
+  echo "Release branch with the same Git tree: $branch"
+  cat target/release/version.env
+  jq -r '[.workflow_runs[] | select(.path == ".github/workflows/test.yml" or .path == ".github/workflows/formal.yml")] | group_by(.path)[] | max_by(.id) | "- \(.name): \(.html_url)"' target/release/workflow-runs.json
+} >> "$GITHUB_STEP_SUMMARY"

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,69 @@
+# Publishing EACL to Clojars
+
+Publication is an explicit version-tag operation followed by approval of the
+`clojars` GitHub environment. Pushing `main`, a feature branch, or a snapshot
+branch runs CI without publishing anything.
+
+1. Open a PR into `vMAJOR.MINOR.PATCH-SNAPSHOT` and wait for its push-event
+   **Tests** and **Formal verification** workflows to succeed. Fix failed jobs
+   first; rerun failed jobs instead of restarting successful formal verification.
+2. Merge the PR. Keep the green PR head SHA: the release guard accepts it when
+   it is an ancestor of the release branch and its entire Git tree equals the
+   branch's current tree. A merge commit with different contents requires its
+   own green CI. Do not squash/rebase if you intend to reuse the PR head's CI.
+3. Create and push an annotated tag on that green SHA, or create a GitHub Release
+   targeting it. Tag names determine the Maven version:
+
+   | Tag | Published version |
+   | --- | --- |
+   | `v8.0.0-SNAPSHOT-2026-09-12` | `8.0.0-SNAPSHOT` |
+   | `v8.0.0-SNAPSHOT-2026-09-12T141530Z` | `8.0.0-SNAPSHOT` |
+   | `v8.0.0-RC-2026-09-12` | `8.0.0-RC-2026-09-12` |
+   | `v8.0.0` | `8.0.0` |
+
+   All these tags use release branch `v8.0.0-SNAPSHOT`. Use a new dated tag for
+   each snapshot. Never move a published tag or reuse an immutable Maven version.
+4. Open **Actions → Clojars release**, inspect the source and CI links in the
+   provenance summary, and approve the `clojars` deployment. The workflow checks
+   provenance and CI again after approval, downloads generated runtimes from the
+   verified Tests run, and builds, audits, and cold-smokes all five artifacts
+   before uploading any of them.
+
+For example, with `source_sha` set to the green PR head:
+
+```sh
+git tag -a v8.0.0-RC-2026-09-12 "$source_sha" -m 'EACL 8.0.0 RC 2026-09-12'
+git push origin refs/tags/v8.0.0-RC-2026-09-12
+```
+
+Tags do not restart Tests or Formal verification. The latest push run of each
+trusted workflow must be green for the exact tagged SHA; PR-event checks,
+different commits, skipped required jobs, and truncated listings cannot pass.
+Missing/red/in-progress CI fails immediately instead of waiting for 90 minutes.
+The tested runtime artifact must still be retained in GitHub Actions; if it has
+expired, rerun Tests on the source branch to regenerate it. Formal verification
+does not need to be rerun for an unchanged commit.
+
+After correcting an operational failure, use **Re-run failed jobs**. Manual
+dispatch also works on an existing tag once this workflow is on the default
+branch:
+
+```sh
+gh workflow run release.yml --ref v8.0.0-RC-2026-09-12
+```
+
+Dispatching on a branch is rejected. If a Clojars upload failed partway through
+an immutable release, inspect the remote artifact set before retrying: Clojars
+does not support overwriting released versions.
+
+The release set is `dev.eacl/eacl`, `eacl-caveats-jvm`, `eacl-datomic`,
+`eacl-datahike`, and `eacl-datascript`, all at the same version. Datalevin remains
+excluded until its maintained fork dependency is published.
+
+Repository configuration: allow merge commits and auto-merge, require all ten
+Tests/Formal jobs on the snapshot branch, restrict the `clojars` environment to
+version tags with maintainer approval, and prevent version-tag updates/deletion.
+Keep the release workflow on `main` as well as the snapshot branch so manual
+dispatch remains available. GitHub's [tag triggers](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+and [deployment environment rules](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
+describe these controls.

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/design.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`eacl.release-guard/evaluate-checks` read
+`GET /repos/{owner}/{repo}/commits/{sha}/check-runs` and grouped the required
+check names by name. GitHub Actions creates one check suite per workflow run
+and attaches every check run to the run's head commit, so a commit carries one
+set of check runs per (workflow, event, ref) that ran on it:
+
+- push runs of the release branch: the evidence the gate wants;
+- `pull_request` runs when the release branch heads an open pull request:
+  these check out `refs/pull/N/merge`, a synthetic merge with the base branch;
+- push runs of any other branch pointing at the same commit, for example
+  `main` when a release branch is cut from its head.
+
+## Decisions
+
+### 1. Correlate through the check suites of branch push runs
+
+`GET /repos/{owner}/{repo}/actions/runs?head_sha=SHA&event=push&branch=BRANCH`
+returns the workflow runs of the release branch's own push, each with its
+`check_suite_id`. A check run whose `check_suite.id` is outside that set is
+not release evidence. The guard re-applies the event, branch, and commit
+filter itself, so the shell query is not load-bearing.
+
+Alternative considered: skip every job on same-repo `pull_request` events in
+`test.yml` and `formal.yml`. That removes one duplicate source, still leaves
+`skipped` check runs with required names on the commit, and does nothing for
+a second branch at the same commit.
+
+Alternative considered: accept duplicates when every copy succeeded. That
+admits pull-request results that verified a different tree and hides a real
+disagreement between runs of the same commit.
+
+### 2. Keep the exactness rules inside the admitted suites
+
+Within the admitted suites, duplicates, wrong-commit runs, non-success
+conclusions (including `skipped`), and results absent or pending past the
+deadline reject exactly as before.
+
+### 3. Refuse truncated listings
+
+Both listing endpoints report `total_count`. A page holding fewer items than
+GitHub counted is rejected rather than judged, so a busy commit cannot pass by
+omission.
+
+## Verification
+
+- `eacl.release-guard-test` covers the failing shape (pull-request and
+  other-branch results on the release commit, including a skipped and a failed
+  foreign copy), branch-scoped suite derivation, pending-until-runs-exist,
+  truncation, and the workflow's query strings.
+- The new guard evaluates the recorded GitHub payloads of commit `87fc228e`
+  to `ready`; the previous guard rejects them with the duplicate error.
+- The `v8.0.0` release run exercises the fix under the conditions that failed.

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/proposal.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/proposal.md
@@ -1,0 +1,43 @@
+# Scope the Clojars release gate to the release branch's push runs
+
+## Why
+
+The Clojars release run for `v8.0.0-SNAPSHOT` commit `87fc228e` failed in
+`required_checks` with "Required checks have duplicate ambiguous results"
+although every Tests and Formal verification job for that commit had
+succeeded. The release guard judges every check run GitHub attaches to the
+release commit. GitHub attaches check runs to a commit regardless of the ref
+or event that produced them, so the commit carried a second set of Tests and
+Formal check runs from the `pull_request` event of PR #189, which was open from
+the release branch at the time. Those runs verify a synthetic merge commit,
+not the pushed tree, and the guard could not tell the two sets apart.
+
+The same defect blocks the intended `8.0.0` release: a `v8.0.0` branch cut
+from the head of `main` shares its commit with `main`, so `main`'s push runs
+also attach to the release commit and the gate reports duplicates again.
+
+## What Changes
+
+- Correlate required check runs with the push-event workflow runs whose head
+  branch and head commit are exactly the release branch and release commit,
+  through each workflow run's check-suite id. Check runs the commit carries
+  from pull-request events or from other branches are ignored: they never
+  count as evidence and are never reported as ambiguous duplicates.
+- Reject a truncated GitHub listing page instead of judging a partial view.
+- Query both listings in the release workflow; the credential-free guard
+  remains the only judge.
+- Record the current five-module release set in the pipeline specification
+  (`dev.eacl/eacl-caveats-jvm` joined the coordinated set with the v9 Caveat
+  foundation).
+
+## Capabilities
+
+### Modified Capabilities
+- `clojars-release-pipeline`: ordinary gating judges only the release
+  branch's own push-event runs at the release commit; the coordinated
+  release set lists all five published modules.
+
+## Impact
+
+`src-build/eacl/release_guard.clj`, its tests, and
+`.github/workflows/release.yml`. No published artifact source changes.

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/specs/clojars-release-pipeline/spec.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/specs/clojars-release-pipeline/spec.md
@@ -1,0 +1,40 @@
+## REMOVED Requirements
+
+### Requirement: Coordinated module publication
+**Reason**: The coordinated release set gained `dev.eacl/eacl-caveats-jvm` with the v9 Caveat foundation; the four-artifact wording no longer describes the pipeline.
+**Migration**: Replaced by the five-module requirement "Coordinated release-set publication" below.
+
+## ADDED Requirements
+
+### Requirement: Coordinated release-set publication
+The release pipeline SHALL build and publish `dev.eacl/eacl`, `dev.eacl/eacl-caveats-jvm`, `dev.eacl/eacl-datomic`, `dev.eacl/eacl-datahike`, and `dev.eacl/eacl-datascript` at one identical Maven version. Each dependent POM SHALL depend on `dev.eacl/eacl` at that exact version and SHALL declare its own runtime dependencies.
+
+#### Scenario: Coordinated release set
+- **WHEN** a release candidate is prepared for publication
+- **THEN** all five JARs and POMs are built and validated before the first remote upload
+- **AND** core is deployed before the artifacts that depend on it
+
+#### Scenario: Backend-only consumer
+- **WHEN** a consumer resolves one backend artifact from Clojars
+- **THEN** Maven dependency resolution brings in the matching core artifact and only that adapter's declared runtime dependencies
+
+## MODIFIED Requirements
+
+### Requirement: Ordinary release provenance and gating
+Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-SNAPSHOT`, SHALL derive the Maven version from that branch name, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. Release evidence SHALL consist only of the check runs produced by the release branch's own push-event workflow runs at the release commit, correlated through their check suites. Check runs the same commit carries from pull-request events or from other branches SHALL be ignored: they SHALL neither satisfy a required gate nor be reported as ambiguous duplicates. A listing page that omits results GitHub counted SHALL be rejected rather than judged. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
+
+#### Scenario: Green version branch
+- **WHEN** branch `v8.1.0` completes every required gate successfully for a commit
+- **THEN** the release pipeline is eligible to publish that commit only as version `8.1.0`
+
+#### Scenario: Same commit verified by other refs
+- **WHEN** the release commit also carries Tests and Formal verification results from an open pull request headed by the release branch, or from another branch pushed to the same commit
+- **THEN** the gate judges only the release branch's push-event results and publishes once those succeed
+
+#### Scenario: Main or arbitrary branch
+- **WHEN** CI runs on `main`, `release/v8.0`, `feature/example`, or another non-matching ref
+- **THEN** no job with Clojars credentials can upload an artifact
+
+#### Scenario: Failed or mismatched CI
+- **WHEN** any required gate fails, times out, is cancelled, or reports a different source commit
+- **THEN** ordinary publication is rejected before Clojars credentials are used

--- a/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/tasks.md
+++ b/openspec/changes/archive/2026-09-10-scope-release-gate-to-branch-push-runs/tasks.md
@@ -1,0 +1,13 @@
+## 1. Reproduce
+- [x] Reproduce the `required_checks` rejection of commit `87fc228e` locally from the recorded check-run payload.
+
+## 2. Correlate release evidence with the branch push runs
+- [x] Derive admitted check-suite ids from push-event workflow runs of exactly the release branch and commit.
+- [x] Judge only check runs inside admitted suites; keep duplicate, wrong-commit, non-success, and deadline rejections within them.
+- [x] Reject truncated listing pages.
+- [x] Query workflow runs and check runs in `release.yml` and pass both listings to the guard.
+
+## 3. Verify and record
+- [x] Cover the failing shape and the new rules in `eacl.release-guard-test`; run it and `eacl.build.release-test` through nREPL.
+- [x] Evaluate the recorded payloads of commit `87fc228e` to `ready` with the new guard.
+- [x] Update the `clojars-release-pipeline` specification, including the five-module release set.

--- a/openspec/specs/clojars-release-pipeline/spec.md
+++ b/openspec/specs/clojars-release-pipeline/spec.md
@@ -2,18 +2,8 @@
 
 ## Purpose
 Define a secure, coordinated Clojars publication contract for EACL's core and backend artifacts, including version provenance, generated-runtime integrity, and exceptional snapshot handling.
+
 ## Requirements
-### Requirement: Coordinated module publication
-The release pipeline SHALL build and publish `dev.eacl/eacl`, `dev.eacl/eacl-datomic`, `dev.eacl/eacl-datahike`, and `dev.eacl/eacl-datascript` at one identical Maven version. Each backend POM SHALL depend on `dev.eacl/eacl` at that exact version and SHALL declare its own runtime dependencies.
-
-#### Scenario: Four-artifact release set
-- **WHEN** a release candidate is prepared for publication
-- **THEN** all four JARs and POMs are built and validated before the first remote upload
-- **AND** core is deployed before the backend artifacts that depend on it
-
-#### Scenario: Backend-only consumer
-- **WHEN** a consumer resolves one backend artifact from Clojars
-- **THEN** Maven dependency resolution brings in the matching core artifact and only that adapter's declared runtime dependencies
 
 ### Requirement: Publish complete verifiable artifacts
 The core release artifact SHALL contain the Clojure and ClojureScript sources, `deps.cljs`, the generated JVM kernel classes and their Dafny runtime classes, and the generated browser runtime. Every release POM SHALL contain valid coordinates, project metadata, source-control information, and the EPL-2.0 licence declaration required by Clojars.
@@ -42,11 +32,15 @@ The EACL 8 generated kernel build SHALL default to Java 25 and SHALL permit an e
 - **THEN** the generated sources are compiled and audited at that target and the artifact can run on that Java release or newer, subject to backend dependency requirements
 
 ### Requirement: Ordinary release provenance and gating
-Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH`, SHALL derive Maven version `MAJOR.MINOR.PATCH` from that branch, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
+Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-SNAPSHOT`, SHALL derive the Maven version from that branch name, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. Release evidence SHALL consist only of the check runs produced by the release branch's own push-event workflow runs at the release commit, correlated through their check suites. Check runs the same commit carries from pull-request events or from other branches SHALL be ignored: they SHALL neither satisfy a required gate nor be reported as ambiguous duplicates. A listing page that omits results GitHub counted SHALL be rejected rather than judged. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
 
 #### Scenario: Green version branch
 - **WHEN** branch `v8.1.0` completes every required gate successfully for a commit
 - **THEN** the release pipeline is eligible to publish that commit only as version `8.1.0`
+
+#### Scenario: Same commit verified by other refs
+- **WHEN** the release commit also carries Tests and Formal verification results from an open pull request headed by the release branch, or from another branch pushed to the same commit
+- **THEN** the gate judges only the release branch's push-event results and publishes once those succeed
 
 #### Scenario: Main or arbitrary branch
 - **WHEN** CI runs on `main`, `release/v8.0`, `feature/example`, or another non-matching ref
@@ -77,3 +71,15 @@ Only a job that references the GitHub `clojars` environment after satisfying rep
 #### Scenario: Unauthorized Maven group
 - **WHEN** the configured Clojars user cannot deploy the verified `dev.eacl` group
 - **THEN** a preflight fails before artifact upload and reports that group creation or authorization is required
+
+### Requirement: Coordinated release-set publication
+The release pipeline SHALL build and publish `dev.eacl/eacl`, `dev.eacl/eacl-caveats-jvm`, `dev.eacl/eacl-datomic`, `dev.eacl/eacl-datahike`, and `dev.eacl/eacl-datascript` at one identical Maven version. Each dependent POM SHALL depend on `dev.eacl/eacl` at that exact version and SHALL declare its own runtime dependencies.
+
+#### Scenario: Coordinated release set
+- **WHEN** a release candidate is prepared for publication
+- **THEN** all five JARs and POMs are built and validated before the first remote upload
+- **AND** core is deployed before the artifacts that depend on it
+
+#### Scenario: Backend-only consumer
+- **WHEN** a consumer resolves one backend artifact from Clojars
+- **THEN** Maven dependency resolution brings in the matching core artifact and only that adapter's declared runtime dependencies

--- a/openspec/specs/clojars-release-pipeline/spec.md
+++ b/openspec/specs/clojars-release-pipeline/spec.md
@@ -31,35 +31,29 @@ The EACL 8 generated kernel build SHALL default to Java 25 and SHALL permit an e
 - **WHEN** a source or custom artifact build explicitly selects Java 8 through Java 26
 - **THEN** the generated sources are compiled and audited at that target and the artifact can run on that Java release or newer, subject to backend dependency requirements
 
-### Requirement: Ordinary release provenance and gating
-Ordinary remote publication SHALL occur only for a branch whose entire name matches `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-SNAPSHOT`, SHALL derive the Maven version from that branch name, and SHALL require the repository's test and formal-verification gates to succeed for the same commit. Release evidence SHALL consist only of the check runs produced by the release branch's own push-event workflow runs at the release commit, correlated through their check suites. Check runs the same commit carries from pull-request events or from other branches SHALL be ignored: they SHALL neither satisfy a required gate nor be reported as ambiguous duplicates. A listing page that omits results GitHub counted SHALL be rejected rather than judged. `main`, pull requests, tags, branch names that merely contain a version, and caller-supplied version overrides SHALL NOT publish.
+### Requirement: Tagged release provenance and gating
+Publication SHALL require a version tag pushed or manually dispatched on that tag. Tags SHALL match `vMAJOR.MINOR.PATCH`, `vMAJOR.MINOR.PATCH-RC-YYYY-MM-DD`, or `vMAJOR.MINOR.PATCH-SNAPSHOT-YYYY-MM-DD[THHMMSSZ]`. Snapshot tags SHALL publish `MAJOR.MINOR.PATCH-SNAPSHOT`; other tags SHALL publish their version without the leading `v`. The tag SHALL be unchanged, merged into `vMAJOR.MINOR.PATCH-SNAPSHOT`, and have the same complete Git tree as that branch's current head.
 
-#### Scenario: Green version branch
-- **WHEN** branch `v8.1.0` completes every required gate successfully for a commit
-- **THEN** the release pipeline is eligible to publish that commit only as version `8.1.0`
+The latest push-event runs of `.github/workflows/test.yml` and `.github/workflows/formal.yml` for the exact tagged SHA SHALL both be completed successfully. Their required check jobs SHALL all be successful, correlated through check-suite IDs. PR-event results, unrelated workflows, and different commits SHALL NOT satisfy the gate. Incomplete listings SHALL be rejected. Missing, pending, or failed CI SHALL fail immediately. Publication SHALL reuse generated runtime artifacts from that verified Tests run without rerunning formal verification.
 
-#### Scenario: Same commit verified by other refs
-- **WHEN** the release commit also carries Tests and Formal verification results from an open pull request headed by the release branch, or from another branch pushed to the same commit
-- **THEN** the gate judges only the release branch's push-event results and publishes once those succeed
+#### Scenario: Green PR head merged without content changes
+- **WHEN** the green PR head becomes an ancestor of the snapshot branch and the complete Git trees are identical
+- **THEN** a tag on that PR head may reuse its push CI, without waiting for the merge commit's redundant CI
 
-#### Scenario: Main or arbitrary branch
-- **WHEN** CI runs on `main`, `release/v8.0`, `feature/example`, or another non-matching ref
-- **THEN** no job with Clojars credentials can upload an artifact
+#### Scenario: Versioned snapshot and release candidate
+- **WHEN** tags `v8.0.0-SNAPSHOT-2026-09-12` and `v8.0.0-RC-2026-09-12` identify the same admitted green source
+- **THEN** they publish `8.0.0-SNAPSHOT` and `8.0.0-RC-2026-09-12` through separately approved, serialized deployments
 
-#### Scenario: Failed or mismatched CI
-- **WHEN** any required gate fails, times out, is cancelled, or reports a different source commit
-- **THEN** ordinary publication is rejected before Clojars credentials are used
+#### Scenario: Branch push or manual dispatch on a branch
+- **WHEN** code is pushed to `main`, a feature branch, or the snapshot branch, or publication is manually dispatched on a branch
+- **THEN** no Clojars publication occurs
 
-### Requirement: Narrow initial snapshot exception
-The release pipeline SHALL provide one explicit exception that accepts only branch `codex/v8-demand-bounded-authorization`, source commit checked out from that branch, and Maven version `8.0.0-SNAPSHOT`. This exception SHALL permit the initial snapshot despite the existing formal-workflow result, require an intentional manual dispatch and protected `clojars` environment access, and be removed or disabled after the integration test succeeds.
+#### Scenario: CI or source changed while approval was pending
+- **WHEN** approval is granted after the tag or branch tree changed, or the latest required source CI is no longer green
+- **THEN** the repeated provenance checks reject publication before upload
 
-#### Scenario: Authorized initial snapshot
-- **WHEN** an authorized maintainer manually dispatches the exception from `codex/v8-demand-bounded-authorization` with exact version `8.0.0-SNAPSHOT`
-- **THEN** the four validated artifacts may be deployed without the ordinary formal-success condition
-
-#### Scenario: Exception input changed
-- **WHEN** the exception receives any other branch, ref type, commit provenance, or version, including `8.0-SNAPSHOT`
-- **THEN** it fails before credentials are exposed or an upload begins
+### Requirement: No verification exception
+Every publication, including snapshots, SHALL require green Tests and Formal verification. The historical initial-snapshot exception SHALL remain removed.
 
 ### Requirement: Protected deployment credentials
 Only a job that references the GitHub `clojars` environment after satisfying repository-side release guards SHALL receive the Clojars username and deploy token. The workflow SHALL map those secrets to the deployment tool without printing them and SHALL serialize deployments to prevent concurrent releases.

--- a/src-build/eacl/build/config.clj
+++ b/src-build/eacl/build/config.clj
@@ -108,7 +108,7 @@
   [candidate]
   (boolean
    (and (string? candidate)
-        (re-matches #"[0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT)?"
+        (re-matches #"[0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT|-RC-[0-9]{4}-[0-9]{2}-[0-9]{2})?"
                     candidate))))
 
 (defn version
@@ -122,7 +122,7 @@
     (when-not (valid-version? candidate)
       (throw
        (ex-info
-        "EACL version must be MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-SNAPSHOT."
+        "EACL version must be MAJOR.MINOR.PATCH, optionally followed by -SNAPSHOT or -RC-YYYY-MM-DD."
         {:type :eacl.build/invalid-version
          :version candidate})))
     candidate))

--- a/src-build/eacl/build/config_test.clj
+++ b/src-build/eacl/build/config_test.clj
@@ -52,6 +52,12 @@
     (is (= "8.1.0" (config/version {:version "8.1.0"})))
     (is (= "8.0.0-SNAPSHOT"
            (config/version {:version "8.0.0-SNAPSHOT"})))
+    (is (= "8.0.0-RC-2026-09-12"
+           (config/version {:version "8.0.0-RC-2026-09-12"})))
+    (doseq [module-id (rest config/release-module-order)]
+      (is (= {:mvn/version "8.0.0-RC-2026-09-12"}
+             (get (config/dependencies module-id "8.0.0-RC-2026-09-12")
+                  'dev.eacl/eacl))))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"MAJOR.MINOR.PATCH"

--- a/src-build/eacl/release_guard.clj
+++ b/src-build/eacl/release_guard.clj
@@ -52,10 +52,47 @@
     (assert-branch-head! context)
     version))
 
+(defn branch-name
+  "Branch name of a refs/heads/* ref. Tags and pull-request refs are rejected
+  because required checks are correlated with branch push runs only."
+  [ref]
+  (let [[_ branch] (re-matches #"refs/heads/(.+)" (str ref))]
+    (when (string/blank? branch)
+      (reject! "Release checks are scoped to a branch ref."
+               :eacl.release/invalid-ref-type
+               {:ref ref}))
+    branch))
+
+(defn release-check-suites
+  "Check-suite ids of the push-event workflow runs for exactly this branch and
+  commit. GitHub attaches every check run to its commit, so one SHA also
+  carries pull-request runs (which verify a synthetic merge commit rather than
+  the pushed tree) and the runs of any other branch pushed to the same commit.
+  Only the release branch's own push runs verify the release commit as pushed,
+  and only their check suites are admitted as release evidence."
+  [{:keys [sha branch]} workflow-runs]
+  (into #{}
+        (comp (filter (fn [{:keys [event head_branch head_sha]}]
+                        (and (= "push" event)
+                             (= branch head_branch)
+                             (= sha head_sha))))
+              (map :check_suite_id)
+              (remove nil?))
+        workflow-runs))
+
 (defn evaluate-checks
-  "Return :ready or :pending; reject ambiguity, wrong SHA, or bad conclusions."
-  [sha check-runs final?]
-  (let [relevant (filter #(contains? required-checks (:name %)) check-runs)
+  "Return :ready or :pending; reject ambiguity, wrong SHA, or bad conclusions.
+  Only check runs that belong to the release branch's push-event workflow runs
+  for this commit are judged; results the same commit carries from other refs
+  or events are ignored rather than treated as ambiguous duplicates."
+  [{:keys [sha] :as context} workflow-runs check-runs final?]
+  (let [suites (release-check-suites context workflow-runs)
+        relevant
+        (filter
+         (fn [{:keys [name check_suite]}]
+           (and (contains? required-checks name)
+                (contains? suites (:id check_suite))))
+         check-runs)
         by-name (group-by :name relevant)
         duplicates
         (vec
@@ -94,6 +131,18 @@
                  {:checks (vec (sort pending))})
         :else :pending))))
 
+(defn listing
+  "Items of one GitHub listing payload. A page that does not hold every item
+  GitHub counted is rejected: the gate must never judge a partial view."
+  [{:keys [total_count] :as payload} key]
+  (let [items (vec (get payload key))]
+    (when (and (integer? total_count)
+               (not= total_count (count items)))
+      (reject! "GitHub listing was truncated to one page."
+               :eacl.release/truncated-listing
+               {:key key :total-count total_count :returned (count items)}))
+    items))
+
 (defn- environment-context
   []
   {:event-name (System/getenv "GITHUB_EVENT_NAME")
@@ -103,22 +152,25 @@
    :branch-sha (System/getenv "EACL_BRANCH_SHA")
    :supplied-version (System/getenv "EACL_VERSION")})
 
-(defn- read-check-runs
-  [path]
+(defn- read-listing
+  [path key]
   (let [read-json (requiring-resolve 'clojure.data.json/read-str)]
-    (:check_runs (read-json (slurp path) :key-fn keyword))))
+    (listing (read-json (slurp path) :key-fn keyword) key)))
 
 (defn -main
-  [& [operation argument final-argument]]
+  [& [operation & arguments]]
   (case operation
     "ordinary" (println (ordinary-version (environment-context)))
     "checks"
-    (println
-     (name
-      (evaluate-checks
-       (System/getenv "GITHUB_SHA")
-       (read-check-runs argument)
-       (= "true" final-argument))))
+    (let [[workflow-runs-path check-runs-path final-argument] arguments
+          {:keys [sha ref]} (environment-context)]
+      (println
+       (name
+        (evaluate-checks
+         {:sha sha :branch (branch-name ref)}
+         (read-listing workflow-runs-path :workflow_runs)
+         (read-listing check-runs-path :check_runs)
+         (= "true" final-argument)))))
     (reject! "Unknown EACL release-guard operation."
              :eacl.release/unknown-guard-operation
              {:operation operation})))

--- a/src-build/eacl/release_guard.clj
+++ b/src-build/eacl/release_guard.clj
@@ -1,6 +1,7 @@
 (ns eacl.release-guard
   "Credential-free GitHub ref, version, and exact-check-run release guards."
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [eacl.build.config :as config]))
 
 (def required-checks
   #{"generated-runtime"
@@ -18,39 +19,39 @@
   [message type data]
   (throw (ex-info message (assoc data :type type))))
 
-(defn- assert-branch-head!
-  [{:keys [sha branch-sha]}]
-  (when (or (string/blank? sha)
-            (string/blank? branch-sha)
-            (not= sha branch-sha))
-    (reject!
-     "Release commit must still be the exact head of the selected branch."
-     :eacl.release/branch-head-mismatch
-     {:sha sha :branch-sha branch-sha})))
-
-(defn ordinary-version
+(defn tagged-release
   [{:keys [event-name ref ref-type supplied-version] :as context}]
-  (when-not (= "push" event-name)
-    (reject! "Ordinary releases require a push event."
+  (when-not (contains? #{"push" "workflow_dispatch"} event-name)
+    (reject! "Releases require a tag push or manual dispatch on a tag."
              :eacl.release/invalid-event context))
-  (when-not (= "branch" ref-type)
-    (reject! "EACL releases never publish from tags or pull-request refs."
+  (when-not (= "tag" ref-type)
+    (reject! "EACL publication requires an explicit version tag."
              :eacl.release/invalid-ref-type context))
   (when-not (string/blank? supplied-version)
-    (reject! "Ordinary release versions are derived, never supplied."
+    (reject! "Release versions are derived from tags, never supplied."
              :eacl.release/version-override context))
-  (let [[_ version]
-        (re-matches
-         #"refs/heads/v([0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT)?)"
-         ref)]
-    (when-not version
+  (let [[_ base suffix]
+        (re-matches #"refs/tags/v([0-9]+\.[0-9]+\.[0-9]+)(.*)" (str ref))
+        snapshot? (boolean
+                   (re-matches #"-SNAPSHOT-[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{6}Z)?"
+                               (or suffix "")))
+        version (str base (if snapshot? "-SNAPSHOT" suffix))]
+    (when-not (and base (config/valid-version? version)
+                   (or snapshot? (not= suffix "-SNAPSHOT")))
       (reject!
-       (str "Ordinary release branch must exactly match "
-            "vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-SNAPSHOT.")
-       :eacl.release/invalid-version-branch
+       "Use vMAJOR.MINOR.PATCH, vMAJOR.MINOR.PATCH-RC-YYYY-MM-DD, or a dated vMAJOR.MINOR.PATCH-SNAPSHOT-YYYY-MM-DD[THHMMSSZ] tag."
+       :eacl.release/invalid-version-tag
        context))
-    (assert-branch-head! context)
-    version))
+    {:version version :branch (str "v" base "-SNAPSHOT")}))
+
+(defn assert-tag-provenance!
+  [{:keys [sha tag-sha source-tree branch-tree ancestor?] :as context}]
+  (when-not (and (not (string/blank? sha)) (= sha tag-sha)
+                 (not (string/blank? source-tree)) (= source-tree branch-tree)
+                 (= true ancestor?))
+    (reject! "The unchanged tag must be merged into the release branch and match its current Git tree."
+             :eacl.release/tag-provenance-mismatch context))
+  true)
 
 (defn branch-name
   "Branch name of a refs/heads/* ref. Tags and pull-request refs are rejected
@@ -74,11 +75,40 @@
   (into #{}
         (comp (filter (fn [{:keys [event head_branch head_sha]}]
                         (and (= "push" event)
-                             (= branch head_branch)
+                             (or (nil? branch) (= branch head_branch))
                              (= sha head_sha))))
               (map :check_suite_id)
               (remove nil?))
         workflow-runs))
+
+(def required-workflows
+  #{".github/workflows/test.yml" ".github/workflows/formal.yml"})
+
+(defn verified-workflow-runs
+  "Select the latest push run of each trusted workflow at the tagged SHA.
+  A newer failed or pending attempt must never be hidden by older green CI."
+  [sha workflow-runs]
+  (->> workflow-runs
+       (filter #(and (= "push" (:event %)) (= sha (:head_sha %))
+                     (contains? required-workflows (:path %))))
+       (group-by :path)
+       vals
+       (mapv #(apply max-key :id %))))
+
+(declare evaluate-checks)
+
+(defn evaluate-tag-checks
+  [sha workflow-runs check-runs]
+  (let [runs (verified-workflow-runs sha workflow-runs)]
+    (when-not (= required-workflows (set (map :path runs)))
+      (reject! "Run Tests and Formal verification on the source branch before tagging."
+               :eacl.release/missing-workflows {:sha sha}))
+    (doseq [run runs]
+      (when-not (and (= "completed" (:status run)) (= "success" (:conclusion run)))
+        (reject! "The latest source CI must be completed and green before publication."
+                 :eacl.release/workflow-not-green
+                 (select-keys run [:id :path :status :conclusion :html_url]))))
+    (evaluate-checks {:sha sha} runs check-runs true)))
 
 (defn evaluate-checks
   "Return :ready or :pending; reject ambiguity, wrong SHA, or bad conclusions.
@@ -149,7 +179,6 @@
    :ref (System/getenv "GITHUB_REF")
    :ref-type (System/getenv "GITHUB_REF_TYPE")
    :sha (System/getenv "GITHUB_SHA")
-   :branch-sha (System/getenv "EACL_BRANCH_SHA")
    :supplied-version (System/getenv "EACL_VERSION")})
 
 (defn- read-listing
@@ -160,7 +189,23 @@
 (defn -main
   [& [operation & arguments]]
   (case operation
-    "ordinary" (println (ordinary-version (environment-context)))
+    "tag" (let [{:keys [version branch]} (tagged-release (environment-context))]
+            (println (str "version=" version))
+            (println (str "branch=" branch)))
+    "provenance"
+    (assert-tag-provenance!
+     {:sha (System/getenv "GITHUB_SHA")
+      :tag-sha (System/getenv "EACL_TAG_SHA")
+      :source-tree (System/getenv "EACL_SOURCE_TREE")
+      :branch-tree (System/getenv "EACL_BRANCH_TREE")
+      :ancestor? (= "true" (System/getenv "EACL_ANCESTOR"))})
+    "tag-checks"
+    (let [[workflow-runs-path check-runs-path] arguments]
+      (println
+       (name (evaluate-tag-checks
+              (System/getenv "GITHUB_SHA")
+              (read-listing workflow-runs-path :workflow_runs)
+              (read-listing check-runs-path :check_runs)))))
     "checks"
     (let [[workflow-runs-path check-runs-path final-argument] arguments
           {:keys [sha ref]} (environment-context)]

--- a/src-build/eacl/release_guard_test.clj
+++ b/src-build/eacl/release_guard_test.clj
@@ -1,5 +1,6 @@
 (ns eacl.release-guard-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as string]
+            [clojure.test :refer [deftest is testing]]
             [eacl.release-guard :as guard]))
 
 (def ordinary-context
@@ -21,42 +22,152 @@
            (assoc ordinary-context :ref "refs/heads/feature/v8.1.0")
            (assoc ordinary-context :ref "refs/heads/v8.0-SNAPSHOT")
            (assoc ordinary-context :ref "refs/tags/v8.1.0"
-                                   :ref-type "tag")
+                  :ref-type "tag")
            (assoc ordinary-context :event-name "pull_request")
            (assoc ordinary-context :supplied-version "8.1.0")
            (assoc ordinary-context :branch-sha "newer")]]
     (is (thrown? clojure.lang.ExceptionInfo
                  (guard/ordinary-version context)))))
 
+(deftest checks-are-scoped-to-a-branch-ref
+  (is (= "v8.1.0" (guard/branch-name "refs/heads/v8.1.0")))
+  (is (= "release/v8.0" (guard/branch-name "refs/heads/release/v8.0")))
+  (doseq [ref ["refs/tags/v8.1.0" "refs/pull/189/merge" "" nil]]
+    (is (thrown? clojure.lang.ExceptionInfo (guard/branch-name ref)))))
+
+(def check-context
+  {:sha "release-sha" :branch "v8.1.0"})
+
+(def tests-suite 11)
+(def formal-suite 12)
+
+(defn- workflow-run
+  [event branch sha suite]
+  {:event event
+   :head_branch branch
+   :head_sha sha
+   :check_suite_id suite})
+
+(def release-workflow-runs
+  [(workflow-run "push" "v8.1.0" "release-sha" tests-suite)
+   (workflow-run "push" "v8.1.0" "release-sha" formal-suite)])
+
+(def formal-check-names
+  #{"dafny-and-generated-boundaries"
+    "temporal-models"
+    "parity-corpus-and-mutations"})
+
+(defn- check-run
+  ([name sha suite]
+   (check-run name sha suite "completed" "success"))
+  ([name sha suite status conclusion]
+   {:name name
+    :head_sha sha
+    :status status
+    :conclusion conclusion
+    :check_suite {:id suite}}))
+
 (defn- successful-checks
   [sha]
   (mapv
    (fn [name]
-     {:name name
-      :head_sha sha
-      :status "completed"
-      :conclusion "success"})
-   guard/required-checks))
+     (check-run name sha (if (formal-check-names name) formal-suite tests-suite)))
+   (sort guard/required-checks)))
+
+(deftest only-the-release-branch-push-runs-are-release-evidence
+  (is (= #{tests-suite formal-suite}
+         (guard/release-check-suites check-context release-workflow-runs)))
+  (testing "pull-request, other-branch, other-commit, and suite-less runs are ignored"
+    (is (= #{tests-suite}
+           (guard/release-check-suites
+            check-context
+            [(workflow-run "push" "v8.1.0" "release-sha" tests-suite)
+             (workflow-run "pull_request" "v8.1.0" "release-sha" 21)
+             (workflow-run "push" "main" "release-sha" 22)
+             (workflow-run "push" "v8.1.0" "older-sha" 23)
+             (workflow-run "workflow_dispatch" "v8.1.0" "release-sha" 24)
+             (dissoc (workflow-run "push" "v8.1.0" "release-sha" 25)
+                     :check_suite_id)])))))
+
+(deftest same-commit-results-from-other-refs-do-not-make-the-gate-ambiguous
+  (let [sha "release-sha"
+        checks (successful-checks sha)
+        pull-request-suite 21
+        main-suite 22
+        foreign-runs
+        (into release-workflow-runs
+              [(workflow-run "pull_request" "v8.1.0" sha pull-request-suite)
+               (workflow-run "push" "main" sha main-suite)])
+        foreign-checks
+        (into checks
+              (concat
+               ;; The pull-request event verified a synthetic merge commit.
+               (map #(assoc % :check_suite {:id pull-request-suite}) checks)
+               ;; A same-repo pull request skips its duplicate test job.
+               [(check-run "test" sha pull-request-suite "completed" "skipped")]
+               ;; main was pushed to the same commit and one of its jobs failed.
+               (map #(assoc % :check_suite {:id main-suite}) checks)
+               [(check-run "test" sha main-suite "completed" "failure")]))]
+    (is (= :ready (guard/evaluate-checks check-context foreign-runs foreign-checks false)))
+    (is (= :ready (guard/evaluate-checks check-context foreign-runs foreign-checks true)))
+    (testing "the foreign results also never stand in for absent release evidence"
+      (is (= :pending
+             (guard/evaluate-checks
+              check-context foreign-runs
+              (remove #(= tests-suite (get-in % [:check_suite :id]))
+                      foreign-checks)
+              false))))))
 
 (deftest exact-sha-check-gate-rejects-every-ambiguous-state
   (let [sha "release-sha"
         checks (successful-checks sha)]
-    (is (= :ready (guard/evaluate-checks sha checks false)))
+    (is (= :ready (guard/evaluate-checks check-context release-workflow-runs checks false)))
     (is (= :pending
-           (guard/evaluate-checks sha (pop checks) false)))
+           (guard/evaluate-checks check-context release-workflow-runs (pop checks) false)))
     (is (thrown? clojure.lang.ExceptionInfo
-                 (guard/evaluate-checks sha (pop checks) true)))
-    (is (thrown?
-         clojure.lang.ExceptionInfo
-         (guard/evaluate-checks sha (conj checks (first checks)) false)))
+                 (guard/evaluate-checks check-context release-workflow-runs (pop checks) true)))
+    (testing "release evidence is pending until the branch push runs exist"
+      (is (= :pending (guard/evaluate-checks check-context [] checks false)))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (guard/evaluate-checks check-context [] checks true)))
+      (is (= :pending
+             (guard/evaluate-checks
+              (assoc check-context :branch "v8.2.0") release-workflow-runs checks false))))
+    (testing "a duplicate inside the release branch's own runs stays ambiguous"
+      (is (thrown?
+           clojure.lang.ExceptionInfo
+           (guard/evaluate-checks
+            check-context release-workflow-runs (conj checks (first checks)) false))))
     (doseq [changed [(assoc-in checks [0 :head_sha] "wrong-sha")
                      (assoc-in checks [0 :status] "in_progress")
                      (assoc-in checks [0 :conclusion] "failure")
                      (assoc-in checks [0 :conclusion] "cancelled")
-                     (assoc-in checks [0 :conclusion] "timed_out")]]
+                     (assoc-in checks [0 :conclusion] "timed_out")
+                     (assoc-in checks [0 :conclusion] "skipped")]]
       (testing (str "rejected check state " (first changed))
         (if (= "in_progress" (:status (first changed)))
           (is (thrown? clojure.lang.ExceptionInfo
-                       (guard/evaluate-checks sha changed true)))
+                       (guard/evaluate-checks
+                        check-context release-workflow-runs changed true)))
           (is (thrown? clojure.lang.ExceptionInfo
-                       (guard/evaluate-checks sha changed false))))))))
+                       (guard/evaluate-checks
+                        check-context release-workflow-runs changed false))))))))
+
+(deftest truncated-github-listings-are-never-judged
+  (is (= [{:id 1} {:id 2}]
+         (guard/listing {:total_count 2 :check_runs [{:id 1} {:id 2}]}
+                        :check_runs)))
+  (is (= [] (guard/listing {:total_count 0 :workflow_runs []} :workflow_runs)))
+  (is (thrown? clojure.lang.ExceptionInfo
+               (guard/listing {:total_count 3 :check_runs [{:id 1} {:id 2}]}
+                              :check_runs))))
+
+(deftest release-workflow-correlates-branch-push-runs
+  (let [workflow (slurp ".github/workflows/release.yml")]
+    (is (string/includes?
+         workflow
+         "actions/runs?head_sha=$GITHUB_SHA&event=push&branch=$GITHUB_REF_NAME"))
+    (is (string/includes? workflow "commits/$GITHUB_SHA/check-runs"))
+    (is (string/includes?
+         workflow
+         "clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json"))))

--- a/src-build/eacl/release_guard_test.clj
+++ b/src-build/eacl/release_guard_test.clj
@@ -3,37 +3,40 @@
             [clojure.test :refer [deftest is testing]]
             [eacl.release-guard :as guard]))
 
-(def ordinary-context
+(def tag-context
   {:event-name "push"
-   :ref "refs/heads/v8.1.0"
-   :ref-type "branch"
-   :sha "abc123"
-   :branch-sha "abc123"
-   :supplied-version nil})
+   :ref "refs/tags/v8.0.0-RC-2026-09-12"
+   :ref-type "tag"})
 
-(deftest versioned-branch-derives-an-immutable-version
-  (is (= "8.1.0" (guard/ordinary-version ordinary-context)))
-  (is (= "8.0.0-SNAPSHOT"
-         (guard/ordinary-version
-          (assoc ordinary-context :ref "refs/heads/v8.0.0-SNAPSHOT"))))
-  (doseq [context
-          [(assoc ordinary-context :ref "refs/heads/main")
-           (assoc ordinary-context :ref "refs/heads/release/v8.0")
-           (assoc ordinary-context :ref "refs/heads/feature/v8.1.0")
-           (assoc ordinary-context :ref "refs/heads/v8.0-SNAPSHOT")
-           (assoc ordinary-context :ref "refs/tags/v8.1.0"
-                  :ref-type "tag")
-           (assoc ordinary-context :event-name "pull_request")
-           (assoc ordinary-context :supplied-version "8.1.0")
-           (assoc ordinary-context :branch-sha "newer")]]
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (guard/ordinary-version context)))))
+(deftest only-explicit-version-tags-can-release
+  (doseq [[tag version] [["v8.0.0" "8.0.0"]
+                         ["v8.0.0-RC-2026-09-12" "8.0.0-RC-2026-09-12"]
+                         ["v8.0.0-SNAPSHOT-2026-09-12" "8.0.0-SNAPSHOT"]
+                         ["v8.0.0-SNAPSHOT-2026-09-12T141530Z" "8.0.0-SNAPSHOT"]]
+          event ["push" "workflow_dispatch"]]
+    (is (= {:version version :branch "v8.0.0-SNAPSHOT"}
+           (guard/tagged-release
+            (assoc tag-context :ref (str "refs/tags/" tag) :event-name event)))))
+  (doseq [context [(assoc tag-context :ref "refs/heads/main" :ref-type "branch")
+                   (assoc tag-context :ref "refs/heads/v8.0.0-SNAPSHOT" :ref-type "branch")
+                   (assoc tag-context :ref "refs/heads/feature/example" :ref-type "branch")
+                   (assoc tag-context :ref "refs/tags/v8.0.0-SNAPSHOT")
+                   (assoc tag-context :ref "refs/tags/v8.0-SNAPSHOT")
+                   (assoc tag-context :ref "refs/tags/v8.0.0-RC-2026-09-12/evil")
+                   (assoc tag-context :event-name "pull_request")
+                   (assoc tag-context :supplied-version "8.0.0")
+                   (assoc tag-context :ref nil)]]
+    (is (thrown? clojure.lang.ExceptionInfo (guard/tagged-release context)))))
 
-(deftest checks-are-scoped-to-a-branch-ref
-  (is (= "v8.1.0" (guard/branch-name "refs/heads/v8.1.0")))
-  (is (= "release/v8.0" (guard/branch-name "refs/heads/release/v8.0")))
-  (doseq [ref ["refs/tags/v8.1.0" "refs/pull/189/merge" "" nil]]
-    (is (thrown? clojure.lang.ExceptionInfo (guard/branch-name ref)))))
+(deftest tag-must-be-merged-and-match-the-current-release-tree
+  (let [context {:sha "green-pr-head" :tag-sha "green-pr-head"
+                 :source-tree "identical-tree" :branch-tree "identical-tree"
+                 :ancestor? true}]
+    (is (true? (guard/assert-tag-provenance! context)))
+    (doseq [[key value] [[:tag-sha "moved-tag"] [:source-tree nil]
+                         [:branch-tree "different-code"] [:ancestor? false] [:sha nil]]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (guard/assert-tag-provenance! (assoc context key value)))))))
 
 (def check-context
   {:sha "release-sha" :branch "v8.1.0"})
@@ -162,12 +165,51 @@
                (guard/listing {:total_count 3 :check_runs [{:id 1} {:id 2}]}
                               :check_runs))))
 
-(deftest release-workflow-correlates-branch-push-runs
-  (let [workflow (slurp ".github/workflows/release.yml")]
-    (is (string/includes?
-         workflow
-         "actions/runs?head_sha=$GITHUB_SHA&event=push&branch=$GITHUB_REF_NAME"))
-    (is (string/includes? workflow "commits/$GITHUB_SHA/check-runs"))
-    (is (string/includes?
-         workflow
-         "clojure -M:release-guard checks target/release/workflow-runs.json target/release/check-runs.json"))))
+(def tagged-workflow-runs
+  (mapv (fn [run path id]
+          (assoc run :path path :id id :status "completed" :conclusion "success"))
+        release-workflow-runs
+        [".github/workflows/test.yml" ".github/workflows/formal.yml"]
+        [101 102]))
+
+(deftest tag-publication-reuses-exact-source-ci-and-fails-fast
+  (let [checks (successful-checks "release-sha")]
+    (is (= :ready (guard/evaluate-tag-checks "release-sha" tagged-workflow-runs checks)))
+    (testing "a green PR branch push can be reused after its head is merged"
+      (is (= :ready (guard/evaluate-tag-checks
+                     "release-sha"
+                     (mapv #(assoc % :head_branch "feature/release") tagged-workflow-runs)
+                     checks))))
+    (doseq [runs [(pop tagged-workflow-runs)
+                  (mapv #(assoc % :head_sha "older-sha") tagged-workflow-runs)
+                  (mapv #(assoc % :event "pull_request") tagged-workflow-runs)
+                  (assoc-in tagged-workflow-runs [0 :path] ".github/workflows/pretend.yml")
+                  (assoc-in tagged-workflow-runs [0 :status] "in_progress")
+                  (assoc-in tagged-workflow-runs [0 :conclusion] "failure")
+                  (conj tagged-workflow-runs
+                        (assoc (first tagged-workflow-runs) :id 200 :conclusion "failure"))]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (guard/evaluate-tag-checks "release-sha" runs checks))))
+    (testing "an older failed attempt does not poison a newer successful run"
+      (is (= :ready (guard/evaluate-tag-checks
+                     "release-sha"
+                     (conj tagged-workflow-runs
+                           (assoc (first tagged-workflow-runs)
+                                  :id 1 :check_suite_id 99 :conclusion "failure"))
+                     (conj checks (check-run "test" "release-sha" 99 "completed" "failure"))))))
+    (testing "required jobs must still succeed even if a workflow reports success"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (guard/evaluate-tag-checks
+                    "release-sha" tagged-workflow-runs
+                    (assoc-in checks [0 :conclusion] "skipped")))))))
+
+(deftest release-workflow-is-tagged-and-reuses-tested-runtime-artifacts
+  (let [workflow (slurp ".github/workflows/release.yml")
+        preflight (slurp "bin/release-preflight")]
+    (is (string/includes? workflow "tags: ['v[0-9]*']"))
+    (is (not (string/includes? workflow "branches:")))
+    (is (string/includes? workflow "environment: clojars"))
+    (is (string/includes? workflow "run-id: ${{ steps.guard.outputs.tests-run-id }}"))
+    (is (not (string/includes? workflow "bin/formal")))
+    (is (string/includes? preflight "actions/runs?head_sha=$GITHUB_SHA&event=push"))
+    (is (string/includes? preflight "clojure -M:release-guard tag-checks"))))


### PR DESCRIPTION
EACL snapshot publication failed when push and PR runs created duplicate check names, and the build rejected dated RC versions. Bring the existing check-suite fix and latest main into `v8.0.0-SNAPSHOT`, support `8.0.0-RC-2026-09-12`, and replace automatic branch publication with version tags and the protected Clojars approval gate.

The tagged commit must be merged into the matching snapshot branch and have the same complete Git tree as its current head. Publication requires the latest successful Tests and Formal push runs at that exact SHA and every required job; it fails immediately on missing/red CI. A merged green PR head can therefore publish both a dated snapshot tag and an RC tag without rerunning long formal checks. Generated runtimes come from the verified Tests artifact, and every Maven artifact is rebuilt, audited, and cold-smoked before upload. Provenance and CI are rechecked after approval.

Branch pushes never publish. The publishing guide documents tags, retries, immutable versions, and GitHub settings. The historical verification exception remains removed.

Validation: all build-tool tests through nREPL (26 tests, 473 assertions, zero failures/errors); all five RC artifacts built, audited, and cold-smoked through nREPL using the previously verified generated runtimes; the new gate accepted real GitHub API evidence from the previous green source commit. Actionlint, shell syntax, and Git whitespace checks passed. [Full Tests](https://github.com/theronic/eacl/actions/runs/34686699433) and [Formal verification](https://github.com/theronic/eacl/actions/runs/34686699431) are green on the same PR push commit.

GitHub configuration now requires the ten Tests/Formal checks before merging into the snapshot branch, permits auto-merge, keeps manual approval at the Clojars environment, restricts that environment to version tags, and forbids moving or deleting release tags.

Both protected publications succeeded using that same verified source: [8.0.0-SNAPSHOT](https://github.com/theronic/eacl/actions/runs/34688008692) and [8.0.0-RC-2026-09-12](https://github.com/theronic/eacl/actions/runs/34688216640). All ten public Clojars POMs and JARs were retrieved and checked for the expected versions, coordinated dependencies, source commit, and packaged generated runtimes. The workflow is also on main via #193 for manual dispatch.
